### PR TITLE
Deliver shared SKU operations updates

### DIFF
--- a/docs/solutions/logic-errors/athena-shared-sku-search-and-detail-surfaces-2026-05-27.md
+++ b/docs/solutions/logic-errors/athena-shared-sku-search-and-detail-surfaces-2026-05-27.md
@@ -1,0 +1,84 @@
+---
+title: Athena SKU Search And Detail Surfaces Share One Matcher
+date: 2026-05-27
+category: logic-errors
+module: athena-webapp
+problem_type: shared_search_and_detail_drift
+component: sku-search-and-admin-detail-surfaces
+symptoms:
+  - "Searching a multi-word SKU query such as hair bands returned broad category-only matches"
+  - "Stock adjustment and procurement search controls repeated the same SKU filtering UI"
+  - "Product, procurement, stock count, and quick-add surfaces did not expose the same SKU metadata"
+root_cause: sku_search_and_presentation_logic_was_reimplemented_by_surface
+resolution_type: shared_matcher_plus_shared_filter_bar_and_metadata_projection
+severity: medium
+tags:
+  - sku
+  - search
+  - procurement
+  - stock-adjustments
+  - products
+  - service-operations
+---
+
+# Athena SKU Search And Detail Surfaces Share One Matcher
+
+## Problem
+
+SKU search had drifted across admin surfaces. Stock adjustment and procurement
+workspaces each owned their own search/filter controls, while product and SKU
+tables assembled searchable metadata in slightly different ways. The shared
+fuzzy scorer also treated multi-word input as an OR search: if one token matched,
+the row stayed visible. That made a query like `hair bands` return every row with
+`hair` in category or product metadata even when `bands` was absent.
+
+At the same time, detail surfaces were missing fields operators needed for the
+same SKU identity checks: product detail, stock count rows, attach-barcode
+options, and procurement recommendations did not consistently carry size,
+length, color, price, category, and barcode.
+
+## Solution
+
+Keep one browser-safe SKU matcher and one reusable SKU search/filter bar:
+
+- Use `matchesSkuSearchTerms` for admin SKU/product filtering instead of local
+  `toLowerCase().includes(...)` checks.
+- Keep barcode-shaped queries exact so a mistyped barcode does not fuzzy-match
+  numeric SKU fragments.
+- Require every meaningful text query token to match somewhere in the row before
+  ranking. Fuzzy tolerance still applies per token, but unmatched query words
+  drop the row.
+- Route stock adjustment and procurement filters through `SkuSearchFilterBar` so
+  the search input, scanner slot, availability/status select, quick action, and
+  result summary do not fork again.
+- Include SKU detail metadata in the searchable term arrays and option labels:
+  name, SKU, barcode, category, color, size, length, and price where relevant.
+
+This makes broad category terms useful only when they are the whole query. When
+operators type a product phrase, each word must be represented in the candidate
+row, which keeps prod inventory counts from exploding into unrelated categories.
+
+## Service Catalog Boundary
+
+The same branch also normalized service-operation form handling. Keep service
+catalog form helpers in a local presentation module and let Convex service
+commands own durable validation, price normalization, and case/intake status
+changes. Browser components should present clean operator labels and reuse the
+form parser rather than duplicating raw command payload shaping in each view.
+
+## Prevention
+
+- Add shared matcher tests for any SKU search behavior change, especially
+  multi-word queries and barcode-shaped input.
+- Pair helper tests with at least one consuming surface test for stock
+  adjustment, procurement, products, or quick-add when their term arrays change.
+- Do not add new SKU search inputs as bespoke `Input` plus `Select` blocks when
+  `SkuSearchFilterBar` can represent the workflow.
+- Keep generated graphify artifacts refreshed after broad code edits.
+
+## Related Validation
+
+- `bun run --filter '@athena/webapp' test -- src/lib/stockOps/skuSearch.test.ts src/lib/pos/presentation/register/catalogSearch.test.ts`
+- `bun run --filter '@athena/webapp' test -- src/components/operations/StockAdjustmentWorkspace.test.tsx src/components/procurement/ProcurementView.test.tsx src/components/products/Products.test.tsx src/components/product/QuickAddProductDialog.test.tsx`
+- `bun run --filter '@athena/webapp' test -- convex/operations/serviceIntake.test.ts convex/serviceOps/serviceCases.test.ts src/components/services/ServiceCatalogView.test.tsx src/components/services/ServiceIntakeView.test.tsx src/components/services/ServicesWorkspaceView.test.tsx`
+- `bun run pr:athena`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1783 files · ~0 words
+- 1788 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5781 nodes · 6101 edges · 1711 communities detected
+- 5808 nodes · 6126 edges · 1716 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1721,6 +1721,11 @@
 - [[_COMMUNITY_Community 1708|Community 1708]]
 - [[_COMMUNITY_Community 1709|Community 1709]]
 - [[_COMMUNITY_Community 1710|Community 1710]]
+- [[_COMMUNITY_Community 1711|Community 1711]]
+- [[_COMMUNITY_Community 1712|Community 1712]]
+- [[_COMMUNITY_Community 1713|Community 1713]]
+- [[_COMMUNITY_Community 1714|Community 1714]]
+- [[_COMMUNITY_Community 1715|Community 1715]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1770,7 +1775,7 @@ Nodes (26): addLocalAvailabilityConsumption(), addLocalAvailabilityDeltaConsumpt
 
 ### Community 5 - "Community 5"
 Cohesion: 0.07
-Nodes (18): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleCreateDraftPurchaseOrders() (+10 more)
+Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.15
@@ -1925,372 +1930,372 @@ Cohesion: 0.12
 Nodes (7): createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), normalizeStaffAuthorityRecord(), normalizeUsername(), PosLocalStoreSchemaError, preserveWrappedStaffProof(), staffAuthorityKey()
 
 ### Community 44 - "Community 44"
-Cohesion: 0.18
-Nodes (17): bestFuzzyTokenScore(), extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isBarcodeShapedInput(), isProbablySameToken(), levenshteinDistance(), normalizeIdentifier() (+9 more)
-
-### Community 45 - "Community 45"
 Cohesion: 0.15
 Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
-### Community 46 - "Community 46"
+### Community 45 - "Community 45"
 Cohesion: 0.21
 Nodes (16): commandForPort(), defaultCommand(), isProcessAlive(), isReachable(), listPreviews(), optionsFromEnv(), pruneState(), readState() (+8 more)
 
-### Community 47 - "Community 47"
+### Community 46 - "Community 46"
 Cohesion: 0.19
 Nodes (16): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle(), listInventorySnapshotWithCtx(), listProductSkusForStockAdjustmentScopeWithCtx() (+8 more)
 
-### Community 48 - "Community 48"
+### Community 47 - "Community 47"
 Cohesion: 0.17
 Nodes (13): buildSkuContinuityContextById(), deriveContinuityStatus(), getPlannedActionAt(), getStartOfCurrentDay(), hasLateInbound(), hasRelatedPurchaseOrderContext(), hasStalePlannedAction(), isInboundStatus() (+5 more)
 
-### Community 49 - "Community 49"
+### Community 48 - "Community 48"
 Cohesion: 0.11
 Nodes (0):
 
-### Community 50 - "Community 50"
+### Community 49 - "Community 49"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
-### Community 51 - "Community 51"
+### Community 50 - "Community 50"
 Cohesion: 0.18
 Nodes (10): getTransactionById(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile(), loadPendingItemAdjustmentApprovals(), normalizeAdjustmentLineItem(), normalizeAdjustmentMetadata(), numberFromMetadata() (+2 more)
 
-### Community 52 - "Community 52"
+### Community 51 - "Community 51"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 53 - "Community 53"
+### Community 52 - "Community 52"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 54 - "Community 54"
+### Community 53 - "Community 53"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 55 - "Community 55"
+### Community 54 - "Community 54"
 Cohesion: 0.15
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
-### Community 56 - "Community 56"
+### Community 55 - "Community 55"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
-### Community 57 - "Community 57"
+### Community 56 - "Community 56"
 Cohesion: 0.14
 Nodes (4): DailyCloseHistoryView(), getDailyCloseHistoryApi(), getHistoryRecordSnapshot(), normalizeHistorySnapshot()
 
-### Community 58 - "Community 58"
+### Community 57 - "Community 57"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 59 - "Community 59"
+### Community 58 - "Community 58"
 Cohesion: 0.26
 Nodes (13): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget() (+5 more)
 
-### Community 60 - "Community 60"
+### Community 59 - "Community 59"
 Cohesion: 0.33
 Nodes (14): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+6 more)
 
-### Community 61 - "Community 61"
+### Community 60 - "Community 60"
 Cohesion: 0.26
 Nodes (12): assertRegisterNumberIsAvailable(), cleanBrowserInfo(), cleanDiagnosticMessage(), cleanOptionalString(), mapRegisterTerminalError(), nonNegativeInteger(), normalizeRegisterNumber(), omitUndefined() (+4 more)
 
-### Community 62 - "Community 62"
+### Community 61 - "Community 61"
 Cohesion: 0.17
 Nodes (6): buildServerPricedCheckoutProducts(), calculateItemsSubtotal(), deriveDeliveryOptionFromAddress(), isDeliveryFeeWaived(), normalizeDeliveryOption(), resolveServerDeliveryFee()
 
