### PR TITLE
[V26-625 V26-626 V26-627 V26-628 V26-629] Explain POS terminal review evidence

### DIFF
--- a/docs/plans/2026-05-26-001-fix-pos-terminal-review-gap-plan.html
+++ b/docs/plans/2026-05-26-001-fix-pos-terminal-review-gap-plan.html
@@ -1,0 +1,290 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>fix: Close POS terminal review evidence gaps</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f8fb;
+      --surface: #ffffff;
+      --text: #162033;
+      --muted: #5e6a7d;
+      --border: #d9deea;
+      --accent: #3556b8;
+      --accent-soft: #eef2ff;
+      --warning: #8a5a00;
+      --warning-soft: #fff7df;
+      --danger: #9f2626;
+      --success: #166a4a;
+      --code: #f3f5f9;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 48px 24px 72px;
+    }
+    header {
+      margin-bottom: 28px;
+    }
+    .eyebrow {
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: .12em;
+      text-transform: uppercase;
+    }
+    h1 {
+      margin: 8px 0 12px;
+      font-size: clamp(34px, 5vw, 56px);
+      line-height: 1;
+      letter-spacing: 0;
+    }
+    h2 {
+      margin: 0 0 14px;
+      font-size: 22px;
+      letter-spacing: 0;
+    }
+    h3 {
+      margin: 22px 0 10px;
+      font-size: 16px;
+      letter-spacing: 0;
+    }
+    p { margin: 0 0 12px; }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      color: var(--muted);
+      font-size: 13px;
+    }
+    .pill {
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      background: var(--surface);
+      padding: 4px 10px;
+    }
+    nav {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin: 24px 0;
+    }
+    nav a {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: var(--surface);
+      color: var(--text);
+      padding: 8px 10px;
+      font-size: 13px;
+    }
+    section {
+      margin-top: 18px;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: var(--surface);
+      padding: 24px;
+      box-shadow: 0 14px 34px rgba(22, 32, 51, .05);
+    }
+    .callout {
+      border-color: #f0d48c;
+      background: var(--warning-soft);
+      color: #392800;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 14px;
+    }
+    .card {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 14px;
+      background: #fbfcff;
+    }
+    .card strong {
+      display: block;
+      margin-bottom: 5px;
+    }
+    ul, ol {
+      margin: 8px 0 0 20px;
+      padding: 0;
+    }
+    li { margin: 6px 0; }
+    code {
+      border-radius: 5px;
+      background: var(--code);
+      padding: 1px 5px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: .92em;
+    }
+    pre {
+      overflow-x: auto;
+      border-radius: 8px;
+      background: var(--code);
+      padding: 14px;
+      white-space: pre;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 10px;
+      font-size: 14px;
+    }
+    th, td {
+      border: 1px solid var(--border);
+      padding: 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: #f5f7fb; }
+    .unit {
+      border-left: 4px solid var(--accent);
+    }
+    .unit h3 {
+      margin-top: 0;
+      font-size: 18px;
+    }
+    .tag-warning { color: var(--warning); font-weight: 700; }
+    .tag-danger { color: var(--danger); font-weight: 700; }
+    .tag-success { color: var(--success); font-weight: 700; }
+    @media (max-width: 760px) {
+      main { padding: 28px 14px 48px; }
+      section { padding: 18px; }
+      .grid { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div class="eyebrow">Plan Review Artifact</div>
+      <h1>fix: Close POS terminal review evidence gaps</h1>
+      <div class="meta">
+        <span class="pill">Type: fix</span>
+        <span class="pill">Status: active</span>
+        <span class="pill">Date: 2026-05-26</span>
+        <span class="pill">Source: <a href="./2026-05-26-001-fix-pos-terminal-review-gap-plan.md">Markdown plan</a></span>
+      </div>
+    </header>
+
+    <nav aria-label="Plan sections">
+      <a href="#summary">Summary</a>
+      <a href="#requirements">Requirements</a>
+      <a href="#design">Design</a>
+      <a href="#units">Implementation Units</a>
+      <a href="#risks">Risks</a>
+      <a href="#verification">Verification</a>
+    </nav>
+
+    <section id="summary">
+      <h2>Summary</h2>
+      <p>Align POS terminal health with the evidence operators can actually see: backend health summaries will return explicit attention reasons, the terminal detail page will explain local runtime review state beside cloud sync evidence, and the local sync runtime will stop leaving already-resolved review events stuck on the terminal.</p>
+    </section>
+
+    <section class="callout">
+      <h2>Production Gap</h2>
+      <p>Terminal <code>M Supplies</code> was labeled <span class="tag-warning">Needs review</span> because its runtime check-in reported <code>sync.status: needs_review</code> and <code>reviewEventCount: 1</code>. The visible detail page emphasized cloud evidence, which showed projected events and a resolved conflict, so the badge looked unsupported.</p>
+    </section>
+
+    <section id="requirements">
+      <h2>Requirements</h2>
+      <ul>
+        <li>Expose explicit backend attention reasons for terminal health classifications.</li>
+        <li>Show local runtime review state when it drives the terminal detail badge.</li>
+        <li>Clear local review counts after server-side projection or intentional settlement.</li>
+        <li>Keep Cash Controls and Operations as the manager-review action surfaces.</li>
+        <li>Keep operator copy clear and avoid exposing raw local payloads or secrets.</li>
+        <li>Cover the production mismatch with regression tests.</li>
+      </ul>
+    </section>
+
+    <section id="design">
+      <h2>High-Level Design</h2>
+      <p>The backend should answer why a terminal needs attention. The frontend should render that explanation alongside cloud evidence, rather than recalculating and implying that cloud conflicts are the only possible cause.</p>
+      <pre><code>Browser local event log
+  -> Runtime status builder
+  -> Terminal runtime check-in
+  -> Terminal health summary + attention reasons
+  -> Terminal list/detail/register diagnostics</code></pre>
+      <div class="grid">
+        <div class="card">
+          <strong>Local runtime evidence</strong>
+          <p>Review count, oldest event age, next upload sequence, last trigger, local store health.</p>
+        </div>
+        <div class="card">
+          <strong>Cloud sync evidence</strong>
+          <p>Accepted cursor, projected/held/rejected/conflicted counts, latest event sample.</p>
+        </div>
+        <div class="card">
+          <strong>Review ownership</strong>
+          <p>Terminal health explains support evidence; Cash Controls and Approvals retain actions.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="units">
+      <h2>Implementation Units</h2>
+      <article class="card unit">
+        <h3>U1. Backend attention reasons</h3>
+        <p>Add validator-safe <code>attentionReasons</code> to terminal health summaries from the same inputs that derive <code>health</code>.</p>
+        <p><strong>Primary files:</strong> <code>convex/pos/application/queries/terminals.ts</code>, <code>convex/pos/public/terminals.ts</code>, <code>src/components/pos/terminals/terminalHealthTypes.ts</code>.</p>
+      </article>
+      <article class="card unit">
+        <h3>U2. Terminal detail explanation</h3>
+        <p>Render a compact "why this needs attention" section and clarify when local runtime review exists even with no unresolved cloud conflicts.</p>
+        <p><strong>Primary files:</strong> <code>POSTerminalDetailView.tsx</code>, <code>terminalHealthPresentation.ts</code>.</p>
+      </article>
+      <article class="card unit">
+        <h3>U3. Local review lifecycle reconciliation</h3>
+        <p>Characterize and fix stale local review events after server-side projection or settlement, especially reviewed <code>register_closed</code> events.</p>
+        <p><strong>Primary files:</strong> <code>usePosLocalSyncRuntime.ts</code>, <code>terminalRuntimeStatus.ts</code>, <code>projectLocalEvents.ts</code>, <code>ingestLocalEvents.ts</code>.</p>
+      </article>
+      <article class="card unit">
+        <h3>U4. Terminal health parity</h3>
+        <p>Keep list rows, detail headers, and register diagnostics aligned around the same reason model.</p>
+        <p><strong>Primary files:</strong> <code>POSTerminalHealthView.tsx</code>, <code>POSRegisterView.tsx</code>.</p>
+      </article>
+      <article class="card unit">
+        <h3>U5. Validation map and operational handoff</h3>
+        <p>Document the production failure mode and update validation coverage for reason generation, UI explanation, and review clearing.</p>
+      </article>
+    </section>
+
+    <section id="risks">
+      <h2>Risks &amp; Mitigations</h2>
+      <table>
+        <thead>
+          <tr><th>Risk</th><th>Mitigation</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Clearing local review state too early hides real work.</td><td>Only clear after server-projected or intentionally settled evidence.</td></tr>
+          <tr><td>Reason logic drifts again between backend and frontend.</td><td>Backend returns reason payloads; frontend renders instead of rediscovering.</td></tr>
+          <tr><td>Copy implies terminal health owns approval actions.</td><td>Route actions back to Cash Controls and Operations approval flows.</td></tr>
+          <tr><td>Older deployments lack the new reason field.</td><td>Make frontend handling optional with fallback rendering.</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="verification">
+      <h2>Verification Strategy</h2>
+      <ul>
+        <li>Backend tests prove runtime review + clear cloud conflicts returns a local runtime attention reason.</li>
+        <li>Detail view tests prove the production mismatch is explained without relying on the register debug strip.</li>
+        <li>Local sync runtime tests prove projected reviewed closeout events clear from local review counts.</li>
+        <li>Terminal list/detail/register diagnostics tests prove status wording stays aligned.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/plans/2026-05-26-001-fix-pos-terminal-review-gap-plan.md
+++ b/docs/plans/2026-05-26-001-fix-pos-terminal-review-gap-plan.md
@@ -1,0 +1,364 @@
+---
+title: "fix: Close POS terminal review evidence gaps"
+type: fix
+status: active
+date: 2026-05-26
+---
+
+# fix: Close POS terminal review evidence gaps
+
+## Summary
+
+Align POS terminal health with the evidence operators can actually see: backend health summaries will return explicit attention reasons, the terminal detail page will explain local runtime review state beside cloud sync evidence, and the local sync runtime will stop leaving already-resolved review events stuck on the terminal.
+
+---
+
+## Problem Frame
+
+Production terminal `M Supplies` showed a `Needs review` badge even though the terminal detail page said there were no unresolved conflicts. The backend check-in explains why: the latest terminal runtime status reported `sync.status: needs_review` and `reviewEventCount: 1`, while cloud evidence showed only projected events and one resolved permission conflict. The system is technically reading the local runtime counter, but the support surface presents cloud conflict evidence as if it were the whole reason.
+
+---
+
+## Requirements
+
+- R1. Terminal health summaries must expose the reason a terminal is classified as `needs_attention`.
+- R2. Terminal detail must make local runtime review state visible when it drives the `Needs review` label, even if cloud conflicts are clear.
+- R3. Local sync review events that have been projected or resolved in cloud must be eligible to clear from the terminal's local review count on the next sync/runtime refresh.
+- R4. Cash Controls and Operations review ownership must remain unchanged: terminal health explains support evidence, while manager review and register reconciliation stay in the existing register/approval flows.
+- R5. Operator-facing copy must distinguish local runtime review, cloud held/rejected/conflicted events, resolved conflicts, pending sync, and stale telemetry without exposing raw local payloads or secrets.
+- R6. Regression coverage must prove the production mismatch case: runtime review count is non-zero, cloud conflicts are resolved or absent, and the UI still explains why the terminal needs review.
+
+---
+
+## Scope Boundaries
+
+- This plan does not change the POS local-first checkout contract.
+- This plan does not add a new terminal-owned manager approval workflow.
+- This plan does not auto-approve or auto-reject register closeout review work.
+- This plan does not persist raw IndexedDB event payloads, staff proof tokens, sync secrets, PIN material, customer details, or payment details in terminal health.
+- This plan does not redesign the terminal health console beyond the fields needed to explain the current health status.
+
+### Deferred to Follow-Up Work
+
+- Fleet-level alerting for terminals with unresolved local review counters can follow after the reason model is stable.
+- Historical terminal-runtime trend charts are deferred; this plan keeps the latest-status model.
+- Bulk terminal repair tooling is deferred until the local review clearing behavior is proven on the current recovery paths.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/convex/pos/application/queries/terminals.ts` currently derives `needs_attention` when runtime sync status is `failed`, `needs_review`, `unavailable`, has failed/review counts, or when cloud evidence has conflicted/held/rejected events.
+- `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts` independently classifies the public summary into labels. It prioritizes runtime `needs_review`, runtime `reviewEventCount`, and review evidence count before failed/pending/stale states.
+- `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx` renders cloud sync evidence, conflicts, and support notes, but does not show the runtime sync reason that can drive the `Needs review` badge.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts` builds runtime `reviewEventCount` by counting local events whose sync status remains `needs_review`.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts` marks returned review events as `needs_review` and marks projected events as synced; that boundary is the likely place to clear or reconcile local review state after server-side projection/recovery.
+- `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts` and `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts` own server-side sync projection, held/rejected/conflicted outcomes, and returned event statuses.
+- `packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx` already surfaces richer terminal-local diagnostics than the terminal detail page, including review count, oldest pending item, and upload sequence.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture/athena-pos-terminal-health-visibility-2026-05-20.md` establishes terminal health as telemetry and support visibility, not the owner of manager review work.
+- `docs/solutions/logic-errors/athena-pos-register-sync-closeout-review-recovery-2026-05-23.md` establishes that resolving review metadata without settling the source local sync event creates stale review states.
+- `docs/solutions/logic-errors/athena-pos-register-sync-and-catalog-recovery-2026-05-26.md` establishes that POS and Cash Controls should share sync review state and avoid duplicate interpretations of closeout review.
+
+### Production Evidence
+
+- Terminal: `rs72p1j2hb64a133a0mfx3c9e17wn7gn`, display name `M Supplies`, register `1`.
+- Latest runtime check-in reported `sync.status: needs_review`, `reviewEventCount: 1`, `nextPendingUploadSequence: 23`, and `oldestPendingEventAt: 2026-05-23T19:15:51.397Z`.
+- Latest sampled cloud sync evidence showed 75 `projected` events, no held events, no rejected events, and one resolved permission conflict for the same register-close sequence.
+- The visible page explained cloud evidence but not the runtime review counter, so the badge looked unsupported.
+
+### External References
+
+- External research skipped. The fix is specific to Athena's POS local sync model, Convex runtime status summaries, and existing terminal health UI.
+
+---
+
+## Key Technical Decisions
+
+- Add explicit backend attention reasons rather than asking the frontend to rediscover why `health` is `needs_attention`: the query that computes health has the full runtime/cloud evidence set and can preserve reason precedence consistently.
+- Keep the frontend classifier as presentation-only, or remove duplicated reason logic where practical: the UI should label and style the status, but it should render backend reasons as the support explanation.
+- Treat local runtime review and cloud conflict evidence as separate evidence classes: a terminal can need review because its browser still has a local review item even when the cloud has no unresolved conflict.
+- Clear stale local review state through the sync recovery path, not by hiding the badge: if a local event remains `needs_review`, the support page should say so until the runtime can safely mark it resolved/synced.
+- Preserve terminal health as read-only support telemetry: any action that approves, rejects, or projects register activity remains in Cash Controls / Operations approval flows.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Why does the terminal show `Needs review`? The runtime status payload reports `sync.status: needs_review` and `reviewEventCount: 1`; cloud conflict evidence is not the cause in the current production snapshot.
+- Should projected cloud events count as review evidence? No. They are evidence that the server accepted/projected events, not unresolved manager-review work.
+- Should terminal detail hide the badge when cloud conflicts are resolved? No. The badge should remain if the terminal runtime still reports local review state, but the page must explain that source.
+
+### Deferred to Implementation
+
+- Exact local event clearing mechanism: implementation should inspect how `register_closed` review recovery returns accepted/projected event ids and choose the smallest safe way to mark the local source event synced after projection.
+- Exact `attentionReasons` shape: implementation should keep it validator-safe and presentation-oriented, but final field names can follow local Convex DTO conventions.
+- Whether a one-time production data repair is needed: implementation should first ship the lifecycle fix; only then decide whether affected terminals need a targeted manual sync retry or local refresh.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+  local["Browser local event log"]
+  runtime["Runtime status builder"]
+  report["Terminal runtime check-in"]
+  backend["Terminal health summary"]
+  evidence["Cloud sync evidence"]
+  reasons["Attention reasons"]
+  detail["Terminal detail page"]
+  review["Cash Controls / Approvals"]
+
+  local --> runtime
+  runtime --> report
+  report --> backend
+  evidence --> backend
+  backend --> reasons
+  reasons --> detail
+  evidence --> detail
+  detail --> review
+```
+
+The health summary should answer two different questions separately: "what state did the browser report?" and "what did the server observe in cloud sync evidence?" The terminal detail page then shows both instead of collapsing them into one conflicts panel.
+
+---
+
+## Implementation Units
+
+- U1. **Backend attention reasons**
+
+**Goal:** Return explicit, validator-safe reasons for terminal health classifications from the backend summary.
+
+**Requirements:** R1, R2, R5, R6.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/queries/terminals.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/terminals.ts`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts`
+- Test: `packages/athena-webapp/convex/pos/application/terminals.test.ts`
+- Test: `packages/athena-webapp/convex/pos/public/terminals.test.ts`
+
+**Approach:**
+- Add an `attentionReasons` array to terminal health summaries with reason type, source, severity/tone, count/sequence/timestamp fields where safe, and concise operator-facing summary fields.
+- Build reasons from the same inputs as `deriveTerminalHealth`: runtime sync status/counts, local store availability, browser online/freshness, and sync evidence counts.
+- Preserve precedence: local runtime review reasons should explain `Needs review`; failed/unavailable reasons should explain sync/local-store issues; held/rejected/conflicted cloud evidence should explain cloud review.
+- Keep existing `health` for compatibility while making `attentionReasons` the source for detailed explanation.
+
+**Patterns to follow:**
+- Existing public validator shaping in `packages/athena-webapp/convex/pos/public/terminals.ts`.
+- Existing sync-evidence aggregation in `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts`.
+
+**Test scenarios:**
+- Happy path: runtime `sync.status` is `needs_review` and `reviewEventCount` is `1`, cloud conflicts are clear -> summary health is `needs_attention` and includes one local runtime review reason.
+- Happy path: cloud held/rejected/conflicted counts are non-zero while runtime is idle -> summary includes cloud evidence reasons.
+- Edge case: runtime is stale/offline but no review counts exist -> summary does not create review reasons.
+- Error path: unsafe runtime fields are absent from returned attention reasons.
+- Integration: public query validator accepts the reason payload returned by the application query.
+
+**Verification:**
+- A backend caller can tell exactly why a terminal needs attention without reimplementing classifier logic.
+
+---
+
+- U2. **Terminal detail explanation**
+
+**Goal:** Show local runtime review state and cloud evidence side by side so the `Needs review` badge is explainable on the terminal detail page.
+
+**Requirements:** R2, R4, R5, R6.
+
+**Dependencies:** U1.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`
+- Test: `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts`
+
+**Approach:**
+- Add a compact "Why this terminal needs attention" section near the status header or before cloud sync evidence.
+- Render backend `attentionReasons` first. For local runtime review, include count, oldest event age, next upload sequence, last trigger, and a clear distinction that cloud conflicts may already be resolved.
+- Keep "Cloud sync evidence" focused on server-observed event status, cursor, and latest event sample.
+- Update empty conflict copy so "No unresolved terminal conflicts" no longer implies the terminal has no local review item.
+- Use calm operational copy that points operators to existing review surfaces only when the reason is actionable there.
+
+**Patterns to follow:**
+- Existing detail panel structure in `POSTerminalDetailView.tsx`.
+- Existing status label helpers in `terminalHealthPresentation.ts`.
+- Product copy guidance in `docs/product-copy-tone.md`.
+
+**Test scenarios:**
+- Happy path: local runtime review reason exists and cloud conflicts are absent -> page renders "local review item" explanation and still shows cloud conflicts clear.
+- Happy path: cloud held/rejected/conflicted reason exists -> page renders cloud review explanation with sequence/count context.
+- Edge case: no attention reasons but health is `online` -> no reason panel is rendered.
+- Edge case: older API response has no `attentionReasons` -> page falls back to current classifier and support notes without crashing.
+- Error path: unsafe fields are not rendered even when runtime status contains browser info and sync counters.
+
+**Verification:**
+- The production mismatch state can be understood from the terminal detail page without opening the register debug strip.
+
+---
+
+- U3. **Local review lifecycle reconciliation**
+
+**Goal:** Ensure local events no longer remain in `needs_review` after the server-side review/projection path has safely settled the source event.
+
+**Requirements:** R3, R4, R6.
+
+**Dependencies:** U1.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts`
+
+**Approach:**
+- Characterize the current review-event lifecycle for a `register_closed` event that was previously marked review and later projected after manager proof.
+- Ensure the server response gives the browser enough safe evidence to mark the source local event synced when projection is complete.
+- Keep true rejected/conflicted events in `needs_review`; only clear review state for server-projected or intentionally settled events.
+- Preserve local precursor handling for transaction/session events so clearing a reviewed closeout does not accidentally mark unrelated pending work synced.
+- Update runtime status derivation so stale review counts come from current local event state, not debug leftovers.
+
+**Execution note:** Start with characterization tests around the stale local review event before changing lifecycle behavior.
+
+**Patterns to follow:**
+- `collectServerSyncedLocalEventIds`, `collectServerReviewLocalEventIds`, and `collectAcceptedEventIdsWithLocalPrecursors` in `usePosLocalSyncRuntime.ts`.
+- Register closeout projection recovery guidance in `docs/solutions/logic-errors/athena-pos-register-sync-closeout-review-recovery-2026-05-23.md`.
+
+**Test scenarios:**
+- Happy path: reviewed `register_closed` event is projected by the server -> returned sync result lets the browser mark the local source event synced and runtime `reviewEventCount` becomes `0`.
+- Edge case: reviewed event is rejected -> local source event remains review/rejected and terminal continues to report an attention reason.
+- Edge case: reviewed event belongs to another terminal/register scope -> current terminal does not clear it.
+- Error path: mapping write fails after projection -> local event is not marked synced and runtime reports review/failure evidence.
+- Integration: runtime status after a successful reviewed closeout projection no longer reports `sync.status: needs_review`.
+
+**Verification:**
+- A terminal with a resolved/projected closeout review stops carrying the stale local review counter after sync refresh.
+
+---
+
+- U4. **Terminal health parity across list, detail, and register diagnostics**
+
+**Goal:** Keep terminal-health list rows, detail header badges, and POS register diagnostics aligned around the same status reasons.
+
+**Requirements:** R1, R2, R5, R6.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`
+- Modify: `packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx`
+- Test: `packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts`
+- Test: `packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx`
+
+**Approach:**
+- Update terminal list rows to use the same attention reason summary as detail, so "Needs review" is not a dead-end label.
+- Preserve the register debug strip's richer technical details, but align the top-level wording with the terminal-health reason model.
+- Avoid making terminal health copy sound like manager review unless the reason is local review or cloud review evidence.
+- Keep pending sync, failed sync, stale check-in, and local store issue visually distinct.
+
+**Patterns to follow:**
+- Existing terminal health row metrics in `POSTerminalHealthView.tsx`.
+- Existing register diagnostics field grouping in `POSRegisterView.tsx`.
+
+**Test scenarios:**
+- Happy path: terminal list item with local runtime review reason shows a concise review explanation and links to detail.
+- Happy path: register debug strip and terminal detail agree on review count and status label.
+- Edge case: pending sync without review shows pending copy, not review copy.
+- Edge case: stale check-in with prior review reason still indicates freshness so support can tell whether the reason may be outdated.
+
+**Verification:**
+- POS hub terminal health, terminal detail, and register diagnostics do not contradict each other for the same runtime status.
+
+---
+
+- U5. **Validation map and operational handoff**
+
+**Goal:** Update validation and support notes so future POS sync changes preserve terminal reason visibility and local review clearing.
+
+**Requirements:** R6.
+
+**Dependencies:** U1, U2, U3, U4.
+
+**Files:**
+- Modify: `docs/solutions/architecture/athena-pos-terminal-health-visibility-2026-05-20.md`
+- Create: `docs/solutions/logic-errors/athena-pos-terminal-review-reason-reconciliation-2026-05-26.md`
+- Modify: `docs/solutions/logic-errors/athena-pos-register-sync-and-catalog-recovery-2026-05-26.md`
+- Modify: `packages/athena-webapp/docs/validation-map.md` if this validation surface is listed there
+- Test: `scripts/validation-map-check.test.ts` if the validation map has automated coverage for these surfaces
+
+**Approach:**
+- Document the production failure mode: runtime review counter was true, cloud conflicts were clear, and the UI only showed cloud evidence.
+- Record the corrected boundary: terminal health must return reason evidence, and local sync recovery must clear projected review events.
+- Ensure validation references cover backend reason generation, terminal detail explanation, runtime status derivation, and reviewed closeout projection.
+
+**Patterns to follow:**
+- Existing `docs/solutions/logic-errors/*` root-cause note structure.
+- Existing validation-map conventions in the repo.
+
+**Test scenarios:**
+- Test expectation: none for the prose-only docs. If validation-map automation exists for changed entries, add or update the corresponding assertion.
+
+**Verification:**
+- Future implementers have a durable note for this exact terminal-health inconsistency and know which tests protect it.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** POS local event log -> runtime status builder -> terminal runtime check-in -> terminal health summary -> terminal list/detail/register diagnostics. Cloud sync evidence and Cash Controls remain separate inputs that the terminal detail page summarizes.
+- **Error propagation:** Runtime status failures should explain terminal support state without blocking POS sale commands. Sync projection failures still flow through existing local review/failed states.
+- **State lifecycle risks:** The highest risk is clearing a true review event too early. U3 must only clear local review state when server-side projection or intentional settlement is confirmed.
+- **API surface parity:** Public terminal health list/detail responses, frontend types, and presentation helpers must change together.
+- **Integration coverage:** Unit tests alone are not enough; coverage must include a cross-layer mismatch case where local runtime review count exists but cloud conflicts are resolved or absent.
+- **Unchanged invariants:** Terminal health remains telemetry; Cash Controls and Operations remain the manager-review action surfaces.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Clearing local review state could hide real unresolved register activity. | Require server-projected or intentionally settled evidence before marking local events synced. Keep rejected/conflicted outcomes in review. |
+| Duplicating reason logic between backend and frontend could drift again. | Make backend `attentionReasons` the explanation source; frontend presentation should style and render reasons, not recalculate them. |
+| Operator copy could imply the terminal detail page can approve review work. | Keep copy support-oriented and route actions back to existing Cash Controls / Approvals surfaces. |
+| Older frontend/backend deployments may temporarily disagree on the new field. | Treat missing `attentionReasons` as optional in frontend types and preserve fallback rendering during rollout. |
+| Production terminals may already have stale local review events. | Ship lifecycle correction first, then decide whether a targeted retry/refresh or manual recovery is needed. |
+
+---
+
+## Documentation / Operational Notes
+
+- After implementation, verify the same production terminal or a matching seeded state no longer shows unexplained `Needs review`.
+- If the terminal still reports `reviewEventCount: 1` after the lifecycle fix, use the new reason panel to identify the local sequence and decide whether a targeted recovery command or local terminal refresh is required.
+- If code files change during implementation, run `bun run graphify:rebuild` per repo guidance.
+
+---
+
+## Sources & References
+
+- Related plan: `docs/plans/2026-05-20-001-feat-pos-terminal-health-visibility-plan.md`
+- Related learning: `docs/solutions/architecture/athena-pos-terminal-health-visibility-2026-05-20.md`
+- Related learning: `docs/solutions/logic-errors/athena-pos-register-sync-closeout-review-recovery-2026-05-23.md`
+- Related learning: `docs/solutions/logic-errors/athena-pos-register-sync-and-catalog-recovery-2026-05-26.md`
+- Related code: `packages/athena-webapp/convex/pos/application/queries/terminals.ts`
+- Related code: `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx`
+- Related code: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`
+- Related code: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts`

--- a/docs/solutions/architecture/athena-pos-terminal-health-visibility-2026-05-20.md
+++ b/docs/solutions/architecture/athena-pos-terminal-health-visibility-2026-05-20.md
@@ -65,6 +65,9 @@ presentation boundaries:
 - Render Terminal Health as a POS operations console and terminal detail route.
   Keep POS Settings focused on current-device setup and link from settings to
   the health console for support review.
+- Return explicit attention reasons with terminal health summaries so support
+  pages can explain whether attention comes from local runtime review, failed or
+  unavailable local sync, local store readiness, or cloud sync evidence.
 - Link Cash Controls and register diagnostics to terminal detail/support
   evidence without treating stale telemetry as reconciliation work. Existing
   POS local sync conflict records continue to own needs-review copy.
@@ -103,6 +106,9 @@ and register-detail tests.
   copy, not needs-review copy.
 - Keep explicit conflict statuses such as `conflict`, `conflicted`, and
   `review` mapped to manager-review presentation.
+- Keep local runtime review separate from cloud conflicts. A terminal can need
+  attention because its browser still has an uploaded local review item even
+  after the server-side conflict has been projected or resolved.
 - Link support evidence from Cash Controls detail pages without adding a new
   terminal-management workflow there.
 - Regenerate harness docs from `scripts/harness-app-registry.ts` after changing

--- a/docs/solutions/logic-errors/athena-pos-register-sync-and-catalog-recovery-2026-05-26.md
+++ b/docs/solutions/logic-errors/athena-pos-register-sync-and-catalog-recovery-2026-05-26.md
@@ -54,6 +54,10 @@ Use shared register sync review state and idempotent projection semantics:
   activity to reject or clear.
 - In POS, block selling from the same closeout review source rather than from a
   separate register-session interpretation.
+- Terminal health should explain local runtime review separately from cloud
+  conflicts. When an uploaded local review event is later projected by Cash
+  Controls review, the terminal runtime can retry that uploaded review event and
+  clear the local review counter from the server's projected source status.
 
 Use compact catalog recovery for unknown scanned identifiers:
 
@@ -102,6 +106,8 @@ Use shared operational workspace patterns for broad store work:
   compare the applied count and variance before deciding.
 - Do not surface raw conflict summaries as final operator copy when the system
   knows the next action.
+- Do not clear terminal-local review counts from resolved conflict metadata
+  alone; use the source `posLocalSyncEvent` settlement status.
 - Do not make barcode recovery create-only. Existing SKU linking is the safer
   first path when the catalog item already exists.
 - Run `bun run pr:athena` for main-bound batches and add or update
@@ -114,3 +120,4 @@ Use shared operational workspace patterns for broad store work:
 - [Athena POS Register Search Uses A Local Catalog Index](./athena-pos-register-local-catalog-search-2026-05-04.md)
 - [Athena POS Register Review And Adjusted Sale Projection](./athena-pos-register-review-and-adjusted-sale-projection-2026-05-21.md)
 - [Athena POS Register Sync Closeout Review Recovery](./athena-pos-register-sync-closeout-review-recovery-2026-05-23.md)
+- [Athena POS Terminal Review Reasons And Local Settlement](./athena-pos-terminal-review-reason-reconciliation-2026-05-26.md)

--- a/docs/solutions/logic-errors/athena-pos-terminal-review-reason-reconciliation-2026-05-26.md
+++ b/docs/solutions/logic-errors/athena-pos-terminal-review-reason-reconciliation-2026-05-26.md
@@ -1,0 +1,98 @@
+---
+title: Athena POS Terminal Review Reasons And Local Settlement
+date: 2026-05-26
+category: logic-errors
+module: athena-webapp
+problem_type: terminal_runtime_review_reason_gap
+component: pos-terminal-health
+symptoms:
+  - "Terminal health can show Needs review while terminal detail shows no unresolved cloud conflicts"
+  - "A resolved server-side sync review can leave the browser terminal carrying a local review counter"
+  - "Support surfaces can blur local runtime review, cloud sync evidence, and manager-owned register review"
+root_cause: runtime_review_counter_was_not_explained_or_reconciled_with_cloud_settlement
+resolution_type: reasoned_terminal_health_and_review_retry
+severity: medium
+tags:
+  - pos
+  - terminal-health
+  - local-sync
+  - cash-controls
+  - diagnostics
+---
+
+# Athena POS Terminal Review Reasons And Local Settlement
+
+## Problem
+
+Terminal health combines two evidence classes: the browser runtime check-in and
+cloud sync records. A terminal can truthfully report `needs_review` because its
+local event log still has a `needs_review` item even when cloud conflicts are
+resolved or absent. If terminal detail only shows cloud conflict evidence, the
+badge looks unsupported and operators cannot tell whether the issue is local
+runtime review, held/rejected cloud sync evidence, stale telemetry, or pending
+sync.
+
+The lifecycle gap is separate but related. Once a browser marks an uploaded
+local event as `needs_review`, that event stops being a normal upload
+candidate. If Cash Controls later approves the source sync event and the server
+patches it to `projected`, the terminal needs a safe way to learn that durable
+settlement and mark the local source event synced.
+
+## Solution
+
+Expose terminal health reasons from the backend and keep them presentation-safe:
+
+- `convex/pos/application/queries/terminals.ts` should return
+  `attentionReasons` from the same evidence used to derive terminal health.
+- Local runtime review reasons must be distinct from cloud conflict, held, and
+  rejected evidence.
+- Reasons can include counts, sequence/timestamp context, and source labels, but
+  must not include raw local payloads, sync secrets, staff proof tokens, PIN
+  material, customer data, payment data, or raw browser fingerprints.
+- Frontend terminal list/detail surfaces should render backend reasons as the
+  single source of explanatory text. Older responses can still classify basic
+  status from runtime fields, but they should not re-derive reason objects.
+
+Reconcile local review settlement by manually retrying only uploaded local
+review events:
+
+- A local event with `sync.status: needs_review` and `sync.uploaded: true` can
+  be sent back through the sync mutation to ask the server for the durable
+  source status.
+- If the duplicate source event is now `projected`, the runtime can mark the
+  local source event synced and clear the terminal review count.
+- If the server still returns `conflicted` or `rejected`, the local event stays
+  in review and terminal health continues to explain why.
+- Foreground polling and event-appended drains should not automatically requeue
+  uploaded review events, or unresolved server review states can loop forever.
+- Do not clear local review merely because a conflict row was resolved. The
+  source `posLocalSyncEvent` status is the settlement signal.
+
+## Boundaries
+
+Terminal health is support telemetry. It explains why a terminal needs
+attention, but it does not approve closeouts, reject register activity, or create
+new manager-review workflows. Cash Controls and Operations continue to own
+register-session review and reconciliation actions.
+
+## Regression Targets
+
+- `convex/pos/application/terminals.test.ts` should prove runtime review count
+  plus clear cloud conflicts returns `needs_attention` with a local runtime
+  reason.
+- `convex/pos/public/terminals.test.ts` should prove public validators include
+  reason fields without unsafe payloads or secrets.
+- `src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts` should prove
+  uploaded review events retry and clear locally only when the server source
+  event is projected.
+- `POSTerminalDetailView.test.tsx`, `POSTerminalHealthView.test.tsx`, and
+  `terminalHealthPresentation.test.ts` should prove list/detail copy uses the
+  same backend reason model.
+
+## Prevention
+
+- Do not derive terminal detail explanations solely from cloud conflict counts.
+- Do not label stale telemetry or pending sync as manager-review work.
+- Do not add another approval surface to terminal health.
+- Keep the POS terminal health validation-map scenario current when reason,
+  runtime, register diagnostics, or Cash Controls evidence surfaces change.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5808 nodes · 6126 edges · 1716 communities detected
+- 5811 nodes · 6132 edges · 1716 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2086,28 +2086,28 @@ Cohesion: 0.18
 Nodes (2): handleKeyDown(), isDebugShortcut()
 
 ### Community 83 - "Community 83"
+Cohesion: 0.24
+Nodes (7): classifyTerminalHealth(), formatAge(), formatStatusLabel(), getPrimaryTerminalAttentionReason(), getReviewEvidenceCount(), getSnapshotAgeSummary(), getTerminalAttentionReasons()
+
+### Community 84 - "Community 84"
 Cohesion: 0.2
 Nodes (3): handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.21
 Nodes (5): formatDeposit(), formatMoney(), handleCancelEdit(), handleSaveEdit(), summarizeService()
 
-### Community 85 - "Community 85"
+### Community 86 - "Community 86"
 Cohesion: 0.27
 Nodes (8): extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isBarcodeShapedInput(), normalizeIdentifier(), parseCatalogSearchInput(), searchByText(), searchRegisterCatalog()
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.29
 Nodes (10): bestFuzzyTokenScore(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreFuzzySearchEntry(), scoreFuzzyTokenMatch(), scoreQueryTokenForEntry() (+2 more)
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
-
-### Community 88 - "Community 88"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 89 - "Community 89"
 Cohesion: 0.36
@@ -2134,40 +2134,40 @@ Cohesion: 0.18
 Nodes (0):
 
 ### Community 95 - "Community 95"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 96 - "Community 96"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.22
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.31
 Nodes (7): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), parseVariantDisplayMoney(), saveProduct(), updateVariantSku()
 
-### Community 102 - "Community 102"
+### Community 103 - "Community 103"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
-
-### Community 103 - "Community 103"
-Cohesion: 0.27
-Nodes (5): classifyTerminalHealth(), formatAge(), formatStatusLabel(), getReviewEvidenceCount(), getSnapshotAgeSummary()
 
 ### Community 104 - "Community 104"
 Cohesion: 0.27
@@ -2198,88 +2198,88 @@ Cohesion: 0.42
 Nodes (7): getRegisterCatalogPrice(), listRegisterCatalog(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
 
 ### Community 111 - "Community 111"
+Cohesion: 0.33
+Nodes (5): buildTerminalHealthSummary(), deriveTerminalHealth(), deriveTerminalHealthAttentionReasons(), getTerminalHealthSummary(), stripRuntimeStatusIdentity()
+
+### Community 112 - "Community 112"
 Cohesion: 0.28
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.43
 Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.43
 Nodes (6): assertActiveTerminal(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.5
 Nodes (7): findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), isBarcodeLike(), mapSkuToCatalogResult(), quickAddCatalogItem()
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 131 - "Community 131"
-Cohesion: 0.36
-Nodes (4): buildTerminalHealthSummary(), deriveTerminalHealth(), getTerminalHealthSummary(), stripRuntimeStatusIdentity()
 
 ### Community 132 - "Community 132"
 Cohesion: 0.25
@@ -2574,8 +2574,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 205 - "Community 205"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 206 - "Community 206"
 Cohesion: 0.33
@@ -2594,12 +2594,12 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 210 - "Community 210"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
-
-### Community 211 - "Community 211"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 211 - "Community 211"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 212 - "Community 212"
 Cohesion: 0.33
@@ -2610,40 +2610,40 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 214 - "Community 214"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 215 - "Community 215"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 216 - "Community 216"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 217 - "Community 217"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 218 - "Community 218"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 219 - "Community 219"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 220 - "Community 220"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 222 - "Community 222"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 223 - "Community 223"
 Cohesion: 0.53

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1788
-- Graph nodes: 5808
-- Graph edges: 6126
+- Graph nodes: 5811
+- Graph edges: 6132
 - Communities: 1716
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (14 edges, Community 63) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 118) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 119) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 63) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `createRedisCluster()` (3 edges, Community 63) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `deleteKeysIndividually()` (3 edges, Community 63) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.ts
@@ -27,6 +27,25 @@ export type TerminalHealth =
   | "needs_attention"
   | "unknown";
 
+export type TerminalHealthAttentionReason = {
+  count?: number;
+  latestEventSequence?: number;
+  latestEventStatus?: string;
+  nextPendingUploadSequence?: number;
+  oldestPendingEventAt?: number;
+  source: "cloud_sync" | "local_runtime" | "terminal_runtime";
+  summary: string;
+  type:
+    | "cloud_conflict"
+    | "cloud_held"
+    | "cloud_rejected"
+    | "local_review"
+    | "local_store_unavailable"
+    | "sync_failed"
+    | "sync_unavailable"
+    | "terminal_seed_missing";
+};
+
 export type TerminalHealthSummary = {
   terminal: {
     _id: Id<"posTerminal">;
@@ -43,6 +62,7 @@ export type TerminalHealthSummary = {
     Doc<"posTerminalRuntimeStatus">,
     "_id" | "_creationTime" | "storeId" | "terminalId"
   > | null;
+  attentionReasons: TerminalHealthAttentionReason[];
   syncEvidence: TerminalSyncEvidence;
 };
 
@@ -130,6 +150,11 @@ async function buildTerminalHealthSummary(
   const runtimeAgeMs = runtimeStatus
     ? Math.max(0, args.now - runtimeStatus.receivedAt)
     : null;
+  const attentionReasons = deriveTerminalHealthAttentionReasons({
+    runtimeStatus,
+    syncEvidence,
+    terminalStatus: args.terminal.status,
+  });
 
   return {
     terminal: {
@@ -142,6 +167,7 @@ async function buildTerminalHealthSummary(
       browserInfo: args.terminal.browserInfo,
     },
     health: deriveTerminalHealth({
+      attentionReasons,
       runtimeAgeMs,
       runtimeStatus,
       syncEvidence,
@@ -149,11 +175,13 @@ async function buildTerminalHealthSummary(
     }),
     runtimeAgeMs,
     runtimeStatus: runtimeStatus ? stripRuntimeStatusIdentity(runtimeStatus) : null,
+    attentionReasons,
     syncEvidence,
   };
 }
 
 function deriveTerminalHealth(input: {
+  attentionReasons: TerminalHealthAttentionReason[];
   runtimeAgeMs: number | null;
   runtimeStatus: Doc<"posTerminalRuntimeStatus"> | null;
   syncEvidence: TerminalSyncEvidence;
@@ -163,21 +191,12 @@ function deriveTerminalHealth(input: {
     return "offline";
   }
 
-  if (!input.runtimeStatus || input.runtimeAgeMs === null) {
-    return "unknown";
+  if (input.attentionReasons.length > 0) {
+    return "needs_attention";
   }
 
-  if (
-    input.runtimeStatus.sync.status === "failed" ||
-    input.runtimeStatus.sync.status === "needs_review" ||
-    input.runtimeStatus.sync.status === "unavailable" ||
-    input.runtimeStatus.sync.failedEventCount > 0 ||
-    input.runtimeStatus.sync.reviewEventCount > 0 ||
-    input.syncEvidence.conflictedCount > 0 ||
-    input.syncEvidence.heldCount > 0 ||
-    input.syncEvidence.rejectedCount > 0
-  ) {
-    return "needs_attention";
+  if (!input.runtimeStatus || input.runtimeAgeMs === null) {
+    return "unknown";
   }
 
   if (
@@ -188,6 +207,103 @@ function deriveTerminalHealth(input: {
   }
 
   return input.runtimeAgeMs <= 15 * 60 * 1000 ? "stale" : "offline";
+}
+
+function deriveTerminalHealthAttentionReasons(input: {
+  runtimeStatus: Doc<"posTerminalRuntimeStatus"> | null;
+  syncEvidence: TerminalSyncEvidence;
+  terminalStatus: Doc<"posTerminal">["status"];
+}): TerminalHealthAttentionReason[] {
+  if (input.terminalStatus !== "active") {
+    return [];
+  }
+
+  const reasons: TerminalHealthAttentionReason[] = [];
+  const sync = input.runtimeStatus?.sync;
+  const latestEvent = input.syncEvidence.latestEvent;
+
+  if (sync && (sync.status === "needs_review" || sync.reviewEventCount > 0)) {
+    const count = Math.max(1, sync.reviewEventCount);
+    reasons.push({
+      count,
+      nextPendingUploadSequence: sync.nextPendingUploadSequence,
+      oldestPendingEventAt: sync.oldestPendingEventAt,
+      source: "local_runtime",
+      summary: `${count} local review item${count === 1 ? " is" : "s are"} still on this terminal.`,
+      type: "local_review",
+    });
+  }
+
+  if (sync && (sync.status === "failed" || sync.failedEventCount > 0)) {
+    const count = Math.max(1, sync.failedEventCount);
+    reasons.push({
+      count,
+      nextPendingUploadSequence: sync.nextPendingUploadSequence,
+      oldestPendingEventAt: sync.oldestPendingEventAt,
+      source: "local_runtime",
+      summary: `${count} local sync item${count === 1 ? " has" : "s have"} failed on this terminal.`,
+      type: "sync_failed",
+    });
+  }
+
+  if (sync?.status === "unavailable") {
+    reasons.push({
+      source: "local_runtime",
+      summary: "Local sync runtime is unavailable on this terminal.",
+      type: "sync_unavailable",
+    });
+  }
+
+  if (input.runtimeStatus?.localStore.available === false) {
+    reasons.push({
+      source: "terminal_runtime",
+      summary: "Local terminal storage is not available.",
+      type: "local_store_unavailable",
+    });
+  }
+
+  if (input.runtimeStatus?.localStore.terminalSeedReady === false) {
+    reasons.push({
+      source: "terminal_runtime",
+      summary: "Terminal setup data is not ready on this checkout station.",
+      type: "terminal_seed_missing",
+    });
+  }
+
+  if (input.syncEvidence.conflictedCount > 0) {
+    reasons.push({
+      count: input.syncEvidence.conflictedCount,
+      latestEventSequence: latestEvent?.sequence,
+      latestEventStatus: latestEvent?.status,
+      source: "cloud_sync",
+      summary: `${input.syncEvidence.conflictedCount} cloud sync conflict${input.syncEvidence.conflictedCount === 1 ? " needs" : "s need"} review.`,
+      type: "cloud_conflict",
+    });
+  }
+
+  if (input.syncEvidence.heldCount > 0) {
+    reasons.push({
+      count: input.syncEvidence.heldCount,
+      latestEventSequence: latestEvent?.sequence,
+      latestEventStatus: latestEvent?.status,
+      source: "cloud_sync",
+      summary: `${input.syncEvidence.heldCount} synced item${input.syncEvidence.heldCount === 1 ? " is" : "s are"} held before projection.`,
+      type: "cloud_held",
+    });
+  }
+
+  if (input.syncEvidence.rejectedCount > 0) {
+    reasons.push({
+      count: input.syncEvidence.rejectedCount,
+      latestEventSequence: latestEvent?.sequence,
+      latestEventStatus: latestEvent?.status,
+      source: "cloud_sync",
+      summary: `${input.syncEvidence.rejectedCount} synced item${input.syncEvidence.rejectedCount === 1 ? " was" : "s were"} rejected by the server.`,
+      type: "cloud_rejected",
+    });
+  }
+
+  return reasons;
 }
 
 function stripRuntimeStatusIdentity(status: Doc<"posTerminalRuntimeStatus">) {

--- a/packages/athena-webapp/convex/pos/application/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminals.test.ts
@@ -489,6 +489,229 @@ describe("terminal health summaries", () => {
     );
   });
 
+  it("returns a local runtime review reason when runtime review is the attention source", async () => {
+    vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
+    vi.mocked(getLatestRuntimeStatusForTerminal).mockResolvedValue(
+      buildPersistedRuntimeStatus({
+        sync: {
+          ...buildRuntimeStatus().sync,
+          failedEventCount: 0,
+          lastFailureMessage:
+            "Bearer raw.token.value and Authorization: ApiKey custom-secret",
+          reviewEventCount: 1,
+          status: "needs_review" as never,
+        },
+      }),
+    );
+    vi.mocked(getTerminalSyncEvidence).mockResolvedValue({
+      latestEvent: null,
+      sampledEventCount: 75,
+      acceptedCount: 0,
+      projectedCount: 75,
+      conflictedCount: 0,
+      heldCount: 0,
+      rejectedCount: 0,
+      acceptedThroughSequence: 22,
+      cursorUpdatedAt: 180,
+    });
+
+    const result = await getTerminalHealthSummary(
+      { db: null as never } as never,
+      {
+        storeId: "store-1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        now: 220,
+      },
+    );
+
+    expect(result?.health).toBe("needs_attention");
+    expect(result?.attentionReasons).toEqual([
+      expect.objectContaining({
+        count: 1,
+        nextPendingUploadSequence: 4,
+        source: "local_runtime",
+        summary: "1 local review item is still on this terminal.",
+        type: "local_review",
+      }),
+    ]);
+    expect(JSON.stringify(result?.attentionReasons)).not.toContain("Bearer");
+    expect(JSON.stringify(result?.attentionReasons)).not.toContain(
+      "custom-secret",
+    );
+  });
+
+  it("returns runtime failure, availability, and setup reasons when terminal check-in reports them", async () => {
+    vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
+    vi.mocked(getLatestRuntimeStatusForTerminal).mockResolvedValue(
+      buildPersistedRuntimeStatus({
+        localStore: {
+          ...buildRuntimeStatus().localStore,
+          available: false,
+          terminalSeedReady: false,
+        },
+        sync: {
+          ...buildRuntimeStatus().sync,
+          failedEventCount: 2,
+          pendingEventCount: 0,
+          reviewEventCount: 0,
+          status: "unavailable" as never,
+          uploadableEventCount: 0,
+        },
+      }),
+    );
+    vi.mocked(getTerminalSyncEvidence).mockResolvedValue({
+      latestEvent: null,
+      sampledEventCount: 0,
+      acceptedCount: 0,
+      projectedCount: 0,
+      conflictedCount: 0,
+      heldCount: 0,
+      rejectedCount: 0,
+    });
+
+    const result = await getTerminalHealthSummary(
+      { db: null as never } as never,
+      {
+        storeId: "store-1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        now: 220,
+      },
+    );
+
+    expect(result?.health).toBe("needs_attention");
+    expect(result?.attentionReasons).toEqual([
+      expect.objectContaining({
+        count: 2,
+        source: "local_runtime",
+        summary: "2 local sync items have failed on this terminal.",
+        type: "sync_failed",
+      }),
+      expect.objectContaining({
+        source: "local_runtime",
+        summary: "Local sync runtime is unavailable on this terminal.",
+        type: "sync_unavailable",
+      }),
+      expect.objectContaining({
+        source: "terminal_runtime",
+        summary: "Local terminal storage is not available.",
+        type: "local_store_unavailable",
+      }),
+      expect.objectContaining({
+        source: "terminal_runtime",
+        summary: "Terminal setup data is not ready on this checkout station.",
+        type: "terminal_seed_missing",
+      }),
+    ]);
+  });
+
+  it("returns cloud evidence reasons when server sync evidence needs review", async () => {
+    vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
+    vi.mocked(getLatestRuntimeStatusForTerminal).mockResolvedValue(
+      buildPersistedRuntimeStatus({
+        sync: {
+          ...buildRuntimeStatus().sync,
+          failedEventCount: 0,
+          pendingEventCount: 0,
+          reviewEventCount: 0,
+          status: "idle" as never,
+          uploadableEventCount: 0,
+        },
+      }),
+    );
+    vi.mocked(getTerminalSyncEvidence).mockResolvedValue({
+      latestEvent: {
+        localEventId: "local-event-1",
+        localRegisterSessionId: "local-register-1",
+        sequence: 9,
+        eventType: "register_closed",
+        status: "conflicted",
+        occurredAt: 120,
+        submittedAt: 130,
+      },
+      sampledEventCount: 3,
+      acceptedCount: 0,
+      projectedCount: 2,
+      conflictedCount: 1,
+      heldCount: 1,
+      rejectedCount: 1,
+      acceptedThroughSequence: 8,
+      cursorUpdatedAt: 180,
+    });
+
+    const result = await getTerminalHealthSummary(
+      { db: null as never } as never,
+      {
+        storeId: "store-1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        now: 220,
+      },
+    );
+
+    expect(result?.health).toBe("needs_attention");
+    expect(result?.attentionReasons).toEqual([
+      expect.objectContaining({
+        count: 1,
+        source: "cloud_sync",
+        summary: "1 cloud sync conflict needs review.",
+        type: "cloud_conflict",
+      }),
+      expect.objectContaining({
+        count: 1,
+        source: "cloud_sync",
+        summary: "1 synced item is held before projection.",
+        type: "cloud_held",
+      }),
+      expect.objectContaining({
+        count: 1,
+        source: "cloud_sync",
+        summary: "1 synced item was rejected by the server.",
+        type: "cloud_rejected",
+      }),
+    ]);
+  });
+
+  it("treats cloud review evidence as needing attention even without runtime status", async () => {
+    vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
+    vi.mocked(getLatestRuntimeStatusForTerminal).mockResolvedValue(null);
+    vi.mocked(getTerminalSyncEvidence).mockResolvedValue({
+      latestEvent: {
+        localEventId: "local-event-1",
+        localRegisterSessionId: "local-register-1",
+        sequence: 9,
+        eventType: "register_closed",
+        status: "conflicted",
+        occurredAt: 120,
+        submittedAt: 130,
+      },
+      sampledEventCount: 1,
+      acceptedCount: 0,
+      projectedCount: 0,
+      conflictedCount: 1,
+      heldCount: 0,
+      rejectedCount: 0,
+    });
+
+    const result = await getTerminalHealthSummary(
+      { db: null as never } as never,
+      {
+        storeId: "store-1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        now: 220,
+      },
+    );
+
+    expect(result?.health).toBe("needs_attention");
+    expect(result?.runtimeStatus).toBeNull();
+    expect(result?.attentionReasons).toEqual([
+      expect.objectContaining({
+        count: 1,
+        source: "cloud_sync",
+        summary: "1 cloud sync conflict needs review.",
+        type: "cloud_conflict",
+      }),
+    ]);
+  });
+
   it.each([
     {
       expectedHealth: "offline",
@@ -598,6 +821,7 @@ describe("terminal health summaries", () => {
     );
 
     expect(result[0]?.health).toBe(scenario.expectedHealth);
+    expect(result[0]?.attentionReasons).toEqual([]);
   });
 
   it("returns null for detail when the terminal is outside the requested store", async () => {

--- a/packages/athena-webapp/convex/pos/public/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.test.ts
@@ -484,6 +484,32 @@ describe("POS terminal public mutations", () => {
     );
   });
 
+  it("exports validator-safe terminal health attention reasons", () => {
+    const returnValidator = JSON.stringify(
+      (listTerminalHealthSummaries as any).exportReturns(),
+    );
+
+    for (const value of [
+      "attentionReasons",
+      "local_review",
+      "sync_failed",
+      "sync_unavailable",
+      "local_store_unavailable",
+      "terminal_seed_missing",
+      "cloud_conflict",
+      "cloud_held",
+      "cloud_rejected",
+      "cloud_sync",
+      "local_runtime",
+      "terminal_runtime",
+    ]) {
+      expect(returnValidator).toContain(value);
+    }
+    expect(returnValidator).not.toContain("payload");
+    expect(returnValidator).not.toContain("syncSecret");
+    expect(returnValidator).not.toContain("staffProofToken");
+  });
+
   it("requires store membership before loading terminal health detail", async () => {
     const ctx = buildCtx();
 

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -129,6 +129,30 @@ const terminalHealthStatusValidator = v.union(
   v.literal("unknown"),
 );
 
+const terminalHealthAttentionReasonReturnValidator = v.object({
+  count: v.optional(v.number()),
+  latestEventSequence: v.optional(v.number()),
+  latestEventStatus: v.optional(v.string()),
+  nextPendingUploadSequence: v.optional(v.number()),
+  oldestPendingEventAt: v.optional(v.number()),
+  source: v.union(
+    v.literal("cloud_sync"),
+    v.literal("local_runtime"),
+    v.literal("terminal_runtime"),
+  ),
+  summary: v.string(),
+  type: v.union(
+    v.literal("cloud_conflict"),
+    v.literal("cloud_held"),
+    v.literal("cloud_rejected"),
+    v.literal("local_review"),
+    v.literal("local_store_unavailable"),
+    v.literal("sync_failed"),
+    v.literal("sync_unavailable"),
+    v.literal("terminal_seed_missing"),
+  ),
+});
+
 const terminalRegistrationSummaryReturnValidator = v.object({
   _id: v.id("posTerminal"),
   displayName: v.string(),
@@ -144,6 +168,7 @@ const terminalHealthSummaryReturnValidator = v.object({
   health: terminalHealthStatusValidator,
   runtimeAgeMs: v.union(v.number(), v.null()),
   runtimeStatus: v.union(runtimeStatusSnapshotReturnValidator, v.null()),
+  attentionReasons: v.array(terminalHealthAttentionReasonReturnValidator),
   syncEvidence: terminalSyncEvidenceReturnValidator,
 });
 

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -500,6 +500,7 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("2026-05-15T12:34:56Z")).toBeInTheDocument();
     expect(screen.getByText("local 4 synced 4 next n/a")).toBeInTheDocument();
     expect(screen.getByText("eligible uploads")).toBeInTheDocument();
+    expect(screen.getByText("local review items")).toBeInTheDocument();
     expect(screen.getByText("runtime mode")).toBeInTheDocument();
     expect(screen.getByText("Status only")).toBeInTheDocument();
     expect(screen.getByText("local-only events")).toBeInTheDocument();

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -468,7 +468,7 @@ function POSLocalDebugStrip({
         : String(debug.syncFlow.lastHeldEventCount),
     ],
     [
-      "review events",
+      "local review items",
       [
         `local ${debug.syncFlow.reviewEventCount ?? 0}`,
         `last ${debug.syncFlow.lastReviewEventCount ?? "n/a"}`,
@@ -524,7 +524,9 @@ function POSLocalDebugStrip({
           ? "Uploading"
           : debug.syncFlow.status === "synced"
             ? "Uploaded"
-            : "Upload",
+            : debug.syncFlow.status === "needs_review"
+              ? "Local review"
+              : "Upload",
       state:
         debug.syncFlow.status === "needs_review"
           ? "blocked"
@@ -539,7 +541,7 @@ function POSLocalDebugStrip({
         debug.syncFlow.status === "synced"
           ? "Server current"
           : debug.syncFlow.status === "needs_review"
-            ? "Needs review"
+            ? "Local review item"
             : "Server update",
       state:
         debug.syncFlow.status === "synced"

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
@@ -99,6 +99,23 @@ vi.mock("@/components/states/signed-out/ProtectedAdminSignInView", () => ({
 }));
 
 const detail: TerminalHealthDetail = {
+  attentionReasons: [
+    {
+      count: 1,
+      nextPendingUploadSequence: 14,
+      source: "local_runtime",
+      summary: "1 local review item is still on this terminal.",
+      type: "local_review",
+    },
+    {
+      count: 1,
+      latestEventSequence: 14,
+      latestEventStatus: "held",
+      source: "cloud_sync",
+      summary: "1 synced item is held before projection.",
+      type: "cloud_held",
+    },
+  ],
   health: "needs_attention",
   runtimeStatus: {
     _id: "status-1",
@@ -197,10 +214,66 @@ describe("POSTerminalDetailViewContent", () => {
     expect(screen.getByRole("heading", { name: "Front counter" })).toBeInTheDocument();
     expect(screen.getAllByText("Register 1").length).toBeGreaterThan(0);
     expect(screen.getByText("Latest check-in")).toBeInTheDocument();
-    expect(screen.getByText("Cloud sync evidence")).toBeInTheDocument();
+    expect(
+      screen.getByText("Why this terminal needs attention"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("1 local review item is still on this terminal."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("1 synced item is held before projection."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Local runtime review / next upload #14")).toBeInTheDocument();
+    expect(screen.getAllByText("Cloud sync evidence").length).toBeGreaterThan(0);
     expect(screen.getByText("Staff authority changed before sync.")).toBeInTheDocument();
     expect(screen.getByText("IndexedDB blocked")).toBeInTheDocument();
     expect(screen.getByText("Upload failed")).toBeInTheDocument();
+  });
+
+  it("does not render attention reasons for a healthy terminal", () => {
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          attentionReasons: [],
+          health: "online",
+          runtimeStatus: {
+            ...detail.runtimeStatus!,
+            localStore: { available: true, terminalSeedReady: true },
+            sync: {
+              ...detail.runtimeStatus!.sync,
+              failedEventCount: 0,
+              pendingEventCount: 0,
+              reviewEventCount: 0,
+              status: "idle",
+              uploadableEventCount: 0,
+            },
+          },
+          syncEvidence: {
+            acceptedCount: 4,
+            acceptedThroughSequence: 9,
+            conflictedCount: 0,
+            heldCount: 0,
+            latestEvent: null,
+            projectedCount: 3,
+            rejectedCount: 0,
+            sampledEventCount: 5,
+            unresolvedConflictCount: 0,
+            unresolvedConflicts: [],
+          },
+        }}
+        isLoading={false}
+      />,
+    );
+
+    expect(
+      screen.queryByText("Why this terminal needs attention"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "No unresolved cloud sync conflicts are currently reported. Local runtime review, pending sync, or stale check-ins may still need attention above.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("renders no-data and query unavailable states", () => {

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
@@ -29,6 +29,7 @@ import {
   getReviewEvidenceCount,
   getSnapshotAgeSummary,
   getStaffAuthorityLabel,
+  getTerminalAttentionReasons,
 } from "./terminalHealthPresentation";
 import type {
   TerminalHealthDetail,
@@ -163,7 +164,7 @@ function ConflictSection({
         <p className="text-sm text-muted-foreground">
           {reviewCount > 0
             ? `${reviewCount} sync item${reviewCount === 1 ? "" : "s"} need review; detailed conflict records were not returned.`
-            : "No unresolved terminal conflicts are currently reported."}
+            : "No unresolved cloud sync conflicts are currently reported. Local runtime review, pending sync, or stale check-ins may still need attention above."}
         </p>
       ) : (
         <div className="space-y-layout-sm">
@@ -182,6 +183,48 @@ function ConflictSection({
           ))}
         </div>
       )}
+    </DetailPanel>
+  );
+}
+
+function AttentionReasonsSection({
+  detail,
+}: {
+  detail: TerminalHealthDetail;
+}) {
+  const reasons = getTerminalAttentionReasons(detail);
+
+  if (reasons.length === 0) {
+    return null;
+  }
+
+  return (
+    <DetailPanel
+      icon={<AlertTriangle className="h-4 w-4 text-warning" />}
+      title="Why this terminal needs attention"
+    >
+      <div className="space-y-layout-sm">
+        {reasons.map((reason, index) => (
+          <div
+            className="rounded-md border border-warning/30 bg-warning/10 px-layout-md py-layout-sm"
+            key={`${reason.type}-${index}`}
+          >
+            <p className="text-sm font-medium text-foreground">
+              {reason.summary}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {reason.source === "cloud_sync"
+                ? "Cloud sync evidence"
+                : reason.source === "local_runtime"
+                  ? "Local runtime review"
+                  : "Terminal check-in"}
+              {reason.nextPendingUploadSequence == null
+                ? ""
+                : ` / next upload #${reason.nextPendingUploadSequence}`}
+            </p>
+          </div>
+        ))}
+      </div>
     </DetailPanel>
   );
 }
@@ -309,6 +352,7 @@ export function POSTerminalDetailViewContent({
             </aside>
 
             <main className="space-y-layout-md">
+              <AttentionReasonsSection detail={detail} />
               <SyncEvidenceSection syncEvidence={detail.syncEvidence} />
               <ConflictSection syncEvidence={detail.syncEvidence} />
               <SupportNotesSection runtimeStatus={runtimeStatus} />

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx
@@ -179,12 +179,54 @@ describe("POSTerminalHealthViewContent", () => {
           },
           {
             ...baseSummary,
+            attentionReasons: [
+              {
+                count: 1,
+                source: "local_runtime",
+                summary: "1 local review item is still on this terminal.",
+                type: "local_review",
+              },
+            ],
             runtimeStatus: null,
+            health: "needs_attention",
             terminal: {
               ...baseSummary.terminal,
               _id: "terminal-3",
               displayName: "Spare laptop",
               registerNumber: null,
+            },
+          },
+          {
+            ...baseSummary,
+            attentionReasons: [
+              {
+                count: 1,
+                latestEventSequence: 8,
+                latestEventStatus: "held",
+                source: "cloud_sync",
+                summary: "1 synced item is held before projection.",
+                type: "cloud_held",
+              },
+              {
+                source: "terminal_runtime",
+                summary:
+                  "Terminal setup data is not ready on this checkout station.",
+                type: "terminal_seed_missing",
+              },
+            ],
+            health: "needs_attention",
+            runtimeStatus: {
+              ...baseSummary.runtimeStatus!,
+              localStore: {
+                ...baseSummary.runtimeStatus!.localStore,
+                terminalSeedReady: false,
+              },
+            },
+            terminal: {
+              ...baseSummary.terminal,
+              _id: "terminal-4",
+              displayName: "Review kiosk",
+              registerNumber: "4",
             },
           },
         ]}
@@ -199,7 +241,15 @@ describe("POSTerminalHealthViewContent", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Healthy")).toBeInTheDocument();
     expect(screen.getAllByText("Pending sync").length).toBeGreaterThan(0);
-    expect(screen.getByText("No check-in")).toBeInTheDocument();
+    expect(screen.queryByText("No check-in")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Needs review").length).toBeGreaterThan(0);
+    expect(
+      screen.getByText("1 local review item is still on this terminal."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("1 synced item is held before projection."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Review kiosk")).toBeInTheDocument();
     expect(screen.getAllByText("Staff authority ready").length).toBeGreaterThan(0);
     expect(
       screen.getAllByText("Register session evidence is shown in cash controls").length,

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx
@@ -25,6 +25,7 @@ import {
   getReviewEvidenceCount,
   getSnapshotAgeSummary,
   getStaffAuthorityLabel,
+  getPrimaryTerminalAttentionReason,
 } from "./terminalHealthPresentation";
 import type { TerminalHealthSummary } from "./terminalHealthTypes";
 import { getOrigin } from "~/src/lib/navigationUtils";
@@ -128,6 +129,8 @@ export function POSTerminalHealthViewContent({
                 <section className="space-y-layout-sm">
                   {healthRows.map(({ classification, summary }) => {
                     const runtimeStatus = summary.runtimeStatus;
+                    const primaryReason =
+                      getPrimaryTerminalAttentionReason(summary);
 
                     return (
                       <article
@@ -184,6 +187,9 @@ export function POSTerminalHealthViewContent({
                               {runtimeStatus
                                 ? `${runtimeStatus.sync.pendingEventCount} pending / ${runtimeStatus.sync.reviewEventCount + getReviewEvidenceCount(summary.syncEvidence)} review`
                                 : "No runtime sync check-in"}
+                            </p>
+                            <p className="mt-1 text-xs text-muted-foreground">
+                              {primaryReason?.summary ?? classification.description}
                             </p>
                           </div>
                           <div>

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
@@ -4,6 +4,8 @@ import {
   classifyTerminalHealth,
   formatAge,
   formatTerminalTimestamp,
+  getPrimaryTerminalAttentionReason,
+  getTerminalAttentionReasons,
   getSnapshotAgeSummary,
 } from "./terminalHealthPresentation";
 
@@ -56,6 +58,14 @@ describe("terminal health presentation", () => {
 
     expect(
       classifyTerminalHealth({
+        attentionReasons: [
+          {
+            count: 1,
+            source: "local_runtime",
+            summary: "1 local review item is still on this terminal.",
+            type: "local_review",
+          },
+        ],
         runtimeStatus: {
           receivedAt: Date.now(),
           sync: {
@@ -88,7 +98,215 @@ describe("terminal health presentation", () => {
       }).label,
     ).toBe("Needs review");
 
+    expect(
+      classifyTerminalHealth({
+        attentionReasons: [
+          {
+            count: 1,
+            source: "local_runtime",
+            summary: "1 local review item is still on this terminal.",
+            type: "local_review",
+          },
+        ],
+        runtimeStatus: {
+          receivedAt: Date.now(),
+          sync: {
+            failedEventCount: 0,
+            pendingEventCount: 0,
+            reviewEventCount: 1,
+            status: "needs_review",
+            uploadableEventCount: 0,
+          },
+        },
+        syncEvidence: { unresolvedConflictCount: 0 },
+        terminal: { status: "active" },
+      }).description,
+    ).toBe("1 local review item is still on this terminal.");
+
     vi.useRealTimers();
+  });
+
+  it("returns backend attention reasons without synthesizing fallback reasons", () => {
+    expect(
+      getPrimaryTerminalAttentionReason({
+        attentionReasons: [
+          {
+            source: "cloud_sync",
+            summary: "1 cloud sync conflict needs review.",
+            type: "cloud_conflict",
+          },
+        ],
+        runtimeStatus: null,
+        syncEvidence: {},
+        terminal: { status: "active" },
+      })?.summary,
+    ).toBe("1 cloud sync conflict needs review.");
+
+    expect(
+      getTerminalAttentionReasons({
+        runtimeStatus: {
+          sync: {
+            failedEventCount: 0,
+            nextPendingUploadSequence: 23,
+            pendingEventCount: 0,
+            reviewEventCount: 1,
+            status: "needs_review",
+            uploadableEventCount: 0,
+          },
+        },
+        syncEvidence: { conflictedCount: 0, heldCount: 0, rejectedCount: 0 },
+        terminal: { status: "active" },
+      }),
+    ).toEqual([]);
+  });
+
+  it("classifies backend-only attention reasons", () => {
+    expect(
+      classifyTerminalHealth({
+        attentionReasons: [
+          {
+            source: "terminal_runtime",
+            summary: "Terminal setup data is not ready on this checkout station.",
+            type: "terminal_seed_missing",
+          },
+        ],
+        health: "needs_attention",
+        runtimeStatus: {
+          receivedAt: Date.now(),
+          localStore: { available: true, terminalSeedReady: false },
+          sync: {
+            failedEventCount: 0,
+            pendingEventCount: 0,
+            reviewEventCount: 0,
+            status: "idle",
+            uploadableEventCount: 0,
+          },
+        },
+        syncEvidence: { unresolvedConflictCount: 0 },
+        terminal: { status: "active" },
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        description: "Terminal setup data is not ready on this checkout station.",
+        label: "Setup needed",
+      }),
+    );
+  });
+
+  it("honors backend attention reasons when runtime status is missing", () => {
+    expect(
+      classifyTerminalHealth({
+        attentionReasons: [
+          {
+            count: 1,
+            source: "cloud_sync",
+            summary: "1 cloud sync conflict needs review.",
+            type: "cloud_conflict",
+          },
+        ],
+        health: "needs_attention",
+        runtimeStatus: null,
+        syncEvidence: { unresolvedConflictCount: 1 },
+        terminal: { status: "active" },
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        description: "1 cloud sync conflict needs review.",
+        label: "Needs review",
+      }),
+    );
+  });
+
+  it.each([
+    {
+      expectedLabel: "Needs review",
+      reason: {
+        source: "local_runtime" as const,
+        summary: "1 local review item is still on this terminal.",
+        type: "local_review" as const,
+      },
+    },
+    {
+      expectedLabel: "Sync failed",
+      reason: {
+        source: "local_runtime" as const,
+        summary: "1 local sync item has failed on this terminal.",
+        type: "sync_failed" as const,
+      },
+    },
+    {
+      expectedLabel: "Sync unavailable",
+      reason: {
+        source: "local_runtime" as const,
+        summary: "Local sync runtime is unavailable on this terminal.",
+        type: "sync_unavailable" as const,
+      },
+    },
+    {
+      expectedLabel: "Local store issue",
+      reason: {
+        source: "terminal_runtime" as const,
+        summary: "Local terminal storage is not available.",
+        type: "local_store_unavailable" as const,
+      },
+    },
+    {
+      expectedLabel: "Setup needed",
+      reason: {
+        source: "terminal_runtime" as const,
+        summary: "Terminal setup data is not ready on this checkout station.",
+        type: "terminal_seed_missing" as const,
+      },
+    },
+    {
+      expectedLabel: "Needs review",
+      reason: {
+        source: "cloud_sync" as const,
+        summary: "1 cloud sync conflict needs review.",
+        type: "cloud_conflict" as const,
+      },
+    },
+    {
+      expectedLabel: "Needs review",
+      reason: {
+        source: "cloud_sync" as const,
+        summary: "1 synced item is held before projection.",
+        type: "cloud_held" as const,
+      },
+    },
+    {
+      expectedLabel: "Needs review",
+      reason: {
+        source: "cloud_sync" as const,
+        summary: "1 synced item was rejected by the server.",
+        type: "cloud_rejected" as const,
+      },
+    },
+  ])("classifies $reason.type attention reasons", ({ expectedLabel, reason }) => {
+    expect(
+      classifyTerminalHealth({
+        attentionReasons: [reason],
+        health: "needs_attention",
+        runtimeStatus: {
+          receivedAt: Date.now(),
+          localStore: { available: true, terminalSeedReady: true },
+          sync: {
+            failedEventCount: 0,
+            pendingEventCount: 0,
+            reviewEventCount: 0,
+            status: "idle",
+            uploadableEventCount: 0,
+          },
+        },
+        syncEvidence: { unresolvedConflictCount: 0 },
+        terminal: { status: "active" },
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        description: reason.summary,
+        label: expectedLabel,
+      }),
+    );
   });
 
   it("formats timestamps and snapshot ages in operator-readable labels", () => {

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
@@ -3,6 +3,7 @@ import type {
   TerminalSyncEvent,
   TerminalSyncEvidence,
   TerminalRuntimeStatus,
+  TerminalHealthAttentionReason,
 } from "./terminalHealthTypes";
 
 export type TerminalHealthClassification = {
@@ -12,6 +13,7 @@ export type TerminalHealthClassification = {
 };
 
 type TerminalHealthClassificationInput = {
+  attentionReasons?: TerminalHealthAttentionReason[];
   health?: "needs_attention" | "offline" | "online" | "stale" | "unknown" | string;
   runtimeStatus:
     | (Omit<Partial<TerminalRuntimeStatus>, "localStore" | "sync"> & {
@@ -143,6 +145,18 @@ export function getRecentSyncEvents(
   return syncEvidence.latestEvent ? [syncEvidence.latestEvent] : [];
 }
 
+export function getTerminalAttentionReasons(
+  summary: TerminalHealthClassificationInput,
+): TerminalHealthAttentionReason[] {
+  return summary.attentionReasons ?? [];
+}
+
+export function getPrimaryTerminalAttentionReason(
+  summary: TerminalHealthClassificationInput,
+) {
+  return getTerminalAttentionReasons(summary)[0] ?? null;
+}
+
 export function classifyTerminalHealth(
   summary: TerminalHealthClassificationInput,
 ): TerminalHealthClassification {
@@ -155,6 +169,45 @@ export function classifyTerminalHealth(
   }
 
   const runtimeStatus = summary.runtimeStatus;
+  const primaryReason = getPrimaryTerminalAttentionReason(summary);
+  if (summary.health === "needs_attention" && primaryReason) {
+    switch (primaryReason.type) {
+      case "local_review":
+      case "cloud_conflict":
+      case "cloud_held":
+      case "cloud_rejected":
+        return {
+          description: primaryReason.summary,
+          label: "Needs review",
+          toneClassName: "border-warning/30 bg-warning/15 text-warning",
+        };
+      case "sync_failed":
+        return {
+          description: primaryReason.summary,
+          label: "Sync failed",
+          toneClassName: "border-danger/30 bg-danger/10 text-danger",
+        };
+      case "sync_unavailable":
+        return {
+          description: primaryReason.summary,
+          label: "Sync unavailable",
+          toneClassName: "border-danger/30 bg-danger/10 text-danger",
+        };
+      case "local_store_unavailable":
+        return {
+          description: primaryReason.summary,
+          label: "Local store issue",
+          toneClassName: "border-danger/30 bg-danger/10 text-danger",
+        };
+      case "terminal_seed_missing":
+        return {
+          description: primaryReason.summary,
+          label: "Setup needed",
+          toneClassName: "border-warning/30 bg-warning/15 text-warning",
+        };
+    }
+  }
+
   if (!runtimeStatus) {
     return {
       description: "This terminal has not reported runtime health yet.",
@@ -170,7 +223,8 @@ export function classifyTerminalHealth(
     getReviewEvidenceCount(summary.syncEvidence) > 0
   ) {
     return {
-      description: "Local activity needs manager or support review.",
+      description:
+        primaryReason?.summary ?? "Local activity needs manager or support review.",
       label: "Needs review",
       toneClassName: "border-warning/30 bg-warning/15 text-warning",
     };
@@ -178,7 +232,7 @@ export function classifyTerminalHealth(
 
   if (sync?.status === "failed" || (sync?.failedEventCount ?? 0) > 0) {
     return {
-      description: "The last sync attempt failed.",
+      description: primaryReason?.summary ?? "The last sync attempt failed.",
       label: "Sync failed",
       toneClassName: "border-danger/30 bg-danger/10 text-danger",
     };
@@ -186,7 +240,8 @@ export function classifyTerminalHealth(
 
   if (runtimeStatus.localStore?.available === false) {
     return {
-      description: "Local terminal storage is not available.",
+      description:
+        primaryReason?.summary ?? "Local terminal storage is not available.",
       label: "Local store issue",
       toneClassName: "border-danger/30 bg-danger/10 text-danger",
     };
@@ -227,7 +282,7 @@ export function classifyTerminalHealth(
   ) {
     return {
       description: "Local events are waiting for cloud sync.",
-    label: sync?.status === "syncing" ? "Syncing" : "Pending sync",
+      label: sync?.status === "syncing" ? "Syncing" : "Pending sync",
       toneClassName: "border-warning/30 bg-warning/15 text-warning",
     };
   }

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
@@ -119,7 +119,28 @@ export type TerminalSyncEvidence = {
   unresolvedConflicts?: TerminalSyncConflict[];
 };
 
+export type TerminalHealthAttentionReason = {
+  count?: number;
+  latestEventSequence?: number;
+  latestEventStatus?: string;
+  nextPendingUploadSequence?: number;
+  oldestPendingEventAt?: number;
+  source: "cloud_sync" | "local_runtime" | "terminal_runtime" | string;
+  summary: string;
+  type:
+    | "cloud_conflict"
+    | "cloud_held"
+    | "cloud_rejected"
+    | "local_review"
+    | "local_store_unavailable"
+    | "sync_failed"
+    | "sync_unavailable"
+    | "terminal_seed_missing"
+    | string;
+};
+
 export type TerminalHealthSummary = {
+  attentionReasons?: TerminalHealthAttentionReason[];
   health?: "needs_attention" | "offline" | "online" | "stale" | "unknown" | string;
   runtimeStatus: TerminalRuntimeStatus | null;
   syncEvidence: TerminalSyncEvidence;

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
@@ -564,6 +564,11 @@ describe("posLocalStore", () => {
       staffProofToken: "proof-token-1",
       payload: { total: 25 },
     });
+    await store.markEventsNeedsReview(
+      ["local-event-2"],
+      "Cloud sync needs review before this local event can finish.",
+      { uploaded: true },
+    );
 
     await expect(
       store.markEventsSynced(["local-event-2"], { uploaded: true }),
@@ -602,6 +607,7 @@ describe("posLocalStore", () => {
     });
     if (listed.ok) {
       expect(listed.value[1]).not.toHaveProperty("staffProofToken");
+      expect(listed.value[1]?.sync.error).toBeUndefined();
     }
   });
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
@@ -821,6 +821,7 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
                 ...eventWithoutProof,
                 sync: {
                   ...event.sync,
+                  error: undefined,
                   status: "synced" as const,
                   ...(markOptions?.uploaded ? { uploaded: true } : {}),
                 },

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -668,6 +668,190 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     );
   });
 
+  it("retries uploaded review events from status-only manual retry so projected server settlement clears local review", async () => {
+    mocks.ingestLocalEvents.mockResolvedValue({
+      kind: "ok",
+      data: {
+        accepted: [
+          {
+            localEventId: "event-closeout",
+            sequence: 1,
+            status: "projected",
+          },
+        ],
+        held: [],
+        mappings: [
+          {
+            _id: "mapping-closeout",
+            storeId: "store-1",
+            terminalId: "terminal-cloud-1",
+            localRegisterSessionId: "register-1",
+            localEventId: "event-closeout",
+            localIdKind: "closeout",
+            localId: "event-closeout",
+            cloudTable: "registerSession",
+            cloudId: "register-session-1",
+            createdAt: 12,
+          },
+        ],
+        conflicts: [],
+        syncCursor: {
+          localRegisterSessionId: "register-1",
+          acceptedThroughSequence: 1,
+        },
+      },
+    });
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            localEventId: "event-closeout",
+            payload: {
+              countedCash: 100,
+              notes: "End of day",
+            },
+            sequence: 1,
+            sync: { status: "needs_review", uploaded: true },
+            type: "register.closeout_started",
+          }),
+        ],
+      })),
+      markEventsSynced: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      markEventsNeedsReview: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      writeLocalCloudMapping: vi.fn(async () => ({
+        ok: true,
+        value: {},
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+    };
+    const storeFactory = () => store as never;
+
+    const { result } = renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        mode: "status-only",
+        storeFactory,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          status: "needs_review",
+        }),
+      ),
+    );
+    expect(mocks.ingestLocalEvents).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current?.onRetrySync?.();
+    });
+
+    await waitFor(() =>
+      expect(mocks.ingestLocalEvents).toHaveBeenCalledWith(
+        expect.objectContaining({
+          events: [
+            expect.objectContaining({
+              eventType: "register_closed",
+              localEventId: "event-closeout",
+            }),
+          ],
+        }),
+      ),
+    );
+    await waitFor(() =>
+      expect(store.markEventsSynced).toHaveBeenCalledWith(["event-closeout"], {
+        uploaded: true,
+      }),
+    );
+    expect(store.markEventsNeedsReview).not.toHaveBeenCalled();
+  });
+
+  it("does not manually retry review events that were never uploaded", async () => {
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            localEventId: "event-closeout",
+            payload: {
+              countedCash: 100,
+              notes: "End of day",
+            },
+            sequence: 1,
+            sync: { status: "needs_review" },
+            type: "register.closeout_started",
+          }),
+        ],
+      })),
+      markEventsSynced: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      markEventsNeedsReview: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+    };
+    const storeFactory = () => store as never;
+
+    const { result } = renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        mode: "status-only",
+        storeFactory,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          status: "needs_review",
+        }),
+      ),
+    );
+    act(() => {
+      result.current?.onRetrySync?.();
+    });
+
+    await waitFor(() => expect(store.listEvents.mock.calls.length).toBeGreaterThan(1));
+    expect(mocks.ingestLocalEvents).not.toHaveBeenCalled();
+    expect(store.markEventsSynced).not.toHaveBeenCalled();
+    expect(store.markEventsNeedsReview).not.toHaveBeenCalled();
+  });
+
   it("marks uploaded events for review when the server rejects the batch", async () => {
     mocks.ingestLocalEvents.mockResolvedValue({
       kind: "user_error",

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -256,6 +256,10 @@ export function usePosLocalSyncRuntimeStatus(input: {
 
       const createDrainScheduler = (
         syncSeed: NonNullable<typeof provisionedSeed>,
+        options: {
+          includeUploadedReviewEvents?: boolean;
+          onlyUploadedReviewEvents?: boolean;
+        } = {},
       ) => createPosLocalSyncScheduler({
         isOnline: () =>
           typeof navigator === "undefined" ? true : navigator.onLine,
@@ -273,12 +277,22 @@ export function usePosLocalSyncRuntimeStatus(input: {
             throw new Error(pending.error.message);
           }
           const uploadableEvents = pending.value.events
-            .filter(
-              (event) =>
+            .filter((event) => {
+              const isUploadedReviewEvent =
+                options.includeUploadedReviewEvents === true &&
+                event.sync.status === "needs_review" &&
+                event.sync.uploaded;
+              if (options.onlyUploadedReviewEvents === true) {
+                return isUploadedReviewEvent;
+              }
+
+              return (
                 event.sync.status === "pending" ||
-                  event.sync.status === "syncing" ||
-                  event.sync.status === "failed",
-            )
+                event.sync.status === "syncing" ||
+                event.sync.status === "failed" ||
+                isUploadedReviewEvent
+              );
+            })
             .filter((event) => isSyncablePosLocalEvent(event));
           if (!shouldStop()) {
             setDebug((current) => ({
@@ -452,15 +466,24 @@ export function usePosLocalSyncRuntimeStatus(input: {
         );
 
         if (
-          drainOnAppend &&
-          trigger === "event-appended" &&
           provisionedSeed &&
           provisionedSeed.syncSecretHash &&
           provisionedSeed.cloudTerminalId === cloudTerminalId
         ) {
-          const scheduler = createDrainScheduler(provisionedSeed);
-          stopSchedulers.push(() => scheduler.stop());
-          scheduler.trigger("event-appended", { priority: "high" });
+          if (drainOnAppend && trigger === "event-appended") {
+            const scheduler = createDrainScheduler(provisionedSeed);
+            stopSchedulers.push(() => scheduler.stop());
+            scheduler.trigger("event-appended", { priority: "high" });
+          }
+
+          if (trigger === "manual-retry") {
+            const scheduler = createDrainScheduler(provisionedSeed, {
+              includeUploadedReviewEvents: true,
+              onlyUploadedReviewEvents: true,
+            });
+            stopSchedulers.push(() => scheduler.stop());
+            scheduler.trigger("manual-retry", { priority: "high" });
+          }
         }
         return;
       }
@@ -473,9 +496,19 @@ export function usePosLocalSyncRuntimeStatus(input: {
         return;
       }
 
-      const scheduler = createDrainScheduler(provisionedSeed);
-      stopSchedulers.push(scheduler.startForegroundTriggers());
-      scheduler.trigger(trigger, { priority: "high" });
+      const foregroundScheduler = createDrainScheduler(provisionedSeed);
+      stopSchedulers.push(foregroundScheduler.startForegroundTriggers());
+
+      if (trigger === "manual-retry") {
+        const manualRetryScheduler = createDrainScheduler(provisionedSeed, {
+          includeUploadedReviewEvents: true,
+        });
+        stopSchedulers.push(() => manualRetryScheduler.stop());
+        manualRetryScheduler.trigger("manual-retry", { priority: "high" });
+        return;
+      }
+
+      foregroundScheduler.trigger(trigger, { priority: "high" });
     })();
 
     return () => {
@@ -823,7 +856,8 @@ function isPendingUploadCandidate(event: PosLocalEventRecord) {
   return (
     event.sync.status === "pending" ||
     event.sync.status === "syncing" ||
-    event.sync.status === "failed"
+    event.sync.status === "failed" ||
+    (event.sync.status === "needs_review" && event.sync.uploaded)
   );
 }
 


### PR DESCRIPTION
## Summary
- Adds backend POS terminal health attention reasons for local runtime review, sync failure/unavailable states, terminal setup/storage readiness, and cloud conflict/held/rejected evidence.
- Renders the same backend reason model in terminal list/detail/register diagnostics so local review is distinct from manager-owned Cash Controls review.
- Makes uploaded local `needs_review` settlement retry manual-only, clears stale local review errors when events sync, and keeps unuploaded review rows out of retry drains.
- Adds plan/solution docs and refreshed graphify artifacts.

## Review
- Used subagents for implementation research and repeated review rounds.
- Final review consent: correctness, testing, maintainability, project standards, API contract, reliability, data integrity, and security all PASS.

## Validation
- `bun run pr:athena`
- Pre-push reused current `pr:athena` proof for tree `a12737fddeb3705d1d35c7f45ad2d85d936db753`.

## Linear
- V26-625
- V26-626
- V26-627
- V26-628
- V26-629