-### Community 63 - "Community 63"
+### Community 62 - "Community 62"
 Cohesion: 0.24
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
-### Community 64 - "Community 64"
+### Community 63 - "Community 63"
 Cohesion: 0.22
 Nodes (10): createApp(), createHandlers(), createRedisClient(), createRedisCluster(), deleteKeysIndividually(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline(), scanNodeForPattern() (+2 more)
 
-### Community 65 - "Community 65"
+### Community 64 - "Community 64"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 66 - "Community 66"
+### Community 65 - "Community 65"
 Cohesion: 0.31
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getOperationalWorkItemStatus() (+5 more)
 
-### Community 67 - "Community 67"
+### Community 66 - "Community 66"
 Cohesion: 0.15
 Nodes (2): formatTimelineRange(), formatTimelineTime()
 
-### Community 68 - "Community 68"
+### Community 67 - "Community 67"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 69 - "Community 69"
+### Community 68 - "Community 68"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 70 - "Community 70"
+### Community 69 - "Community 69"
 Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
-### Community 71 - "Community 71"
+### Community 70 - "Community 70"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 72 - "Community 72"
+### Community 71 - "Community 71"
 Cohesion: 0.18
 Nodes (4): getLatestRuntimeStatusForTerminal(), getTerminalByFingerprint(), mapTerminalRecord(), upsertLatestRuntimeStatus()
 
-### Community 73 - "Community 73"
+### Community 72 - "Community 72"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 74 - "Community 74"
+### Community 73 - "Community 73"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
 
-### Community 75 - "Community 75"
+### Community 74 - "Community 74"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 76 - "Community 76"
+### Community 75 - "Community 75"
 Cohesion: 0.37
 Nodes (11): asRecord(), buildPosLocalSyncUploadEvents(), customerInfoFromPayload(), getCompletedSaleItems(), hasLaterCompletedSale(), nullableStringToOptional(), numberOrZero(), stringOrEmpty() (+3 more)
 
-### Community 77 - "Community 77"
+### Community 76 - "Community 76"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 78 - "Community 78"
+### Community 77 - "Community 77"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 79 - "Community 79"
+### Community 78 - "Community 78"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
 
-### Community 80 - "Community 80"
+### Community 79 - "Community 79"
 Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
 
-### Community 81 - "Community 81"
+### Community 80 - "Community 80"
 Cohesion: 0.31
 Nodes (12): collectFilesUnder(), collectProofSnapshot(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof(), hashValidationWiring(), normalizeRepoPath(), readPrAthenaScript(), recordPrePushValidationProof() (+4 more)
 
-### Community 82 - "Community 82"
+### Community 81 - "Community 81"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 83 - "Community 83"
+### Community 82 - "Community 82"
 Cohesion: 0.18
 Nodes (2): handleKeyDown(), isDebugShortcut()
 
+### Community 83 - "Community 83"
+Cohesion: 0.2
+Nodes (3): handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
+
 ### Community 84 - "Community 84"
-Cohesion: 0.18
-Nodes (2): formatBlockerList(), runPrePushReview()
+Cohesion: 0.21
+Nodes (5): formatDeposit(), formatMoney(), handleCancelEdit(), handleSaveEdit(), summarizeService()
 
 ### Community 85 - "Community 85"
-Cohesion: 0.36
-Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
+Cohesion: 0.27
+Nodes (8): extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isBarcodeShapedInput(), normalizeIdentifier(), parseCatalogSearchInput(), searchByText(), searchRegisterCatalog()
 
 ### Community 86 - "Community 86"
-Cohesion: 0.33
-Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
+Cohesion: 0.29
+Nodes (10): bestFuzzyTokenScore(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreFuzzySearchEntry(), scoreFuzzyTokenMatch(), scoreQueryTokenForEntry() (+2 more)
 
 ### Community 87 - "Community 87"
-Cohesion: 0.24
-Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
+Cohesion: 0.18
+Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 88 - "Community 88"
 Cohesion: 0.29
 Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 89 - "Community 89"
+Cohesion: 0.36
+Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
+
+### Community 90 - "Community 90"
+Cohesion: 0.33
+Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
+
+### Community 91 - "Community 91"
+Cohesion: 0.24
+Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
+
+### Community 92 - "Community 92"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 90 - "Community 90"
-Cohesion: 0.22
-Nodes (3): handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
-
-### Community 91 - "Community 91"
-Cohesion: 0.25
-Nodes (6): handleEdit(), handleReset(), handleSubmit(), itemToFormState(), parseServiceCatalogForm(), validateServiceCatalogForm()
-
-### Community 92 - "Community 92"
+### Community 93 - "Community 93"
 Cohesion: 0.25
 Nodes (6): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), usePrewarmRegisterCatalogOfflineSnapshots()
-
-### Community 93 - "Community 93"
-Cohesion: 0.18
-Nodes (0):
 
 ### Community 94 - "Community 94"
 Cohesion: 0.18
 Nodes (0):
 
 ### Community 95 - "Community 95"
+Cohesion: 0.18
+Nodes (0):
+
+### Community 96 - "Community 96"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.22
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.31
 Nodes (7): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), parseVariantDisplayMoney(), saveProduct(), updateVariantSku()
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 102 - "Community 102"
+### Community 103 - "Community 103"
 Cohesion: 0.27
 Nodes (5): classifyTerminalHealth(), formatAge(), formatStatusLabel(), getReviewEvidenceCount(), getSnapshotAgeSummary()
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.27
 Nodes (5): blocked(), evaluateLocalPosReadiness(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.38
 Nodes (7): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), mapSyncStatus(), normalizeStaffAuthorityStatus(), snapshotAges(), toSafeFailureMessage()
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.42
 Nodes (7): getRegisterCatalogPrice(), listRegisterCatalog(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.28
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.43
 Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.43
 Nodes (6): assertActiveTerminal(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.5
 Nodes (7): findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), isBarcodeLike(), mapSkuToCatalogResult(), quickAddCatalogItem()
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.36
 Nodes (4): buildTerminalHealthSummary(), deriveTerminalHealth(), getTerminalHealthSummary(), stripRuntimeStatusIdentity()
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
-
-### Community 135 - "Community 135"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 136 - "Community 136"
 Cohesion: 0.25
@@ -2301,12 +2306,12 @@ Cohesion: 0.25
 Nodes (0):
 
 ### Community 138 - "Community 138"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
-
-### Community 139 - "Community 139"
 Cohesion: 0.25
 Nodes (0):
+
+### Community 139 - "Community 139"
+Cohesion: 0.39
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 140 - "Community 140"
 Cohesion: 0.25
@@ -2317,228 +2322,228 @@ Cohesion: 0.25
 Nodes (0):
 
 ### Community 142 - "Community 142"
-Cohesion: 0.46
-Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
-
-### Community 143 - "Community 143"
-Cohesion: 0.43
-Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
-
-### Community 144 - "Community 144"
 Cohesion: 0.25
 Nodes (0):
 
+### Community 143 - "Community 143"
+Cohesion: 0.46
+Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
+
+### Community 144 - "Community 144"
+Cohesion: 0.43
+Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
+
 ### Community 145 - "Community 145"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 146 - "Community 146"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.33
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.33
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 155 - "Community 155"
+### Community 156 - "Community 156"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.33
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.33
 Nodes (2): handlePinChange(), normalizeOtpCode()
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.33
 Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 167 - "Community 167"
-Cohesion: 0.38
-Nodes (3): formatDeposit(), formatMoney(), summarizeService()
-
 ### Community 168 - "Community 168"
+Cohesion: 0.33
+Nodes (2): handleReset(), handleSubmit()
+
+### Community 169 - "Community 169"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 170 - "Community 170"
+### Community 171 - "Community 171"
 Cohesion: 0.33
 Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
-
-### Community 171 - "Community 171"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 172 - "Community 172"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 173 - "Community 173"
-Cohesion: 0.52
-Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 174 - "Community 174"
 Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
+### Community 174 - "Community 174"
+Cohesion: 0.29
+Nodes (0):
+
 ### Community 175 - "Community 175"
+Cohesion: 0.52
+Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 176 - "Community 176"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 177 - "Community 177"
+### Community 178 - "Community 178"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 178 - "Community 178"
+### Community 179 - "Community 179"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 179 - "Community 179"
-Cohesion: 0.33
-Nodes (1): ValkeyClient
-
 ### Community 180 - "Community 180"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ValkeyClient
 
 ### Community 181 - "Community 181"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 182 - "Community 182"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 183 - "Community 183"
 Cohesion: 0.4
 Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 191 - "Community 191"
+### Community 192 - "Community 192"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 195 - "Community 195"
+### Community 196 - "Community 196"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
-
-### Community 197 - "Community 197"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 198 - "Community 198"
 Cohesion: 0.33
@@ -2553,20 +2558,20 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 201 - "Community 201"
-Cohesion: 0.53
-Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
+Cohesion: 0.33
+Nodes (1): ResizeObserverStub
 
 ### Community 202 - "Community 202"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 203 - "Community 203"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
 ### Community 204 - "Community 204"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.53
+Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 205 - "Community 205"
 Cohesion: 0.33
@@ -2577,8 +2582,8 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 207 - "Community 207"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 208 - "Community 208"
 Cohesion: 0.33
@@ -2589,88 +2594,88 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 210 - "Community 210"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 211 - "Community 211"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 212 - "Community 212"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 213 - "Community 213"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 214 - "Community 214"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 215 - "Community 215"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 216 - "Community 216"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 217 - "Community 217"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 214 - "Community 214"
+### Community 218 - "Community 218"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 215 - "Community 215"
+### Community 219 - "Community 219"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 216 - "Community 216"
+### Community 220 - "Community 220"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 217 - "Community 217"
+### Community 221 - "Community 221"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 218 - "Community 218"
+### Community 222 - "Community 222"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
-### Community 219 - "Community 219"
+### Community 223 - "Community 223"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 220 - "Community 220"
+### Community 224 - "Community 224"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 221 - "Community 221"
+### Community 225 - "Community 225"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 222 - "Community 222"
+### Community 226 - "Community 226"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 223 - "Community 223"
+### Community 227 - "Community 227"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 224 - "Community 224"
+### Community 228 - "Community 228"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 225 - "Community 225"
+### Community 229 - "Community 229"
 Cohesion: 0.5
 Nodes (2): createAuthorizedRegisterDepositCtx(), createQueryCtx()
 
-### Community 226 - "Community 226"
+### Community 230 - "Community 230"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 227 - "Community 227"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 228 - "Community 228"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 229 - "Community 229"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
-
-### Community 230 - "Community 230"
-Cohesion: 0.7
-Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
 ### Community 231 - "Community 231"
 Cohesion: 0.4
@@ -2681,12 +2686,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 233 - "Community 233"
-Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 234 - "Community 234"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
 ### Community 235 - "Community 235"
 Cohesion: 0.4
@@ -2698,43 +2703,43 @@ Nodes (0):
 
 ### Community 237 - "Community 237"
 Cohesion: 0.7
-Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
 ### Community 238 - "Community 238"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 239 - "Community 239"
-Cohesion: 0.6
-Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
-
-### Community 240 - "Community 240"
-Cohesion: 0.5
-Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
-
-### Community 241 - "Community 241"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 240 - "Community 240"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 241 - "Community 241"
+Cohesion: 0.7
+Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
 ### Community 242 - "Community 242"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 243 - "Community 243"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
 ### Community 244 - "Community 244"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
 ### Community 245 - "Community 245"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 246 - "Community 246"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 247 - "Community 247"
 Cohesion: 0.4
@@ -2749,16 +2754,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 250 - "Community 250"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
+
+### Community 251 - "Community 251"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 251 - "Community 251"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
-
 ### Community 252 - "Community 252"
-Cohesion: 0.6
-Nodes (3): handleAttachBarcodeSubmit(), handleClearSearch(), handleQuickAddSubmit()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 253 - "Community 253"
 Cohesion: 0.4
@@ -2769,16 +2774,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 255 - "Community 255"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 256 - "Community 256"
-Cohesion: 0.4
-Nodes (1): ResizeObserverStub
+Cohesion: 0.6
+Nodes (3): handleAttachBarcodeSubmit(), handleClearSearch(), handleQuickAddSubmit()
 
 ### Community 257 - "Community 257"
 Cohesion: 0.4
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 258 - "Community 258"
 Cohesion: 0.4
@@ -2793,32 +2798,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 261 - "Community 261"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+Cohesion: 0.4
+Nodes (1): ResizeObserverStub
 
 ### Community 262 - "Community 262"
-Cohesion: 0.7
-Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 263 - "Community 263"
 Cohesion: 0.4
-Nodes (1): MockImage
+Nodes (0):
 
 ### Community 264 - "Community 264"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 265 - "Community 265"
-Cohesion: 0.6
-Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
+Cohesion: 0.7
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
 ### Community 266 - "Community 266"
-Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
+Cohesion: 0.7
+Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
 ### Community 267 - "Community 267"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): MockImage
 
 ### Community 268 - "Community 268"
 Cohesion: 0.4
@@ -2826,11 +2831,11 @@ Nodes (0):
 
 ### Community 269 - "Community 269"
 Cohesion: 0.6
-Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+Nodes (3): calculatePosCartTotals(), calculatePosItemTotal(), roundPosAmount()
 
 ### Community 270 - "Community 270"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 271 - "Community 271"
 Cohesion: 0.4
@@ -2841,96 +2846,96 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 273 - "Community 273"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
 ### Community 274 - "Community 274"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 275 - "Community 275"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
+Cohesion: 0.6
+Nodes (3): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier()
 
 ### Community 276 - "Community 276"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 277 - "Community 277"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 278 - "Community 278"
-Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 279 - "Community 279"
-Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Cohesion: 0.5
+Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 280 - "Community 280"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 281 - "Community 281"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 282 - "Community 282"
 Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 283 - "Community 283"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 284 - "Community 284"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 285 - "Community 285"
-Cohesion: 0.6
-Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 286 - "Community 286"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 287 - "Community 287"
+### Community 286 - "Community 286"
 Cohesion: 0.7
-Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+
+### Community 287 - "Community 287"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 288 - "Community 288"
-Cohesion: 0.5
+Cohesion: 0.4
 Nodes (0):
 
 ### Community 289 - "Community 289"
-Cohesion: 0.67
-Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
+Cohesion: 0.6
+Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
 ### Community 290 - "Community 290"
-Cohesion: 0.83
-Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 291 - "Community 291"
-Cohesion: 0.83
-Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
+Cohesion: 0.7
+Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
 ### Community 292 - "Community 292"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 293 - "Community 293"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
 ### Community 294 - "Community 294"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
+Cohesion: 0.83
+Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
 ### Community 295 - "Community 295"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
 
 ### Community 296 - "Community 296"
 Cohesion: 0.5
@@ -2942,47 +2947,47 @@ Nodes (0):
 
 ### Community 298 - "Community 298"
 Cohesion: 0.67
-Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 299 - "Community 299"
-Cohesion: 0.83
-Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 300 - "Community 300"
-Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 301 - "Community 301"
-Cohesion: 0.67
-Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 302 - "Community 302"
 Cohesion: 0.67
-Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
+Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
 ### Community 303 - "Community 303"
+Cohesion: 0.83
+Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+
+### Community 304 - "Community 304"
+Cohesion: 0.67
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+
+### Community 305 - "Community 305"
+Cohesion: 0.67
+Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
+
+### Community 306 - "Community 306"
+Cohesion: 0.67
+Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
+
+### Community 307 - "Community 307"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 304 - "Community 304"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 305 - "Community 305"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 306 - "Community 306"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
-
-### Community 307 - "Community 307"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 308 - "Community 308"
-Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 309 - "Community 309"
 Cohesion: 0.5
@@ -2990,15 +2995,15 @@ Nodes (0):
 
 ### Community 310 - "Community 310"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 311 - "Community 311"
-Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 312 - "Community 312"
-Cohesion: 0.67
-Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
+Cohesion: 0.83
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 313 - "Community 313"
 Cohesion: 0.5
@@ -3006,55 +3011,55 @@ Nodes (0):
 
 ### Community 314 - "Community 314"
 Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 315 - "Community 315"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 316 - "Community 316"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
 ### Community 317 - "Community 317"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 318 - "Community 318"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 319 - "Community 319"
-Cohesion: 0.83
-Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 320 - "Community 320"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 321 - "Community 321"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 322 - "Community 322"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 323 - "Community 323"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
 ### Community 324 - "Community 324"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 325 - "Community 325"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 326 - "Community 326"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 327 - "Community 327"
 Cohesion: 0.5
@@ -3069,8 +3074,8 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 330 - "Community 330"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 331 - "Community 331"
 Cohesion: 0.5
@@ -3081,44 +3086,44 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 333 - "Community 333"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 334 - "Community 334"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 335 - "Community 335"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 336 - "Community 336"
-Cohesion: 0.67
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 337 - "Community 337"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 338 - "Community 338"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 339 - "Community 339"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 340 - "Community 340"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 340 - "Community 340"
+Cohesion: 0.67
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
 ### Community 341 - "Community 341"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 342 - "Community 342"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 343 - "Community 343"
 Cohesion: 0.5
@@ -3129,24 +3134,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 345 - "Community 345"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
-
-### Community 346 - "Community 346"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 347 - "Community 347"
+### Community 346 - "Community 346"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): applyCommandResult(), handleCreateCase()
+
+### Community 347 - "Community 347"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 348 - "Community 348"
-Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 349 - "Community 349"
-Cohesion: 1.0
-Nodes (3): canAccessFullAdminSurface(), canAccessStoreDaySurface(), getSurfaceAccess()
+Cohesion: 0.67
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 350 - "Community 350"
 Cohesion: 0.5
@@ -3154,79 +3159,79 @@ Nodes (0):
 
 ### Community 351 - "Community 351"
 Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 352 - "Community 352"
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+
+### Community 353 - "Community 353"
+Cohesion: 1.0
+Nodes (3): canAccessFullAdminSurface(), canAccessStoreDaySurface(), getSurfaceAccess()
+
+### Community 354 - "Community 354"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 353 - "Community 353"
+### Community 355 - "Community 355"
+Cohesion: 0.67
+Nodes (2): extractTraceId(), runCommand()
+
+### Community 356 - "Community 356"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 357 - "Community 357"
 Cohesion: 0.67
 Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
-### Community 354 - "Community 354"
+### Community 358 - "Community 358"
 Cohesion: 0.67
 Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
-### Community 355 - "Community 355"
+### Community 359 - "Community 359"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 356 - "Community 356"
+### Community 360 - "Community 360"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 357 - "Community 357"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 358 - "Community 358"
-Cohesion: 0.67
-Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
-
-### Community 359 - "Community 359"
-Cohesion: 0.83
-Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
-
-### Community 360 - "Community 360"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 361 - "Community 361"
-Cohesion: 0.83
-Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 362 - "Community 362"
 Cohesion: 0.67
-Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
+Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
 ### Community 363 - "Community 363"
 Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
+Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
 ### Community 364 - "Community 364"
-Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 365 - "Community 365"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
 ### Community 366 - "Community 366"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
 ### Community 367 - "Community 367"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 368 - "Community 368"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 369 - "Community 369"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 370 - "Community 370"
 Cohesion: 0.5
@@ -3245,71 +3250,71 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 374 - "Community 374"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 375 - "Community 375"
-Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 376 - "Community 376"
-Cohesion: 0.83
-Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 377 - "Community 377"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 378 - "Community 378"
+Cohesion: 0.67
+Nodes (2): useOptionalStoreContext(), useStoreContext()
+
+### Community 379 - "Community 379"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 380 - "Community 380"
+Cohesion: 0.83
+Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
+
+### Community 381 - "Community 381"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 382 - "Community 382"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 379 - "Community 379"
+### Community 383 - "Community 383"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 380 - "Community 380"
+### Community 384 - "Community 384"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 381 - "Community 381"
+### Community 385 - "Community 385"
 Cohesion: 0.67
 Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
-### Community 382 - "Community 382"
+### Community 386 - "Community 386"
 Cohesion: 0.67
 Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
-### Community 383 - "Community 383"
+### Community 387 - "Community 387"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 384 - "Community 384"
+### Community 388 - "Community 388"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 385 - "Community 385"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 386 - "Community 386"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 387 - "Community 387"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 388 - "Community 388"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 389 - "Community 389"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 390 - "Community 390"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 391 - "Community 391"
@@ -3321,8 +3326,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 393 - "Community 393"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 394 - "Community 394"
 Cohesion: 0.67
@@ -3341,8 +3346,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 398 - "Community 398"
-Cohesion: 1.0
-Nodes (2): buildCtx(), createDb()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 399 - "Community 399"
 Cohesion: 0.67
@@ -3357,16 +3362,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 402 - "Community 402"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildCtx(), createDb()
 
 ### Community 403 - "Community 403"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 404 - "Community 404"
-Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 405 - "Community 405"
 Cohesion: 0.67
@@ -3374,15 +3379,15 @@ Nodes (0):
 
 ### Community 406 - "Community 406"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 407 - "Community 407"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 408 - "Community 408"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 409 - "Community 409"
 Cohesion: 0.67
@@ -3390,11 +3395,11 @@ Nodes (0):
 
 ### Community 410 - "Community 410"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 411 - "Community 411"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 412 - "Community 412"
 Cohesion: 0.67
@@ -3405,12 +3410,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 414 - "Community 414"
-Cohesion: 1.0
-Nodes (2): buildServiceCatalogItem(), normalizeServiceCatalogNameKey()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 415 - "Community 415"
 Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 416 - "Community 416"
 Cohesion: 0.67
@@ -3421,40 +3426,40 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 418 - "Community 418"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildServiceCatalogItem(), normalizeServiceCatalogNameKey()
 
 ### Community 419 - "Community 419"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 420 - "Community 420"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 420 - "Community 420"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
-
 ### Community 421 - "Community 421"
-Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 422 - "Community 422"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 423 - "Community 423"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 424 - "Community 424"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 425 - "Community 425"
 Cohesion: 1.0
-Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 426 - "Community 426"
-Cohesion: 0.67
-Nodes (1): View()
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 427 - "Community 427"
 Cohesion: 0.67
@@ -3465,16 +3470,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 429 - "Community 429"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
 ### Community 430 - "Community 430"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 431 - "Community 431"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 432 - "Community 432"
 Cohesion: 0.67
@@ -3489,8 +3494,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 435 - "Community 435"
-Cohesion: 0.67
-Nodes (1): FadeIn()
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 436 - "Community 436"
 Cohesion: 0.67
@@ -3502,11 +3507,11 @@ Nodes (0):
 
 ### Community 438 - "Community 438"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 439 - "Community 439"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (1): FadeIn()
 
 ### Community 440 - "Community 440"
 Cohesion: 0.67
@@ -3518,11 +3523,11 @@ Nodes (0):
 
 ### Community 442 - "Community 442"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 443 - "Community 443"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 444 - "Community 444"
 Cohesion: 0.67
@@ -3570,91 +3575,91 @@ Nodes (0):
 
 ### Community 455 - "Community 455"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 456 - "Community 456"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (0):
 
 ### Community 457 - "Community 457"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (0):
 
 ### Community 458 - "Community 458"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (0):
 
 ### Community 459 - "Community 459"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 460 - "Community 460"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 461 - "Community 461"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): AppSkeleton()
 
 ### Community 462 - "Community 462"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
+Cohesion: 0.67
+Nodes (1): DashboardSkeleton()
 
 ### Community 463 - "Community 463"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (1): TableSkeleton()
 
 ### Community 464 - "Community 464"
 Cohesion: 0.67
-Nodes (1): Badge()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 465 - "Community 465"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): NotFound()
 
 ### Community 466 - "Community 466"
-Cohesion: 0.67
-Nodes (1): LoadingButton()
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
 ### Community 467 - "Community 467"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): AppContextMenu()
 
 ### Community 468 - "Community 468"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): Badge()
 
 ### Community 469 - "Community 469"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (0):
 
 ### Community 470 - "Community 470"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): LoadingButton()
 
 ### Community 471 - "Community 471"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): onChange()
 
 ### Community 472 - "Community 472"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): AlertModal()
 
 ### Community 473 - "Community 473"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): OverlayModal()
 
 ### Community 474 - "Community 474"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Skeleton()
 
 ### Community 475 - "Community 475"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 476 - "Community 476"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 477 - "Community 477"
 Cohesion: 0.67
@@ -3674,7 +3679,7 @@ Nodes (0):
 
 ### Community 481 - "Community 481"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 482 - "Community 482"
 Cohesion: 0.67
@@ -3689,56 +3694,56 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 485 - "Community 485"
-Cohesion: 1.0
-Nodes (2): getApprovalGuidance(), presentCommandToast()
+Cohesion: 0.67
+Nodes (1): useAuth()
 
 ### Community 486 - "Community 486"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (0):
 
 ### Community 487 - "Community 487"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 488 - "Community 488"
-Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
-
-### Community 489 - "Community 489"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 489 - "Community 489"
+Cohesion: 1.0
+Nodes (2): getApprovalGuidance(), presentCommandToast()
 
 ### Community 490 - "Community 490"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 491 - "Community 491"
-Cohesion: 1.0
-Nodes (2): readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
-
-### Community 492 - "Community 492"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 493 - "Community 493"
+### Community 492 - "Community 492"
 Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
+
+### Community 493 - "Community 493"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 494 - "Community 494"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 495 - "Community 495"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
 ### Community 496 - "Community 496"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 497 - "Community 497"
 Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 498 - "Community 498"
 Cohesion: 0.67
@@ -3749,68 +3754,68 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 500 - "Community 500"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 501 - "Community 501"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 502 - "Community 502"
 Cohesion: 0.67
-Nodes (1): hashPassword()
+Nodes (0):
 
 ### Community 503 - "Community 503"
 Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Nodes (0):
 
 ### Community 504 - "Community 504"
-Cohesion: 0.67
-Nodes (1): manualChunks()
+Cohesion: 1.0
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 505 - "Community 505"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 506 - "Community 506"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 507 - "Community 507"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (1): createVersionChecker()
 
 ### Community 508 - "Community 508"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 509 - "Community 509"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
-
-### Community 510 - "Community 510"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
-
-### Community 511 - "Community 511"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 510 - "Community 510"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 511 - "Community 511"
+Cohesion: 1.0
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 512 - "Community 512"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 513 - "Community 513"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 514 - "Community 514"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 515 - "Community 515"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 516 - "Community 516"
 Cohesion: 0.67
@@ -3826,7 +3831,7 @@ Nodes (0):
 
 ### Community 519 - "Community 519"
 Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 520 - "Community 520"
 Cohesion: 0.67
@@ -3841,8 +3846,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 523 - "Community 523"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 524 - "Community 524"
 Cohesion: 0.67
@@ -3897,60 +3902,60 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 537 - "Community 537"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 538 - "Community 538"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 539 - "Community 539"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 540 - "Community 540"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 541 - "Community 541"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
 
 ### Community 542 - "Community 542"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 543 - "Community 543"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 544 - "Community 544"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 545 - "Community 545"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 546 - "Community 546"
 Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 547 - "Community 547"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 548 - "Community 548"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 549 - "Community 549"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 550 - "Community 550"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 551 - "Community 551"
 Cohesion: 1.0
@@ -8592,1350 +8597,1362 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1711 - "Community 1711"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1712 - "Community 1712"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1713 - "Community 1713"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1714 - "Community 1714"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1715 - "Community 1715"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 547`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 551`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 548`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 552`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 549`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 553`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 550`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 554`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 551`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 555`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 552`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 556`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 557`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 558`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 559`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 560`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 561`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 562`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 563`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 564`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 565`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 566`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 567`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 568`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 569`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 570`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 571`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 572`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 573`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 574`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 575`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 576`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 577`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 578`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 579`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 580`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 581`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 582`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 583`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 584`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 585`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 586`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 587`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 588`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 589`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 590`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 591`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 592`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 593`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 594`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 595`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 596`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 597`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
+- **Thin community `Community 598`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
+- **Thin community `Community 599`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 600`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 601`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 602`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 603`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 604`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
+- **Thin community `Community 605`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 606`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 607`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 608`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 609`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 610`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 611`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 612`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 613`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 614`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 615`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 616`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 617`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 618`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 619`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 620`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 621`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 622`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 623`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 624`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 625`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 626`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 627`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 628`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 629`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 630`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 631`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 632`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 633`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 634`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 635`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 636`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 637`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 638`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 639`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 640`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 641`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 642`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 643`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 644`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 645`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 646`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 647`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 648`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 649`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 650`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 651`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 652`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 653`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 654`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 655`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 656`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 657`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 658`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 659`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 660`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 661`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 662`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 663`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 664`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 665`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 666`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 667`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 668`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 669`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 670`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 671`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 672`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 673`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 674`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 675`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 676`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 677`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 678`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 679`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 680`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 681`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 682`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 683`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 684`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 685`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 686`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 687`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `cn()`, `CartItems.tsx`
+- **Thin community `Community 688`** (2 nodes): `cn()`, `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
+- **Thin community `Community 689`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 690`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 691`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 692`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 693`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `ProductCard.tsx`, `handleClick()`
+- **Thin community `Community 694`** (2 nodes): `ProductCard.tsx`, `handleClick()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 695`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 696`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 697`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 698`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 699`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 700`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
+- **Thin community `Community 701`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 702`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 703`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 704`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 705`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 706`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 707`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 708`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 709`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 710`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 711`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 712`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 713`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 714`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 715`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 716`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 717`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 718`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 719`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 720`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 721`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 722`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 723`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 724`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 725`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 726`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 727`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 728`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 729`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 730`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 731`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 732`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 733`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `ServiceIntakeForm.tsx`, `ServiceIntakeForm()`
+- **Thin community `Community 734`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 735`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `ServiceIntakeView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 736`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
+- **Thin community `Community 737`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 738`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 739`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 740`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 741`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 742`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 743`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 744`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 745`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 746`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 747`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 748`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 749`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 750`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 751`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 752`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 753`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 754`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 755`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 756`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 757`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 758`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 759`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 760`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 761`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 762`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 763`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 764`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 765`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 766`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 767`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 768`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 769`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 770`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 771`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 772`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 773`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 774`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 775`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 776`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 777`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 778`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 779`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 780`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 781`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 782`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 783`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 784`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 785`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 786`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 787`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 788`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 789`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 790`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 791`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 792`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 793`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 794`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 795`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 796`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 797`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 798`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 799`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 800`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 801`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 802`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 803`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 804`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 805`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 806`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 807`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 808`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 809`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 810`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 811`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 812`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 813`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 814`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 815`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 816`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 817`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 818`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 819`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 820`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 821`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 822`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 823`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 824`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 825`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 826`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 827`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 828`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 829`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 830`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 831`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 832`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 833`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 834`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 835`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 836`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 837`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 838`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 839`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 840`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 841`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 842`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 843`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 844`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 845`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 846`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 847`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 848`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 849`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 850`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 851`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 852`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 853`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 854`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 855`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 856`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 857`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 858`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 859`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 860`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 861`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 862`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 863`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 864`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 865`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 866`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 867`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 868`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 869`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 870`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 871`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 872`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 873`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 874`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 875`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 876`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 877`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 878`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 879`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 880`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 881`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 882`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 883`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 884`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 885`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 886`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 887`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 888`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 889`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 890`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 891`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 892`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 893`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 894`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 895`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 896`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 897`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 898`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 899`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 900`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 901`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 902`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 903`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 904`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 905`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 906`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 907`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 908`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 909`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 910`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 911`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 912`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 913`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 914`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 915`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 916`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 917`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 918`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 919`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 920`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 921`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 922`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 923`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 924`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 925`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 926`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 927`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 928`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 929`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 930`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 931`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 932`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 933`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 934`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 935`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 936`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 937`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 938`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 939`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 940`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 941`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 942`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 943`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 944`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 945`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 946`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 947`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 948`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 949`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 950`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 951`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 952`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 953`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 954`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 955`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 956`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 957`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 958`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 959`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 960`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 961`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 962`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 963`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 964`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 965`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 966`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (1 nodes): `api.d.ts`
+- **Thin community `Community 967`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (1 nodes): `api.js`
+- **Thin community `Community 968`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 969`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (1 nodes): `server.d.ts`
+- **Thin community `Community 970`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (1 nodes): `server.js`
+- **Thin community `Community 971`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (1 nodes): `app.ts`
+- **Thin community `Community 972`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (1 nodes): `auth.config.js`
+- **Thin community `Community 973`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `auth.ts`
+- **Thin community `Community 974`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 975`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 976`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 977`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `countries.ts`
+- **Thin community `Community 978`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `email.ts`
+- **Thin community `Community 979`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `ghana.ts`
+- **Thin community `Community 980`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `payment.ts`
+- **Thin community `Community 981`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `crons.ts`
+- **Thin community `Community 982`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 983`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `internal.ts`
+- **Thin community `Community 984`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `public.test.ts`
+- **Thin community `Community 985`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `token.test.ts`
+- **Thin community `Community 986`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 987`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 988`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 989`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 990`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 991`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 992`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 993`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 994`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 995`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `env.ts`
+- **Thin community `Community 996`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `analytics.ts`
+- **Thin community `Community 997`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `auth.ts`
+- **Thin community `Community 998`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 999`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `colors.ts`
+- **Thin community `Community 1000`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `index.ts`
+- **Thin community `Community 1001`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1002`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `products.ts`
+- **Thin community `Community 1003`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1004`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `stores.ts`
+- **Thin community `Community 1005`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `bag.ts`
+- **Thin community `Community 1006`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `guest.ts`
+- **Thin community `Community 1007`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `index.ts`
+- **Thin community `Community 1008`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `me.ts`
+- **Thin community `Community 1009`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `offers.ts`
+- **Thin community `Community 1010`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1011`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1012`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1013`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1014`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1015`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1016`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1017`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1018`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1019`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `user.ts`
+- **Thin community `Community 1020`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1021`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `index.ts`
+- **Thin community `Community 1022`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1023`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `http.ts`
+- **Thin community `Community 1024`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1025`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1026`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1027`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `categories.ts`
+- **Thin community `Community 1028`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `colors.ts`
+- **Thin community `Community 1029`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1030`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 1031`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1032`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1033`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1034`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1035`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `pos.ts`
+- **Thin community `Community 1036`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1037`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1038`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1039`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1040`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1041`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1042`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1043`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1044`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1045`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1046`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1047`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1048`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1049`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1050`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1051`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1052`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `types.ts`
+- **Thin community `Community 1053`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1054`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1055`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1056`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1057`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1058`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1059`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `dto.ts`
+- **Thin community `Community 1060`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1061`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1062`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `types.ts`
+- **Thin community `Community 1063`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `types.ts`
+- **Thin community `Community 1064`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1065`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `customers.ts`
+- **Thin community `Community 1066`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `register.ts`
+- **Thin community `Community 1067`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `sync.ts`
+- **Thin community `Community 1068`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `schema.ts`
+- **Thin community `Community 1069`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1070`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `index.ts`
+- **Thin community `Community 1071`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1072`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1073`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1074`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1075`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1076`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `category.ts`
+- **Thin community `Community 1077`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `color.ts`
+- **Thin community `Community 1078`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1079`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1080`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `index.ts`
+- **Thin community `Community 1081`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1082`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1083`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `organization.ts`
+- **Thin community `Community 1084`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1085`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `product.ts`
+- **Thin community `Community 1086`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1087`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1088`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `store.ts`
+- **Thin community `Community 1089`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1090`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `index.ts`
+- **Thin community `Community 1091`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1092`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1093`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1094`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1095`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1096`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1097`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1098`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `index.ts`
+- **Thin community `Community 1099`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1100`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1101`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1102`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1103`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1104`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1105`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1106`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1107`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1108`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1109`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1110`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `customer.ts`
+- **Thin community `Community 1111`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1112`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1113`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1114`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1115`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `index.ts`
+- **Thin community `Community 1116`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1117`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1118`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1119`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1120`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1121`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1122`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1123`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1124`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1125`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1126`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1127`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1128`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1129`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1130`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `index.ts`
+- **Thin community `Community 1131`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1132`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1133`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1134`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1135`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1136`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1137`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `index.ts`
+- **Thin community `Community 1138`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1139`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1140`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1141`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1142`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1143`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1144`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `bag.ts`
+- **Thin community `Community 1145`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1146`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1147`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1148`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `guest.ts`
+- **Thin community `Community 1149`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `index.ts`
+- **Thin community `Community 1150`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `offer.ts`
+- **Thin community `Community 1151`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1152`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1153`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `review.ts`
+- **Thin community `Community 1154`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1155`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1156`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1157`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1158`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1159`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1160`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1161`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1162`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1163`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `bag.ts`
+- **Thin community `Community 1164`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1165`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `customer.ts`
+- **Thin community `Community 1166`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `guest.ts`
+- **Thin community `Community 1167`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1168`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1169`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1170`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1171`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `payment.ts`
+- **Thin community `Community 1172`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1173`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1174`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1175`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `users.ts`
+- **Thin community `Community 1176`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `payment.ts`
+- **Thin community `Community 1177`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1178`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1179`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1180`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1181`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1182`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `index.ts`
+- **Thin community `Community 1183`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1184`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1185`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `auth.ts`
+- **Thin community `Community 1186`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1187`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1188`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1189`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1190`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1191`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1192`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1193`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1194`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1195`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1196`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1197`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1198`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1199`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1200`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `constants.ts`
+- **Thin community `Community 1201`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1202`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1203`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1204`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `types.ts`
+- **Thin community `Community 1205`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1206`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1207`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1208`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1209`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1210`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1211`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1212`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1213`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `data-table-faceted-filter.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `data-table-pagination.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `data-table-toolbar.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `data-table.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1214`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1215`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1216`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1217`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1218`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -9943,985 +9960,995 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1220`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1221`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `constants.ts`
+- **Thin community `Community 1222`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1223`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1224`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1225`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `data.ts`
+- **Thin community `Community 1226`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1227`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1228`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1229`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1230`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1231`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1232`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1233`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1234`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1235`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `constants.ts`
+- **Thin community `Community 1236`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1237`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1238`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1239`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `data.ts`
+- **Thin community `Community 1240`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1241`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1242`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1243`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1244`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1245`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1246`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1247`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1248`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1249`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1250`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `constants.ts`
+- **Thin community `Community 1251`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1252`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1253`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1254`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1255`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1256`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1257`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1258`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1259`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1260`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1261`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1262`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1263`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1264`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1265`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1266`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1267`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1268`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1269`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1270`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1271`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1272`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1273`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1274`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1275`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1276`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1277`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1278`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1279`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1280`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1281`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1282`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1283`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `constants.ts`
+- **Thin community `Community 1284`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1285`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1286`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1287`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `data.ts`
+- **Thin community `Community 1288`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1289`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1290`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `constants.ts`
+- **Thin community `Community 1291`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1292`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1293`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1294`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1295`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `data.ts`
+- **Thin community `Community 1296`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1297`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `constants.ts`
+- **Thin community `Community 1298`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1299`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1300`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1301`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1302`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `data.ts`
+- **Thin community `Community 1303`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1304`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1305`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1306`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1307`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1308`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1309`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1310`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1311`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1312`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1313`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1314`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1315`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1316`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1317`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1318`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1319`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1320`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1321`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1322`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1323`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1324`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1325`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1326`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1327`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1328`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `POSSettingsView.test.tsx`
+- **Thin community `Community 1329`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1330`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `POSTerminalHealthView.test.tsx`
+- **Thin community `Community 1331`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1332`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1333`** (1 nodes): `POSSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1334`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `types.ts`
+- **Thin community `Community 1335`** (1 nodes): `POSTerminalHealthView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1336`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1337`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1338`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1339`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `ProductDetailView.tsx`
+- **Thin community `Community 1340`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1341`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1342`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1343`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1344`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1345`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1346`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1347`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1348`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1349`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1350`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `data.ts`
+- **Thin community `Community 1351`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1352`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1353`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1354`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1355`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1356`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1357`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1358`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1359`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1360`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1361`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1362`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1363`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `constants.ts`
+- **Thin community `Community 1364`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1365`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1366`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1367`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `data.ts`
+- **Thin community `Community 1368`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `types.ts`
+- **Thin community `Community 1369`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1370`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1371`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1372`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1373`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `ServicesWorkspaceView.test.tsx`
+- **Thin community `Community 1374`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `index.tsx`
+- **Thin community `Community 1375`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1376`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1377`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1378`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1379`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1380`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1381`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1382`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `index.tsx`
+- **Thin community `Community 1383`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1384`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1385`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1386`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `button.tsx`
+- **Thin community `Community 1387`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1388`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `card.tsx`
+- **Thin community `Community 1389`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1390`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1391`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `command.tsx`
+- **Thin community `Community 1392`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1393`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1394`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1395`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `form.tsx`
+- **Thin community `Community 1396`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1397`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1398`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `input.tsx`
+- **Thin community `Community 1399`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1400`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1401`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1402`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1403`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1404`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1405`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `select.tsx`
+- **Thin community `Community 1406`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1407`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1408`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1409`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `table.tsx`
+- **Thin community `Community 1410`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1411`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1412`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1413`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1414`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1415`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1416`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1417`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1418`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `constants.ts`
+- **Thin community `Community 1419`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1420`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1421`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1422`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `data.ts`
+- **Thin community `Community 1423`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1424`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1425`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1426`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1427`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1428`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1429`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1430`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1431`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1432`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1433`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1434`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `index.ts`
+- **Thin community `Community 1435`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1436`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1437`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1438`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1439`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1440`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1441`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1442`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1443`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1444`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1445`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `aws.ts`
+- **Thin community `Community 1446`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `constants.ts`
+- **Thin community `Community 1447`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `countries.ts`
+- **Thin community `Community 1448`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1449`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1450`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1451`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1452`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1453`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1454`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `dto.ts`
+- **Thin community `Community 1455`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `ports.ts`
+- **Thin community `Community 1456`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `constants.ts`
+- **Thin community `Community 1457`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1458`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1459`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `index.ts`
+- **Thin community `Community 1460`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1461`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `types.ts`
+- **Thin community `Community 1462`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1463`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1464`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1465`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `localCommandGateway.test.ts`
+- **Thin community `Community 1466`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1467`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1468`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1469`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1470`** (1 nodes): `localCommandGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1471`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1472`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1473`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `category.ts`
+- **Thin community `Community 1474`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `product.ts`
+- **Thin community `Community 1475`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `store.ts`
+- **Thin community `Community 1476`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1477`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `user.ts`
+- **Thin community `Community 1478`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1479`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1480`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1481`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1482`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1483`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1484`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `index.tsx`
+- **Thin community `Community 1485`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `index.tsx`
+- **Thin community `Community 1486`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `index.tsx`
+- **Thin community `Community 1487`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1488`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1489`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1490`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1491`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1492`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `index.tsx`
+- **Thin community `Community 1493`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1494`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1495`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1496`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `home.tsx`
+- **Thin community `Community 1497`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1498`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1499`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1500`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `index.tsx`
+- **Thin community `Community 1501`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1502`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `index.tsx`
+- **Thin community `Community 1503`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1504`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1505`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1506`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `index.tsx`
+- **Thin community `Community 1507`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1508`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1509`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1510`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1511`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1512`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1513`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `index.tsx`
+- **Thin community `Community 1514`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1515`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1516`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1517`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1518`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1519`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1520`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1521`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1522`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1523`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `index.tsx`
+- **Thin community `Community 1524`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1525`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `index.tsx`
+- **Thin community `Community 1526`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `new.tsx`
+- **Thin community `Community 1527`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `index.tsx`
+- **Thin community `Community 1528`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `new.tsx`
+- **Thin community `Community 1529`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1530`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1531`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `index.tsx`
+- **Thin community `Community 1532`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `new.tsx`
+- **Thin community `Community 1533`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `index.tsx`
+- **Thin community `Community 1534`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1535`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1536`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1537`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1538`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1539`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1540`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1541`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1542`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `index.tsx`
+- **Thin community `Community 1543`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1544`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1545`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1546`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1547`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1548`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1549`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1550`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1551`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1552`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1553`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1554`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1555`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1556`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1557`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1558`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1559`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1560`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1561`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1562`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1563`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1564`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1565`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1566`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1567`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `setup.ts`
+- **Thin community `Community 1568`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1569`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `types.ts`
+- **Thin community `Community 1570`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1571`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1572`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1573`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1574`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1575`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `types.ts`
+- **Thin community `Community 1576`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1577`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1578`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1579`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1580`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1581`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1582`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1583`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1584`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1585`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `schema.ts`
+- **Thin community `Community 1586`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1587`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1588`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1589`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1590`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1591`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1592`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1593`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1594`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1595`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `types.ts`
+- **Thin community `Community 1596`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1597`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1598`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1599`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1600`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1601`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1602`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1603`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `constants.ts`
+- **Thin community `Community 1604`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1605`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `About.tsx`
+- **Thin community `Community 1606`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1607`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1608`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1609`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1610`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1611`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1612`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1613`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1614`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1615`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1616`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `types.ts`
+- **Thin community `Community 1617`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1618`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1619`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1620`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1621`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1622`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1623`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1624`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1625`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1626`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1627`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1628`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `button.tsx`
+- **Thin community `Community 1629`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `card.tsx`
+- **Thin community `Community 1630`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1631`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `command.tsx`
+- **Thin community `Community 1632`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1633`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1634`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1635`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `form.tsx`
+- **Thin community `Community 1636`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1637`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1638`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1639`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1640`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `input.tsx`
+- **Thin community `Community 1641`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `label.tsx`
+- **Thin community `Community 1642`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1643`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1644`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1645`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `index.ts`
+- **Thin community `Community 1646`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `types.ts`
+- **Thin community `Community 1647`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1648`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1649`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1650`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1651`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `select.tsx`
+- **Thin community `Community 1652`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1653`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1654`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `table.tsx`
+- **Thin community `Community 1655`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1656`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1657`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1658`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1659`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1660`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `config.ts`
+- **Thin community `Community 1661`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1662`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1663`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1664`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1665`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `constants.ts`
+- **Thin community `Community 1666`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `countries.ts`
+- **Thin community `Community 1667`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1668`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1669`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1670`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1671`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `index.ts`
+- **Thin community `Community 1672`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `store.ts`
+- **Thin community `Community 1673`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `bag.ts`
+- **Thin community `Community 1674`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1675`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `category.ts`
+- **Thin community `Community 1676`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `organization.ts`
+- **Thin community `Community 1677`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `product.ts`
+- **Thin community `Community 1678`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `store.ts`
+- **Thin community `Community 1679`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1680`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `user.ts`
+- **Thin community `Community 1681`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `states.ts`
+- **Thin community `Community 1682`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1683`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1684`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1685`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1686`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1687`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1688`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1689`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `index.tsx`
+- **Thin community `Community 1690`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1691`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `index.tsx`
+- **Thin community `Community 1692`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1693`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1694`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1695`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1696`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1697`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `index.tsx`
+- **Thin community `Community 1698`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1699`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1700`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1701`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1702`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1703`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `index.js`
+- **Thin community `Community 1704`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1705`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1706`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1707`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1708`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1709`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1710`** (1 nodes): `harness-app-registry.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1711`** (1 nodes): `athena-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1712`** (1 nodes): `storefront-runtime-api.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1713`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1714`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1715`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1783
-- Graph nodes: 5781
-- Graph edges: 6101
-- Communities: 1711
+- Code files discovered: 1788
+- Graph nodes: 5808
+- Graph edges: 6126
+- Communities: 1716
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (82 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
@@ -18,8 +18,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - `harness-inferential-review.ts` (46 edges, Community 2) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `storefrontJourneyEvents.ts` (45 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `useRegisterViewModel.ts` (44 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
+- `ProcurementView.tsx` (41 edges, Community 5) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
 - `createJourneyEvent()` (40 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `ProcurementView.tsx` (39 edges, Community 5) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
 - `projectLocalEvents.ts` (37 edges, Community 6) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 
 ## Registered Packages

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -20,7 +20,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - `DailyCloseView.tsx` (82 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `useRegisterViewModel.ts` (44 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
-- `ProcurementView.tsx` (39 edges, Community 5) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
+- `ProcurementView.tsx` (41 edges, Community 5) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
 - `projectLocalEvents.ts` (37 edges, Community 6) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 
 ## Navigation

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -20,7 +20,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - `storefrontJourneyEvents.ts` (45 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 3) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 37) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `checkoutSession.ts` (14 edges, Community 58) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `checkoutSession.ts` (14 edges, Community 57) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 - `storeConfig.ts` (14 edges, Community 37) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -17,11 +17,11 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 - [validation-map.json](../../../packages/valkey-proxy-server/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `app.js` (14 edges, Community 64) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 117) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
-- `createRedisClient()` (4 edges, Community 64) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `createRedisCluster()` (3 edges, Community 64) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `deleteKeysIndividually()` (3 edges, Community 64) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.js` (14 edges, Community 63) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.test.js` (6 edges, Community 118) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `createRedisClient()` (4 edges, Community 63) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisCluster()` (3 edges, Community 63) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `deleteKeysIndividually()` (3 edges, Community 63) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/inventory/products.sku.test.ts
+++ b/packages/athena-webapp/convex/inventory/products.sku.test.ts
@@ -8,6 +8,7 @@ import {
   createSku,
   getAll,
   getByIdOrSlug,
+  unarchive,
   updateSku,
 } from "./products";
 
@@ -304,6 +305,37 @@ describe("product archiving", () => {
     });
     expect(deleteSpy).not.toHaveBeenCalled();
   });
+
+  it("unarchives a product with store admin access", async () => {
+    mocks.requireStoreFullAdminAccess.mockResolvedValue({});
+
+    const { ctx, tables } = createSkuMutationCtx({
+      product: [
+        {
+          _id: "product001",
+          availability: "archived",
+          storeId: "storezzzz",
+        },
+      ],
+    });
+
+    const result = await getHandler(unarchive)(ctx, {
+      id: "product001" as Id<"product">,
+      storeId: "storezzzz" as Id<"store">,
+    });
+
+    expect(mocks.requireStoreFullAdminAccess).toHaveBeenCalledWith(
+      ctx,
+      "storezzzz",
+    );
+    expect(result).toMatchObject({
+      _id: "product001",
+      availability: "live",
+    });
+    expect(tables.product.get("product001")).toMatchObject({
+      availability: "live",
+    });
+  });
 });
 
 describe("product catalog visibility", () => {
@@ -457,6 +489,67 @@ describe("product detail availability", () => {
       inventoryCount: 10,
       quantityAvailable: 5,
       reservedQuantity: 3,
+    });
+  });
+
+  it("returns archived product details only when explicitly requested", async () => {
+    const seed = {
+      product: [
+        {
+          _id: "product-archived",
+          availability: "archived",
+          categoryId: "category-1",
+          inventoryCount: 4,
+          name: "Archived product",
+          storeId: "storezzzz",
+          subcategoryId: "subcategory-1",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku-archived",
+          images: [],
+          inventoryCount: 4,
+          price: 1000,
+          productId: "product-archived",
+          quantityAvailable: 4,
+          sku: "ARCH-01",
+          storeId: "storezzzz",
+        },
+      ],
+    };
+
+    const defaultCtx = createProductsQueryCtx(seed).ctx;
+    await expect(
+      getHandler(getByIdOrSlug)(defaultCtx, {
+        identifier: "product-archived" as Id<"product">,
+        storeId: "storezzzz" as Id<"store">,
+      }),
+    ).resolves.toBeNull();
+
+    const includeArchivedCtx = createProductsQueryCtx(seed).ctx;
+    const archivedProduct = await getHandler(getByIdOrSlug)(
+      includeArchivedCtx,
+      {
+        identifier: "product-archived" as Id<"product">,
+        storeId: "storezzzz" as Id<"store">,
+        filters: {
+          includeArchived: true,
+          isVisible: false,
+        },
+      },
+    );
+
+    expect(archivedProduct).toMatchObject({
+      _id: "product-archived",
+      availability: "archived",
+      name: "Archived product",
+      skus: [
+        {
+          _id: "sku-archived",
+          sku: "ARCH-01",
+        },
+      ],
     });
   });
 });

--- a/packages/athena-webapp/convex/inventory/products.ts
+++ b/packages/athena-webapp/convex/inventory/products.ts
@@ -517,6 +517,7 @@ export const getByIdOrSlug = query({
       v.object({
         isVisible: v.boolean(),
         excludeStorefrontHidden: v.optional(v.boolean()),
+        includeArchived: v.optional(v.boolean()),
       })
     ),
     storeId: v.id("store"),
@@ -590,7 +591,10 @@ export const getByIdOrSlug = query({
       return null;
     }
 
-    if (product.availability === "archived") {
+    if (
+      product.availability === "archived" &&
+      !args.filters?.includeArchived
+    ) {
       return null;
     }
 
@@ -954,6 +958,34 @@ export const archive = mutation({
       {
         storeId: product.storeId,
       }
+    );
+
+    return await ctx.db.get("product", args.id);
+  },
+});
+
+export const unarchive = mutation({
+  args: {
+    id: v.id(entity),
+    storeId: v.id("store"),
+  },
+  handler: async (ctx, args) => {
+    await requireStoreFullAdminAccess(ctx, args.storeId);
+
+    const product = await ctx.db.get("product", args.id);
+
+    if (!product || product.storeId !== args.storeId) {
+      return null;
+    }
+
+    await ctx.db.patch("product", args.id, { availability: "live" });
+
+    await ctx.scheduler.runAfter(
+      0,
+      internal.inventory.productUtil.invalidateProductCache,
+      {
+        storeId: product.storeId,
+      },
     );
 
     return await ctx.db.get("product", args.id);

--- a/packages/athena-webapp/convex/operations/serviceIntake.test.ts
+++ b/packages/athena-webapp/convex/operations/serviceIntake.test.ts
@@ -19,6 +19,7 @@ function buildCreateServiceIntakeArgs(
   return {
     assignedStaffProfileId: "staff-1",
     customerFullName: "Ama Mensah",
+    customerPhoneNumber: "+233200000000",
     intakeChannel: "walk_in",
     serviceTitle: "Wash and restyle",
     storeId: "store-1",
@@ -80,6 +81,7 @@ describe("service intake validation", () => {
       })
     ).toEqual([
       "An assignee is required.",
+      "Customer phone number is required.",
       "Deposit amount must be greater than zero.",
       "Select how the deposit was collected.",
     ]);
@@ -90,6 +92,7 @@ describe("service intake validation", () => {
       validateServiceIntakeInput({
         assignedStaffProfileId: "staff_1",
         customerProfileId: "customer_1",
+        customerPhoneNumber: "+233200000000",
         serviceTitle: "Install closure wig",
       })
     ).toEqual([]);

--- a/packages/athena-webapp/convex/operations/serviceIntake.ts
+++ b/packages/athena-webapp/convex/operations/serviceIntake.ts
@@ -214,6 +214,7 @@ export const createServiceIntake = mutation({
     const validationErrors = validateServiceIntakeInput({
       assignedStaffProfileId: args.assignedStaffProfileId,
       customerFullName: args.customerFullName,
+      customerPhoneNumber: args.customerPhoneNumber,
       customerProfileId: args.customerProfileId,
       depositAmount: args.depositAmount,
       depositMethod: args.depositMethod,

--- a/packages/athena-webapp/convex/serviceOps/catalog.ts
+++ b/packages/athena-webapp/convex/serviceOps/catalog.ts
@@ -169,12 +169,12 @@ export const createServiceCatalogItem = mutation({
 
 export const updateServiceCatalogItem = mutation({
   args: {
-    basePrice: v.optional(v.number()),
+    basePrice: v.optional(v.union(v.number(), v.null())),
     depositType: v.optional(
       v.union(v.literal("none"), v.literal("flat"), v.literal("percentage"))
     ),
-    depositValue: v.optional(v.number()),
-    description: v.optional(v.string()),
+    depositValue: v.optional(v.union(v.number(), v.null())),
+    description: v.optional(v.union(v.string(), v.null())),
     durationMinutes: v.optional(v.number()),
     name: v.optional(v.string()),
     pricingModel: v.optional(
@@ -208,18 +208,30 @@ export const updateServiceCatalogItem = mutation({
       });
     }
 
-    const nextCatalogItemResult = buildServiceCatalogItem({
-      basePrice:
-        args.basePrice === undefined ? existingCatalogItem.basePrice : args.basePrice,
-      depositType: args.depositType ?? existingCatalogItem.depositType,
-      depositValue:
-        args.depositValue === undefined
+    const nextBasePrice =
+      args.basePrice === null
+        ? undefined
+        : args.basePrice === undefined
+          ? existingCatalogItem.basePrice
+          : args.basePrice;
+    const nextDepositValue =
+      args.depositValue === null
+        ? undefined
+        : args.depositValue === undefined
           ? existingCatalogItem.depositValue
-          : args.depositValue,
-      description:
-        args.description === undefined
+          : args.depositValue;
+    const nextDescription =
+      args.description === null
+        ? undefined
+        : args.description === undefined
           ? existingCatalogItem.description
-          : args.description,
+          : args.description;
+
+    const nextCatalogItemResult = buildServiceCatalogItem({
+      basePrice: nextBasePrice,
+      depositType: args.depositType ?? existingCatalogItem.depositType,
+      depositValue: nextDepositValue,
+      description: nextDescription,
       durationMinutes:
         args.durationMinutes ?? existingCatalogItem.durationMinutes,
       name: args.name ?? existingCatalogItem.name,

--- a/packages/athena-webapp/convex/serviceOps/serviceCases.test.ts
+++ b/packages/athena-webapp/convex/serviceOps/serviceCases.test.ts
@@ -93,6 +93,7 @@ describe("service ops schema foundations", () => {
   it("shapes service cases and line items with persistence-safe defaults", () => {
     const serviceCase = buildServiceCase({
       assignedStaffProfileId: "staff_1" as Id<"staffProfile">,
+      createdByUserId: "user_1" as Id<"athenaUser">,
       customerProfileId: "customer_1" as Id<"customerProfile">,
       operationalWorkItemId: "work_item_1" as Id<"operationalWorkItem">,
       quotedAmount: 450,
@@ -107,6 +108,7 @@ describe("service ops schema foundations", () => {
       serviceMode: "same_day",
       status: "intake",
     });
+    expect(serviceCase).not.toHaveProperty("createdByUserId");
 
     expect(
       buildServiceCaseLineItem({

--- a/packages/athena-webapp/convex/serviceOps/serviceCases.ts
+++ b/packages/athena-webapp/convex/serviceOps/serviceCases.ts
@@ -252,9 +252,10 @@ export function buildServiceCase(args: {
 }) {
   const totalAmount = args.quotedAmount ?? 0;
   const now = Date.now();
+  const { createdByUserId: _createdByUserId, ...serviceCaseFields } = args;
 
   return {
-    ...args,
+    ...serviceCaseFields,
     balanceDueAmount: totalAmount,
     createdAt: now,
     lastStatusChangedAt: now,

--- a/packages/athena-webapp/convex/stockOps/adjustments.test.ts
+++ b/packages/athena-webapp/convex/stockOps/adjustments.test.ts
@@ -96,8 +96,10 @@ function createInventorySnapshotQueryCtx() {
           color: "color-1",
           images: [],
           inventoryCount: 10,
+          price: 4500,
           productId: "product-1",
           quantityAvailable: 8,
+          size: "Large",
           sku: "CW-18",
           storeId: "store-1",
         },
@@ -562,8 +564,10 @@ describe("stock ops adjustments", () => {
         _id: "sku-1",
         durableQuantityAvailable: 8,
         inventoryCount: 10,
+        price: 4500,
         quantityAvailable: 6,
         reservedQuantity: 2,
+        size: "Large",
       }),
     ]);
   });

--- a/packages/athena-webapp/convex/stockOps/adjustments.ts
+++ b/packages/athena-webapp/convex/stockOps/adjustments.ts
@@ -549,6 +549,7 @@ export async function listInventorySnapshotWithCtx(
           imageUrl: productSku.images[0] ?? null,
           inventoryCount: productSku.inventoryCount,
           length: productSku.length ?? null,
+          price: productSku.price,
           productCategory: category?.name ?? null,
           productId: productSku.productId,
           productName:
@@ -560,6 +561,7 @@ export async function listInventorySnapshotWithCtx(
           posReservedQuantity,
           quantityAvailable,
           reservedQuantity,
+          size: productSku.size ?? null,
           sku: productSku.sku ?? null,
         };
       })

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -7,13 +7,13 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Core app surfaces
 
 - [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 86 file(s); key children: __root.tsx, _authed, _authed.test.tsx, _authed.tsx, index.test.tsx.
-- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 582 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
+- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 584 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
 - [`src/components/traces`](../../src/components/traces) — Shared workflow trace screens, ordered timelines, and trace detail primitives. Currently 3 file(s); key children: WorkflowTraceRouteLink.tsx, WorkflowTraceView.test.tsx, WorkflowTraceView.tsx.
 - [`src/components/operations`](../../src/components/operations) — Manager-queue and stock-adjustment workflows that share approval rails with other operational surfaces. Currently 24 file(s); key children: CommandApprovalDialog.test.tsx, CommandApprovalDialog.tsx, DailyCloseHistoryView.test.tsx, DailyCloseHistoryView.tsx, DailyCloseView.test.tsx.
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.
 - [`src/hooks`](../../src/hooks) — React hooks that fan out auth, shell, and feature state. Currently 42 file(s); key children: use-image-upload.ts, use-mobile.tsx, use-navigate-back.ts, use-navigation-keyboard-shortcuts.ts, use-pagination-persistence.ts.
 - [`src/contexts`](../../src/contexts) — Context providers for app-wide state and wiring. Currently 8 file(s); key children: AppShellFullscreenContext.tsx, ManagerElevationContext.test.tsx, ManagerElevationContext.tsx, OnlineOrderContext.tsx, PermissionsContext.tsx.
-- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 116 file(s); key children: access, aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts.
+- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 119 file(s); key children: access, aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts.
 - [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 14 file(s); key children: approvalPolicy.ts, auth.ts, commandResult.test.ts, commandResult.ts, currencyFormatter.test.ts.
 - [`src/utils`](../../src/utils) — Cross-cutting browser helpers and lower-level utilities. Currently 3 file(s); key children: formatNumber.ts, index.ts, versionChecker.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -273,6 +273,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/lib/pos/presentation/syncStatusPresentation.test.ts`](../../src/lib/pos/presentation/syncStatusPresentation.test.ts)
 - [`src/lib/productUtils.test.ts`](../../src/lib/productUtils.test.ts)
 - [`src/lib/security/localPinVerifier.test.ts`](../../src/lib/security/localPinVerifier.test.ts)
+- [`src/lib/stockOps/skuSearch.test.ts`](../../src/lib/stockOps/skuSearch.test.ts)
 - [`src/lib/storeConfig.test.ts`](../../src/lib/storeConfig.test.ts)
 - [`src/lib/traces/createWorkflowTraceId.test.ts`](../../src/lib/traces/createWorkflowTraceId.test.ts)
 - [`src/lib/utils.test.ts`](../../src/lib/utils.test.ts)

--- a/packages/athena-webapp/shared/serviceIntake.ts
+++ b/packages/athena-webapp/shared/serviceIntake.ts
@@ -2,6 +2,7 @@ export function validateServiceIntakeInput(args: {
   assignedStaffProfileId?: string | null;
   customerFullName?: string | null;
   customerProfileId?: string | null;
+  customerPhoneNumber?: string | null;
   depositAmount?: number | null;
   depositMethod?: string | null;
   serviceTitle?: string | null;
@@ -18,6 +19,10 @@ export function validateServiceIntakeInput(args: {
 
   if (!args.customerProfileId && !args.customerFullName?.trim()) {
     errors.push("A customer name is required when no customer is linked.");
+  }
+
+  if (!args.customerPhoneNumber?.trim()) {
+    errors.push("Customer phone number is required.");
   }
 
   if (args.depositAmount !== undefined && args.depositAmount !== null) {

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
@@ -105,10 +105,12 @@ const baseProps = {
       imageUrl: "https://cdn.example.com/closure-wig.jpg",
       inventoryCount: 8,
       length: 18,
+      price: 4500,
       productCategory: "Hair",
       productId: "product-1" as Id<"product">,
       productName: "closure wig",
       quantityAvailable: 6,
+      size: "Large",
       sku: "CW-18",
     },
     {
@@ -310,6 +312,15 @@ describe("StockAdjustmentWorkspaceContent", () => {
     const onSearchStateChange = vi.fn();
 
     renderStockAdjustmentWorkspace({
+      inventoryItems: [
+        baseProps.inventoryItems[0],
+        {
+          ...baseProps.inventoryItems[1],
+          colorName: "dark brown",
+          length: 24,
+          size: "Medium",
+        },
+      ],
       onSearchStateChange,
       searchState: { query: "123212312" },
     });
@@ -319,6 +330,9 @@ describe("StockAdjustmentWorkspaceContent", () => {
     const dialog = within(screen.getByRole("dialog"));
     await user.type(dialog.getByLabelText(/search existing sku/i), "body");
     await user.click(dialog.getByRole("button", { name: /body wave bundle/i }));
+    expect(
+      dialog.getByText('BW-24 - Hair - dark brown - Medium - 24"'),
+    ).toBeInTheDocument();
     await user.click(dialog.getByRole("button", { name: /attach barcode/i }));
 
     await waitFor(() =>
@@ -347,9 +361,7 @@ describe("StockAdjustmentWorkspaceContent", () => {
       showBackButton: true,
     });
 
-    expect(
-      screen.getByRole("button", { name: "Go back" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Go back" })).toBeInTheDocument();
   });
 
   it("hydrates cycle count inputs from saved draft lines", () => {
@@ -1047,6 +1059,29 @@ describe("StockAdjustmentWorkspaceContent", () => {
     expect(screen.getByText("Showing 1 of 2 SKUs.")).toBeInTheDocument();
   });
 
+  it("fuzzy matches stock rows by product and variant terms", async () => {
+    const user = userEvent.setup();
+
+    renderStockAdjustmentWorkspace();
+
+    const table = screen.getByRole("table");
+
+    await user.type(
+      screen.getByRole("textbox", {
+        name: /search products, skus, or barcodes/i,
+      }),
+      "natrual blak",
+    );
+
+    expect(
+      within(table).getByText('18" Natural Black Closure Wig'),
+    ).toBeInTheDocument();
+    expect(
+      within(table).queryByText("Body Wave Bundle"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 2 SKUs.")).toBeInTheDocument();
+  });
+
   it("filters stock rows by barcode", async () => {
     const user = userEvent.setup();
 
@@ -1122,14 +1157,13 @@ describe("StockAdjustmentWorkspaceContent", () => {
     await user.click(
       screen.getByRole("button", { name: /scan barcode with camera/i }),
     );
-    await user.click(screen.getByRole("button", { name: /start camera/i }));
 
-    await waitFor(() =>
-      expect(mockedScanner.decode).toHaveBeenCalled(),
-    );
-    await waitFor(() =>
-      expect(mockedToast.success).toHaveBeenCalledWith("Barcode scanned"),
-    );
+    expect(
+      screen.queryByRole("button", { name: /start camera/i }),
+    ).not.toBeInTheDocument();
+
+    await waitFor(() => expect(mockedScanner.decode).toHaveBeenCalled());
+
     await waitFor(() =>
       expect(
         screen.getByRole("textbox", {
@@ -1202,15 +1236,22 @@ describe("StockAdjustmentWorkspaceContent", () => {
     await user.click(
       screen.getByRole("button", { name: /scan barcode with camera/i }),
     );
-    await user.click(screen.getByRole("button", { name: /start camera/i }));
 
     await waitFor(() =>
       expect(mockedScanner.decodeFromConstraints).toHaveBeenCalled(),
     );
-    expect(getUserMedia).not.toHaveBeenCalled();
-    await waitFor(() =>
-      expect(mockedToast.success).toHaveBeenCalledWith("Barcode scanned"),
+    expect(mockedScanner.decodeFromConstraints).toHaveBeenCalledWith(
+      {
+        audio: false,
+        video: {
+          facingMode: { exact: "environment" },
+        },
+      },
+      expect.any(HTMLVideoElement),
+      expect.any(Function),
     );
+    expect(getUserMedia).not.toHaveBeenCalled();
+
     expect(
       screen.getByRole("textbox", {
         name: /search products, skus, or barcodes/i,
@@ -1285,18 +1326,20 @@ describe("StockAdjustmentWorkspaceContent", () => {
     await user.click(
       screen.getByRole("button", { name: /scan barcode with camera/i }),
     );
-    await user.click(screen.getByRole("button", { name: /start camera/i }));
 
     await waitFor(() =>
       expect(mockedScanner.decodeFromCanvas).toHaveBeenCalled(),
     );
     expect(mockedScanner.decodeFromConstraints).not.toHaveBeenCalled();
-    expect(getUserMedia).toHaveBeenCalled();
+    expect(getUserMedia).toHaveBeenCalledWith({
+      audio: false,
+      video: {
+        facingMode: { exact: "environment" },
+      },
+    });
     expect(drawImage).toHaveBeenCalledWith(frame, 0, 0, 640, 480);
     expect(frame.close).toHaveBeenCalled();
-    await waitFor(() =>
-      expect(mockedToast.success).toHaveBeenCalledWith("Barcode scanned"),
-    );
+
     expect(
       screen.getByRole("textbox", {
         name: /search products, skus, or barcodes/i,
@@ -1343,9 +1386,7 @@ describe("StockAdjustmentWorkspaceContent", () => {
           "blob:barcode-photo",
         ),
       );
-      await waitFor(() =>
-        expect(mockedToast.success).toHaveBeenCalledWith("Barcode scanned"),
-      );
+
       expect(
         screen.getByRole("textbox", {
           name: /search products, skus, or barcodes/i,
@@ -1372,7 +1413,6 @@ describe("StockAdjustmentWorkspaceContent", () => {
     await user.click(
       screen.getByRole("button", { name: /scan barcode with camera/i }),
     );
-    await user.click(screen.getByRole("button", { name: /start camera/i }));
 
     expect(
       await screen.findByText(
@@ -1393,11 +1433,15 @@ describe("StockAdjustmentWorkspaceContent", () => {
     expect(within(row!).getByText("CW-18")).toBeInTheDocument();
     expect(within(row!).getByText("1234567890123")).toBeInTheDocument();
     expect(within(row!).getByText("Hair")).toBeInTheDocument();
+    expect(within(row!).getByText("Large")).toBeInTheDocument();
     expect(within(row!).getByText('18"')).toBeInTheDocument();
     expect(within(row!).getByText("natural black")).toBeInTheDocument();
     expect(screen.getAllByText("SKU").length).toBeGreaterThan(1);
     expect(screen.getByText("Barcode")).toBeInTheDocument();
+    expect(screen.getByText("Price")).toBeInTheDocument();
+    expect(screen.getAllByText("GH₵45").length).toBeGreaterThan(0);
     expect(screen.getByText("Category")).toBeInTheDocument();
+    expect(screen.getByText("Size")).toBeInTheDocument();
     expect(screen.getByText("Length")).toBeInTheDocument();
     expect(screen.getByText("Color")).toBeInTheDocument();
   });

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
@@ -21,7 +21,6 @@ import {
   PackagePlus,
   RotateCcw,
   ScanBarcode,
-  Search,
   X,
 } from "lucide-react";
 import { toast } from "sonner";
@@ -39,6 +38,11 @@ import { useAuth } from "~/src/hooks/useAuth";
 import { usePOSQuickAddProductSku } from "~/src/hooks/usePOSProducts";
 import { getProductName } from "~/src/lib/productUtils";
 import { getOrigin } from "~/src/lib/navigationUtils";
+import { formatStoredCurrencyAmount } from "@/lib/pos/displayAmounts";
+import {
+  matchesSkuSearchTerms,
+  normalizeSkuSearchQuery,
+} from "@/lib/stockOps/skuSearch";
 import type { NormalizedCommandResult } from "../../lib/errors/runCommand";
 import { presentCommandToast } from "../../lib/errors/presentCommandToast";
 import { DataTableColumnHeader } from "../base/table/data-table-column-header";
@@ -56,6 +60,7 @@ import {
   type QuickAddProductSubmitPayload,
 } from "../product/QuickAddProductDialog";
 import { normalizeQuickAddInitialLookupCode } from "../product/quickAddProductDialogUtils";
+import { SkuSearchFilterBar } from "../stock-ops/SkuSearchFilterBar";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
@@ -81,11 +86,13 @@ export type InventorySnapshotItem = {
   inventoryCount: number;
   length?: number | null;
   posReservedQuantity?: number;
+  price?: number | null;
   productCategory?: string | null;
   productId?: Id<"product"> | null;
   productName: string;
   quantityAvailable: number;
   reservedQuantity?: number;
+  size?: string | null;
   sku?: string | null;
 };
 
@@ -289,8 +296,7 @@ function getInventoryItemDisplayName(item: InventorySnapshotItem) {
 function getReservationLabels(item: InventorySnapshotItem) {
   const checkoutReservedQuantity = item.checkoutReservedQuantity ?? 0;
   const posReservedQuantity = item.posReservedQuantity ?? 0;
-  const knownReservedQuantity =
-    checkoutReservedQuantity + posReservedQuantity;
+  const knownReservedQuantity = checkoutReservedQuantity + posReservedQuantity;
   const fallbackReservedQuantity = Math.max(
     0,
     (item.reservedQuantity ?? 0) - knownReservedQuantity,
@@ -348,9 +354,18 @@ function getSkuDetailEntries(item: InventorySnapshotItem) {
   return [
     item.sku ? { label: "SKU", value: item.sku } : null,
     item.barcode ? { label: "Barcode", value: item.barcode } : null,
+    typeof item.price === "number"
+      ? {
+          label: "Price",
+          value: formatStoredCurrencyAmount("GHS", item.price, {
+            revealMinorUnits: true,
+          }),
+        }
+      : null,
     item.productCategory
       ? { label: "Category", value: item.productCategory }
       : null,
+    item.size ? { label: "Size", value: item.size } : null,
     item.length !== null && item.length !== undefined
       ? { label: "Length", value: `${item.length}"` }
       : null,
@@ -365,10 +380,6 @@ function getSkuDetailEntries(item: InventorySnapshotItem) {
     (entry): entry is { label: string; value: string } =>
       entry !== null && entry.value.trim().length > 0,
   );
-}
-
-function normalizeStockAdjustmentSearch(value?: string | null) {
-  return value?.trim().toLowerCase() ?? "";
 }
 
 function parseCountScopeKeys(value?: string | null) {
@@ -391,22 +402,35 @@ function rowMatchesStockAdjustmentSearch(
   if (!query) return true;
 
   const item = row.inventoryItem;
-  const searchableText = [
-    getInventoryItemDisplayName(item),
-    item.sku,
-    item.barcode,
-    item.colorName,
-    item.productCategory,
-    item.length === null || item.length === undefined
-      ? undefined
-      : String(item.length),
-  ]
-    .filter(Boolean)
-    .join(" ")
-    .toLowerCase();
-
-  return searchableText.includes(query);
+  return matchesSkuSearchTerms(
+    [
+      getInventoryItemDisplayName(item),
+      item.sku,
+      item.barcode,
+      item.colorName,
+      item.productCategory,
+      item.size,
+      item.length === null || item.length === undefined
+        ? undefined
+        : String(item.length),
+    ],
+    query,
+  );
 }
+
+function getStockAdjustmentAvailabilityFilterOptions() {
+  return (
+    Object.keys(
+      STOCK_ADJUSTMENT_AVAILABILITY_FILTER_LABELS,
+    ) as StockAdjustmentAvailabilityFilter[]
+  ).map((value) => ({
+    label: STOCK_ADJUSTMENT_AVAILABILITY_FILTER_LABELS[value],
+    value,
+  }));
+}
+
+const STOCK_ADJUSTMENT_AVAILABILITY_FILTER_OPTIONS =
+  getStockAdjustmentAvailabilityFilterOptions();
 
 function rowMatchesAvailabilityFilter(
   row: StockAdjustmentRow,
@@ -596,8 +620,9 @@ function StockAdjustmentBarcodeScannerDialog({
   const scannerRunIdRef = useRef(0);
   const activeStreamRef = useRef<MediaStream | null>(null);
   const hasDetectedBarcodeRef = useRef(false);
-  const [scannerDebug, setScannerDebug] = useState<StockScannerDebugSnapshot>(
-    () => buildEmptyScannerDebugSnapshot(),
+  const hasAutoStartedScannerRef = useRef(false);
+  const [, setScannerDebug] = useState<StockScannerDebugSnapshot>(() =>
+    buildEmptyScannerDebugSnapshot(),
   );
   const [scannerState, setScannerState] = useState<
     | "idle"
@@ -610,59 +635,54 @@ function StockAdjustmentBarcodeScannerDialog({
     | "error"
   >("idle");
 
-  const captureScannerDebug = useCallback(
-    (event: string, error?: unknown) => {
-      const video = videoRef.current;
-      const videoStream =
-        typeof MediaStream !== "undefined" &&
-        video?.srcObject instanceof MediaStream
-          ? video.srcObject
-          : null;
-      const stream = activeStreamRef.current ?? videoStream;
-      const tracks =
-        stream
-          ?.getTracks()
-          .map((track) => {
-            const settings =
-              typeof track.getSettings === "function"
-                ? track.getSettings()
-                : {};
-            const size =
-              settings.width && settings.height
-                ? ` ${settings.width}x${settings.height}`
-                : "";
+  const captureScannerDebug = useCallback((event: string, error?: unknown) => {
+    const video = videoRef.current;
+    const videoStream =
+      typeof MediaStream !== "undefined" &&
+      video?.srcObject instanceof MediaStream
+        ? video.srcObject
+        : null;
+    const stream = activeStreamRef.current ?? videoStream;
+    const tracks =
+      stream
+        ?.getTracks()
+        .map((track) => {
+          const settings =
+            typeof track.getSettings === "function" ? track.getSettings() : {};
+          const size =
+            settings.width && settings.height
+              ? ` ${settings.width}x${settings.height}`
+              : "";
 
-            return `${track.kind}:${track.readyState}:${
-              track.enabled ? "enabled" : "disabled"
-            }${size}`;
-          })
-          .join(", ") || "none";
+          return `${track.kind}:${track.readyState}:${
+            track.enabled ? "enabled" : "disabled"
+          }${size}`;
+        })
+        .join(", ") || "none";
 
-      setScannerDebug((current) => {
-        const time = new Date().toLocaleTimeString();
-        const isHeartbeat = event === "diagnostic heartbeat";
-        const formattedError = error ? formatScannerError(error) : undefined;
+    setScannerDebug((current) => {
+      const time = new Date().toLocaleTimeString();
+      const isHeartbeat = event === "diagnostic heartbeat";
+      const formattedError = error ? formatScannerError(error) : undefined;
 
-        return {
-          currentTime: video ? video.currentTime.toFixed(2) : "n/a",
-          error: formattedError ?? current.error,
-          event: isHeartbeat ? current.event : event,
-          events: isHeartbeat
-            ? current.events
-            : [`${time} ${event}`, ...current.events].slice(0, 14),
-          mediaDevices: navigator.mediaDevices ? "available" : "missing",
-          readyState: video ? String(video.readyState) : "n/a",
-          secureContext: String(window.isSecureContext),
-          srcObject: video?.srcObject ? "attached" : "none",
-          time,
-          tracks,
-          userAgent: navigator.userAgent,
-          video: video ? `${video.videoWidth}x${video.videoHeight}` : "none",
-        };
-      });
-    },
-    [],
-  );
+      return {
+        currentTime: video ? video.currentTime.toFixed(2) : "n/a",
+        error: formattedError ?? current.error,
+        event: isHeartbeat ? current.event : event,
+        events: isHeartbeat
+          ? current.events
+          : [`${time} ${event}`, ...current.events].slice(0, 14),
+        mediaDevices: navigator.mediaDevices ? "available" : "missing",
+        readyState: video ? String(video.readyState) : "n/a",
+        secureContext: String(window.isSecureContext),
+        srcObject: video?.srcObject ? "attached" : "none",
+        time,
+        tracks,
+        userAgent: navigator.userAgent,
+        video: video ? `${video.videoWidth}x${video.videoHeight}` : "none",
+      };
+    });
+  }, []);
 
   const ensureVideoPreviewElement = useCallback(() => {
     if (videoRef.current) {
@@ -896,9 +916,11 @@ function StockAdjustmentBarcodeScannerDialog({
       {
         constraints: {
           audio: false,
-          video: true,
+          video: {
+            facingMode: { exact: "environment" },
+          },
         },
-        label: "touch safari default camera",
+        label: "touch safari rear camera",
       },
       {
         constraints: {
@@ -909,11 +931,19 @@ function StockAdjustmentBarcodeScannerDialog({
         },
         label: "touch safari environment camera",
       },
+      {
+        constraints: {
+          audio: false,
+          video: true,
+        },
+        label: "touch safari default camera",
+      },
     ];
 
     const buildCameraAttempts = async () => {
-      const enumerateDevices =
-        navigator.mediaDevices?.enumerateDevices?.bind(navigator.mediaDevices);
+      const enumerateDevices = navigator.mediaDevices?.enumerateDevices?.bind(
+        navigator.mediaDevices,
+      );
 
       if (!enumerateDevices) {
         return baseCameraAttempts;
@@ -953,9 +983,7 @@ function StockAdjustmentBarcodeScannerDialog({
               deviceId: { exact: device.deviceId },
             },
           },
-          label: `device ${index + 1}${
-            device.label ? ` ${device.label}` : ""
-          }`,
+          label: `device ${index + 1}${device.label ? ` ${device.label}` : ""}`,
         }));
 
         return [...deviceAttempts, ...baseCameraAttempts];
@@ -1229,7 +1257,6 @@ function StockAdjustmentBarcodeScannerDialog({
               captureScannerDebug("barcode decoded");
               controls.stop();
               onBarcodeDetected(decodedValue);
-              toast.success("Barcode scanned");
               onOpenChange(false);
               return;
             }
@@ -1310,7 +1337,6 @@ function StockAdjustmentBarcodeScannerDialog({
                 captureScannerDebug("barcode decoded");
                 controls.stop();
                 onBarcodeDetected(decodedValue);
-                toast.success("Barcode scanned");
                 onOpenChange(false);
               }
             },
@@ -1376,7 +1402,6 @@ function StockAdjustmentBarcodeScannerDialog({
                 captureScannerDebug("barcode decoded");
                 controls.stop();
                 onBarcodeDetected(decodedValue);
-                toast.success("Barcode scanned");
                 onOpenChange(false);
                 return;
               }
@@ -1436,6 +1461,15 @@ function StockAdjustmentBarcodeScannerDialog({
     videoElement,
   ]);
 
+  useEffect(() => {
+    if (!open || hasAutoStartedScannerRef.current) {
+      return;
+    }
+
+    hasAutoStartedScannerRef.current = true;
+    void startScanner();
+  }, [open, startScanner]);
+
   const handleBarcodePhotoSelected = async (
     event: ChangeEvent<HTMLInputElement>,
   ) => {
@@ -1462,7 +1496,6 @@ function StockAdjustmentBarcodeScannerDialog({
 
       captureScannerDebug("barcode photo decoded");
       onBarcodeDetected(decodedValue);
-      toast.success("Barcode scanned");
       onOpenChange(false);
     } catch (error) {
       captureScannerDebug("barcode photo decode failed", error);
@@ -1479,6 +1512,7 @@ function StockAdjustmentBarcodeScannerDialog({
 
     stopScanner();
     removeVideoPreviewElement();
+    hasAutoStartedScannerRef.current = false;
     setScannerState("idle");
     setScannerDebug(buildEmptyScannerDebugSnapshot());
   }, [open, removeVideoPreviewElement, stopScanner]);
@@ -1486,23 +1520,23 @@ function StockAdjustmentBarcodeScannerDialog({
   const scannerMessage =
     scannerState === "requesting"
       ? "Requesting camera access..."
-      : scannerState === "starting"
+      : scannerState === "idle"
         ? "Starting camera..."
-      : scannerState === "decoding_photo"
-        ? "Reading barcode photo..."
-      : scannerState === "scanning"
-        ? "Scanning barcode..."
-        : scannerState === "unsupported"
-          ? "Camera barcode scanning is not available in this browser."
-          : scannerState === "blocked"
-            ? "Camera access is blocked for this site."
-            : scannerState === "error"
-              ? "Could not read from the camera."
-              : "Camera scanner ready.";
+        : scannerState === "starting"
+          ? "Starting camera..."
+          : scannerState === "decoding_photo"
+            ? "Reading barcode photo..."
+            : scannerState === "scanning"
+              ? "Scanning barcode..."
+              : scannerState === "unsupported"
+                ? "Camera barcode scanning is not available in this browser."
+                : scannerState === "blocked"
+                  ? "Camera access is blocked for this site."
+                  : scannerState === "error"
+                    ? "Could not read from the camera."
+                    : "Camera scanner ready.";
   const canStartScanner =
-    scannerState === "idle" ||
-    scannerState === "error" ||
-    scannerState === "blocked";
+    scannerState === "error" || scannerState === "blocked";
   const canUsePhotoScanner =
     scannerState === "idle" ||
     scannerState === "error" ||
@@ -1567,9 +1601,7 @@ function StockAdjustmentBarcodeScannerDialog({
                         variant="secondary"
                       >
                         <ScanBarcode className="h-4 w-4" />
-                        {scannerState === "idle"
-                          ? "Start camera"
-                          : "Try again"}
+                        Try again
                       </Button>
                     ) : null}
                     {canUsePhotoScanner ? (
@@ -1597,56 +1629,6 @@ function StockAdjustmentBarcodeScannerDialog({
           {scannerState === "scanning" ? (
             <p className="text-sm text-muted-foreground">{scannerMessage}</p>
           ) : null}
-          <div className="rounded-md border border-dashed border-border bg-muted/30 p-3 text-[11px] text-muted-foreground">
-            <div className="flex items-center justify-between gap-3">
-              <p className="font-medium uppercase tracking-[0.14em] text-foreground">
-                Scanner diagnostics
-              </p>
-              <span className="rounded-sm bg-background px-2 py-0.5 font-mono text-[10px] text-foreground">
-                {scannerState}
-              </span>
-            </div>
-            <dl className="mt-3 grid grid-cols-[96px_minmax(0,1fr)] gap-x-3 gap-y-1 font-mono">
-              {[
-                ["event", scannerDebug.event],
-                ["time", scannerDebug.time || "n/a"],
-                ["secure", scannerDebug.secureContext],
-                ["media", scannerDebug.mediaDevices],
-                ["video", scannerDebug.video],
-                ["ready", scannerDebug.readyState],
-                [
-                  "paused",
-                  videoRef.current ? String(videoRef.current.paused) : "n/a",
-                ],
-                ["current", scannerDebug.currentTime],
-                ["src", scannerDebug.srcObject],
-                ["tracks", scannerDebug.tracks],
-                ["error", scannerDebug.error],
-                ["agent", scannerDebug.userAgent],
-              ].map(([label, value]) => (
-                <div className="contents" key={label}>
-                  <dt className="uppercase tracking-[0.12em]">{label}</dt>
-                  <dd className="min-w-0 break-words text-foreground">
-                    {value}
-                  </dd>
-                </div>
-              ))}
-            </dl>
-            {scannerDebug.events.length > 0 ? (
-              <div className="mt-3 border-t border-border/70 pt-2">
-                <p className="font-medium uppercase tracking-[0.12em] text-muted-foreground">
-                  Events
-                </p>
-                <ol className="mt-1 space-y-1 font-mono text-[10px] text-foreground">
-                  {scannerDebug.events.map((entry, index) => (
-                    <li className="break-words" key={`${entry}-${index}`}>
-                      {entry}
-                    </li>
-                  ))}
-                </ol>
-              </div>
-            ) : null}
-          </div>
         </div>
       </section>
     </div>,
@@ -1947,7 +1929,7 @@ export function StockAdjustmentWorkspaceContent({
         : rows,
     [rows, selectedCountScopeKeySet, selectedCountScopeKeys],
   );
-  const normalizedFilterQuery = normalizeStockAdjustmentSearch(filters.query);
+  const normalizedFilterQuery = normalizeSkuSearchQuery(filters.query);
   const quickAddInitialLookupCode = normalizeQuickAddInitialLookupCode(
     filters.query,
   );
@@ -1964,6 +1946,13 @@ export function StockAdjustmentWorkspaceContent({
           sku: item.sku ?? "",
           category: item.productCategory ?? undefined,
           barcode: item.barcode ?? undefined,
+          variantAttributes: [
+            item.colorName,
+            item.size,
+            item.length === null || item.length === undefined
+              ? undefined
+              : `${item.length}"`,
+          ].filter((value): value is string => Boolean(value?.trim())),
         })),
     [inventoryItems],
   );
@@ -2088,9 +2077,7 @@ export function StockAdjustmentWorkspaceContent({
               totals.onHandUnits,
               "unit",
             )} are available to sell.${
-              totals.reservedUnits > 0
-                ? ` ${reservationSummary}`
-                : ""
+              totals.reservedUnits > 0 ? ` ${reservationSummary}` : ""
             }`,
       title:
         itemCount === 0
@@ -2903,102 +2890,55 @@ export function StockAdjustmentWorkspaceContent({
             </div>
           </section>
 
-          <section
-            aria-label="SKU search and filters"
-            className="rounded-md border border-border bg-surface-raised px-layout-md py-layout-md"
-          >
-            <div className="flex flex-col gap-layout-md lg:flex-row lg:items-end lg:justify-between">
-              <div className="min-w-0 flex-1">
-                <Label
-                  className="sr-only"
-                  htmlFor="stock-adjustment-sku-search"
-                >
-                  Search products, SKUs, or barcodes
-                </Label>
-                <div className="relative">
-                  <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                  <Input
-                    id="stock-adjustment-sku-search"
-                    onChange={(event) =>
-                      handleFilterChange({ query: event.target.value })
-                    }
-                    placeholder="Search product, SKU, or barcode"
-                    value={filters.query}
-                    className="pl-9 pr-12"
-                  />
-                  <Button
-                    aria-label="Scan barcode with camera"
-                    className="absolute right-1 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                    onClick={() => setIsBarcodeScannerOpen(true)}
-                    size="icon"
-                    type="button"
-                    variant="ghost"
-                  >
-                    <ScanBarcode className="h-4 w-4" />
-                  </Button>
-                </div>
-              </div>
-              <div className="flex flex-wrap items-center gap-2">
-                <Label
-                  className="sr-only"
-                  htmlFor="stock-adjustment-availability-filter"
-                >
-                  Filter by availability
-                </Label>
-                <Select
-                  onValueChange={(value) =>
-                    handleFilterChange({
-                      availability: value as StockAdjustmentAvailabilityFilter,
-                    })
-                  }
-                  value={filters.availability}
-                >
-                  <SelectTrigger
-                    className="w-[180px]"
-                    id="stock-adjustment-availability-filter"
-                  >
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {(
-                      Object.keys(
-                        STOCK_ADJUSTMENT_AVAILABILITY_FILTER_LABELS,
-                      ) as StockAdjustmentAvailabilityFilter[]
-                    ).map((option) => (
-                      <SelectItem key={option} value={option}>
-                        {STOCK_ADJUSTMENT_AVAILABILITY_FILTER_LABELS[option]}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <Button
-                  disabled={!storeId || !user?._id}
-                  onClick={() => setIsQuickAddOpen(true)}
-                  type="button"
-                  variant="workflow"
-                >
-                  <PackagePlus className="h-4 w-4" />
-                  Quick add
-                </Button>
-                {filters.query || filters.availability !== "all" ? (
-                  <Button
-                    className="text-muted-foreground"
-                    onClick={handleClearFilters}
-                    type="button"
-                    variant="outline"
-                  >
-                    <X className="h-4 w-4" />
-                    Clear
-                  </Button>
-                ) : null}
-              </div>
-            </div>
-            <p className="mt-layout-sm text-xs text-muted-foreground">
-              Showing {formatInventoryNumber(filteredRows.length)} of{" "}
-              {formatInventoryNumber(scopedRows.length)}{" "}
-              {pluralize(scopedRows.length, "SKU")}.
-            </p>
-          </section>
+          <SkuSearchFilterBar
+            action={
+              <Button
+                disabled={!storeId || !user?._id}
+                onClick={() => setIsQuickAddOpen(true)}
+                type="button"
+                variant="workflow"
+              >
+                <PackagePlus className="h-4 w-4" />
+                Quick add
+              </Button>
+            }
+            ariaLabel="SKU search and filters"
+            filterId="stock-adjustment-availability-filter"
+            filterLabel="Filter by availability"
+            filterOptions={STOCK_ADJUSTMENT_AVAILABILITY_FILTER_OPTIONS}
+            filterValue={filters.availability}
+            hasActiveFilters={Boolean(
+              filters.query || filters.availability !== "all",
+            )}
+            onClearFilters={handleClearFilters}
+            onFilterChange={(availability) =>
+              handleFilterChange({ availability })
+            }
+            onQueryChange={(query) => handleFilterChange({ query })}
+            query={filters.query}
+            scanAction={
+              <Button
+                aria-label="Scan barcode with camera"
+                className="absolute right-1 top-1/2 h-8 w-8 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                onClick={() => setIsBarcodeScannerOpen(true)}
+                size="icon"
+                type="button"
+                variant="ghost"
+              >
+                <ScanBarcode className="h-4 w-4" />
+              </Button>
+            }
+            searchId="stock-adjustment-sku-search"
+            searchLabel="Search products, SKUs, or barcodes"
+            searchPlaceholder="Search product, SKU, or barcode"
+            summary={
+              <>
+                Showing {formatInventoryNumber(filteredRows.length)} of{" "}
+                {formatInventoryNumber(scopedRows.length)}{" "}
+                {pluralize(scopedRows.length, "SKU")}.
+              </>
+            }
+          />
 
           <div className="flex min-h-0 flex-col">
             <GenericDataTable

--- a/packages/athena-webapp/src/components/pos/ProductEntry.tsx
+++ b/packages/athena-webapp/src/components/pos/ProductEntry.tsx
@@ -191,6 +191,13 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
             sku: item.sku,
             category: item.category,
             barcode: item.barcode,
+            variantAttributes: [
+              item.color,
+              item.size,
+              item.length === null || item.length === undefined
+                ? undefined
+                : `${item.length}"`,
+            ].filter((value): value is string => Boolean(value?.trim())),
           })),
       [registerCatalog],
     );

--- a/packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx
+++ b/packages/athena-webapp/src/components/procurement/ProcurementView.test.tsx
@@ -276,9 +276,7 @@ const baseProps: React.ComponentProps<typeof ProcurementViewContent> = {
   ],
 };
 
-function makeRecommendation(
-  index: number,
-): typeof exposedRecommendation {
+function makeRecommendation(index: number): typeof exposedRecommendation {
   return {
     ...exposedRecommendation,
     _id: `sku-page-${index}` as Id<"productSku">,
@@ -319,6 +317,16 @@ function installMutationMocks() {
 
     return mutation;
   });
+}
+
+async function chooseProcurementMode(
+  user: { click: (target: Element) => Promise<void> },
+  name: string | RegExp,
+) {
+  await user.click(
+    screen.getByRole("combobox", { name: /filter procurement mode/i }),
+  );
+  await user.click(await screen.findByRole("option", { name }));
 }
 
 async function chooseDraftVendor(
@@ -402,7 +410,7 @@ describe("ProcurementViewContent", () => {
     expect(screen.queryByText("Frontal Wig")).not.toBeInTheDocument();
     expect(screen.queryByText("Silk Press Kit")).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("tab", { name: /planned/i }));
+    await chooseProcurementMode(user, /planned/i);
 
     expect(screen.getByText("Frontal Wig")).toBeInTheDocument();
     expect(screen.getByText("1 planned stock item")).toBeInTheDocument();
@@ -456,7 +464,7 @@ describe("ProcurementViewContent", () => {
     ).toBeInTheDocument();
     expect(screen.queryByText("Closure Wig")).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("tab", { name: /inbound/i }));
+    await chooseProcurementMode(user, /inbound/i);
 
     expect(screen.getByText("Silk Press Kit")).toBeInTheDocument();
     expect(screen.getByText("Lace Adhesive")).toBeInTheDocument();
@@ -466,10 +474,70 @@ describe("ProcurementViewContent", () => {
       ),
     ).toHaveClass("text-success");
 
-    await user.click(screen.getByRole("tab", { name: /exceptions/i }));
+    await chooseProcurementMode(user, /exceptions/i);
 
     expect(screen.getByText("Lace Adhesive")).toBeInTheDocument();
     expect(screen.queryByText("Silk Press Kit")).not.toBeInTheDocument();
+  });
+
+  it("filters procurement stock pressure by product, SKU, and barcode search", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+
+    render(<ProcurementViewContent {...baseProps} />);
+
+    const searchInput = screen.getByRole("textbox", {
+      name: /search products, skus, or barcodes/i,
+    });
+
+    await user.type(searchInput, "LA-01");
+
+    expect(screen.queryByText("Closure Wig")).not.toBeInTheDocument();
+    expect(screen.getByText("Lace Adhesive")).toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 2 stock items.")).toBeInTheDocument();
+
+    await user.clear(searchInput);
+    await user.type(searchInput, "Lce Adhsive");
+
+    expect(screen.queryByText("Closure Wig")).not.toBeInTheDocument();
+    expect(screen.getByText("Lace Adhesive")).toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 2 stock items.")).toBeInTheDocument();
+
+    await user.clear(searchInput);
+    await user.type(searchInput, "BAR-CW-18");
+
+    expect(screen.getByText("Closure Wig")).toBeInTheDocument();
+    expect(screen.queryByText("Lace Adhesive")).not.toBeInTheDocument();
+  });
+
+  it("reports procurement search changes for route state", async () => {
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const user = userEvent.setup();
+    const onQueryChange = vi.fn();
+    const onSelectedSkuChange = vi.fn();
+
+    render(
+      <ProcurementViewContent
+        {...baseProps}
+        onQueryChange={onQueryChange}
+        onSelectedSkuChange={onSelectedSkuChange}
+      />,
+    );
+
+    await user.type(
+      screen.getByRole("textbox", {
+        name: /search products, skus, or barcodes/i,
+      }),
+      "CW",
+    );
+
+    expect(onQueryChange).toHaveBeenLastCalledWith("CW");
+    expect(onSelectedSkuChange).toHaveBeenLastCalledWith(null);
+
+    await user.click(screen.getByRole("button", { name: /clear/i }));
+
+    expect(onQueryChange).toHaveBeenLastCalledWith(undefined);
+    expect(onSelectedSkuChange).toHaveBeenLastCalledWith(null);
   });
 
   it("marks planned purchase orders ordered through the streamlined command", async () => {
@@ -478,7 +546,7 @@ describe("ProcurementViewContent", () => {
 
     render(<ProcurementViewContent {...baseProps} />);
 
-    await user.click(screen.getByRole("tab", { name: /planned/i }));
+    await chooseProcurementMode(user, /planned/i);
     await user.click(
       within(screen.getByText("Frontal Wig").closest("article")!).getAllByRole(
         "button",
@@ -606,7 +674,7 @@ describe("ProcurementViewContent", () => {
       />,
     );
 
-    await user.click(screen.getByRole("tab", { name: /planned/i }));
+    await chooseProcurementMode(user, /planned/i);
 
     const plannedRow = screen.getByText("Camera").closest("article")!;
     expect(within(plannedRow).getByText("Planned + inbound")).toHaveClass(
@@ -627,7 +695,7 @@ describe("ProcurementViewContent", () => {
       purchaseOrderId: "po-draft-2",
     });
 
-    await user.click(screen.getByRole("tab", { name: /inbound/i }));
+    await chooseProcurementMode(user, /inbound/i);
 
     expect(screen.getByText("Camera")).toBeInTheDocument();
   });
@@ -643,12 +711,12 @@ describe("ProcurementViewContent", () => {
       />,
     );
 
-    await user.click(screen.getByRole("tab", { name: /inbound/i }));
+    await chooseProcurementMode(user, /inbound/i);
 
     expect(screen.getByText("Logitech Mouse")).toBeInTheDocument();
     expect(
-      screen.queryByRole("tab", { name: /handled/i }),
-    ).not.toBeInTheDocument();
+      screen.getByRole("combobox", { name: /filter procurement mode/i }),
+    ).not.toHaveTextContent(/handled/i);
 
     const resolvedRow = screen.getByText("Logitech Mouse").closest("article")!;
     expect(within(resolvedRow).getByText("Handled")).toBeInTheDocument();
@@ -1020,7 +1088,7 @@ describe("ProcurementViewContent", () => {
         .querySelector("button"),
     ).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("tab", { name: /planned/i }));
+    await chooseProcurementMode(user, /planned/i);
     await user.click(
       within(screen.getByText("Frontal Wig").closest("article")!).getAllByRole(
         "button",
@@ -1045,10 +1113,9 @@ describe("ProcurementViewContent", () => {
     await user.click(screen.getByRole("button", { name: /po-draft/i }));
 
     const plannedRow = screen.getByText("Frontal Wig").closest("article")!;
-    expect(screen.getByRole("tab", { name: /planned/i })).toHaveAttribute(
-      "data-state",
-      "active",
-    );
+    expect(
+      screen.getByRole("combobox", { name: /filter procurement mode/i }),
+    ).toHaveTextContent(/planned/i);
     expect(plannedRow).toHaveClass("bg-muted/30");
     await waitFor(() =>
       expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalledWith({
@@ -1078,7 +1145,10 @@ describe("ProcurementViewContent", () => {
     render(
       <ProcurementViewContent
         {...baseProps}
-        recommendations={[...fillerRecommendations, singlePlannedRecommendation]}
+        recommendations={[
+          ...fillerRecommendations,
+          singlePlannedRecommendation,
+        ]}
       />,
     );
 
@@ -1101,16 +1171,14 @@ describe("ProcurementViewContent", () => {
 
     render(<ProcurementViewContent {...baseProps} />);
 
-    await user.click(screen.getByRole("tab", { name: /inbound/i }));
+    await chooseProcurementMode(user, /inbound/i);
     const silkPressRow = screen.getByText("Silk Press Kit").closest("article")!;
     const receiveButton = within(silkPressRow).getByRole("button", {
       name: /receive/i,
     });
 
     expect(receiveButton).toHaveClass("w-[92px]");
-    await user.click(
-      receiveButton,
-    );
+    await user.click(receiveButton);
 
     expect(screen.getByText("Receiving form for po-1")).toBeInTheDocument();
     expect(

--- a/packages/athena-webapp/src/components/procurement/ProcurementView.tsx
+++ b/packages/athena-webapp/src/components/procurement/ProcurementView.tsx
@@ -25,15 +25,19 @@ import {
   SelectTrigger,
   SelectValue,
 } from "../ui/select";
-import { Tabs, TabsList, TabsTrigger } from "../ui/tabs";
 import {
   SkuDetailPanel,
   type InventorySnapshotItem,
 } from "../operations/StockAdjustmentWorkspace";
+import { SkuSearchFilterBar } from "../stock-ops/SkuSearchFilterBar";
 import { ReceivingView } from "./ReceivingView";
 import { useProtectedAdminPageState } from "@/hooks/useProtectedAdminPageState";
 import { presentCommandToast } from "@/lib/errors/presentCommandToast";
 import { runCommand } from "@/lib/errors/runCommand";
+import {
+  matchesSkuSearchTerms,
+  normalizeSkuSearchQuery,
+} from "@/lib/stockOps/skuSearch";
 import { cn } from "@/lib/utils";
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
@@ -135,9 +139,11 @@ type ProcurementViewContentProps = {
   mode?: ProcurementMode;
   onModeChange?: (mode: ProcurementMode) => void;
   onPageChange?: (page: number) => void;
+  onQueryChange?: (query: string | undefined) => void;
   onSelectedSkuChange?: (sku: string | null, page?: number) => void;
   page?: number;
   purchaseOrders: ProcurementOrderSummary[];
+  query?: string;
   recommendations: ReplenishmentRecommendation[];
   selectedSku?: string;
   storeId?: Id<"store">;
@@ -153,6 +159,11 @@ const MODE_OPTIONS = [
 ] as const;
 
 type ProcurementMode = (typeof MODE_OPTIONS)[number]["value"];
+
+const PROCUREMENT_MODE_FILTER_OPTIONS = MODE_OPTIONS.map((option) => ({
+  label: option.label,
+  value: option.value,
+}));
 
 const RECOMMENDATIONS_PER_PAGE = 10;
 
@@ -547,15 +558,18 @@ export function ProcurementViewContent({
   mode: controlledMode,
   onModeChange,
   onPageChange,
+  onQueryChange,
   onSelectedSkuChange,
   page: controlledPage,
   purchaseOrders,
+  query: controlledQuery,
   recommendations,
   selectedSku,
   storeId,
   vendors,
 }: ProcurementViewContentProps) {
   const [localMode, setLocalMode] = useState<ProcurementMode>("needs_action");
+  const [localQuery, setLocalQuery] = useState("");
   const [draftLines, setDraftLines] = useState<ReorderDraftLine[]>([]);
   const [quickAddVendorName, setQuickAddVendorName] = useState("");
   const [createdVendors, setCreatedVendors] = useState<VendorSummary[]>([]);
@@ -604,6 +618,7 @@ export function ProcurementViewContent({
     [inventoryItems],
   );
   const mode = controlledMode ?? localMode;
+  const query = controlledQuery ?? localQuery;
   const controlledSelectedProductSkuId = selectedSku
     ? (recommendations.find((recommendation) =>
         matchesRecommendationSku(recommendation, selectedSku),
@@ -637,6 +652,33 @@ export function ProcurementViewContent({
 
     onModeChange?.(nextMode);
   };
+  const handleQueryChange = (nextQuery: string) => {
+    setActiveRecommendationPage(1);
+    setSelectedProductSkuId(null);
+
+    if (controlledQuery === undefined) {
+      setLocalQuery(nextQuery);
+    }
+
+    onQueryChange?.(nextQuery.trim() ? nextQuery : undefined);
+    onSelectedSkuChange?.(null);
+  };
+  const handleClearRecommendationFilters = () => {
+    setActiveRecommendationPage(1);
+    setSelectedProductSkuId(null);
+
+    if (!controlledMode) {
+      setLocalMode("needs_action");
+    }
+
+    if (controlledQuery === undefined) {
+      setLocalQuery("");
+    }
+
+    onModeChange?.("needs_action");
+    onQueryChange?.(undefined);
+    onSelectedSkuChange?.(null);
+  };
   const handleRecommendationPageChange = (nextPage: number) => {
     const boundedPage = Math.min(
       Math.max(nextPage, 1),
@@ -646,12 +688,37 @@ export function ProcurementViewContent({
     setActiveRecommendationPage(boundedPage);
   };
 
-  const visibleRecommendations = useMemo(
+  const modeRecommendations = useMemo(
     () =>
       recommendations.filter((recommendation) =>
         isRecommendationVisible(recommendation, mode),
       ),
     [mode, recommendations],
+  );
+  const normalizedRecommendationQuery = normalizeSkuSearchQuery(query);
+  const visibleRecommendations = useMemo(
+    () =>
+      modeRecommendations.filter((recommendation) => {
+        const inventoryItem = inventoryItemsById.get(recommendation._id);
+
+        return matchesSkuSearchTerms(
+          [
+            recommendation.productName,
+            recommendation.sku,
+            recommendation.guidance,
+            inventoryItem?.barcode,
+            inventoryItem?.productCategory,
+            inventoryItem?.colorName,
+            inventoryItem?.size,
+            inventoryItem?.length === null ||
+            inventoryItem?.length === undefined
+              ? undefined
+              : String(inventoryItem.length),
+          ],
+          normalizedRecommendationQuery,
+        );
+      }),
+    [inventoryItemsById, modeRecommendations, normalizedRecommendationQuery],
   );
   const recommendationPageCount = Math.max(
     Math.ceil(visibleRecommendations.length / RECOMMENDATIONS_PER_PAGE),
@@ -1075,59 +1142,57 @@ export function ProcurementViewContent({
                 description="Review stock pressure, create vendor-backed orders, and track receiving in one workspace."
               />
 
-              <div className="flex flex-wrap items-start justify-between gap-layout-xl">
-                <div className="max-w-2xl space-y-6">
-                  <div className="grid max-w-2xl grid-cols-2 gap-2 sm:grid-cols-4">
-                    <div className="rounded-md border border-border bg-muted/30 px-3 py-2">
-                      <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                        Needs action
-                      </p>
-                      <p className="mt-1 text-sm font-medium tabular-nums text-foreground">
-                        {summary.needsAction}
-                      </p>
-                    </div>
-                    <div className="rounded-md border border-border bg-muted/30 px-3 py-2">
-                      <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                        Planned
-                      </p>
-                      <p className="mt-1 text-sm font-medium tabular-nums text-foreground">
-                        {summary.planned}
-                      </p>
-                    </div>
-                    <div className="rounded-md border border-border bg-muted/30 px-3 py-2">
-                      <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                        Inbound
-                      </p>
-                      <p className="mt-1 text-sm font-medium tabular-nums text-foreground">
-                        {summary.inbound}
-                      </p>
-                    </div>
-                    <div className="rounded-md border border-border bg-muted/30 px-3 py-2">
-                      <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                        Exceptions
-                      </p>
-                      <p className="mt-1 text-sm font-medium tabular-nums text-foreground">
-                        {summary.exceptions}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-
-                <Tabs
-                  onValueChange={(value) =>
-                    handleModeChange(value as ProcurementMode)
+              <section
+                aria-label="Procurement workspace controls"
+                className="space-y-layout-sm"
+              >
+                <SkuSearchFilterBar
+                  ariaLabel="Procurement SKU search and filters"
+                  className="min-w-0"
+                  clearLabel="Clear"
+                  filterId="procurement-mode-filter"
+                  filterLabel="Filter procurement mode"
+                  filterOptions={PROCUREMENT_MODE_FILTER_OPTIONS}
+                  filterValue={mode}
+                  filterTriggerClassName="w-[210px]"
+                  hasActiveFilters={Boolean(query || mode !== "needs_action")}
+                  onClearFilters={handleClearRecommendationFilters}
+                  onFilterChange={handleModeChange}
+                  onQueryChange={handleQueryChange}
+                  query={query}
+                  searchId="procurement-sku-search"
+                  searchLabel="Search products, SKUs, or barcodes"
+                  searchPlaceholder="Search product, SKU, or barcode"
+                  summary={
+                    <>
+                      Showing {visibleRecommendations.length} of{" "}
+                      {modeRecommendations.length} stock{" "}
+                      {modeRecommendations.length === 1 ? "item" : "items"}.
+                    </>
                   }
-                  value={mode}
-                >
-                  <TabsList>
-                    {MODE_OPTIONS.map((option) => (
-                      <TabsTrigger key={option.value} value={option.value}>
-                        {option.label}
-                      </TabsTrigger>
-                    ))}
-                  </TabsList>
-                </Tabs>
-              </div>
+                />
+
+                <div className="grid overflow-hidden rounded-md border border-border bg-muted/20 sm:grid-cols-4">
+                  {[
+                    ["Needs action", summary.needsAction],
+                    ["Planned", summary.planned],
+                    ["Inbound", summary.inbound],
+                    ["Exceptions", summary.exceptions],
+                  ].map(([label, value]) => (
+                    <div
+                      className="border-border px-layout-md py-layout-sm sm:border-l sm:first:border-l-0"
+                      key={label}
+                    >
+                      <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                        {label}
+                      </p>
+                      <p className="mt-1 text-lg font-semibold tabular-nums text-foreground">
+                        {value}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </section>
 
               <section
                 className="overflow-hidden rounded-lg border border-border bg-surface-raised shadow-surface"
@@ -1847,15 +1912,19 @@ export function ProcurementView({
   mode,
   onModeChange,
   onPageChange,
+  onQueryChange,
   onSelectedSkuChange,
   page,
+  query,
   selectedSku,
 }: {
   mode?: ProcurementMode;
   onModeChange?: (mode: ProcurementMode) => void;
   onPageChange?: (page: number) => void;
+  onQueryChange?: (query: string | undefined) => void;
   onSelectedSkuChange?: (sku: string | null, page?: number) => void;
   page?: number;
+  query?: string;
   selectedSku?: string;
 } = {}) {
   const {
@@ -1913,9 +1982,11 @@ export function ProcurementView({
       mode={mode}
       onModeChange={onModeChange}
       onPageChange={onPageChange}
+      onQueryChange={onQueryChange}
       onSelectedSkuChange={onSelectedSkuChange}
       page={page}
       purchaseOrders={purchaseOrders ?? []}
+      query={query}
       recommendations={recommendations ?? []}
       selectedSku={selectedSku}
       storeId={activeStore?._id}

--- a/packages/athena-webapp/src/components/product/AnalyticsInsights.tsx
+++ b/packages/athena-webapp/src/components/product/AnalyticsInsights.tsx
@@ -8,14 +8,12 @@ import {
   Eye,
   Users,
 } from "lucide-react";
-import useGetActiveProduct from "~/src/hooks/useGetActiveProduct";
 import { getRelativeTime } from "~/src/lib/utils";
 import { FadeIn } from "../common/FadeIn";
 
 export const AnalyticsInsights = () => {
   const { activeStore } = useGetActiveStore();
-  const { activeProductVariant } = useProduct();
-  const { activeProduct } = useGetActiveProduct();
+  const { activeProductVariant, activeProduct } = useProduct();
 
   const analytics = useQuery(
     api.storeFront.analytics.getAll,

--- a/packages/athena-webapp/src/components/product/BarcodeView.tsx
+++ b/packages/athena-webapp/src/components/product/BarcodeView.tsx
@@ -1,14 +1,12 @@
 import { useRef } from "react";
 import { useProduct } from "~/src/contexts/ProductContext";
-import useGetActiveProduct from "~/src/hooks/useGetActiveProduct";
 import View from "../View";
 import QRCode from "react-qr-code";
 import config from "~/src/config";
 import { FadeIn } from "../common/FadeIn";
 
 export function BarcodeView() {
-  const { activeProductVariant } = useProduct();
-  const { activeProduct } = useGetActiveProduct();
+  const { activeProductVariant, activeProduct } = useProduct();
   const qrCodeRef = useRef<HTMLDivElement>(null);
 
   if (!activeProductVariant.barcode) {

--- a/packages/athena-webapp/src/components/product/ImagesView.tsx
+++ b/packages/athena-webapp/src/components/product/ImagesView.tsx
@@ -7,7 +7,6 @@ import View from "../View";
 import { useProduct } from "~/src/contexts/ProductContext";
 import { Button } from "../ui/button";
 import config from "~/src/config";
-import useGetActiveProduct from "~/src/hooks/useGetActiveProduct";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { getOrigin } from "~/src/lib/navigationUtils";
 import { usePermissions } from "~/src/hooks/usePermissions";
@@ -16,8 +15,8 @@ import { useEffect } from "react";
 import { ProductStatus } from "./ProductStatus";
 
 export function ImagesView() {
-  const { activeProductVariant } = useProduct();
-  const { activeProduct } = useGetActiveProduct();
+  const { activeProductVariant, activeProduct } = useProduct();
+  const isArchived = activeProduct?.availability === "archived";
 
   const { hasFullAdminAccess } = usePermissions();
 
@@ -25,7 +24,12 @@ export function ImagesView() {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "e" && hasFullAdminAccess && activeProduct) {
+      if (
+        event.key === "e" &&
+        hasFullAdminAccess &&
+        activeProduct &&
+        !isArchived
+      ) {
         navigate({
           to: "/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit",
           params: (prev) => ({
@@ -41,7 +45,7 @@ export function ImagesView() {
         });
       }
 
-      if (event.key === "v" && activeProduct) {
+      if (event.key === "v" && activeProduct && !isArchived) {
         window.open(
           `${config.storeFrontUrl}/shop/product/${activeProduct._id}?variant=${activeProductVariant?.sku}`,
           "_blank",
@@ -52,7 +56,13 @@ export function ImagesView() {
     window.addEventListener("keydown", handleKeyDown);
 
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [navigate, activeProduct, activeProductVariant?.sku, hasFullAdminAccess]);
+  }, [
+    navigate,
+    activeProduct,
+    activeProductVariant?.sku,
+    hasFullAdminAccess,
+    isArchived,
+  ]);
 
   if (activeProduct === undefined) return null;
   if (activeProduct === null) return null;
@@ -99,7 +109,7 @@ export function ImagesView() {
           )}
         </div>
 
-        {hasFullAdminAccess && activeProduct && (
+        {hasFullAdminAccess && activeProduct && !isArchived && (
           <div className="flex items-center gap-4">
             <Link
               to="/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug/edit"

--- a/packages/athena-webapp/src/components/product/ProductDetailView.tsx
+++ b/packages/athena-webapp/src/components/product/ProductDetailView.tsx
@@ -1,49 +1,91 @@
-import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import { CheckCircledIcon, TrashIcon } from "@radix-ui/react-icons";
+import { ArchiveRestore } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { useMutation } from "convex/react";
+
 import View from "../View";
-import { Button } from "../ui/button";
-import { ArrowLeftIcon, TrashIcon } from "@radix-ui/react-icons";
-import { Badge } from "../ui/badge";
+import { LoadingButton } from "../ui/loading-button";
 import { SKUSelector } from "./SKUSelector";
-import { ProductProvider, useProduct } from "~/src/contexts/ProductContext";
+import { ProductProvider } from "~/src/contexts/ProductContext";
 import { DetailsView } from "./DetailsView";
 import { AttributesView } from "./AttributesView";
-import { CategorizationView } from "./CategorizationView";
 import useGetActiveProduct from "~/src/hooks/useGetActiveProduct";
 import { ImagesView } from "./ImagesView";
-import { PackageX, PenIcon, Trash } from "lucide-react";
 import { ProductStatus } from "./ProductStatus";
-import { ProductStockStatus } from "./ProductStock";
 import { ComposedPageHeader } from "../common/PageHeader";
 import { capitalizeWords } from "~/src/lib/utils";
-import { getOrigin } from "~/src/lib/navigationUtils";
 import { AnalyticsInsights } from "./AnalyticsInsights";
 import { BarcodeView } from "./BarcodeView";
-import { FadeIn } from "../common/FadeIn";
 import { EmptyState } from "../states/empty/empty-state";
+import useGetActiveStore from "~/src/hooks/useGetActiveStore";
+import { api } from "~/convex/_generated/api";
+import { presentUnexpectedErrorToast } from "~/src/lib/errors/presentUnexpectedErrorToast";
 
 const ProductDetailViewHeader = () => {
-  const { activeProduct } = useGetActiveProduct();
+  const [isUnarchiving, setIsUnarchiving] = useState(false);
+  const { activeProduct } = useGetActiveProduct({ includeArchived: true });
+  const { activeStore } = useGetActiveStore();
+  const unarchiveProduct = useMutation(api.inventory.products.unarchive);
 
   if (activeProduct === undefined) return null;
+
+  const isArchived = activeProduct?.availability === "archived";
+
+  const handleUnarchiveProduct = async () => {
+    if (!activeProduct || !activeStore) {
+      return;
+    }
+
+    try {
+      setIsUnarchiving(true);
+      await unarchiveProduct({
+        id: activeProduct._id,
+        storeId: activeStore._id,
+      });
+
+      toast(`Product '${activeProduct.name}' unarchived`, {
+        icon: <CheckCircledIcon className="w-4 h-4" />,
+      });
+    } catch {
+      presentUnexpectedErrorToast("Something went wrong");
+    } finally {
+      setIsUnarchiving(false);
+    }
+  };
 
   return (
     <ComposedPageHeader
       leadingContent={
-        <>
+        <div className="flex items-center gap-3">
           <p className="text-sm">
             {capitalizeWords(activeProduct?.name || "")}
           </p>
-        </>
+          {activeProduct && <ProductStatus product={activeProduct} />}
+        </div>
+      }
+      trailingContent={
+        isArchived ? (
+          <LoadingButton
+            isLoading={isUnarchiving}
+            variant="outline"
+            onClick={handleUnarchiveProduct}
+            className="flex items-center gap-2"
+          >
+            <ArchiveRestore className="w-3.5 h-3.5" />
+            <span>Unarchive</span>
+          </LoadingButton>
+        ) : null
       }
     />
   );
 };
 
 export const ProductDetailView = () => {
-  const { activeProduct } = useGetActiveProduct();
+  const { activeProduct } = useGetActiveProduct({ includeArchived: true });
 
   return (
-    <ProductProvider>
+    <ProductProvider includeArchived>
       <View header={<ProductDetailViewHeader />}>
         <div className="container mx-auto h-full w-full p-8 space-y-12">
           {activeProduct !== null && (

--- a/packages/athena-webapp/src/components/product/QuickAddProductDialog.test.tsx
+++ b/packages/athena-webapp/src/components/product/QuickAddProductDialog.test.tsx
@@ -39,6 +39,7 @@ function renderQuickAddDialog(input?: {
           name: "gelato cookies",
           sku: "6N2Y-D3-4RC",
           category: "POS quick add",
+          variantAttributes: ["Green", "2 oz"],
         },
       ]}
       initialName={input?.initialName ?? "Quick item"}
@@ -133,5 +134,8 @@ describe("QuickAddProductDialog", () => {
     await user.type(screen.getByLabelText(/search existing sku/i), "gelato");
 
     expect(screen.getByText("Gelato Cookies")).toBeInTheDocument();
+    expect(
+      screen.getByText("6N2Y-D3-4RC - POS quick add - Green - 2 oz"),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx
+++ b/packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx
@@ -37,6 +37,7 @@ export type QuickAddExistingSkuOption = {
   sku: string;
   category?: string;
   barcode?: string;
+  variantAttributes?: string[];
 };
 
 export type QuickAddAttachBarcodePayload = {
@@ -106,6 +107,16 @@ function validateQuickAddLookupCode(lookupCode: string) {
   }
 
   return "Lookup code must be a numeric barcode (digits only)";
+}
+
+function getExistingSkuMetadata(option: QuickAddExistingSkuOption) {
+  return [
+    option.sku || "No SKU",
+    option.category,
+    ...(option.variantAttributes ?? []),
+  ]
+    .map((value) => value?.trim())
+    .filter((value): value is string => Boolean(value));
 }
 
 export function QuickAddProductDialog({
@@ -375,7 +386,12 @@ export function QuickAddProductDialog({
 
     return unbarcodedOptions
       .filter((option) =>
-        [option.name, option.sku, option.category]
+        [
+          option.name,
+          option.sku,
+          option.category,
+          ...(option.variantAttributes ?? []),
+        ]
           .filter(Boolean)
           .some((value) => value!.toLowerCase().includes(normalizedQuery)),
       )
@@ -509,6 +525,7 @@ export function QuickAddProductDialog({
                       matchingExistingSkus.map((option) => {
                         const isSelected =
                           selectedExistingSkuId === option.productSkuId;
+                        const metadata = getExistingSkuMetadata(option);
 
                         return (
                           <button
@@ -531,8 +548,7 @@ export function QuickAddProductDialog({
                                 {capitalizeWords(option.name)}
                               </span>
                               <span className="block truncate text-xs text-muted-foreground">
-                                {option.sku || "No SKU"}
-                                {option.category ? ` - ${option.category}` : ""}
+                                {metadata.join(" - ")}
                               </span>
                             </span>
                             {isSelected && (

--- a/packages/athena-webapp/src/components/products/Products.test.tsx
+++ b/packages/athena-webapp/src/components/products/Products.test.tsx
@@ -2,9 +2,15 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { Product } from "~/types";
+import type { Id } from "~/convex/_generated/dataModel";
+
 import Products from "./Products";
 
 const quickAddProductSkuMock = vi.fn();
+const mockedProducts = vi.hoisted(() => ({
+  allProducts: [] as Product[],
+}));
 
 class ResizeObserverStub {
   observe() {}
@@ -26,8 +32,12 @@ vi.mock("~/src/hooks/useGetCategories", () => ({
 }));
 
 vi.mock("~/src/hooks/useGetProducts", () => ({
-  useGetProducts: () => [],
+  useGetProducts: () => mockedProducts.allProducts,
   useGetUnresolvedProducts: () => [],
+}));
+
+vi.mock("convex/react", () => ({
+  useQuery: () => ({ name: "Home Care" }),
 }));
 
 vi.mock("~/src/hooks/usePermissions", () => ({
@@ -59,6 +69,7 @@ vi.mock("~/src/hooks/usePOSProducts", () => ({
 describe("Products", () => {
   beforeEach(() => {
     quickAddProductSkuMock.mockReset();
+    mockedProducts.allProducts = [];
   });
 
   it("quick adds a product with variants from the products workspace", async () => {
@@ -106,5 +117,126 @@ describe("Products", () => {
       quantityAvailable: 1,
       productId: "product-1",
     });
+  });
+
+  it("prefills quick add barcode from a numeric product search", async () => {
+    const user = userEvent.setup();
+
+    render(<Products />);
+
+    await user.type(
+      screen.getByPlaceholderText(/search products/i),
+      "075724640412",
+    );
+    await user.click(screen.getByRole("button", { name: /quick add/i }));
+
+    expect(screen.getByLabelText(/product name/i)).toHaveValue("");
+    expect(screen.getByLabelText(/barcode/i)).toHaveValue("075724640412");
+  });
+
+  it("prefills quick add product name from a text product search", async () => {
+    const user = userEvent.setup();
+
+    render(<Products />);
+
+    await user.type(
+      screen.getByPlaceholderText(/search products/i),
+      "Mahogany Teakwood",
+    );
+    await user.click(screen.getByRole("button", { name: /quick add/i }));
+
+    expect(screen.getByLabelText(/product name/i)).toHaveValue(
+      "Mahogany Teakwood",
+    );
+    expect(screen.getByLabelText(/barcode/i)).toHaveValue("");
+  });
+
+  it("fuzzy matches product search across product and SKU fields", async () => {
+    const user = userEvent.setup();
+    mockedProducts.allProducts = [
+      {
+        _id: "product-1" as Id<"product">,
+        _creationTime: 1,
+        availability: "live",
+        categoryId: "category-1" as Id<"category">,
+        categoryName: "Home Care",
+        createdByUserId: "user-1" as Id<"athenaUser">,
+        currency: "GHS",
+        inventoryCount: 12,
+        isVisible: true,
+        name: "Mahogany Teakwood",
+        organizationId: "org-1" as Id<"organization">,
+        slug: "mahogany-teakwood",
+        skus: [
+          {
+            _id: "sku-1" as Id<"productSku">,
+            _creationTime: 1,
+            barcode: "839293889923",
+            colorName: "Amber",
+            images: [],
+            inventoryCount: 12,
+            length: undefined,
+            price: 2500,
+            productCategory: "Home Care",
+            productId: "product-1" as Id<"product">,
+            productName: "Mahogany Teakwood",
+            quantityAvailable: 12,
+            size: "Large",
+            sku: "6N2Y-9W1-PNN",
+            storeId: "store-1" as Id<"store">,
+          },
+        ],
+        storeId: "store-1" as Id<"store">,
+        subcategoryId: "subcategory-1" as Id<"subcategory">,
+      },
+      {
+        _id: "product-2" as Id<"product">,
+        _creationTime: 1,
+        availability: "live",
+        categoryId: "category-1" as Id<"category">,
+        categoryName: "Hair",
+        createdByUserId: "user-1" as Id<"athenaUser">,
+        currency: "GHS",
+        inventoryCount: 8,
+        isVisible: true,
+        name: "Closure Wig",
+        organizationId: "org-1" as Id<"organization">,
+        slug: "closure-wig",
+        skus: [
+          {
+            _id: "sku-2" as Id<"productSku">,
+            _creationTime: 1,
+            barcode: "1234567890123",
+            colorName: "Natural black",
+            images: [],
+            inventoryCount: 8,
+            length: 18,
+            price: 4500,
+            productCategory: "Hair",
+            productId: "product-2" as Id<"product">,
+            productName: "Closure Wig",
+            quantityAvailable: 8,
+            size: "Large",
+            sku: "CW-18",
+            storeId: "store-1" as Id<"store">,
+          },
+        ],
+        storeId: "store-1" as Id<"store">,
+        subcategoryId: "subcategory-1" as Id<"subcategory">,
+      },
+    ];
+
+    render(<Products />);
+
+    await user.type(screen.getByPlaceholderText(/search products/i), "mahogny");
+
+    expect(screen.getByText("Mahogany Teakwood")).toBeInTheDocument();
+    expect(screen.queryByText("Closure Wig")).not.toBeInTheDocument();
+
+    await user.clear(screen.getByPlaceholderText(/search products/i));
+    await user.type(screen.getByPlaceholderText(/search products/i), "natrual");
+
+    expect(screen.getByText("Closure Wig")).toBeInTheDocument();
+    expect(screen.queryByText("Mahogany Teakwood")).not.toBeInTheDocument();
   });
 });

--- a/packages/athena-webapp/src/components/products/Products.tsx
+++ b/packages/athena-webapp/src/components/products/Products.tsx
@@ -21,6 +21,7 @@ import { EmptyState } from "../states/empty/empty-state";
 import { usePermissions } from "~/src/hooks/usePermissions";
 import { QuickAddProductDialog } from "../product/QuickAddProductDialog";
 import type { QuickAddProductSubmitPayload } from "../product/QuickAddProductDialog";
+import { normalizeQuickAddInitialLookupCode } from "../product/quickAddProductDialogUtils";
 import { usePOSQuickAddProductSku } from "~/src/hooks/usePOSProducts";
 import useGetActiveStore from "~/src/hooks/useGetActiveStore";
 import { useAuth } from "~/src/hooks/useAuth";
@@ -34,6 +35,11 @@ import {
 } from "../common/PageLevelHeader";
 import { Badge } from "../ui/badge";
 import { cn } from "~/src/lib/utils";
+import {
+  matchesSkuSearchTerms,
+  normalizeSkuSearchQuery,
+} from "~/src/lib/stockOps/skuSearch";
+import type { Product } from "~/types";
 
 export default function Products() {
   const categories = useGetCategories();
@@ -41,6 +47,9 @@ export default function Products() {
   const allProducts = useGetProducts();
   const [searchValue, setSearchValue] = useState("");
   const [isQuickAddOpen, setIsQuickAddOpen] = useState(false);
+  const [quickAddInitialName, setQuickAddInitialName] = useState("");
+  const [quickAddInitialLookupCode, setQuickAddInitialLookupCode] =
+    useState("");
   const { hasFullAdminAccess } = usePermissions();
   const { activeStore } = useGetActiveStore();
   const { user } = useAuth();
@@ -51,19 +60,11 @@ export default function Products() {
     if (!allProducts) return null;
     if (!searchValue.trim()) return null;
 
-    const searchLower = searchValue.toLowerCase();
-    return allProducts.filter((product) => {
-      // Check if product name matches
-      const productName = product.name.toLowerCase();
-      if (productName.includes(searchLower)) {
-        return true;
-      }
+    const normalizedQuery = normalizeSkuSearchQuery(searchValue);
 
-      // Check if any SKU matches
-      return product.skus.some((sku) =>
-        sku.sku?.toLowerCase().includes(searchLower),
-      );
-    });
+    return allProducts.filter((product) =>
+      productMatchesCatalogSearch(product, normalizedQuery),
+    );
   }, [allProducts, searchValue]);
 
   const hasSearchInput = searchValue.trim().length > 0;
@@ -114,6 +115,16 @@ export default function Products() {
     );
   };
 
+  const handleOpenQuickAdd = () => {
+    const trimmedSearchValue = searchValue.trim();
+    const initialLookupCode =
+      normalizeQuickAddInitialLookupCode(trimmedSearchValue);
+
+    setQuickAddInitialName(initialLookupCode ? "" : trimmedSearchValue);
+    setQuickAddInitialLookupCode(initialLookupCode);
+    setIsQuickAddOpen(true);
+  };
+
   return (
     <PageWorkspace>
       <PageLevelHeader
@@ -123,12 +134,12 @@ export default function Products() {
         showBackButton={Boolean(o)}
       />
 
-      <PageWorkspaceGrid className="xl:grid-cols-[minmax(0,1fr)_360px]">
+      <PageWorkspaceGrid className="xl:grid-cols-[minmax(0,1fr)_300px] 2xl:grid-cols-[minmax(0,1fr)_280px]">
         <PageWorkspaceMain>
-          <section className="overflow-hidden rounded-lg border border-border bg-surface-raised shadow-surface">
-            <div className="space-y-layout-lg px-layout-md py-layout-md">
+          <section className="min-w-0 overflow-hidden rounded-lg border border-border bg-surface-raised shadow-surface">
+            <div className="min-w-0 space-y-layout-lg px-layout-md py-layout-md">
               <div className="flex flex-col gap-layout-sm lg:flex-row lg:items-center lg:justify-between">
-                <div className="relative max-w-xl flex-1">
+                <div className="relative max-w-2xl flex-1">
                   <Search
                     aria-hidden
                     className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
@@ -142,10 +153,7 @@ export default function Products() {
                 </div>
                 {hasFullAdminAccess ? (
                   <div className="flex flex-wrap items-center gap-2">
-                    <Button
-                      variant="ghost"
-                      onClick={() => setIsQuickAddOpen(true)}
-                    >
+                    <Button variant="ghost" onClick={handleOpenQuickAdd}>
                       <PlusIcon className="h-4 w-4" />
                       Quick add
                     </Button>
@@ -168,7 +176,7 @@ export default function Products() {
               </div>
 
               {showSearchResults ? (
-                <div className="overflow-hidden rounded-lg border border-border bg-background">
+                <div className="min-w-0 overflow-hidden rounded-lg border border-border bg-background">
                   <div className="flex items-center justify-between border-b border-border/70 px-layout-md py-layout-sm">
                     <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
                       Search results
@@ -241,9 +249,6 @@ export default function Products() {
 
         <PageWorkspaceRail>
           <section className="rounded-lg border border-border bg-surface-raised p-layout-md shadow-surface">
-            <h2 className="text-sm font-medium text-foreground">
-              Product metrics
-            </h2>
             <div className="mt-layout-md grid grid-cols-2 gap-2">
               <div className="rounded-md border border-border bg-background px-3 py-2">
                 <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
@@ -323,9 +328,35 @@ export default function Products() {
         open={isQuickAddOpen}
         onOpenChange={setIsQuickAddOpen}
         onSubmit={handleQuickAddSubmit}
+        initialName={quickAddInitialName}
+        initialLookupCode={quickAddInitialLookupCode}
         description="Add a sellable product without opening the full product editor."
         submitErrorMessage="Could not quick add this product. Try again."
       />
     </PageWorkspace>
+  );
+}
+
+function productMatchesCatalogSearch(product: Product, query: string) {
+  return matchesSkuSearchTerms(
+    [
+      product.name,
+      product.categoryName,
+      product.subcategoryName,
+      product.categorySlug,
+      product.subcategorySlug,
+      ...product.skus.flatMap((sku) => [
+        sku.sku,
+        sku.barcode,
+        sku.productCategory,
+        sku.productName,
+        sku.colorName,
+        sku.size,
+        sku.length === null || sku.length === undefined
+          ? undefined
+          : String(sku.length),
+      ]),
+    ],
+    query,
   );
 }

--- a/packages/athena-webapp/src/components/services/ServiceCatalogView.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceCatalogView.tsx
@@ -33,62 +33,25 @@ import {
 } from "@/lib/errors/runCommand";
 import { presentCommandToast } from "@/lib/errors/presentCommandToast";
 import { getOrigin } from "@/lib/navigationUtils";
-import { cn, toSlug } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
-import { toDisplayAmount } from "~/convex/lib/currency";
-import { parseDisplayAmountInput } from "~/src/lib/pos/displayAmounts";
 import { currencyDisplaySymbol } from "~/shared/currencyFormatter";
-
-type ServiceCatalogItem = {
-  _id: string;
-  basePrice?: number;
-  depositType: "none" | "flat" | "percentage";
-  depositValue?: number;
-  description?: string;
-  durationMinutes: number;
-  name: string;
-  pricingModel: "fixed" | "starting_at" | "quote_after_consultation";
-  requiresManagerApproval: boolean;
-  serviceMode: "same_day" | "consultation" | "repair" | "revamp";
-  status: "active" | "archived";
-};
-
-type ServiceCatalogFormState = {
-  basePrice: string;
-  depositType: "none" | "flat" | "percentage";
-  depositValue: string;
-  description: string;
-  durationMinutes: string;
-  name: string;
-  pricingModel: "fixed" | "starting_at" | "quote_after_consultation";
-  requiresManagerApproval: boolean;
-  serviceMode: "same_day" | "consultation" | "repair" | "revamp";
-};
-
-type CreateServiceCatalogArgs = Omit<ServiceCatalogItem, "_id" | "status">;
-
-type UpdateServiceCatalogArgs = Partial<CreateServiceCatalogArgs> & {
-  serviceCatalogId: string;
-};
-
-const serviceModeLabels: Record<ServiceCatalogItem["serviceMode"], string> = {
-  consultation: "Consultation",
-  repair: "Repair",
-  revamp: "Revamp",
-  same_day: "Same-day",
-};
-
-const depositTypeLabels: Record<ServiceCatalogItem["depositType"], string> = {
-  flat: "Flat deposit",
-  none: "No deposit",
-  percentage: "Percentage deposit",
-};
-
-const serviceStatusLabels: Record<ServiceCatalogItem["status"], string> = {
-  active: "Active",
-  archived: "Archived",
-};
+import {
+  type CreateServiceCatalogArgs,
+  type ServiceCatalogFormState,
+  type ServiceCatalogItem,
+  type UpdateServiceCatalogArgs,
+  depositTypeLabels,
+  formatServiceCatalogName,
+  initialServiceCatalogFormState,
+  itemToServiceCatalogFormState,
+  parseServiceCatalogCreateForm,
+  parseServiceCatalogUpdateForm,
+  serviceModeLabels,
+  serviceStatusLabels,
+  validateServiceCatalogForm,
+} from "./serviceCatalogForm";
 
 const serviceStatusBadgeClasses: Record<ServiceCatalogItem["status"], string> =
   {
@@ -100,127 +63,6 @@ const serviceStatusDotClasses: Record<ServiceCatalogItem["status"], string> = {
   active: "bg-success",
   archived: "bg-muted-foreground",
 };
-
-function formatServiceCatalogName(name: string) {
-  const trimmedName = name.trim();
-
-  if (!trimmedName) {
-    return trimmedName;
-  }
-
-  return `${trimmedName[0].toUpperCase()}${trimmedName.slice(1)}`;
-}
-
-const initialFormState: ServiceCatalogFormState = {
-  basePrice: "",
-  depositType: "none",
-  depositValue: "",
-  description: "",
-  durationMinutes: "",
-  name: "",
-  pricingModel: "fixed",
-  requiresManagerApproval: false,
-  serviceMode: "same_day",
-};
-
-function validateServiceCatalogForm({
-  editingId,
-  form,
-  items,
-}: {
-  editingId: string | null;
-  form: ServiceCatalogFormState;
-  items: ServiceCatalogItem[];
-}) {
-  const errors: string[] = [];
-  const parsedDuration = Number(form.durationMinutes);
-  const serviceNameKey = toSlug(form.name);
-
-  if (!form.name.trim()) {
-    errors.push("Service name is required");
-  }
-
-  if (
-    serviceNameKey &&
-    items.some(
-      (item) => item._id !== editingId && toSlug(item.name) === serviceNameKey,
-    )
-  ) {
-    errors.push("A service catalog item with this name already exists.");
-  }
-
-  if (
-    !form.durationMinutes.trim() ||
-    Number.isNaN(parsedDuration) ||
-    parsedDuration <= 0
-  ) {
-    errors.push("Duration must be greater than zero");
-  }
-
-  if (
-    form.basePrice.trim() &&
-    parseDisplayAmountInput(form.basePrice) === undefined
-  ) {
-    errors.push("Base price must be a valid amount");
-  }
-
-  if (
-    form.depositValue.trim() &&
-    form.depositType === "flat" &&
-    parseDisplayAmountInput(form.depositValue) === undefined
-  ) {
-    errors.push("Deposit value must be a valid amount");
-  }
-
-  return errors;
-}
-
-function itemToFormState(item: ServiceCatalogItem): ServiceCatalogFormState {
-  return {
-    basePrice:
-      item.basePrice === undefined
-        ? ""
-        : toDisplayAmount(item.basePrice).toString(),
-    depositType: item.depositType,
-    depositValue:
-      item.depositValue === undefined
-        ? ""
-        : item.depositType === "flat"
-          ? toDisplayAmount(item.depositValue).toString()
-          : item.depositValue.toString(),
-    description: item.description ?? "",
-    durationMinutes: item.durationMinutes.toString(),
-    name: item.name,
-    pricingModel: item.pricingModel,
-    requiresManagerApproval: item.requiresManagerApproval,
-    serviceMode: item.serviceMode,
-  };
-}
-
-function parseServiceCatalogForm(
-  form: ServiceCatalogFormState,
-): CreateServiceCatalogArgs {
-  const basePrice = form.basePrice.trim()
-    ? parseDisplayAmountInput(form.basePrice)
-    : undefined;
-  const depositValue = form.depositValue.trim()
-    ? form.depositType === "percentage"
-      ? Number(form.depositValue)
-      : parseDisplayAmountInput(form.depositValue)
-    : undefined;
-
-  return {
-    basePrice,
-    depositType: form.depositType,
-    depositValue,
-    description: form.description.trim() || undefined,
-    durationMinutes: Number(form.durationMinutes),
-    name: form.name.trim(),
-    pricingModel: form.pricingModel,
-    requiresManagerApproval: form.requiresManagerApproval,
-    serviceMode: form.serviceMode,
-  };
-}
 
 type ServiceCatalogViewContentProps = {
   currency: string;
@@ -249,7 +91,9 @@ export function ServiceCatalogViewContent({
   servicesWorkspaceHref = "#services-workspace",
   onUpdate,
 }: ServiceCatalogViewContentProps) {
-  const [form, setForm] = useState<ServiceCatalogFormState>(initialFormState);
+  const [form, setForm] = useState<ServiceCatalogFormState>(
+    initialServiceCatalogFormState,
+  );
   const [editingId, setEditingId] = useState<string | null>(null);
   const [validationErrors, setValidationErrors] = useState<string[]>([]);
   const currencySymbol = currencyDisplaySymbol(currency);
@@ -301,13 +145,13 @@ export function ServiceCatalogViewContent({
 
   const handleEdit = (item: ServiceCatalogItem) => {
     setEditingId(item._id);
-    setForm(itemToFormState(item));
+    setForm(itemToServiceCatalogFormState(item));
     setValidationErrors([]);
   };
 
   const handleReset = () => {
     setEditingId(null);
-    setForm(initialFormState);
+    setForm(initialServiceCatalogFormState);
     setValidationErrors([]);
   };
 
@@ -319,15 +163,11 @@ export function ServiceCatalogViewContent({
       return;
     }
 
-    const parsedForm = parseServiceCatalogForm(form);
     setValidationErrors([]);
 
     const result = editingId
-      ? await onUpdate({
-          ...parsedForm,
-          serviceCatalogId: editingId,
-        })
-      : await onCreate(parsedForm);
+      ? await onUpdate(parseServiceCatalogUpdateForm(form, editingId))
+      : await onCreate(parseServiceCatalogCreateForm(form));
 
     if (result.kind !== "ok") {
       setValidationErrors([result.error.message]);

--- a/packages/athena-webapp/src/components/services/ServiceIntakeForm.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceIntakeForm.tsx
@@ -1,6 +1,17 @@
+import { useState } from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
 import { Button } from "../ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "../ui/command";
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import {
   Select,
   SelectContent,
@@ -9,6 +20,12 @@ import {
   SelectValue,
 } from "../ui/select";
 import { Textarea } from "../ui/textarea";
+import { cn } from "@/lib/utils";
+import {
+  formatServiceCatalogName,
+  serviceModeLabels,
+  type ServiceCatalogItem,
+} from "./serviceCatalogForm";
 
 export type ServiceIntakeCustomerResult = {
   _id: string;
@@ -23,6 +40,11 @@ export type ServiceIntakeStaffOption = {
   phoneNumber?: string;
   roles: string[];
 };
+
+export type ServiceIntakeCatalogOption = Pick<
+  ServiceCatalogItem,
+  "_id" | "durationMinutes" | "name" | "serviceMode"
+>;
 
 export type ServiceIntakeFormState = {
   assignedStaffProfileId: string;
@@ -41,6 +63,7 @@ export type ServiceIntakeFormState = {
 };
 
 type ServiceIntakeFormProps = {
+  catalogOptions: ServiceIntakeCatalogOption[];
   customerResults: ServiceIntakeCustomerResult[];
   form: ServiceIntakeFormState;
   isSubmitting: boolean;
@@ -56,7 +79,96 @@ type ServiceIntakeFormProps = {
   validationErrors: string[];
 };
 
+function ServiceCatalogSelect({
+  catalogOptions,
+  onChange,
+  value,
+}: {
+  catalogOptions: ServiceIntakeCatalogOption[];
+  onChange: (value: string) => void;
+  value: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const selectedCatalogItem = catalogOptions.find(
+    (item) => item.name === value,
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          aria-expanded={open}
+          aria-label="Service title"
+          className="h-10 w-full justify-between px-3 py-2 text-left font-normal"
+          id="service-title"
+          role="combobox"
+          type="button"
+          variant="outline"
+        >
+          <span
+            className={cn(
+              "truncate",
+              selectedCatalogItem ? "text-foreground" : "text-muted-foreground",
+            )}
+          >
+            {selectedCatalogItem
+              ? formatServiceCatalogName(selectedCatalogItem.name)
+              : "Select service"}
+          </span>
+          <ChevronsUpDown
+            aria-hidden="true"
+            className="ml-2 h-4 w-4 shrink-0 opacity-50"
+          />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-[--radix-popover-trigger-width] p-0">
+        <Command>
+          <CommandInput placeholder="Search services..." />
+          <CommandList>
+            <CommandEmpty>No service found</CommandEmpty>
+            <CommandGroup heading="Services">
+              {catalogOptions.map((item) => (
+                <CommandItem
+                  key={item._id}
+                  onSelect={() => {
+                    onChange(item.name);
+                    setOpen(false);
+                  }}
+                  value={[
+                    item.name,
+                    serviceModeLabels[item.serviceMode],
+                    `${item.durationMinutes} minutes`,
+                  ].join(" ")}
+                >
+                  <Check
+                    aria-hidden="true"
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      selectedCatalogItem?._id === item._id
+                        ? "opacity-100"
+                        : "opacity-0",
+                    )}
+                  />
+                  <span className="flex min-w-0 flex-col">
+                    <span className="truncate font-medium">
+                      {formatServiceCatalogName(item.name)}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {`${item.durationMinutes} min · ${serviceModeLabels[item.serviceMode]}`}
+                    </span>
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
 export function ServiceIntakeForm({
+  catalogOptions,
   customerResults,
   form,
   isSubmitting,
@@ -158,6 +270,7 @@ export function ServiceIntakeForm({
                   onChange("customerPhoneNumber", event.target.value)
                 }
                 placeholder="+233 20 000 0000"
+                required
                 value={form.customerPhoneNumber}
               />
             </div>
@@ -189,12 +302,9 @@ export function ServiceIntakeForm({
           <div className="grid gap-layout-md sm:grid-cols-2">
             <div className="space-y-2 sm:col-span-2">
               <Label htmlFor="service-title">Service title</Label>
-              <Input
-                id="service-title"
-                onChange={(event) =>
-                  onChange("serviceTitle", event.target.value)
-                }
-                placeholder="Wash and restyle closure wig"
+              <ServiceCatalogSelect
+                catalogOptions={catalogOptions}
+                onChange={(value) => onChange("serviceTitle", value)}
                 value={form.serviceTitle}
               />
             </div>
@@ -214,9 +324,6 @@ export function ServiceIntakeForm({
                   {staffOptions.map((staff) => (
                     <SelectItem key={staff._id} value={staff._id}>
                       {staff.fullName}
-                      {staff.roles.length > 0
-                        ? ` · ${staff.roles.join(", ")}`
-                        : ""}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/packages/athena-webapp/src/components/services/ServiceIntakeView.auth.test.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceIntakeView.auth.test.tsx
@@ -54,6 +54,11 @@ async function chooseSelectOption(
 describe("ServiceIntakeView auth readiness", () => {
   beforeEach(() => {
     window.scrollTo = vi.fn();
+    globalThis.ResizeObserver = vi.fn().mockImplementation(() => ({
+      disconnect: vi.fn(),
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+    }));
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.clearAllMocks();
     mockedHooks.useAuth.mockReturnValue({
@@ -83,6 +88,7 @@ describe("ServiceIntakeView auth readiness", () => {
     expect(mockedHooks.useQuery.mock.calls.map(([, args]) => args)).toEqual([
       "skip",
       "skip",
+      "skip",
     ]);
   });
 
@@ -99,6 +105,7 @@ describe("ServiceIntakeView auth readiness", () => {
     expect(mockedHooks.useQuery.mock.calls.map(([, args]) => args)).toEqual([
       "skip",
       "skip",
+      "skip",
     ]);
   });
 
@@ -112,6 +119,7 @@ describe("ServiceIntakeView auth readiness", () => {
     expect(mockedHooks.useQuery.mock.calls.map(([, args]) => args)).toEqual([
       "skip",
       { storeId: "store-1" },
+      { status: "active", storeId: "store-1" },
     ]);
   });
 
@@ -124,6 +132,17 @@ describe("ServiceIntakeView auth readiness", () => {
     mockedHooks.useQuery.mockImplementation((_, args) => {
       if (args === "skip") {
         return undefined;
+      }
+
+      if ("status" in args) {
+        return [
+          {
+            _id: "catalog-1",
+            durationMinutes: 60,
+            name: "Wash and restyle closure wig",
+            serviceMode: "same_day",
+          },
+        ];
       }
 
       return [
@@ -139,10 +158,8 @@ describe("ServiceIntakeView auth readiness", () => {
     render(<ServiceIntakeView />);
 
     await user.type(screen.getByLabelText(/customer name/i), "Ama Mensah");
-    await user.type(
-      screen.getByLabelText(/service title/i),
-      "Wash and restyle closure wig",
-    );
+    await user.type(screen.getByLabelText(/phone/i), "+233200000001");
+    await chooseSelectOption(user, /service title/i, /wash and restyle closure wig/i);
     await chooseSelectOption(user, /assigned staff/i, /adjoa tetteh/i);
 
     await user.click(screen.getByRole("button", { name: /create intake/i }));

--- a/packages/athena-webapp/src/components/services/ServiceIntakeView.test.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceIntakeView.test.tsx
@@ -13,6 +13,20 @@ vi.mock("sonner", () => ({
 }));
 
 const baseProps = {
+  catalogOptions: [
+    {
+      _id: "catalog-1",
+      durationMinutes: 90,
+      name: "Wash and restyle closure wig",
+      serviceMode: "same_day" as const,
+    },
+    {
+      _id: "catalog-2",
+      durationMinutes: 30,
+      name: "Closure consultation",
+      serviceMode: "consultation" as const,
+    },
+  ],
   customerResults: [] as {
     _id: string;
     email?: string;
@@ -53,9 +67,22 @@ async function chooseSelectOption(
   await user.click(await screen.findByRole("option", { name: option }));
 }
 
+async function chooseServiceCatalogOption(
+  user: ReturnType<typeof userEvent.setup>,
+  option: RegExp,
+) {
+  await user.click(screen.getByRole("combobox", { name: /service title/i }));
+  await user.click(await screen.findByText(option));
+}
+
 describe("ServiceIntakeViewContent", () => {
   beforeEach(() => {
     window.scrollTo = vi.fn();
+    globalThis.ResizeObserver = vi.fn().mockImplementation(() => ({
+      disconnect: vi.fn(),
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+    }));
     vi.clearAllMocks();
   });
 
@@ -78,6 +105,8 @@ describe("ServiceIntakeViewContent", () => {
     expect(
       screen.getByText("A customer name is required when no customer is linked."),
     ).toBeInTheDocument();
+    expect(screen.getByText("Customer phone number is required."))
+      .toBeInTheDocument();
   });
 
   it("submits a linked-customer intake with a parsed deposit", async () => {
@@ -107,10 +136,7 @@ describe("ServiceIntakeViewContent", () => {
     );
 
     await user.click(screen.getByRole("button", { name: /use customer/i }));
-    await user.type(
-      screen.getByLabelText(/service title/i),
-      "Wash and restyle closure wig",
-    );
+    await chooseServiceCatalogOption(user, /^wash and restyle closure wig$/i);
     await chooseSelectOption(user, /assigned staff/i, /adjoa tetteh/i);
     await user.type(screen.getByLabelText(/deposit amount/i), "45.25");
     await chooseSelectOption(user, /deposit method/i, /^card$/i);
@@ -146,7 +172,9 @@ describe("ServiceIntakeViewContent", () => {
       storeId: "store-1",
     });
     expect(toast.success).toHaveBeenCalledWith("Service intake created");
-    expect(screen.getByLabelText(/service title/i)).toHaveValue("");
+    expect(
+      screen.getByRole("combobox", { name: /service title/i }),
+    ).toHaveTextContent("Select service");
   });
 
   it("renders safe user_error copy inline and clears stale validation errors before submit", async () => {
@@ -171,10 +199,8 @@ describe("ServiceIntakeViewContent", () => {
     expect(screen.getByText("An assignee is required.")).toBeInTheDocument();
 
     await user.type(screen.getByLabelText(/customer name/i), "Ama Mensah");
-    await user.type(
-      screen.getByLabelText(/service title/i),
-      "Wash and restyle closure wig",
-    );
+    await user.type(screen.getByLabelText(/phone number/i), "+233200000000");
+    await chooseServiceCatalogOption(user, /^wash and restyle closure wig$/i);
     await chooseSelectOption(user, /assigned staff/i, /adjoa tetteh/i);
 
     await user.click(screen.getByRole("button", { name: /create intake/i }));
@@ -186,6 +212,8 @@ describe("ServiceIntakeViewContent", () => {
     expect(
       screen.queryByText("A customer name is required when no customer is linked."),
     ).not.toBeInTheDocument();
+    expect(screen.queryByText("Customer phone number is required."))
+      .not.toBeInTheDocument();
     expect(screen.queryByText("An assignee is required.")).not.toBeInTheDocument();
     expect(screen.queryByText("A service title is required.")).not.toBeInTheDocument();
     expect(toast.error).not.toHaveBeenCalled();
@@ -210,10 +238,8 @@ describe("ServiceIntakeViewContent", () => {
     );
 
     await user.type(screen.getByLabelText(/customer name/i), "Ama Mensah");
-    await user.type(
-      screen.getByLabelText(/service title/i),
-      "Wash and restyle closure wig",
-    );
+    await user.type(screen.getByLabelText(/phone number/i), "+233200000000");
+    await chooseServiceCatalogOption(user, /^wash and restyle closure wig$/i);
     await chooseSelectOption(user, /assigned staff/i, /adjoa tetteh/i);
 
     await user.click(screen.getByRole("button", { name: /create intake/i }));
@@ -233,5 +259,29 @@ describe("ServiceIntakeViewContent", () => {
     );
 
     expect(screen.getByText("Access Denied")).toBeInTheDocument();
+  });
+
+  it("uses a filterable catalog select for service title and omits staff roles", async () => {
+    const user = userEvent.setup();
+
+    render(<ServiceIntakeViewContent {...baseProps} />);
+
+    await user.click(screen.getByRole("combobox", { name: /service title/i }));
+    await user.type(screen.getByPlaceholderText(/search services/i), "consultation");
+
+    expect(await screen.findByText("Closure consultation")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Wash and restyle closure wig"),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByText("Closure consultation"));
+    expect(
+      screen.getByRole("combobox", { name: /service title/i }),
+    ).toHaveTextContent("Closure consultation");
+
+    await user.click(screen.getByRole("combobox", { name: /assigned staff/i }));
+    expect(await screen.findByRole("option", { name: "Adjoa Tetteh" }))
+      .toBeInTheDocument();
+    expect(screen.queryByText(/stylist/i)).not.toBeInTheDocument();
   });
 });

--- a/packages/athena-webapp/src/components/services/ServiceIntakeView.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceIntakeView.tsx
@@ -18,6 +18,7 @@ import { Id } from "~/convex/_generated/dataModel";
 import { parseDisplayAmountInput } from "~/src/lib/pos/displayAmounts";
 import {
   ServiceIntakeCustomerResult,
+  ServiceIntakeCatalogOption,
   ServiceIntakeForm,
   ServiceIntakeFormState,
   ServiceIntakeStaffOption,
@@ -42,6 +43,7 @@ const initialFormState: ServiceIntakeFormState = {
 };
 
 type ServiceIntakeViewContentProps = {
+  catalogOptions: ServiceIntakeCatalogOption[] | undefined;
   customerResults: ServiceIntakeCustomerResult[];
   hasFullAdminAccess: boolean;
   isLoadingPermissions: boolean;
@@ -82,6 +84,7 @@ type CreateServiceIntakeResult = {
 };
 
 export function ServiceIntakeViewContent({
+  catalogOptions,
   customerResults,
   hasFullAdminAccess,
   isLoadingPermissions,
@@ -104,7 +107,7 @@ export function ServiceIntakeViewContent({
     return <NoPermissionView />;
   }
 
-  if (!staffOptions) {
+  if (!staffOptions || !catalogOptions) {
     return null;
   }
 
@@ -141,6 +144,7 @@ export function ServiceIntakeViewContent({
     const errors = validateServiceIntakeInput({
       assignedStaffProfileId: form.assignedStaffProfileId,
       customerFullName: form.customerFullName,
+      customerPhoneNumber: form.customerPhoneNumber,
       customerProfileId: form.selectedCustomerId,
       depositAmount: hasInvalidDepositAmount ? 0 : parsedDepositAmount,
       depositMethod: form.depositMethod || undefined,
@@ -196,6 +200,7 @@ export function ServiceIntakeViewContent({
             description="Capture walk-in or booked service work with the customer, staff owner, priority, and deposit details ready for operations."
           />
           <ServiceIntakeForm
+            catalogOptions={catalogOptions}
             customerResults={customerResults}
             form={form}
             isSubmitting={isSubmitting}
@@ -237,6 +242,12 @@ export function ServiceIntakeView() {
     operationsApi.serviceIntake.listAssignableStaff,
     canQueryProtectedData ? { storeId: activeStore!._id } : "skip",
   ) as ServiceIntakeStaffOption[] | undefined;
+  const catalogOptions = useQuery(
+    api.serviceOps.catalog.listServiceCatalogItems,
+    canQueryProtectedData
+      ? { status: "active", storeId: activeStore!._id }
+      : "skip",
+  ) as ServiceIntakeCatalogOption[] | undefined;
 
   const createServiceIntake = useMutation(
     operationsApi.serviceIntake.createServiceIntake,
@@ -280,6 +291,7 @@ export function ServiceIntakeView() {
 
   return (
     <ServiceIntakeViewContent
+      catalogOptions={catalogOptions}
       customerResults={customerResults ?? []}
       hasFullAdminAccess={hasFullAdminAccess}
       isLoadingPermissions={false}

--- a/packages/athena-webapp/src/components/services/ServicesWorkspaceView.test.tsx
+++ b/packages/athena-webapp/src/components/services/ServicesWorkspaceView.test.tsx
@@ -1,6 +1,7 @@
 import type { AnchorHTMLAttributes, ReactNode } from "react";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ServicesWorkspaceViewContent } from "./ServicesWorkspaceView";
 
@@ -23,6 +24,21 @@ vi.mock("@tanstack/react-router", () => ({
 vi.mock("~/src/hooks/use-navigate-back", () => ({
   useNavigateBack: () => () => null,
 }));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+  },
+}));
+
+async function chooseSelectOption(
+  user: ReturnType<typeof userEvent.setup>,
+  label: RegExp,
+  option: RegExp,
+) {
+  await user.click(screen.getByRole("combobox", { name: label }));
+  await user.click(await screen.findByRole("option", { name: option }));
+}
 
 const baseItems = [
   {
@@ -146,5 +162,43 @@ describe("ServicesWorkspaceViewContent", () => {
     expect(within(directory).getByText("Page 2 of 2")).toBeInTheDocument();
     expect(within(directory).queryByText("Service 08")).not.toBeInTheDocument();
     expect(within(directory).getByText("Service 09")).toBeInTheDocument();
+  });
+
+  it("loads the selected service into an edit form and saves catalog changes", async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn().mockResolvedValue({ kind: "ok", data: null });
+
+    render(
+      <ServicesWorkspaceViewContent
+        currency="GHS"
+        items={baseItems}
+        onUpdate={onUpdate}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /edit service/i }));
+
+    expect(screen.getByLabelText(/service name/i)).toHaveValue(
+      "closure repair",
+    );
+    expect(screen.getByLabelText(/base price/i)).toHaveValue("300.5");
+    expect(screen.getByLabelText(/deposit value/i)).toHaveValue("100");
+
+    await user.clear(screen.getByLabelText(/service name/i));
+    await user.type(screen.getByLabelText(/service name/i), "Closure Cleanup");
+    await chooseSelectOption(user, /deposit rule/i, /no deposit/i);
+    expect(screen.getByLabelText(/deposit value/i)).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1));
+    expect(onUpdate.mock.calls[0][0]).toMatchObject({
+      basePrice: 30050,
+      depositType: "none",
+      depositValue: null,
+      name: "Closure Cleanup",
+      serviceCatalogId: "catalog-1",
+    });
+    expect(toast.success).toHaveBeenCalledWith("Service updated");
   });
 });

--- a/packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx
+++ b/packages/athena-webapp/src/components/services/ServicesWorkspaceView.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useParams } from "@tanstack/react-router";
-import { useQuery } from "convex/react";
-import { ArrowUpRight } from "lucide-react";
+import { useMutation, useQuery } from "convex/react";
+import { ArrowUpRight, Pencil } from "lucide-react";
+import { toast } from "sonner";
 import View from "../View";
 import { FadeIn } from "../common/FadeIn";
 import { ListPagination } from "../common/ListPagination";
@@ -17,49 +18,42 @@ import { NoPermissionView } from "../states/no-permission/NoPermissionView";
 import { ProtectedAdminSignInView } from "../states/signed-out/ProtectedAdminSignInView";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+import { Textarea } from "../ui/textarea";
 import { useProtectedAdminPageState } from "@/hooks/useProtectedAdminPageState";
+import {
+  type NormalizedCommandResult,
+  runCommand,
+} from "@/lib/errors/runCommand";
 import { cn } from "@/lib/utils";
 import { api } from "~/convex/_generated/api";
+import type { Id } from "~/convex/_generated/dataModel";
 import { toDisplayAmount } from "~/convex/lib/currency";
-import { currencyFormatter } from "~/shared/currencyFormatter";
-
-type ServiceCatalogItem = {
-  _id: string;
-  basePrice?: number;
-  depositType: "none" | "flat" | "percentage";
-  depositValue?: number;
-  description?: string;
-  durationMinutes: number;
-  name: string;
-  pricingModel: "fixed" | "starting_at" | "quote_after_consultation";
-  requiresManagerApproval: boolean;
-  serviceMode: "same_day" | "consultation" | "repair" | "revamp";
-  status: "active" | "archived";
-};
-
-const serviceModeLabels: Record<ServiceCatalogItem["serviceMode"], string> = {
-  consultation: "Consultation",
-  repair: "Repair",
-  revamp: "Revamp",
-  same_day: "Same-day",
-};
-
-const pricingModelLabels: Record<ServiceCatalogItem["pricingModel"], string> = {
-  fixed: "Fixed price",
-  quote_after_consultation: "Quote after consultation",
-  starting_at: "Starting at",
-};
-
-const depositTypeLabels: Record<ServiceCatalogItem["depositType"], string> = {
-  flat: "Flat deposit",
-  none: "No deposit",
-  percentage: "Percentage deposit",
-};
-
-const serviceStatusLabels: Record<ServiceCatalogItem["status"], string> = {
-  active: "Active",
-  archived: "Archived",
-};
+import {
+  currencyDisplaySymbol,
+  currencyFormatter,
+} from "~/shared/currencyFormatter";
+import {
+  type ServiceCatalogFormState,
+  type ServiceCatalogItem,
+  type UpdateServiceCatalogArgs,
+  depositTypeLabels,
+  formatServiceCatalogName,
+  initialServiceCatalogFormState,
+  itemToServiceCatalogFormState,
+  parseServiceCatalogUpdateForm,
+  pricingModelLabels,
+  serviceModeLabels,
+  serviceStatusLabels,
+  validateServiceCatalogForm,
+} from "./serviceCatalogForm";
 
 const serviceStatusClasses: Record<ServiceCatalogItem["status"], string> = {
   active: "border-success/30 bg-success/10 text-success",
@@ -67,16 +61,6 @@ const serviceStatusClasses: Record<ServiceCatalogItem["status"], string> = {
 };
 
 const SERVICES_PAGE_SIZE = 8;
-
-function formatServiceCatalogName(name: string) {
-  const trimmedName = name.trim();
-
-  if (!trimmedName) {
-    return trimmedName;
-  }
-
-  return `${trimmedName[0].toUpperCase()}${trimmedName.slice(1)}`;
-}
 
 function formatMoney(currency: string, value?: number) {
   if (value === undefined) {
@@ -128,22 +112,246 @@ function DetailRow({ label, value }: { label: string; value: string }) {
   );
 }
 
+function ServiceEditForm({
+  currency,
+  form,
+  isSaving,
+  onCancel,
+  onChange,
+  onSave,
+  validationErrors,
+}: {
+  currency: string;
+  form: ServiceCatalogFormState;
+  isSaving: boolean;
+  onCancel: () => void;
+  onChange: <K extends keyof ServiceCatalogFormState>(
+    field: K,
+    value: ServiceCatalogFormState[K],
+  ) => void;
+  onSave: () => void;
+  validationErrors: string[];
+}) {
+  const currencySymbol = currencyDisplaySymbol(currency);
+  const isDepositValueDisabled = form.depositType === "none";
+  const depositValueLabel =
+    form.depositType === "percentage"
+      ? "Deposit value (%)"
+      : form.depositType === "flat"
+        ? `Deposit value (${currencySymbol})`
+        : "Deposit value";
+  const depositValuePlaceholder =
+    form.depositType === "percentage"
+      ? "20"
+      : form.depositType === "flat"
+        ? `${currencySymbol}0.00`
+        : "";
+
+  return (
+    <div className="space-y-layout-lg">
+      {validationErrors.length > 0 ? (
+        <div className="rounded-lg border border-danger/30 bg-danger/10 px-layout-md py-layout-sm text-sm text-danger">
+          <ul className="list-disc pl-5">
+            {validationErrors.map((error) => (
+              <li key={error}>{error}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <div className="space-y-layout-md">
+        <div className="space-y-2">
+          <Label htmlFor="service-edit-name">Service name</Label>
+          <Input
+            id="service-edit-name"
+            onChange={(event) => onChange("name", event.target.value)}
+            value={form.name}
+          />
+        </div>
+
+        <div className="grid gap-layout-md sm:grid-cols-2">
+          <div className="space-y-2">
+            <Label htmlFor="service-edit-duration">Duration (minutes)</Label>
+            <Input
+              id="service-edit-duration"
+              inputMode="numeric"
+              onChange={(event) =>
+                onChange("durationMinutes", event.target.value)
+              }
+              value={form.durationMinutes}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="service-edit-mode">Service mode</Label>
+            <Select
+              onValueChange={(value) =>
+                onChange(
+                  "serviceMode",
+                  value as ServiceCatalogFormState["serviceMode"],
+                )
+              }
+              value={form.serviceMode}
+            >
+              <SelectTrigger aria-label="Service mode" id="service-edit-mode">
+                <SelectValue placeholder="Select service mode" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="same_day">Same-day</SelectItem>
+                <SelectItem value="consultation">Consultation</SelectItem>
+                <SelectItem value="repair">Repair</SelectItem>
+                <SelectItem value="revamp">Revamp</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="service-edit-pricing">Pricing model</Label>
+            <Select
+              onValueChange={(value) =>
+                onChange(
+                  "pricingModel",
+                  value as ServiceCatalogFormState["pricingModel"],
+                )
+              }
+              value={form.pricingModel}
+            >
+              <SelectTrigger
+                aria-label="Pricing model"
+                id="service-edit-pricing"
+              >
+                <SelectValue placeholder="Select pricing model" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="fixed">Fixed</SelectItem>
+                <SelectItem value="starting_at">Starting at</SelectItem>
+                <SelectItem value="quote_after_consultation">
+                  Quote after consultation
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="service-edit-base-price">
+              Base price ({currencySymbol})
+            </Label>
+            <Input
+              id="service-edit-base-price"
+              inputMode="numeric"
+              onChange={(event) => onChange("basePrice", event.target.value)}
+              placeholder={`${currencySymbol}0.00`}
+              value={form.basePrice}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="service-edit-deposit-rule">Deposit rule</Label>
+            <Select
+              onValueChange={(value) =>
+                onChange(
+                  "depositType",
+                  value as ServiceCatalogFormState["depositType"],
+                )
+              }
+              value={form.depositType}
+            >
+              <SelectTrigger
+                aria-label="Deposit rule"
+                id="service-edit-deposit-rule"
+              >
+                <SelectValue placeholder="Select deposit rule" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">No deposit</SelectItem>
+                <SelectItem value="flat">Flat deposit</SelectItem>
+                <SelectItem value="percentage">Percentage deposit</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="service-edit-deposit-value">
+              {depositValueLabel}
+            </Label>
+            <Input
+              disabled={isDepositValueDisabled}
+              id="service-edit-deposit-value"
+              inputMode={
+                form.depositType === "percentage" ? "decimal" : "numeric"
+              }
+              onChange={(event) => onChange("depositValue", event.target.value)}
+              placeholder={depositValuePlaceholder}
+              value={form.depositValue}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="service-edit-description">Description</Label>
+          <Textarea
+            id="service-edit-description"
+            onChange={(event) => onChange("description", event.target.value)}
+            value={form.description}
+          />
+        </div>
+
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            checked={form.requiresManagerApproval}
+            onChange={(event) =>
+              onChange("requiresManagerApproval", event.target.checked)
+            }
+            type="checkbox"
+          />
+          Require manager approval
+        </label>
+      </div>
+
+      <div className="flex flex-wrap gap-3">
+        <Button
+          disabled={isSaving}
+          onClick={onSave}
+          type="button"
+          variant="workflow"
+        >
+          Save changes
+        </Button>
+        <Button onClick={onCancel} type="button" variant="outline">
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 type ServicesWorkspaceViewContentProps = {
   catalogManagementHref?: string;
   currency: string;
+  isSaving?: boolean;
   items: ServiceCatalogItem[];
+  onUpdate?: (
+    args: UpdateServiceCatalogArgs,
+  ) => Promise<NormalizedCommandResult<ServiceCatalogItem | null>>;
 };
 
 export function ServicesWorkspaceViewContent({
   catalogManagementHref = "#catalog-management",
   currency,
+  isSaving = false,
   items,
+  onUpdate,
 }: ServicesWorkspaceViewContentProps) {
   const [query, setQuery] = useState("");
   const [selectedServiceId, setSelectedServiceId] = useState<string | null>(
     null,
   );
   const [page, setPage] = useState(1);
+  const [isEditing, setIsEditing] = useState(false);
+  const [form, setForm] = useState<ServiceCatalogFormState>(
+    initialServiceCatalogFormState,
+  );
+  const [validationErrors, setValidationErrors] = useState<string[]>([]);
   const sortedItems = useMemo(() => sortServices(items), [items]);
   const activeServices = useMemo(
     () => sortedItems.filter((item) => item.status === "active"),
@@ -208,6 +416,75 @@ export function ServicesWorkspaceViewContent({
 
     setSelectedServiceId(paginatedItems[0]?._id ?? null);
   }, [paginatedItems, selectedServiceId]);
+
+  useEffect(() => {
+    setIsEditing(false);
+    setForm(initialServiceCatalogFormState);
+    setValidationErrors([]);
+  }, [selectedServiceId]);
+
+  const handleSelectService = (serviceCatalogId: string) => {
+    setSelectedServiceId(serviceCatalogId);
+  };
+
+  const handleChange = <K extends keyof ServiceCatalogFormState>(
+    field: K,
+    value: ServiceCatalogFormState[K],
+  ) => {
+    setForm((current) => ({
+      ...current,
+      [field]: value,
+      ...(field === "depositType" && value === "none"
+        ? { depositValue: "" }
+        : null),
+    }));
+  };
+
+  const handleEdit = () => {
+    if (!selectedService) {
+      return;
+    }
+
+    setForm(itemToServiceCatalogFormState(selectedService));
+    setValidationErrors([]);
+    setIsEditing(true);
+  };
+
+  const handleCancelEdit = () => {
+    setIsEditing(false);
+    setForm(initialServiceCatalogFormState);
+    setValidationErrors([]);
+  };
+
+  const handleSaveEdit = async () => {
+    if (!selectedService || !onUpdate) {
+      return;
+    }
+
+    const errors = validateServiceCatalogForm({
+      editingId: selectedService._id,
+      form,
+      items,
+    });
+
+    if (errors.length > 0) {
+      setValidationErrors(errors);
+      return;
+    }
+
+    setValidationErrors([]);
+    const result = await onUpdate(
+      parseServiceCatalogUpdateForm(form, selectedService._id),
+    );
+
+    if (result.kind !== "ok") {
+      setValidationErrors([result.error.message]);
+      return;
+    }
+
+    toast.success("Service updated");
+    handleCancelEdit();
+  };
 
   return (
     <View hideBorder hideHeaderBottomBorder scrollMode="page">
@@ -288,7 +565,7 @@ export function ServicesWorkspaceViewContent({
                                 : null,
                             )}
                             key={item._id}
-                            onClick={() => setSelectedServiceId(item._id)}
+                            onClick={() => handleSelectService(item._id)}
                             type="button"
                           >
                             <div className="flex items-start justify-between gap-layout-md">
@@ -344,6 +621,16 @@ export function ServicesWorkspaceViewContent({
                     description="Choose a service to review its details."
                     title="No service selected"
                   />
+                ) : isEditing ? (
+                  <ServiceEditForm
+                    currency={currency}
+                    form={form}
+                    isSaving={isSaving}
+                    onCancel={handleCancelEdit}
+                    onChange={handleChange}
+                    onSave={handleSaveEdit}
+                    validationErrors={validationErrors}
+                  />
                 ) : (
                   <div className="space-y-layout-md">
                     <div className="space-y-2">
@@ -393,6 +680,18 @@ export function ServicesWorkspaceViewContent({
                         }
                       />
                     </div>
+
+                    {onUpdate ? (
+                      <Button
+                        className="w-full justify-center"
+                        onClick={handleEdit}
+                        type="button"
+                        variant="workflow"
+                      >
+                        <Pencil aria-hidden="true" />
+                        Edit service
+                      </Button>
+                    ) : null}
                   </div>
                 )}
               </section>
@@ -412,6 +711,7 @@ export function ServicesWorkspaceView() {
     isAuthenticated,
     isLoadingAccess,
   } = useProtectedAdminPageState();
+  const [isSaving, setIsSaving] = useState(false);
   const { orgUrlSlug, storeUrlSlug } = useParams({ strict: false }) as {
     orgUrlSlug?: string;
     storeUrlSlug?: string;
@@ -422,10 +722,21 @@ export function ServicesWorkspaceView() {
       ? { storeId: activeStore._id }
       : "skip",
   ) as ServiceCatalogItem[] | undefined;
+  const updateServiceCatalogItem = useMutation(
+    api.serviceOps.catalog.updateServiceCatalogItem,
+  );
   const catalogManagementHref =
     orgUrlSlug && storeUrlSlug
       ? `/${orgUrlSlug}/store/${storeUrlSlug}/services/catalog-management`
       : "#catalog-management";
+  const withSaveState = async <T,>(action: () => Promise<T>) => {
+    setIsSaving(true);
+    try {
+      return await action();
+    } finally {
+      setIsSaving(false);
+    }
+  };
 
   if (isLoadingAccess) {
     return null;
@@ -458,7 +769,18 @@ export function ServicesWorkspaceView() {
     <ServicesWorkspaceViewContent
       catalogManagementHref={catalogManagementHref}
       currency={activeStore.currency}
+      isSaving={isSaving}
       items={items ?? []}
+      onUpdate={(args) =>
+        withSaveState(() =>
+          runCommand(() =>
+            updateServiceCatalogItem({
+              ...args,
+              serviceCatalogId: args.serviceCatalogId as Id<"serviceCatalog">,
+            }),
+          ),
+        )
+      }
     />
   );
 }

--- a/packages/athena-webapp/src/components/services/serviceCatalogForm.ts
+++ b/packages/athena-webapp/src/components/services/serviceCatalogForm.ts
@@ -1,0 +1,216 @@
+import { toDisplayAmount } from "~/convex/lib/currency";
+import { parseDisplayAmountInput } from "~/src/lib/pos/displayAmounts";
+import { toSlug } from "@/lib/utils";
+
+export type ServiceCatalogItem = {
+  _id: string;
+  basePrice?: number;
+  depositType: "none" | "flat" | "percentage";
+  depositValue?: number;
+  description?: string;
+  durationMinutes: number;
+  name: string;
+  pricingModel: "fixed" | "starting_at" | "quote_after_consultation";
+  requiresManagerApproval: boolean;
+  serviceMode: "same_day" | "consultation" | "repair" | "revamp";
+  status: "active" | "archived";
+};
+
+export type ServiceCatalogFormState = {
+  basePrice: string;
+  depositType: "none" | "flat" | "percentage";
+  depositValue: string;
+  description: string;
+  durationMinutes: string;
+  name: string;
+  pricingModel: "fixed" | "starting_at" | "quote_after_consultation";
+  requiresManagerApproval: boolean;
+  serviceMode: "same_day" | "consultation" | "repair" | "revamp";
+};
+
+export type CreateServiceCatalogArgs = Omit<
+  ServiceCatalogItem,
+  "_id" | "status"
+>;
+
+export type UpdateServiceCatalogArgs = Omit<
+  CreateServiceCatalogArgs,
+  "basePrice" | "depositValue" | "description"
+> & {
+  basePrice?: number | null;
+  depositValue?: number | null;
+  description?: string | null;
+  serviceCatalogId: string;
+};
+
+export const serviceModeLabels: Record<
+  ServiceCatalogItem["serviceMode"],
+  string
+> = {
+  consultation: "Consultation",
+  repair: "Repair",
+  revamp: "Revamp",
+  same_day: "Same-day",
+};
+
+export const pricingModelLabels: Record<
+  ServiceCatalogItem["pricingModel"],
+  string
+> = {
+  fixed: "Fixed price",
+  quote_after_consultation: "Quote after consultation",
+  starting_at: "Starting at",
+};
+
+export const depositTypeLabels: Record<
+  ServiceCatalogItem["depositType"],
+  string
+> = {
+  flat: "Flat deposit",
+  none: "No deposit",
+  percentage: "Percentage deposit",
+};
+
+export const serviceStatusLabels: Record<ServiceCatalogItem["status"], string> =
+  {
+    active: "Active",
+    archived: "Archived",
+  };
+
+export const initialServiceCatalogFormState: ServiceCatalogFormState = {
+  basePrice: "",
+  depositType: "none",
+  depositValue: "",
+  description: "",
+  durationMinutes: "",
+  name: "",
+  pricingModel: "fixed",
+  requiresManagerApproval: false,
+  serviceMode: "same_day",
+};
+
+export function formatServiceCatalogName(name: string) {
+  const trimmedName = name.trim();
+
+  if (!trimmedName) {
+    return trimmedName;
+  }
+
+  return `${trimmedName[0].toUpperCase()}${trimmedName.slice(1)}`;
+}
+
+export function validateServiceCatalogForm({
+  editingId,
+  form,
+  items,
+}: {
+  editingId: string | null;
+  form: ServiceCatalogFormState;
+  items: ServiceCatalogItem[];
+}) {
+  const errors: string[] = [];
+  const parsedDuration = Number(form.durationMinutes);
+  const serviceNameKey = toSlug(form.name);
+
+  if (!form.name.trim()) {
+    errors.push("Service name is required");
+  }
+
+  if (
+    serviceNameKey &&
+    items.some(
+      (item) => item._id !== editingId && toSlug(item.name) === serviceNameKey,
+    )
+  ) {
+    errors.push("A service catalog item with this name already exists.");
+  }
+
+  if (
+    !form.durationMinutes.trim() ||
+    Number.isNaN(parsedDuration) ||
+    parsedDuration <= 0
+  ) {
+    errors.push("Duration must be greater than zero");
+  }
+
+  if (
+    form.basePrice.trim() &&
+    parseDisplayAmountInput(form.basePrice) === undefined
+  ) {
+    errors.push("Base price must be a valid amount");
+  }
+
+  if (
+    form.depositValue.trim() &&
+    form.depositType === "flat" &&
+    parseDisplayAmountInput(form.depositValue) === undefined
+  ) {
+    errors.push("Deposit value must be a valid amount");
+  }
+
+  return errors;
+}
+
+export function itemToServiceCatalogFormState(
+  item: ServiceCatalogItem,
+): ServiceCatalogFormState {
+  return {
+    basePrice:
+      item.basePrice === undefined
+        ? ""
+        : toDisplayAmount(item.basePrice).toString(),
+    depositType: item.depositType,
+    depositValue:
+      item.depositValue === undefined
+        ? ""
+        : item.depositType === "flat"
+          ? toDisplayAmount(item.depositValue).toString()
+          : item.depositValue.toString(),
+    description: item.description ?? "",
+    durationMinutes: item.durationMinutes.toString(),
+    name: item.name,
+    pricingModel: item.pricingModel,
+    requiresManagerApproval: item.requiresManagerApproval,
+    serviceMode: item.serviceMode,
+  };
+}
+
+export function parseServiceCatalogCreateForm(
+  form: ServiceCatalogFormState,
+): CreateServiceCatalogArgs {
+  const basePrice = form.basePrice.trim()
+    ? parseDisplayAmountInput(form.basePrice)
+    : undefined;
+  const depositValue = form.depositValue.trim()
+    ? form.depositType === "percentage"
+      ? Number(form.depositValue)
+      : parseDisplayAmountInput(form.depositValue)
+    : undefined;
+
+  return {
+    basePrice,
+    depositType: form.depositType,
+    depositValue,
+    description: form.description.trim() || undefined,
+    durationMinutes: Number(form.durationMinutes),
+    name: form.name.trim(),
+    pricingModel: form.pricingModel,
+    requiresManagerApproval: form.requiresManagerApproval,
+    serviceMode: form.serviceMode,
+  };
+}
+
+export function parseServiceCatalogUpdateForm(
+  form: ServiceCatalogFormState,
+  serviceCatalogId: string,
+): UpdateServiceCatalogArgs {
+  const parsedForm = parseServiceCatalogCreateForm(form);
+
+  return {
+    ...parsedForm,
+    basePrice: parsedForm.basePrice ?? null,
+    depositValue: parsedForm.depositValue ?? null,
+    description: parsedForm.description ?? null,
+    serviceCatalogId,
+  };
+}

--- a/packages/athena-webapp/src/components/stock-ops/SkuSearchFilterBar.tsx
+++ b/packages/athena-webapp/src/components/stock-ops/SkuSearchFilterBar.tsx
@@ -1,0 +1,125 @@
+import type { ReactNode } from "react";
+import { Search, X } from "lucide-react";
+
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Label } from "../ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+import { cn } from "@/lib/utils";
+
+type SkuSearchFilterOption<TValue extends string> = {
+  label: string;
+  value: TValue;
+};
+
+type SkuSearchFilterBarProps<TValue extends string> = {
+  action?: ReactNode;
+  ariaLabel: string;
+  className?: string;
+  clearLabel?: string;
+  filterId: string;
+  filterLabel: string;
+  filterOptions: Array<SkuSearchFilterOption<TValue>>;
+  filterTriggerClassName?: string;
+  filterValue: TValue;
+  hasActiveFilters: boolean;
+  onClearFilters: () => void;
+  onFilterChange: (value: TValue) => void;
+  onQueryChange: (query: string) => void;
+  query: string;
+  scanAction?: ReactNode;
+  searchId: string;
+  searchLabel: string;
+  searchPlaceholder: string;
+  summary: ReactNode;
+};
+
+export function SkuSearchFilterBar<TValue extends string>({
+  action,
+  ariaLabel,
+  className,
+  clearLabel = "Clear",
+  filterId,
+  filterLabel,
+  filterOptions,
+  filterTriggerClassName = "w-[180px]",
+  filterValue,
+  hasActiveFilters,
+  onClearFilters,
+  onFilterChange,
+  onQueryChange,
+  query,
+  scanAction,
+  searchId,
+  searchLabel,
+  searchPlaceholder,
+  summary,
+}: SkuSearchFilterBarProps<TValue>) {
+  return (
+    <section
+      aria-label={ariaLabel}
+      className={cn(
+        "rounded-md border border-border bg-surface-raised px-layout-md py-layout-md",
+        className,
+      )}
+    >
+      <div className="flex flex-col gap-layout-md lg:flex-row lg:items-end lg:justify-between">
+        <div className="min-w-0 flex-1">
+          <Label className="sr-only" htmlFor={searchId}>
+            {searchLabel}
+          </Label>
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              className={scanAction ? "pl-9 pr-12" : "pl-9"}
+              id={searchId}
+              onChange={(event) => onQueryChange(event.target.value)}
+              placeholder={searchPlaceholder}
+              value={query}
+            />
+            {scanAction}
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Label className="sr-only" htmlFor={filterId}>
+            {filterLabel}
+          </Label>
+          <Select
+            onValueChange={(value) => onFilterChange(value as TValue)}
+            value={filterValue}
+          >
+            <SelectTrigger className={filterTriggerClassName} id={filterId}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {filterOptions.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {action}
+          {hasActiveFilters ? (
+            <Button
+              className="text-muted-foreground"
+              onClick={onClearFilters}
+              type="button"
+              variant="outline"
+            >
+              <X className="h-4 w-4" />
+              {clearLabel}
+            </Button>
+          ) : null}
+        </div>
+      </div>
+      <p className="mt-layout-sm text-xs text-muted-foreground">{summary}</p>
+    </section>
+  );
+}

--- a/packages/athena-webapp/src/contexts/ProductContext.tsx
+++ b/packages/athena-webapp/src/contexts/ProductContext.tsx
@@ -51,7 +51,13 @@ interface AppState {
 
 const ProductContext = createContext<ProductContextType | undefined>(undefined);
 
-export function ProductProvider({ children }: { children: ReactNode }) {
+export function ProductProvider({
+  children,
+  includeArchived = false,
+}: {
+  children: ReactNode;
+  includeArchived?: boolean;
+}) {
   const [productData, setProductData] = useState<Partial<Product>>({
     availability: "live" as const,
   });
@@ -85,7 +91,7 @@ export function ProductProvider({ children }: { children: ReactNode }) {
 
   const { productSlug } = useParams({ strict: false });
 
-  const { activeProduct } = useGetActiveProduct();
+  const { activeProduct } = useGetActiveProduct({ includeArchived });
 
   const updateAppState = (newState: Partial<AppState>) => {
     setAppState((prevState) => ({ ...prevState, ...newState }));
@@ -98,7 +104,7 @@ export function ProductProvider({ children }: { children: ReactNode }) {
           // If there's an active product, mark the variant for deletion
           // Check if the variant exists in the active product
           const variantExistsInActiveProduct = activeProduct.skus.some(
-            (v: any) => v._id === id
+            (variant: ProductSku) => variant._id === id,
           );
 
           if (variantExistsInActiveProduct) {
@@ -119,7 +125,9 @@ export function ProductProvider({ children }: { children: ReactNode }) {
 
             if (index == prevVariants.length - 1) {
               const lastVariant = updated.at(-1);
-              lastVariant && setActiveProductVariant(lastVariant);
+              if (lastVariant) {
+                setActiveProductVariant(lastVariant);
+              }
             }
 
             return updated;
@@ -166,7 +174,7 @@ export function ProductProvider({ children }: { children: ReactNode }) {
         images: images.map((file) => file.file?.path || file.preview),
       });
       return true;
-    } catch (e) {
+    } catch {
       return false;
     }
   };
@@ -225,7 +233,7 @@ export function ProductProvider({ children }: { children: ReactNode }) {
         skus: undefined, // Exclude skus from productData
       });
 
-      const variants = activeProduct.skus.map((sku: any) =>
+      const variants = activeProduct.skus.map((sku: ProductSku) =>
         convertSkuToVariant(sku)
       );
       updateProductVariants(variants);

--- a/packages/athena-webapp/src/hooks/useGetActiveProduct.ts
+++ b/packages/athena-webapp/src/hooks/useGetActiveProduct.ts
@@ -3,7 +3,13 @@ import useGetActiveStore from "./useGetActiveStore";
 import { useQuery } from "convex/react";
 import { api } from "~/convex/_generated/api";
 
-export default function useGetActiveProduct() {
+type UseGetActiveProductOptions = {
+  includeArchived?: boolean;
+};
+
+export default function useGetActiveProduct(
+  options: UseGetActiveProductOptions = {},
+) {
   const { productSlug } = useParams({ strict: false });
 
   const { activeStore } = useGetActiveStore();
@@ -11,8 +17,14 @@ export default function useGetActiveProduct() {
   const product = useQuery(
     api.inventory.products.getByIdOrSlug,
     activeStore?._id && productSlug
-      ? { storeId: activeStore._id, identifier: productSlug }
-      : "skip"
+      ? {
+          storeId: activeStore._id,
+          identifier: productSlug,
+          filters: options.includeArchived
+            ? { includeArchived: true, isVisible: false }
+            : undefined,
+        }
+      : "skip",
   );
 
   return {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -545,7 +545,9 @@ describe("usePosLocalSyncRuntimeStatus", () => {
       result.current?.onRetrySync?.();
     });
     await waitFor(() => expect(oldStore.listEvents).toHaveBeenCalled());
-    await waitFor(() => expect(mocks.ingestLocalEvents).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.ingestLocalEvents).toHaveBeenCalled(), {
+      timeout: 5000,
+    });
 
     currentStore = newStore;
     rerender({ eventAppendToken: 0, storeId: "store-2" });

--- a/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.test.ts
@@ -158,7 +158,7 @@ describe("catalogSearch", () => {
   it("ranks text token matches by stronger product fields first", () => {
     const result = searchRegisterCatalog(
       buildRegisterCatalogIndex(rows),
-      "shirt accessories",
+      "red shirt",
     );
 
     expect(result.intent).toBe("text");
@@ -166,6 +166,49 @@ describe("catalogSearch", () => {
       "sku-red-small",
       "sku-red-large",
     ]);
+  });
+
+  it("requires every text query token to match somewhere in the row", () => {
+    const result = searchRegisterCatalog(
+      buildRegisterCatalogIndex([
+        ...rows,
+        {
+          productId: "product-hair-bands",
+          productSkuId: "sku-hair-bands",
+          name: "Hair Bands",
+          sku: "KK38-6C-VHT",
+          barcode: "111222333555",
+          category: "POS quick add",
+          description: "Assorted hair bands",
+          price: 25,
+          size: null,
+          color: null,
+          length: null,
+        },
+        {
+          productId: "product-clamps",
+          productSkuId: "sku-clamps",
+          name: "12 Pieces Butterfly Plastic Clamps",
+          sku: "KK38-64H-WTB",
+          barcode: "111222333556",
+          category: "Hair Accessories",
+          description: null,
+          price: 20,
+          size: null,
+          color: null,
+          length: null,
+        },
+      ]),
+      "hair bands",
+    );
+
+    expect(result.intent).toBe("text");
+    expect(result.results.map((row) => row.productSkuId)).toContain(
+      "sku-hair-bands",
+    );
+    expect(result.results.map((row) => row.productSkuId)).not.toContain(
+      "sku-clamps",
+    );
   });
 
   it("normalizes case and punctuation for text search", () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts
@@ -1,3 +1,9 @@
+import {
+  createFuzzySearchEntry,
+  searchFuzzyEntries,
+  type FuzzySearchEntry,
+} from "@/lib/search/fuzzySearch";
+
 export interface RegisterCatalogSearchRow {
   productId: string;
   productSkuId: string;
@@ -43,17 +49,7 @@ export interface RegisterCatalogIndex {
   bySku: Map<string, RegisterCatalogSearchRow[]>;
   byProductSkuId: Map<string, RegisterCatalogSearchRow[]>;
   byProductId: Map<string, RegisterCatalogSearchRow[]>;
-  searchableRows: Array<{
-    row: RegisterCatalogSearchRow;
-    tokens: Set<string>;
-    normalizedFields: {
-      name: string;
-      sku: string;
-      category: string;
-      description: string;
-      attributes: string;
-    };
-  }>;
+  searchableRows: Array<FuzzySearchEntry<RegisterCatalogSearchRow>>;
 }
 
 type ParsedCatalogSearchInput =
@@ -75,23 +71,17 @@ export function buildRegisterCatalogIndex(
     addKey(byProductSkuId, normalizeIdentifier(row.productSkuId), row);
     addKey(byProductId, normalizeIdentifier(row.productId), row);
 
-    const normalizedFields = {
-      name: normalizeSearchText(row.name),
-      sku: normalizeSearchText(row.sku),
-      category: normalizeSearchText(row.category),
-      description: normalizeSearchText(row.description),
+    return createFuzzySearchEntry(row, {
+      name: row.name,
+      sku: row.sku,
+      category: row.category,
+      description: row.description,
       attributes: normalizeSearchText([
         row.size,
         row.length == null ? "" : String(row.length),
         row.color,
       ]),
-    };
-
-    return {
-      row,
-      tokens: tokenizeSearchText(Object.values(normalizedFields)),
-      normalizedFields,
-    };
+    });
   });
 
   return {
@@ -225,157 +215,16 @@ function searchByText(
   input: string,
   limit = 20,
 ): RegisterCatalogSearchRow[] {
-  const queryTokens = [...tokenizeSearchText([input])];
-
-  if (queryTokens.length === 0) {
-    return [];
-  }
-
-  return index.searchableRows
-    .map((entry, position) => ({
-      row: entry.row,
-      position,
-      score: scoreSearchRow(entry, queryTokens),
-    }))
-    .filter((entry) => entry.score > 0)
-    .sort((left, right) => {
-      if (right.score !== left.score) return right.score - left.score;
-      return left.position - right.position;
-    })
-    .slice(0, limit)
-    .map((entry) => entry.row);
-}
-
-function scoreSearchRow(
-  entry: RegisterCatalogIndex["searchableRows"][number],
-  queryTokens: string[],
-): number {
-  let score = 0;
-
-  for (const token of queryTokens) {
-    const tokenScore = scoreQueryTokenForEntry(entry, token);
-
-    if (tokenScore === 0) {
-      continue;
-    }
-
-    score += tokenScore;
-  }
-
-  return score;
-}
-
-function scoreQueryTokenForEntry(
-  entry: RegisterCatalogIndex["searchableRows"][number],
-  token: string,
-): number {
-  if (entry.tokens.has(token)) {
-    return (
-      1 +
-      scoreFieldContains(entry.normalizedFields.name, token, 8) +
-      scoreFieldContains(entry.normalizedFields.sku, token, 6) +
-      scoreFieldContains(entry.normalizedFields.category, token, 4) +
-      scoreFieldContains(entry.normalizedFields.attributes, token, 3) +
-      scoreFieldContains(entry.normalizedFields.description, token, 2)
-    );
-  }
-
-  return bestFuzzyTokenScore(entry.tokens, token);
-}
-
-function scoreFieldContains(field: string, token: string, score: number): number {
-  return field.includes(token) ? score : 0;
-}
-
-function bestFuzzyTokenScore(tokens: Set<string>, queryToken: string): number {
-  if (queryToken.length < 3) {
-    return 0;
-  }
-
-  let bestScore = 0;
-
-  for (const candidateToken of tokens) {
-    bestScore = Math.max(
-      bestScore,
-      scoreFuzzyTokenMatch(candidateToken, queryToken),
-    );
-  }
-
-  return bestScore;
-}
-
-function scoreFuzzyTokenMatch(candidateToken: string, queryToken: string): number {
-  if (candidateToken.length < 3) {
-    return 0;
-  }
-
-  if (
-    candidateToken.includes(queryToken) ||
-    queryToken.includes(candidateToken)
-  ) {
-    return 5;
-  }
-
-  if (!isProbablySameToken(candidateToken, queryToken)) {
-    return 0;
-  }
-
-  const distance = levenshteinDistance(candidateToken, queryToken);
-  const maxLength = Math.max(candidateToken.length, queryToken.length);
-  const similarity = 1 - distance / maxLength;
-
-  if (similarity >= 0.78) {
-    return 4;
-  }
-
-  if (similarity >= 0.68) {
-    return 2;
-  }
-
-  return 0;
-}
-
-function isProbablySameToken(candidateToken: string, queryToken: string): boolean {
-  return (
-    candidateToken[0] === queryToken[0] ||
-    candidateToken.includes(queryToken.slice(0, 2)) ||
-    queryToken.includes(candidateToken.slice(0, 2))
-  );
-}
-
-function levenshteinDistance(left: string, right: string): number {
-  if (left === right) {
-    return 0;
-  }
-
-  if (left.length === 0) {
-    return right.length;
-  }
-
-  if (right.length === 0) {
-    return left.length;
-  }
-
-  let previousRow = Array.from({ length: right.length + 1 }, (_, index) => index);
-
-  for (let leftIndex = 0; leftIndex < left.length; leftIndex += 1) {
-    const currentRow = [leftIndex + 1];
-
-    for (let rightIndex = 0; rightIndex < right.length; rightIndex += 1) {
-      const insertionCost = currentRow[rightIndex] + 1;
-      const deletionCost = previousRow[rightIndex + 1] + 1;
-      const substitutionCost =
-        previousRow[rightIndex] + (left[leftIndex] === right[rightIndex] ? 0 : 1);
-
-      currentRow.push(
-        Math.min(insertionCost, deletionCost, substitutionCost),
-      );
-    }
-
-    previousRow = currentRow;
-  }
-
-  return previousRow[right.length];
+  return searchFuzzyEntries(index.searchableRows, input, {
+    fieldWeights: {
+      name: 8,
+      sku: 6,
+      category: 4,
+      attributes: 3,
+      description: 2,
+    },
+    limit,
+  });
 }
 
 function normalizeIdentifier(value: unknown): string {
@@ -390,20 +239,6 @@ function normalizeSearchText(value: unknown): string {
     .replace(/[^a-z0-9]+/g, " ")
     .trim()
     .replace(/\s+/g, " ");
-}
-
-function tokenizeSearchText(values: unknown[]): Set<string> {
-  const tokens = new Set<string>();
-
-  for (const value of values) {
-    for (const token of normalizeSearchText(value).split(" ")) {
-      if (token) {
-        tokens.add(token);
-      }
-    }
-  }
-
-  return tokens;
 }
 
 function addKey(

--- a/packages/athena-webapp/src/lib/search/fuzzySearch.ts
+++ b/packages/athena-webapp/src/lib/search/fuzzySearch.ts
@@ -1,0 +1,213 @@
+export type FuzzySearchFieldWeights = Record<string, number>;
+
+export interface FuzzySearchEntry<TItem> {
+  item: TItem;
+  tokens: Set<string>;
+  normalizedFields: Record<string, string>;
+}
+
+export function createFuzzySearchEntry<TItem>(
+  item: TItem,
+  fields: Record<string, unknown>,
+): FuzzySearchEntry<TItem> {
+  const normalizedFields = Object.fromEntries(
+    Object.entries(fields).map(([key, value]) => [
+      key,
+      normalizeFuzzySearchText(value),
+    ]),
+  );
+
+  return {
+    item,
+    tokens: tokenizeFuzzySearchText(Object.values(normalizedFields)),
+    normalizedFields,
+  };
+}
+
+export function searchFuzzyEntries<TItem>(
+  entries: Array<FuzzySearchEntry<TItem>>,
+  input: string,
+  options: {
+    fieldWeights?: FuzzySearchFieldWeights;
+    limit?: number;
+  } = {},
+): TItem[] {
+  const queryTokens = [...tokenizeFuzzySearchText([input])];
+
+  if (queryTokens.length === 0) {
+    return [];
+  }
+
+  return entries
+    .map((entry, position) => ({
+      item: entry.item,
+      position,
+      score: scoreFuzzySearchEntry(entry, queryTokens, options.fieldWeights),
+    }))
+    .filter((entry) => entry.score > 0)
+    .sort((left, right) => {
+      if (right.score !== left.score) return right.score - left.score;
+      return left.position - right.position;
+    })
+    .slice(0, options.limit)
+    .map((entry) => entry.item);
+}
+
+export function scoreFuzzySearchEntry<TItem>(
+  entry: FuzzySearchEntry<TItem>,
+  queryTokens: string[],
+  fieldWeights: FuzzySearchFieldWeights = {},
+): number {
+  let score = 0;
+
+  for (const token of queryTokens) {
+    const tokenScore = scoreQueryTokenForEntry(entry, token, fieldWeights);
+
+    if (tokenScore === 0) {
+      return 0;
+    }
+
+    score += tokenScore;
+  }
+
+  return score;
+}
+
+export function normalizeFuzzySearchText(value: unknown): string {
+  const raw = Array.isArray(value) ? value.join(" ") : String(value ?? "");
+
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+export function tokenizeFuzzySearchText(values: unknown[]): Set<string> {
+  const tokens = new Set<string>();
+
+  for (const value of values) {
+    for (const token of normalizeFuzzySearchText(value).split(" ")) {
+      if (token) {
+        tokens.add(token);
+      }
+    }
+  }
+
+  return tokens;
+}
+
+function scoreQueryTokenForEntry<TItem>(
+  entry: FuzzySearchEntry<TItem>,
+  token: string,
+  fieldWeights: FuzzySearchFieldWeights,
+): number {
+  if (entry.tokens.has(token)) {
+    return (
+      1 +
+      Object.entries(fieldWeights).reduce((score, [field, weight]) => {
+        return (
+          score +
+          scoreFieldContains(entry.normalizedFields[field] ?? "", token, weight)
+        );
+      }, 0)
+    );
+  }
+
+  return bestFuzzyTokenScore(entry.tokens, token);
+}
+
+function scoreFieldContains(field: string, token: string, score: number): number {
+  return field.includes(token) ? score : 0;
+}
+
+function bestFuzzyTokenScore(tokens: Set<string>, queryToken: string): number {
+  if (queryToken.length < 3) {
+    return 0;
+  }
+
+  let bestScore = 0;
+
+  for (const candidateToken of tokens) {
+    bestScore = Math.max(
+      bestScore,
+      scoreFuzzyTokenMatch(candidateToken, queryToken),
+    );
+  }
+
+  return bestScore;
+}
+
+function scoreFuzzyTokenMatch(candidateToken: string, queryToken: string): number {
+  if (candidateToken.length < 3) {
+    return 0;
+  }
+
+  if (
+    candidateToken.includes(queryToken) ||
+    queryToken.includes(candidateToken)
+  ) {
+    return 5;
+  }
+
+  if (!isProbablySameToken(candidateToken, queryToken)) {
+    return 0;
+  }
+
+  const distance = levenshteinDistance(candidateToken, queryToken);
+  const maxLength = Math.max(candidateToken.length, queryToken.length);
+  const similarity = 1 - distance / maxLength;
+
+  if (similarity >= 0.78) {
+    return 4;
+  }
+
+  if (similarity >= 0.68) {
+    return 2;
+  }
+
+  return 0;
+}
+
+function isProbablySameToken(candidateToken: string, queryToken: string): boolean {
+  return (
+    candidateToken[0] === queryToken[0] ||
+    candidateToken.includes(queryToken.slice(0, 2)) ||
+    queryToken.includes(candidateToken.slice(0, 2))
+  );
+}
+
+function levenshteinDistance(left: string, right: string): number {
+  if (left === right) {
+    return 0;
+  }
+
+  if (left.length === 0) {
+    return right.length;
+  }
+
+  if (right.length === 0) {
+    return left.length;
+  }
+
+  let previousRow = Array.from({ length: right.length + 1 }, (_, index) => index);
+
+  for (let leftIndex = 0; leftIndex < left.length; leftIndex += 1) {
+    const currentRow = [leftIndex + 1];
+
+    for (let rightIndex = 0; rightIndex < right.length; rightIndex += 1) {
+      const insertionCost = currentRow[rightIndex] + 1;
+      const deletionCost = previousRow[rightIndex + 1] + 1;
+      const substitutionCost =
+        previousRow[rightIndex] + (left[leftIndex] === right[rightIndex] ? 0 : 1);
+
+      currentRow.push(
+        Math.min(insertionCost, deletionCost, substitutionCost),
+      );
+    }
+
+    previousRow = currentRow;
+  }
+
+  return previousRow[right.length];
+}

--- a/packages/athena-webapp/src/lib/stockOps/skuSearch.test.ts
+++ b/packages/athena-webapp/src/lib/stockOps/skuSearch.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { matchesSkuSearchTerms, normalizeSkuSearchQuery } from "./skuSearch";
+
+describe("skuSearch", () => {
+  it("matches exact and prefix text tokens", () => {
+    expect(
+      matchesSkuSearchTerms(
+        ["Mahogany Teakwood", "6N2Y-9W1-PNN", "Home Care"],
+        normalizeSkuSearchQuery("teak"),
+      ),
+    ).toBe(true);
+  });
+
+  it("matches typo-tolerant product terms", () => {
+    expect(
+      matchesSkuSearchTerms(
+        ["Mahogany Teakwood", "6N2Y-9W1-PNN", "Home Care"],
+        normalizeSkuSearchQuery("mahogny"),
+      ),
+    ).toBe(true);
+  });
+
+  it("matches variant attributes with the shared fuzzy matcher", () => {
+    expect(
+      matchesSkuSearchTerms(
+        ["Closure Wig", "CW-18", "natural black", "Large", 18],
+        normalizeSkuSearchQuery("natrual blak"),
+      ),
+    ).toBe(true);
+  });
+
+  it("requires every text query token to match", () => {
+    expect(
+      matchesSkuSearchTerms(
+        ["Hair Bands", "KK38-6C-VHT", "POS quick add"],
+        normalizeSkuSearchQuery("hair bands"),
+      ),
+    ).toBe(true);
+
+    expect(
+      matchesSkuSearchTerms(
+        ["12 Pieces Butterfly Plastic Clamps", "KK38-64H-WTB", "Hair Accessories"],
+        normalizeSkuSearchQuery("hair bands"),
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps barcode-shaped searches exact", () => {
+    expect(
+      matchesSkuSearchTerms(
+        ["Yizia Wax & Mud", "KK38-721-WBJ", "111222333444"],
+        normalizeSkuSearchQuery("6935721830015"),
+      ),
+    ).toBe(false);
+    expect(
+      matchesSkuSearchTerms(
+        ["Yizia Wax & Mud", "KK38-721-WBJ", "111222333444"],
+        normalizeSkuSearchQuery("111222333444"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/athena-webapp/src/lib/stockOps/skuSearch.ts
+++ b/packages/athena-webapp/src/lib/stockOps/skuSearch.ts
@@ -1,0 +1,43 @@
+import {
+  createFuzzySearchEntry,
+  searchFuzzyEntries,
+} from "@/lib/search/fuzzySearch";
+
+export function normalizeSkuSearchQuery(value?: string | null) {
+  return value?.trim() ?? "";
+}
+
+export function matchesSkuSearchTerms(
+  terms: Array<string | number | null | undefined>,
+  query: string,
+) {
+  if (!query) return true;
+
+  if (isBarcodeShapedSearchQuery(query)) {
+    const normalizedQuery = normalizeIdentifier(query);
+
+    return terms.some((term) => normalizeIdentifier(term) === normalizedQuery);
+  }
+
+  const searchableText = terms
+    .filter(
+      (term): term is string | number => term !== null && term !== undefined,
+    )
+    .join(" ");
+
+  return (
+    searchFuzzyEntries(
+      [createFuzzySearchEntry(searchableText, { searchableText })],
+      query,
+      { limit: 1 },
+    ).length > 0
+  );
+}
+
+function isBarcodeShapedSearchQuery(input: string): boolean {
+  return /^[\d\s-]+$/.test(input);
+}
+
+function normalizeIdentifier(value: unknown): string {
+  return String(value ?? "").trim().toLowerCase();
+}

--- a/packages/athena-webapp/src/routes/__root.tsx
+++ b/packages/athena-webapp/src/routes/__root.tsx
@@ -13,7 +13,9 @@ import { useNavigationKeyboardShortcuts } from "@/hooks/use-navigation-keyboard-
 
 const procurementModeSchema = z.preprocess(
   (value) => (value === "resolved" ? undefined : value),
-  z.enum(["needs_action", "planned", "inbound", "exceptions", "all"]).optional(),
+  z
+    .enum(["needs_action", "planned", "inbound", "exceptions", "all"])
+    .optional(),
 );
 
 const rootPageSchema = z.object({
@@ -25,6 +27,7 @@ const rootPageSchema = z.object({
   mode: z.enum(["cycle_count", "manual"]).optional(),
   page: z.coerce.number().int().positive().optional(),
   procurementMode: procurementModeSchema,
+  query: z.string().optional(),
   scope: z.string().optional(),
   sku: z.string().optional(),
 });

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.test.ts
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   getNextProcurementModeSearch,
   getNextProcurementPageSearch,
+  getNextProcurementQuerySearch,
   getNextProcurementSelectedSkuSearch,
   procurementSearchSchema,
 } from "./procurement.index";
@@ -46,8 +47,32 @@ describe("procurement route search state", () => {
       procurementSearchSchema.parse({
         page: "2",
         procurementMode: "resolved",
+        query: "cw",
       }),
-    ).toEqual({ page: 2, procurementMode: undefined });
+    ).toEqual({ page: 2, procurementMode: undefined, query: "cw" });
+  });
+
+  it("encodes SKU search query state and clears the selected SKU", () => {
+    expect(
+      getNextProcurementQuerySearch(
+        {
+          page: 3,
+          procurementMode: "planned",
+          query: "old",
+          sku: "6N2Y-XEH-P6B",
+        },
+        "CW",
+      ),
+    ).toEqual({ page: 1, procurementMode: "planned", query: "CW" });
+  });
+
+  it("clears empty procurement SKU search state", () => {
+    expect(
+      getNextProcurementQuerySearch(
+        { page: 3, procurementMode: "planned", query: "CW", sku: "CW-18" },
+        undefined,
+      ),
+    ).toEqual({ page: 1, procurementMode: "planned" });
   });
 
   it("encodes the visible recommendation page in the URL search state", () => {

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/procurement.index.tsx
@@ -4,12 +4,15 @@ import { ProcurementView } from "~/src/components/procurement/ProcurementView";
 
 const procurementModeSchema = z.preprocess(
   (value) => (value === "resolved" ? undefined : value),
-  z.enum(["needs_action", "planned", "inbound", "exceptions", "all"]).optional(),
+  z
+    .enum(["needs_action", "planned", "inbound", "exceptions", "all"])
+    .optional(),
 );
 
 export const procurementSearchSchema = z.object({
   procurementMode: procurementModeSchema,
   page: z.coerce.number().int().positive().optional(),
+  query: z.string().optional(),
   sku: z.string().optional(),
 });
 
@@ -39,6 +42,21 @@ export function getNextProcurementPageSearch(
     ...current,
     page,
   };
+}
+
+export function getNextProcurementQuerySearch(
+  current: Record<string, unknown>,
+  query: string | undefined,
+) {
+  const next: Record<string, unknown> = { ...current, query, page: 1 };
+
+  delete next.sku;
+
+  if (!query) {
+    delete next.query;
+  }
+
+  return next;
 }
 
 export function getNextProcurementSelectedSkuSearch(
@@ -88,6 +106,13 @@ function ProcurementRoute() {
             getNextProcurementPageSearch(current, page)) as never,
         });
       }}
+      onQueryChange={(query) => {
+        void navigate({
+          replace: true,
+          search: ((current: Record<string, unknown>) =>
+            getNextProcurementQuerySearch(current, query)) as never,
+        });
+      }}
       onSelectedSkuChange={(sku, page) => {
         void navigate({
           replace: true,
@@ -96,6 +121,7 @@ function ProcurementRoute() {
         });
       }}
       page={search.page}
+      query={search.query}
       selectedSku={search.sku}
     />
   );

--- a/packages/athena-webapp/vite.config.ts
+++ b/packages/athena-webapp/vite.config.ts
@@ -47,6 +47,9 @@ export default defineConfig(({ mode }) => ({
             if (id.includes("date-fns")) return "date-vendor";
             if (id.includes("framer-motion")) return "motion-vendor";
             if (id.includes("hls.js")) return "hls-js-vendor";
+            if (normalizedId.includes("/node_modules/@zxing/")) {
+              return "barcode-scanner-vendor";
+            }
             if (id.includes("@aws-sdk") || id.includes("@smithy")) {
               return "aws-vendor";
             }


### PR DESCRIPTION
## Summary
- move the local dirty Athena operations bundle into an isolated main-based worktree
- unify SKU search handling across stock adjustments, procurement, products, and POS catalog search so product-name token matches like "hair bands" rank expected SKU rows ahead of broad fuzzy matches
- carry the related service operations/catalog and product detail updates, generated graphify/harness docs, and compound solution note

## Validation
- bun run pr:athena
- git push pre-push suite: graphify:check, harness:self-review, architecture:check, harness:review, coverage, targeted behavior scenarios

Visual validation intentionally left to manual review.