### PR TITLE
fix(pos): block stale terminal sales

### DIFF
--- a/docs/plans/2026-05-29-001-fix-pos-stale-terminal-sale-block-plan.html
+++ b/docs/plans/2026-05-29-001-fix-pos-stale-terminal-sale-block-plan.html
@@ -1,0 +1,333 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>fix: Block stale POS terminals from local sales</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f8fa;
+      --panel: #ffffff;
+      --text: #172033;
+      --muted: #5f6b7a;
+      --line: #d9dee7;
+      --accent: #0f766e;
+      --warn: #a15c00;
+      --danger: #b42318;
+      --code: #eef2f6;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    header, main {
+      width: min(1120px, calc(100% - 40px));
+      margin: 0 auto;
+    }
+    header {
+      padding: 40px 0 18px;
+    }
+    .eyebrow {
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+    }
+    h1 {
+      margin: 8px 0 10px;
+      font-size: clamp(28px, 4vw, 44px);
+      line-height: 1.1;
+      letter-spacing: 0;
+    }
+    .meta {
+      color: var(--muted);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px 18px;
+    }
+    nav {
+      margin: 22px 0 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    nav a {
+      color: var(--text);
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 6px 10px;
+      text-decoration: none;
+      background: var(--panel);
+    }
+    main { padding: 12px 0 48px; }
+    section {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 22px;
+      margin: 16px 0;
+    }
+    h2 {
+      margin: 0 0 12px;
+      font-size: 22px;
+      letter-spacing: 0;
+    }
+    h3 {
+      margin: 18px 0 8px;
+      font-size: 16px;
+      letter-spacing: 0;
+    }
+    p { margin: 0 0 12px; }
+    ul { margin: 8px 0 0; padding-left: 22px; }
+    li { margin: 5px 0; }
+    code {
+      background: var(--code);
+      border-radius: 4px;
+      padding: 1px 4px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.92em;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 10px;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 9px 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: #f1f4f7; }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      gap: 12px;
+    }
+    .callout {
+      border-left: 4px solid var(--accent);
+      background: #eef8f6;
+      padding: 12px 14px;
+      border-radius: 6px;
+    }
+    .warn {
+      border-left-color: var(--warn);
+      background: #fff7ed;
+    }
+    .danger {
+      border-left-color: var(--danger);
+      background: #fff1f0;
+    }
+    .unit {
+      border-top: 1px solid var(--line);
+      padding-top: 16px;
+      margin-top: 16px;
+    }
+    .unit:first-of-type {
+      border-top: 0;
+      padding-top: 0;
+    }
+    .tag {
+      display: inline-block;
+      border-radius: 999px;
+      padding: 2px 8px;
+      background: #e7f0ff;
+      color: #1f4b99;
+      font-size: 12px;
+      font-weight: 700;
+      margin-right: 6px;
+    }
+    .sequence {
+      display: grid;
+      grid-template-columns: repeat(5, minmax(120px, 1fr));
+      gap: 8px;
+      margin: 12px 0;
+    }
+    .sequence div {
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 10px;
+      background: #fafbfc;
+      min-height: 74px;
+    }
+    .arrow {
+      color: var(--muted);
+      font-size: 13px;
+    }
+    @media (max-width: 760px) {
+      header, main { width: min(100% - 24px, 1120px); }
+      section { padding: 18px; }
+      .sequence { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="eyebrow">Implementation Plan · Fix · Active · 2026-05-29 · Deepened</div>
+    <h1>Block stale POS terminals from local sales</h1>
+    <div class="meta">
+      <span>Markdown source: <a href="2026-05-29-001-fix-pos-stale-terminal-sale-block-plan.md">2026-05-29-001-fix-pos-stale-terminal-sale-block-plan.md</a></span>
+      <span>Origin: <a href="../brainstorms/2026-05-13-pos-local-first-register-requirements.md">POS local-first register requirements</a></span>
+    </div>
+    <nav aria-label="Plan sections">
+      <a href="#summary">Summary</a>
+      <a href="#decisions">Decisions</a>
+      <a href="#units">Implementation Units</a>
+      <a href="#impact">Impact</a>
+      <a href="#risks">Risks</a>
+      <a href="#verification">Verification</a>
+    </nav>
+  </header>
+  <main>
+    <section id="summary">
+      <h2>Summary</h2>
+      <p>Preserve POS local-first checkout for normal offline or pending sync, but pause selling when cloud explicitly rejects the terminal's sync/check-in authorization or when a mapped cloud drawer is closed/rejected while IndexedDB still projects it open. The fix adds persistent terminal-integrity and drawer-lifecycle authority state, threads both through local projection and command boundaries, self-heals eligible sync-secret drift, and falls back to setup or drawer-authority recovery only when repair cannot be trusted.</p>
+      <div class="grid">
+        <div class="callout">
+          <strong>Allowed</strong>
+          <p>Offline, pending upload, ordinary syncing, and normal local-first checkout for provisioned terminals.</p>
+        </div>
+        <div class="callout danger">
+          <strong>Blocked</strong>
+          <p>New sale-affecting events after terminal sync/check-in returns <code>authorization_failed</code>, or after cloud drawer lifecycle contradicts local open state.</p>
+        </div>
+        <div class="callout warn">
+          <strong>Self-heal first</strong>
+          <p>Use the authenticated session and terminal fingerprint to repair eligible sync-secret drift, preserving stranded local event diagnostics.</p>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Problem Frame</h2>
+      <p>Arc completed local-only sales from stale IndexedDB state even though Convex had no active register session for that Arc terminal and rejected its local sync token. Separately, the Codex browser showed a successful terminal check-in while local IndexedDB still projected an open drawer whose mapped cloud register session was closed. In both cases the browser failed to convert explicit cloud authority into a local sale block.</p>
+    </section>
+
+    <section>
+      <h2>Scope</h2>
+      <ul>
+        <li>Do not change POS into cloud-confirm-before-sale.</li>
+        <li>Do not auto-delete local IndexedDB events or stranded sales.</li>
+        <li>Do not move manager reconciliation out of Cash Controls / Operations.</li>
+        <li>Do not add payment-provider-specific offline authorization or cross-terminal offline coordination.</li>
+      </ul>
+    </section>
+
+    <section id="decisions">
+      <h2>Key Decisions</h2>
+      <ul>
+        <li><strong>Terminal auth rejection becomes terminal-integrity state.</strong> This separates stale-terminal rejection from normal pending sync.</li>
+        <li><strong>Persist the block locally.</strong> Reloads and route entry must not resume selling from stale projections.</li>
+        <li><strong>Enforce at command boundaries.</strong> UI gates help operators, but local command writes must also reject blocked sale-affecting events.</li>
+        <li><strong>Cloud drawer lifecycle is authority after mapping.</strong> A mapped cloud register session that is closed, rejected, missing, or not current overrides stale local open/reopen events.</li>
+        <li><strong>Self-healing is the first recovery path.</strong> Eligible sync-secret drift can repair itself after cloud re-attestation and durable local seed persistence.</li>
+        <li><strong>Operator recovery is fallback.</strong> Revoked terminals, ownership conflicts, register conflicts, missing access, and local seed write failures remain blocked.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>State Model</h2>
+      <div class="sequence" aria-label="State model">
+        <div><strong>Sellable</strong><br><span class="arrow">healthy local terminal</span></div>
+        <div><strong>Pending Sync</strong><br><span class="arrow">offline or upload pending</span></div>
+        <div><strong>Repairing</strong><br><span class="arrow">auth rejected, re-attesting</span></div>
+        <div><strong>Lifecycle Blocked</strong><br><span class="arrow">drawer authority rejected or closed</span></div>
+        <div><strong>Repaired</strong><br><span class="arrow">fresh seed persisted</span></div>
+      </div>
+      <p>Pending sync can remain sellable. Authorization failure pauses new sale-affecting commands while safe repair runs; mapped closed/rejected drawer authority blocks until a valid drawer authority is established.</p>
+    </section>
+
+    <section id="units">
+      <h2>Implementation Units</h2>
+
+      <article class="unit">
+        <h3><span class="tag">U1</span>Persist terminal and drawer authority state</h3>
+        <p>Add safe local metadata for terminal-integrity and drawer-lifecycle authority status, then expose it through POS local storage and runtime diagnostics.</p>
+        <p><strong>Primary files:</strong> <code>posLocalStore.ts</code>, <code>terminalRuntimeStatus.ts</code>, and their tests.</p>
+      </article>
+
+      <article class="unit">
+        <h3><span class="tag">U2</span>Classify sync and check-in authorization failures</h3>
+        <p>Convert `authorization_failed` responses from sync upload and runtime check-in into the persistent terminal-integrity block.</p>
+        <p><strong>Primary files:</strong> <code>usePosLocalSyncRuntime.ts</code>, <code>convex/pos/public/sync.ts</code>, <code>convex/pos/public/terminals.ts</code>.</p>
+      </article>
+
+      <article class="unit">
+        <h3><span class="tag">U7</span>Self-heal terminal re-attestation</h3>
+        <p>Automatically repair eligible sync-secret drift using the authenticated Athena session, same terminal fingerprint, same store/register scope, and durable local seed write.</p>
+        <p><strong>Primary files:</strong> <code>registerAndProvisionPosTerminal.ts</code>, <code>usePosLocalSyncRuntime.ts</code>, <code>convex/pos/application/commands/terminals.ts</code>.</p>
+      </article>
+
+      <article class="unit">
+        <h3><span class="tag">U3</span>Block local projection and commands</h3>
+        <p>Thread terminal-integrity, uploaded lifecycle review, and mapped cloud drawer closed/rejected authority through `canSell` and the local command gateway so stale clients cannot append new sale events or reuse a stale local drawer.</p>
+        <p><strong>Primary files:</strong> <code>registerReadModel.ts</code>, <code>localRegisterReader.ts</code>, <code>localCommandGateway.ts</code>, <code>syncStatus.ts</code>.</p>
+      </article>
+
+      <article class="unit">
+        <h3><span class="tag">U4</span>Add POS repair/recovery gate</h3>
+        <p>Render automatic repair progress, drawer authority recovery, or setup recovery in the register, and disable checkout and sale controls while blocked.</p>
+        <p><strong>Primary files:</strong> <code>useRegisterViewModel.ts</code>, <code>POSRegisterView.tsx</code>, <code>syncStatusPresentation.ts</code>.</p>
+      </article>
+
+      <article class="unit">
+        <h3><span class="tag">U5</span>Align setup and health evidence</h3>
+        <p>Keep POS Settings, terminal health/detail, and register diagnostics consistent about stale authorization and stale drawer authority without creating new reconciliation ownership.</p>
+        <p><strong>Primary files:</strong> <code>POSSettingsView.tsx</code>, <code>POSTerminalDetailView.tsx</code>, <code>terminalHealthPresentation.ts</code>, <code>convex/pos/application/queries/terminals.ts</code>.</p>
+      </article>
+
+      <article class="unit">
+        <h3><span class="tag">U6</span>Validation, graph, and docs</h3>
+        <p>Update harness coverage, solution docs, and graphify artifacts so stale-terminal sale blocking remains protected.</p>
+        <p><strong>Primary files:</strong> <code>scripts/harness-app-registry.ts</code>, generated validation docs, solution docs, and graphify output.</p>
+      </article>
+    </section>
+
+    <section id="impact">
+      <h2>System-Wide Impact</h2>
+      <table>
+        <thead><tr><th>Surface</th><th>Impact</th></tr></thead>
+        <tbody>
+          <tr><td>Local store</td><td>New safe terminal-integrity and drawer-authority metadata.</td></tr>
+          <tr><td>Sync runtime</td><td>Auth rejection writes the block and continues preserving local events.</td></tr>
+          <tr><td>Register projection and commands</td><td>Blocked terminals and stale mapped drawers cannot append sale-affecting events.</td></tr>
+          <tr><td>Cloud register session</td><td>Closed/rejected mapped drawer authority is consumed as sale-blocking evidence instead of ignored by local projection.</td></tr>
+          <tr><td>POS UI</td><td>Repair/recovery gate distinguishes self-healing, setup repair, drawer authority repair, drawer closeout, and pending sync.</td></tr>
+          <tr><td>Terminal health</td><td>Support evidence explains stale auth without secrets or manager-review drift.</td></tr>
+          <tr><td>Terminal repair</td><td>Fresh local seed persistence is required before clearing the block.</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="risks">
+      <h2>Risks</h2>
+      <table>
+        <thead><tr><th>Risk</th><th>Mitigation</th></tr></thead>
+        <tbody>
+          <tr><td>Over-blocking breaks local-first POS</td><td>Only explicit auth rejection, lifecycle-authority review, or mapped cloud drawer closure/rejection block; offline/pending remains sellable.</td></tr>
+          <tr><td>UI-only blocking misses bypasses</td><td>Enforce in local command gateway and read model.</td></tr>
+          <tr><td>Stale local drawer keeps bypassing cloud closeout</td><td>Check mapped cloud drawer authority before `openDrawer` can return idempotent local success.</td></tr>
+          <tr><td>Self-healing hides a real access problem</td><td>Repair only when cloud verifies the same active terminal, scope, and allowed user policy.</td></tr>
+          <tr><td>Recovery deletes evidence</td><td>Clear the block and update seed without deleting local events by default.</td></tr>
+          <tr><td>Cloud repair succeeds but local seed write fails</td><td>Keep POS blocked until seed persistence succeeds.</td></tr>
+          <tr><td>Support copy leaks sensitive data</td><td>Reuse runtime redaction and avoid raw payloads/secrets.</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="verification">
+      <h2>Verification Strategy</h2>
+      <ul>
+        <li>Characterize current stale-terminal event/rejection behavior before changing projection.</li>
+        <li>Test local store persistence, auth failure classification, mapped cloud drawer closure, read-model `canSell`, command rejection, register gate rendering, setup re-provision clearing, terminal health copy, harness registry coverage, and graphify rebuild.</li>
+        <li>Run the focused POS local sync/register validation slice, Convex audits, typecheck, build, harness review, and graphify rebuild during implementation.</li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/plans/2026-05-29-001-fix-pos-stale-terminal-sale-block-plan.md
+++ b/docs/plans/2026-05-29-001-fix-pos-stale-terminal-sale-block-plan.md
@@ -1,0 +1,567 @@
+---
+title: "fix: Block stale POS terminals from local sales"
+type: fix
+status: active
+date: 2026-05-29
+origin: docs/brainstorms/2026-05-13-pos-local-first-register-requirements.md
+deepened: 2026-05-29
+---
+
+# fix: Block stale POS terminals from local sales
+
+## Summary
+
+Preserve Athena's POS local-first checkout contract while closing two stale-local-authority gaps found in browser IndexedDB state: ordinary offline or pending sync remains sellable, but a terminal that cloud explicitly rejects for sync/check-in authorization becomes locally sale-blocked while the browser attempts automatic re-attestation, and a local drawer whose mapped cloud register session is closed/rejected stops projecting as sellable. The implementation adds persistent terminal-integrity and drawer-lifecycle authority state, threads both through the local read model and command gateway, self-heals eligible sync-secret drift without deleting stranded local evidence, and falls back to an operator recovery gate only when repair cannot be trusted.
+
+---
+
+## Problem Frame
+
+The Arc browser kept completing local-only POS sales from stale IndexedDB state even though Convex had no active register session for that Arc terminal and rejected the terminal's local sync token. The server behaved correctly by rejecting sync, but the browser treated that rejection like generic local review/pending sync and continued projecting a sellable drawer from local events.
+
+A later Codex-browser investigation exposed a related but separate gap: the Codex terminal's cloud check-ins were succeeding, but IndexedDB still projected an open local drawer for a register session whose cloud register session had already closed. `localCommandGateway.openDrawer()` treated that local open drawer as idempotent success instead of appending a new open event or blocking, so there was no new drawer-open event for sync to upload and the register stayed locally sellable from stale drawer authority.
+
+---
+
+## Requirements
+
+- R1. Keep POS local-first for provisioned terminals: normal offline and pending sync must not block checkout. Origin: R6, R9, R24, R32.
+- R2. Treat sync upload or runtime check-in `authorization_failed` as a terminal integrity failure, not as ordinary pending sync or generic review.
+- R3. Persist terminal-integrity failure locally so a reload or route re-entry cannot resume selling from the stale projection.
+- R4. Make sale-start, cart mutation, payment update, service add, closeout reopen, drawer open, and transaction completion respect terminal-integrity blocks at command boundaries.
+- R5. Make uploaded `needs_review` lifecycle events that affect drawer authority sale-blocking until retry, projection, or explicit operator recovery resolves them.
+- R6. Attempt safe self-healing for eligible terminal sync-secret drift using the authenticated Athena session, terminal fingerprint, store scope, and existing terminal ownership before requiring operator intervention.
+- R7. Show a calm POS recovery gate only when automatic repair is unavailable or fails, while preserving local event diagnostics for support.
+- R8. Keep terminal health as support telemetry and Cash Controls as register reconciliation; do not introduce a new manager approval workflow in terminal setup.
+- R9. Harden terminal re-provisioning so a cloud sync-secret rotation is not presented as successful unless the fresh local seed is durably written.
+- R10. Add regression coverage for the stale Arc shape: local drawer/sale events exist, cloud authorization rejects sync/check-in, automatic repair is attempted, and checkout remains blocked unless repair succeeds without erasing local events.
+- R11. Add regression coverage for the Codex-browser drawer lifecycle shape: the terminal check-in succeeds, local IndexedDB projects an open drawer, the mapped cloud `registerSession` is closed or the latest uploaded lifecycle event was rejected, and local open-drawer/start-sale/complete-sale paths remain blocked until a valid drawer authority is established.
+
+**Origin actors:** A1 Cashier, A2 Store manager, A3 Athena POS terminal, A4 Athena cloud.
+**Origin flows:** F1 Provision a POS terminal for offline use, F2 Operate the register while offline, F4 Finalize a local closeout before sync, F5 Sync and reconcile local POS history.
+**Origin acceptance examples:** AE1, AE3, AE6, AE7, AE9.
+
+---
+
+## Scope Boundaries
+
+- This plan does not change Athena's core local-first POS contract into cloud-confirm-before-sale.
+- This plan does not automatically delete Arc IndexedDB data or stranded local sales.
+- This plan does not add payment-provider-specific offline authorization behavior.
+- This plan does not add cross-terminal offline coordination or real-time stock arbitration.
+- This plan does not move manager reconciliation ownership out of Cash Controls / Operations.
+
+### Deferred to Follow-Up Work
+
+- One-off support tooling to export or repair stranded local IndexedDB events can follow after the sale-blocking invariant is in place.
+- Fleet-wide alerting for terminal sync-secret drift can follow after terminal-integrity state is persisted and visible.
+- Audit history for terminal sync-secret rotations can be planned separately if product support needs exact "who rotated this terminal" provenance.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts` owns IndexedDB stores, terminal seeds, events, mappings, readiness, staff authority, catalog, and availability snapshots.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts` uploads local events, publishes runtime check-ins, records sync debug state, and already observes `authorization_failed` for check-in rejection.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts` redacts local runtime evidence and exposes safe sync/readiness counters.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts` currently derives `canSell` from local drawer state and treats `register.reopened` as sellable without cloud confirmation or mapped cloud drawer lifecycle status.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts` is the local-first command boundary for open drawer, start sale, cart/payment/service events, closeout, reopen, and completion; today `openDrawer` returns success for an existing local open drawer before checking whether mapped cloud drawer authority is still valid.
+- `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts` composes terminal, local read model, drawer gate, sync runtime status, and cashier actions.
+- `packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx` renders the drawer gate, sync strip, local closeout pending workspace, and main register surface.
+- `packages/athena-webapp/convex/pos/public/sync.ts` and `packages/athena-webapp/convex/pos/public/terminals.ts` reject stale terminal sync secrets with `authorization_failed`.
+- `packages/athena-webapp/convex/pos/application/commands/terminals.ts` rotates the stored cloud sync secret when an existing fingerprint is re-provisioned.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md` establishes the browser event log as the cashier-path durable record, with Convex projection as background reconciliation.
+- `docs/solutions/architecture/athena-pos-always-local-first-register-2026-05-14.md` establishes that online state must not switch POS commands back to cloud-first behavior.
+- `docs/solutions/logic-errors/athena-pos-drawer-invariants-at-command-boundaries-2026-04-24.md` establishes that drawer gates are ergonomics and invariants must live at command boundaries.
+- `docs/solutions/architecture/athena-pos-terminal-health-visibility-2026-05-20.md` establishes terminal health as support telemetry, not manager reconciliation.
+- `docs/solutions/logic-errors/athena-pos-terminal-review-reason-reconciliation-2026-05-26.md` establishes that local runtime review and cloud conflict evidence must stay distinct and safe to display.
+
+### External References
+
+- External research skipped. The issue is specific to Athena's POS IndexedDB event log, Convex terminal sync-secret contract, and existing local-first architecture.
+
+---
+
+## Key Technical Decisions
+
+- Terminal auth rejection is a distinct local terminal-integrity state: This keeps normal offline/pending sync sellable while making explicit cloud rejection sale-blocking.
+- Persist terminal-integrity state in POS local storage, not only in React debug state: Reloads and route entry must preserve the block.
+- Block at local command boundaries as well as UI gates: A stale client or hidden control must not append new sale-affecting events after terminal integrity is broken.
+- Treat uploaded lifecycle `needs_review` as drawer-authority-blocking when it affects register open, closeout, reopen, or completed sale state: Review/pending sync for ordinary sales can remain visible, but rejected lifecycle authority must not silently permit more sales.
+- Treat mapped cloud drawer lifecycle as authority once a local drawer has a cloud `registerSession` mapping: If cloud reports that mapped drawer as closed, rejected, missing, or not current for this terminal/register, local projection must stop treating the stale open event as sellable.
+- Self-healing is the first recovery path for eligible sync-secret drift: the browser may re-attest using normal Athena auth, fingerprint, store/register scope, and terminal ownership, but must not clear the block until the fresh local seed is durably stored.
+- Operator intervention is the fallback path: revoked/lost terminals, ownership conflicts, register conflicts, missing access, persistent local storage failure, and ambiguous terminal identity remain blocked until a human repairs setup.
+- Preserve local event evidence during recovery: Support needs diagnostics for stranded local events before any operator chooses to reset the terminal.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should all pending sync block checkout? No. The product contract allows offline/pending local-first selling.
+- Should `authorization_failed` be treated the same as `needs_review`? No. It means the terminal is no longer trusted by cloud and should stop appending sale-affecting local events.
+- Is the Codex-browser drawer case the same as terminal auth failure? No. Terminal check-ins can succeed while drawer lifecycle authority is stale. It belongs to the lifecycle-authority block, not self-healing terminal re-attestation.
+- Can this self-heal without operator intervention? Yes, when the signed-in user still has store access, the browser fingerprint maps to the same active terminal, the register assignment is unchanged, and IndexedDB can persist the returned seed. Otherwise it must stay blocked.
+- Should terminal health own reconciliation? No. Terminal health explains support evidence; Cash Controls / Operations continue to own register review.
+
+### Deferred to Implementation
+
+- Exact local storage shape for terminal-integrity state: implementation should use the smallest compatible extension to `posLocalStore`, likely metadata under the existing local store boundary rather than a broad new persistence abstraction.
+- Exact recovery copy and controls: implementation should follow `docs/product-copy-tone.md` and existing POS terminal setup copy after seeing the current view-model shape.
+- Whether to add audit fields to terminal registration immediately: if implementation finds no safe timestamp/provenance path, keep it deferred rather than expanding this fix.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+stateDiagram-v2
+  [*] --> Sellable
+  Sellable --> PendingSync: offline or upload pending
+  PendingSync --> Sellable: sync projected or still pending
+  Sellable --> TerminalBlocked: sync/check-in authorization_failed
+  PendingSync --> TerminalBlocked: sync/check-in authorization_failed
+  Sellable --> LifecycleBlocked: uploaded lifecycle event needs_review
+  PendingSync --> LifecycleBlocked: uploaded lifecycle event needs_review
+  Sellable --> LifecycleBlocked: mapped cloud drawer closed/rejected
+  PendingSync --> LifecycleBlocked: mapped cloud drawer closed/rejected
+  LifecycleBlocked --> Sellable: retry/projected or permitted recovery
+  TerminalBlocked --> SelfHealing: auth session re-attests terminal
+  SelfHealing --> Sellable: fresh seed durably written
+  SelfHealing --> TerminalBlocked: repair rejected or seed write failed
+  TerminalBlocked --> [*]: operator abandons local terminal state
+```
+
+The important split is between pending local-first work and explicit rejection. Offline, pending, and syncing states remain part of normal POS operation; rejected terminal authorization, unresolved lifecycle authority, or a mapped cloud drawer that is already closed/rejected blocks new sale-affecting commands. When the rejection is likely sync-secret drift, the browser can self-heal by re-attesting through authenticated terminal setup and writing a fresh local seed before resuming sales. When cloud drawer lifecycle contradicts local projection, recovery must establish a valid drawer authority before selling resumes.
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1["U1 terminal integrity state"]
+  U2["U2 auth failure classification"]
+  U3["U3 local projection and command block"]
+  U4["U4 POS recovery gate"]
+  U5["U5 terminal health and setup parity"]
+  U6["U6 validation and docs"]
+  U7["U7 self-healing terminal re-attestation"]
+  U1 --> U2
+  U1 --> U3
+  U2 --> U3
+  U2 --> U7
+  U7 --> U3
+  U3 --> U4
+  U2 --> U5
+  U7 --> U5
+  U4 --> U5
+  U1 --> U6
+  U2 --> U6
+  U3 --> U6
+  U4 --> U6
+  U5 --> U6
+  U7 --> U6
+```
+
+- U1. **Persist terminal integrity and drawer authority state**
+
+**Goal:** Add durable local representations of terminal integrity and drawer lifecycle authority so authorization failures and mapped cloud drawer contradictions survive reloads and can be consumed outside transient runtime debug state.
+
+**Requirements:** R2, R3, R8, R10, R11.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts`
+
+**Approach:**
+- Represent terminal integrity as local metadata with statuses such as healthy, blocked for re-provision, or reset required.
+- Represent drawer lifecycle authority as scoped local metadata tied to store, terminal, local register session, optional cloud register session mapping, and a safe blocked reason such as cloud closed, lifecycle rejected, or authority unknown.
+- Store safe reason, observed timestamp, terminal/store/register identifiers, and last safe sync/check-in or drawer-authority context; do not store secrets, proof tokens, raw payloads, customer details, or payment details.
+- Expose read/write helpers from the local store so the sync runtime, register reader, and view model can share one source of truth.
+- Include terminal-integrity and drawer-authority status in safe runtime diagnostics so support copy can explain the block without exposing sensitive fields.
+
+**Execution note:** Add characterization tests for current local-store terminal seed behavior before adding the integrity metadata path.
+
+**Patterns to follow:**
+- Terminal seed and metadata patterns in `posLocalStore.ts`.
+- Redaction rules in `terminalRuntimeStatus.ts`.
+
+**Test scenarios:**
+- Happy path: writing a `requires_reprovision` integrity state persists it and reading it after a new store instance returns the same safe fields.
+- Happy path: writing a drawer-authority block for a mapped cloud register session persists it and reading it after a new store instance returns the same safe fields.
+- Happy path: clearing integrity state after re-provision removes the sale block without deleting local events.
+- Edge case: integrity state for another store or terminal does not block the current scoped terminal.
+- Edge case: drawer-authority state for another local/cloud register session does not block the current active drawer.
+- Error path: local store write failure returns a user-safe store error.
+- Error path: serialized runtime diagnostics do not contain sync secrets, staff proof tokens, PIN/verifier material, customer data, or payment details.
+
+**Verification:**
+- Terminal-integrity and drawer-authority state are available to local runtime and register code after route reload without reading React debug state.
+
+---
+
+- U2. **Classify sync and check-in authorization failures**
+
+**Goal:** Convert cloud `authorization_failed` responses from local sync upload and runtime check-in into the persistent terminal-integrity block.
+
+**Requirements:** R2, R3, R6, R10.
+
+**Dependencies:** U1.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/sync.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/terminals.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`
+- Test: `packages/athena-webapp/convex/pos/public/sync.test.ts`
+- Test: `packages/athena-webapp/convex/pos/public/terminals.test.ts`
+
+**Approach:**
+- Preserve the existing server-side terminal sync-secret checks; they are the correct trust boundary.
+- When `ingestLocalEvents` returns `authorization_failed`, mark the terminal integrity state as requiring re-provision rather than marking the batch as ordinary review.
+- When runtime check-in returns `authorization_failed`, mark the same terminal integrity state even if no upload batch was attempted.
+- Keep network failure, unavailable server, stale telemetry, and ordinary rejected event payloads out of this terminal-auth bucket unless the server returned an auth failure.
+- Ensure manual retry does not clear the block unless re-provision/reset updates the local seed or explicitly clears the terminal-integrity state.
+
+**Patterns to follow:**
+- Existing `checkInPublishReason` handling in `usePosLocalSyncRuntime.ts`.
+- Existing `CommandResult` error codes in `shared/commandResult.ts` and public Convex terminal/sync mutations.
+
+**Test scenarios:**
+- Happy path: sync upload returns `authorization_failed` -> local terminal-integrity state becomes `requires_reprovision` and events remain preserved.
+- Happy path: runtime check-in returns `authorization_failed` -> same integrity state is written even when there are no pending uploadable events.
+- Happy path: eligible `authorization_failed` state schedules self-healing rather than immediately requiring a manual setup flow.
+- Edge case: network exception during check-in -> runtime status is failed/unavailable but terminal integrity does not become blocked.
+- Edge case: held/rejected local event payload -> event remains review/held but terminal integrity does not become blocked unless auth failed.
+- Integration: manual retry while the stale seed remains unchanged reattempts safely but does not clear the block.
+
+**Verification:**
+- A stale sync token produces a persistent local terminal block instead of a generic needs-review state.
+
+---
+
+- U7. **Self-heal terminal re-attestation and seed persistence**
+
+**Goal:** Automatically repair eligible sync-secret drift without operator intervention, while staying blocked when terminal identity, ownership, access, or local persistence cannot be trusted.
+
+**Requirements:** R2, R3, R6, R7, R9, R10.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/application/registerAndProvisionPosTerminal.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/terminals.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/terminals.ts`
+- Modify: `packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx`
+- Test: `packages/athena-webapp/src/lib/pos/application/registerAndProvisionPosTerminal.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/terminals.test.ts`
+- Test: `packages/athena-webapp/convex/pos/public/terminals.test.ts`
+- Test: `packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx`
+
+**Approach:**
+- Characterize the existing terminal registration behavior: an existing terminal found by fingerprint can rotate the cloud sync-secret hash and return the fresh token for local seed persistence.
+- Add a repair path that can be invoked by the sync runtime when authorization fails and the browser is online with an authenticated Athena session.
+- Allow automatic repair only when cloud confirms the same active terminal fingerprint, same store, same register assignment, same registered user or allowed ownership policy, and current store access.
+- Write the fresh terminal seed locally before clearing the terminal-integrity block; if the seed write fails, keep the block and report repair failure.
+- Preserve all existing local POS events and mappings during repair, then retry sync after the fresh seed is stored.
+- Rate-limit or de-duplicate repair attempts so a bad terminal does not loop through endless cloud secret rotations.
+
+**Execution note:** Start with a failing test where `ingestLocalEvents` returns `authorization_failed`, auto repair succeeds, the fresh seed is persisted, and the original local event uploads on retry.
+
+**Patterns to follow:**
+- Existing terminal provisioning contract in `registerAndProvisionPosTerminal.ts`.
+- Existing `CommandResult` registration style in `convex/pos/public/terminals.ts` and `convex/pos/application/commands/terminals.ts`.
+
+**Test scenarios:**
+- Happy path: same active terminal fingerprint, same store/register, authenticated user still owns or can repair the terminal -> repair writes a fresh seed, clears the block, and retries sync.
+- Happy path: cloud registration succeeds and local seed write succeeds -> terminal setup is considered repaired without manual operator action.
+- Error path: cloud repair succeeds but local seed write fails -> terminal remains blocked and setup is not reported successful.
+- Error path: terminal is revoked/lost, belongs to another user, register number conflicts, or store access is missing -> no self-heal; operator recovery gate remains.
+- Edge case: repeated authorization failures after a repair attempt -> runtime does not spin indefinitely or keep rotating secrets.
+- Integration: unsynced local sale events remain in IndexedDB throughout repair and are upload candidates after the fresh seed is persisted.
+
+**Verification:**
+- Eligible sync-secret drift repairs itself from the POS runtime; unsafe or ambiguous cases stay blocked and visible.
+
+---
+
+- U3. **Block local register projection and commands when terminal authority is broken**
+
+**Goal:** Make the local read model and local command gateway enforce terminal-integrity and lifecycle-authority blocks so UI bypasses cannot append new sale-affecting events.
+
+**Requirements:** R3, R4, R5, R10, R11.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/localRegisterReader.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/syncStatus.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/syncStatus.test.ts`
+
+**Approach:**
+- Thread terminal-integrity state into the local register projection and derive an explicit sale-block reason alongside `canSell`.
+- Thread mapped cloud register-session lifecycle into the local register projection. Once a local drawer has a cloud `registerSession` mapping, closed/rejected/missing/not-current cloud state overrides stale local open/reopen projection for sale authority.
+- Keep `canSell` true for normal offline/pending sync, including uploadable events that have not been rejected by cloud.
+- Set `canSell` false when terminal integrity requires re-provision/reset.
+- Set `canSell` false when uploaded `needs_review` lifecycle events affect drawer authority, such as register open, register closeout, register reopen, or completed sale state for the active register timeline.
+- Set `canSell` false when the active local drawer maps to a cloud `registerSession` that is closed or was rejected in lifecycle sync evidence, even if IndexedDB still contains an earlier open or reopen event.
+- Require local command gateway methods that append sale-affecting events to check the block reason before writing. This includes start session, cart item/service append, payment update, cart clear, transaction completion, closeout, reopen, and drawer open where applicable.
+- Make `openDrawer` respect the same drawer-authority block before returning idempotent success for an existing local open drawer. If cloud has closed/rejected the mapped drawer, `openDrawer` must either follow an explicit safe recovery path that creates a new valid local drawer authority or return a blocked `CommandResult`; it must not silently reuse the stale local drawer.
+- Return operator-safe `CommandResult` messages instead of silent boolean failure for paths that currently return booleans, or at minimum centralize the blocked result before view-model presentation.
+
+**Execution note:** Start with two characterization tests: the Arc-shaped local event log plus a terminal-integrity block, and the Codex-shaped local event log where terminal check-in succeeds but the mapped cloud register session is closed. Prove start/complete/cart/open-drawer commands reject while local events remain intact.
+
+**Patterns to follow:**
+- Drawer command-boundary invariant guidance in `docs/solutions/logic-errors/athena-pos-drawer-invariants-at-command-boundaries-2026-04-24.md`.
+- Existing `CommandResult` style in local `openDrawer` and `startSession`.
+
+**Test scenarios:**
+- Happy path: terminal integrity healthy and upload pending -> local start sale and complete sale still append events.
+- Happy path: terminal integrity requires re-provision -> start sale, add item, add service, payment update, complete sale, closeout, and reopen all reject without appending events.
+- Edge case: stale block belongs to another terminal/store -> current terminal remains sellable.
+- Edge case: uploaded `needs_review` `register.reopened` event exists for the active register -> `canSell` is false and later `session.started` does not reactivate selling.
+- Edge case: active local drawer has a `cloudRegisterSessionId` mapping and Convex says that register session is `closed` -> `canSell` is false and `openDrawer` does not return the stale local drawer as success.
+- Edge case: Codex-browser shape with successful runtime check-in, local open drawer from IndexedDB, no new `register.opened` sync row, and closed cloud drawer -> sale-start and transaction completion remain blocked until valid drawer authority is re-established.
+- Edge case: uploaded `needs_review` ordinary completed sale exists for a past sale but the register lifecycle is healthy -> behavior follows the chosen lifecycle policy and is explicitly covered.
+- Error path: local store read failure returns safe drawer/terminal gate state rather than appending events optimistically.
+
+**Verification:**
+- Stale terminal state cannot create new local sale events through either the UI path or direct local command gateway path.
+
+---
+
+- U4. **Add POS repair/recovery gate for stale terminals**
+
+**Goal:** Give cashiers and managers a clear register-surface explanation while automatic repair is running, and a recovery route only when terminal integrity cannot self-heal.
+
+**Requirements:** R2, R3, R4, R6, R7, R8, R10, R11.
+
+**Dependencies:** U2, U3, U7.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Modify: `packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- Test: `packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.test.ts`
+
+**Approach:**
+- Extend the drawer/terminal gate model with terminal-integrity and drawer-lifecycle-authority modes distinct from missing drawer, closeout blocked, and locally closed pending sync.
+- Disable product entry, service add, payment controls, checkout completion, closeout reopen, and drawer open actions while the terminal is blocked or repair is in progress.
+- Show safe operational copy for three modes: automatic terminal repair in progress, manual setup recovery required, and drawer authority needs repair because cloud no longer considers the local drawer open.
+- Keep sign out and navigation to setup/support available.
+- Preserve existing sync status chip behavior for pending/offline states; only terminal integrity shows the stronger blocking gate.
+
+**Patterns to follow:**
+- Existing drawer gate modes in `useRegisterViewModel.ts` and `POSRegisterView.tsx`.
+- Product copy guidance in `docs/product-copy-tone.md`.
+
+**Test scenarios:**
+- Happy path: terminal-integrity block exists and self-heal is running -> POS renders repair-in-progress gate instead of active register workspace and disables sale controls.
+- Happy path: terminal-integrity block exists and self-heal is not eligible -> POS renders manual recovery gate with setup/support navigation.
+- Happy path: mapped cloud drawer is closed while local IndexedDB still projects open -> POS renders a drawer authority recovery gate instead of active register workspace.
+- Happy path: offline pending sync without auth failure -> POS remains usable and shows pending/offline sync status, not the terminal recovery gate.
+- Edge case: route loads before terminal integrity read resolves -> UI does not briefly enable checkout from a known blocked terminal.
+- Edge case: blocked terminal with active local cart -> cart evidence remains visible only where current UI safely supports it; completion remains disabled.
+- Error path: command handler called while gate is active -> safe toast/inline error and no event append.
+
+**Verification:**
+- A cashier cannot complete a sale from the stale-terminal register surface, automatic repair state is visible, and manual setup recovery appears only when repair cannot proceed.
+
+---
+
+- U5. **Align terminal setup, health, and recovery evidence**
+
+**Goal:** Keep terminal setup, POS register diagnostics, and terminal health consistent about stale terminal authorization and stale drawer lifecycle authority without moving reconciliation ownership.
+
+**Requirements:** R6, R7, R8, R9, R10, R11.
+
+**Dependencies:** U2, U4, U7.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/queries/terminals.ts`
+- Test: `packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/terminals.test.ts`
+
+**Approach:**
+- Surface terminal-integrity failure as automatic repair or setup repair, not as cash reconciliation work.
+- Surface drawer-authority failure as register setup/recovery evidence, not as terminal sync-secret repair and not as cash variance reconciliation by itself.
+- In POS Settings, make successful re-provision write the fresh local terminal seed and clear the terminal-integrity block.
+- In Terminal Health/detail, explain stale terminal authorization as support evidence when the latest runtime status reports it, while continuing to hide secrets and raw payloads.
+- Avoid adding approval or conflict-resolution actions to terminal health; link to existing setup or register evidence surfaces where useful.
+- Keep older terminals without integrity metadata readable by falling back to existing status presentation.
+
+**Patterns to follow:**
+- Terminal health boundary in `docs/solutions/architecture/athena-pos-terminal-health-visibility-2026-05-20.md`.
+- Terminal review reason separation in `docs/solutions/logic-errors/athena-pos-terminal-review-reason-reconciliation-2026-05-26.md`.
+
+**Test scenarios:**
+- Happy path: automatic repair succeeds -> register/terminal health no longer shows the stale-auth block and local sync can retry.
+- Happy path: terminal re-provision succeeds -> local seed updates and terminal-integrity block clears.
+- Happy path: drawer authority is repaired by establishing a valid open drawer -> register/terminal health no longer shows the stale drawer-authority block.
+- Happy path: terminal detail receives runtime authorization-failure evidence -> renders setup-repair/support explanation without manager-review copy.
+- Edge case: terminal health has stale telemetry but no auth failure -> stale/pending copy is shown instead of setup repair.
+- Error path: re-provision returns `authorization_failed` or validation error -> local block remains and copy stays safe.
+- Integration: public terminal summary/detail validators accept any added safe attention reason fields.
+
+**Verification:**
+- Setup, register, and support surfaces tell the same story: terminal-auth failures need terminal repair; mapped drawer lifecycle failures need valid drawer authority; neither should be mislabeled as a drawer variance by default.
+
+---
+
+- U6. **Validation, graph, and operator documentation**
+
+**Goal:** Lock the invariant into tests, harness coverage, graphify output, and reusable solution docs so future POS local-first changes do not reintroduce stale-terminal selling.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11.
+
+**Dependencies:** U1, U2, U3, U4, U5, U7.
+
+**Files:**
+- Modify: `scripts/harness-app-registry.ts`
+- Modify: `packages/athena-webapp/docs/agent/validation-map.json`
+- Modify: `packages/athena-webapp/docs/agent/validation-guide.md`
+- Modify: `docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md`
+- Create: `docs/solutions/logic-errors/athena-pos-stale-terminal-sale-block-2026-05-29.md`
+- Modify: `graphify-out/GRAPH_REPORT.md`
+- Modify: `graphify-out/graph.json`
+- Test: `scripts/harness-app-registry.test.ts`
+- Test: `scripts/harness-audit.test.ts`
+
+**Approach:**
+- Add or tighten validation-map coverage for terminal-integrity state, local sync runtime auth failures, self-healing repair, cloud drawer lifecycle authority, register read-model sale blocking, local command gateway sale blocking, POS register recovery gate, POS Settings re-provision, and terminal health explanation.
+- Document the invariant: local-first allows offline/pending; explicit terminal authorization failure pauses new sale-affecting local events while safe repair runs, and explicit cloud drawer lifecycle rejection/closure pauses selling until valid drawer authority is established.
+- Regenerate harness docs rather than editing generated validation files by hand.
+- Rebuild graphify after code changes during implementation so graph artifacts reflect the new terminal-integrity surfaces.
+
+**Patterns to follow:**
+- Existing validation guidance for POS local sync/register infrastructure in `packages/athena-webapp/docs/agent/testing.md`.
+- Existing solution docs under `docs/solutions/architecture/` and `docs/solutions/logic-errors/`.
+
+**Test scenarios:**
+- Happy path: harness registry maps every touched terminal-integrity and POS register surface to focused tests.
+- Happy path: validation coverage includes the self-healing repair success and repair-denied fallback paths.
+- Happy path: validation coverage includes the Codex-browser shape where runtime check-in succeeds but local drawer projection is stale against a closed mapped cloud register session.
+- Edge case: generated validation-map paths remain current after the new files are added.
+- Integration: graphify rebuild captures the new local integrity state and command-gateway/read-model edges.
+
+**Verification:**
+- Future touched-file review requests the focused POS local sync/register test set when these surfaces change.
+
+---
+
+## System-Wide Impact
+
+```mermaid
+flowchart TB
+  seed["Terminal seed"]
+  runtime["Local sync runtime"]
+  integrity["Terminal integrity state"]
+  drawerAuthority["Drawer lifecycle authority"]
+  readmodel["Local register read model"]
+  gateway["Local command gateway"]
+  registerui["POS register gate"]
+  repair["Self-healing repair"]
+  settings["POS settings repair"]
+  health["Terminal health/detail"]
+  convex["Convex sync and terminal auth"]
+  registerSession["Cloud register session"]
+
+  seed --> runtime
+  runtime --> integrity
+  convex --> runtime
+  registerSession --> drawerAuthority
+  runtime --> drawerAuthority
+  runtime --> repair
+  repair --> seed
+  repair --> integrity
+  integrity --> readmodel
+  integrity --> gateway
+  drawerAuthority --> readmodel
+  drawerAuthority --> gateway
+  readmodel --> registerui
+  gateway --> registerui
+  settings --> seed
+  settings --> integrity
+  runtime --> health
+```
+
+- **Interaction graph:** Terminal seed, local sync runtime, self-healing repair, terminal integrity metadata, drawer lifecycle authority, register read model, local command gateway, register UI, POS Settings, terminal health, cloud register sessions, and Convex sync/terminal auth all interact.
+- **Error propagation:** `authorization_failed` must remain a safe `CommandResult` from Convex, become persistent terminal-integrity state in the browser, and render as setup repair rather than raw backend failure text.
+- **State lifecycle risks:** Cloud can rotate terminal sync secrets while stale IndexedDB remains, and cloud can close/reject a mapped drawer while IndexedDB still projects it open. Blocks must survive reloads and clear only after automatic terminal repair, re-provision, valid drawer authority, or explicit reset.
+- **Repair loop risks:** Automatic repair must be rate-limited/deduplicated and must stop on revoked/lost terminals, ownership conflicts, register conflicts, missing access, or repeated local persistence failure.
+- **API surface parity:** Runtime status, sync status presentation, register view model, terminal health, and POS Settings must agree on blocked vs pending/offline semantics.
+- **Integration coverage:** Tests must cross local store, sync runtime, projection/read model, command gateway, register UI, and terminal setup because the bug was caused by individually correct layers failing to share a blocking state.
+- **Unchanged invariants:** POS remains local-first for normal offline operation; terminal health remains support telemetry; Cash Controls remains manager reconciliation.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Blocking too aggressively breaks the local-first POS promise | Make only explicit cloud authorization failure, uploaded lifecycle-authority review, and mapped cloud drawer closure/rejection sale-blocking; keep offline/pending sellable. |
+| Blocking only the UI leaves command bypasses | Enforce terminal-integrity state inside `localCommandGateway` and projection-derived `canSell`, not just `POSRegisterView`. |
+| Stale local open drawer keeps bypassing cloud closeout | Treat mapped cloud register-session `closed`/rejected/missing authority as sale-blocking before `openDrawer` can return idempotent local success. |
+| Self-healing hides a real security/access problem | Self-heal only when cloud verifies same active terminal fingerprint, same store/register scope, and allowed user/access policy. |
+| Self-healing loops or rotates secrets repeatedly | Rate-limit and de-duplicate repair attempts; keep the terminal blocked after repeated failure. |
+| Re-provision or self-healing clears useful evidence | Clear the integrity block and update the seed without deleting local event history by default. |
+| Cloud repair succeeds but local seed write fails | Treat setup as failed/repair-needed and keep the terminal sale-blocked until seed persistence succeeds. |
+| Existing stale terminals stay confusing in support tools | Surface safe terminal-integrity evidence in runtime status and terminal detail without exposing secrets or payloads. |
+| Local storage schema changes strand older terminals | Add compatibility defaults and scoped reads so missing integrity metadata means unknown/healthy unless explicit auth failure is observed. |
+
+---
+
+## Documentation / Operational Notes
+
+- Document the operational rule as: "offline and pending are allowed; rejected terminal authorization pauses selling while safe repair runs, and rejected or closed cloud drawer authority pauses selling until a valid drawer is established."
+- Include support guidance for exporting or inspecting stranded local events before any manual local reset.
+- Re-run graphify after implementation code changes, per repo AGENTS guidance.
+- If generated Convex artifacts are required, use `bunx convex dev --once` from `packages/athena-webapp`, not `bunx convex codegen`.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-13-pos-local-first-register-requirements.md](../brainstorms/2026-05-13-pos-local-first-register-requirements.md)
+- Related plan: [docs/plans/2026-05-26-001-fix-pos-terminal-review-gap-plan.md](2026-05-26-001-fix-pos-terminal-review-gap-plan.md)
+- Related code: `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`
+- Related code: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`
+- Related code: `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts`
+- Related code: `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts`
+- Related code: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Related code: `packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx`
+- Related code: `packages/athena-webapp/convex/pos/application/queries/getRegisterState.ts`
+- Related data: `registerSession`, `posLocalSyncEvent`, `posLocalSyncCursor`, `posLocalSyncConflict`
+- Related code: `packages/athena-webapp/src/lib/pos/application/registerAndProvisionPosTerminal.ts`
+- Related code: `packages/athena-webapp/convex/pos/public/sync.ts`
+- Related code: `packages/athena-webapp/convex/pos/public/terminals.ts`
+- Related code: `packages/athena-webapp/convex/pos/application/commands/terminals.ts`
+- Institutional learning: [docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md](../solutions/architecture/athena-pos-local-first-sync-2026-05-13.md)
+- Institutional learning: [docs/solutions/architecture/athena-pos-always-local-first-register-2026-05-14.md](../solutions/architecture/athena-pos-always-local-first-register-2026-05-14.md)
+- Institutional learning: [docs/solutions/logic-errors/athena-pos-drawer-invariants-at-command-boundaries-2026-04-24.md](../solutions/logic-errors/athena-pos-drawer-invariants-at-command-boundaries-2026-04-24.md)

--- a/docs/solutions/logic-errors/athena-pos-stale-terminal-sale-block-2026-05-29.md
+++ b/docs/solutions/logic-errors/athena-pos-stale-terminal-sale-block-2026-05-29.md
@@ -1,0 +1,94 @@
+---
+title: Athena POS Stale Terminal Sale Blocks
+date: 2026-05-29
+category: logic-errors
+module: athena-webapp
+problem_type: pos_stale_terminal_local_sale_authority
+component: pos-register
+symptoms:
+  - "A revoked or re-provisioned POS terminal can keep appending local sales"
+  - "Sync authorization failures can be converted into generic local review work"
+  - "Register commands can reuse an open local drawer after terminal authority is lost"
+root_cause: local_sale_authority_was_inferred_from_event_projection_alone
+resolution_type: persisted_terminal_and_drawer_authority_state
+severity: high
+tags:
+  - pos
+  - local-first
+  - terminal-authority
+  - drawer-authority
+  - sync
+---
+
+# Athena POS Stale Terminal Sale Blocks
+
+## Problem
+
+The POS register can continue to look locally operable after the server rejects
+the terminal sync secret or drawer lifecycle authority. That is unsafe because
+the local read model only knows about the event log; it does not remember that
+the terminal itself has lost the right to append more sale-affecting activity.
+
+Treating those failures as ordinary `needs_review` local events also hides the
+right recovery path. A revoked or stale terminal needs setup repair, while an
+invalid drawer lifecycle needs register recovery. Neither should become a new
+sale, payment, or closeout event.
+
+## Solution
+
+Persist sale authority separately from local activity:
+
+- Store terminal integrity by store and terminal. Sync/check-in authorization
+  failures write a non-secret `requires_reprovision` state and leave existing
+  local events intact.
+- Store drawer authority by store, terminal, and local register session. Drawer
+  authority can block one register session without erasing terminal evidence or
+  unrelated local events.
+- Project terminal integrity and drawer authority into the local register read
+  model. `canSell` must require an open drawer, no closeout flow, and no
+  authority block.
+- Gate all sale-affecting local commands at the command gateway: cart item,
+  service line, payment, completion, closeout, reopen, register seed, and drawer
+  reuse. Allow explicit cloud-drawer bootstrap only when no authority block is
+  present.
+- Surface terminal repair in POS Settings and drawer recovery in the register
+  gate. Keep copy operational and preserve local activity for support.
+- Publish authority summaries through terminal runtime status and terminal
+  health without exposing sync secrets, staff proof tokens, payload bodies, or
+  backend error text.
+
+## Regression Targets
+
+- Local store tests should prove authority state survives independently of local
+  events and is cleared only by successful terminal setup repair.
+- Local read-model tests should prove terminal integrity and drawer authority
+  block `canSell`, while pending/offline local events remain recoverable.
+- Local command-gateway tests should prove blocked authority rejects drawer
+  reuse and sale-affecting appends even when the caller supplies an explicit
+  register session id.
+- Sync runtime tests should prove authorization failures persist terminal
+  integrity and do not mark preserved local events as generic review events.
+- Register view-model and drawer-gate tests should prove operators see setup or
+  drawer repair instead of an ordinary sale surface.
+- Terminal health tests should prove new attention reasons route to POS
+  Settings for terminal repair and POS Register for drawer recovery.
+
+## Prevention
+
+- Do not infer terminal authority from the local event log alone. Authority
+  state is a separate durable input to projection.
+- Do not mark events `needs_review` merely because terminal authorization failed.
+  Preserve the events and block future sale-affecting writes.
+- Do not clear local events during terminal repair. A successful re-provision
+  clears terminal integrity state, not cashier activity.
+- Do not expose raw authorization failures in operator copy or runtime evidence.
+  Normalize them to repair actions and redact secrets.
+- Whenever adding a local register command, decide whether it is sale-affecting
+  and route it through the same authority gate.
+
+## Related
+
+- [Athena POS Local First Register](../architecture/athena-pos-always-local-first-register-2026-05-14.md)
+- [Athena POS Local Staff Authority](../architecture/athena-pos-local-staff-authority-2026-05-14.md)
+- [Athena POS Terminal Health Visibility](../architecture/athena-pos-terminal-health-visibility-2026-05-20.md)
+- [Athena POS Terminal Runtime Review Actions](../architecture/athena-pos-terminal-runtime-review-actions-2026-05-28.md)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5879 nodes · 6236 edges · 1721 communities detected
+- 5908 nodes · 6289 edges · 1721 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1735,7 +1735,7 @@
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
 2. `buildDailyCloseSnapshotWithCtx()` - 28 edges
-3. `projectLocalRegisterReadModel()` - 23 edges
+3. `projectLocalRegisterReadModel()` - 24 edges
 4. `buildDailyOpeningSnapshotWithCtx()` - 17 edges
 5. `getStoreConfigV2()` - 17 edges
 6. `DataTableViewOptions()` - 16 edges
@@ -1787,56 +1787,56 @@ Cohesion: 0.07
 Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.08
-Nodes (21): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatTimestamp(), handleAuthenticatedCloseoutStaff() (+13 more)
+Cohesion: 0.07
+Nodes (21): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus(), drawerAuthorityEventKey() (+13 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.08
-Nodes (20): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+12 more)
+Nodes (21): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatTimestamp(), handleAuthenticatedCloseoutStaff() (+13 more)
 
 ### Community 9 - "Community 9"
+Cohesion: 0.08
+Nodes (20): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+12 more)
+
+### Community 10 - "Community 10"
 Cohesion: 0.11
 Nodes (23): canonicalize(), canonicalJson(), createLocalSyncIngestionService(), ingestLocalEventsWithCtx(), isNonEmptyString(), isNonNegativeFiniteNumber(), isOptionalNonEmptyString(), isRecord() (+15 more)
 
-### Community 10 - "Community 10"
+### Community 11 - "Community 11"
 Cohesion: 0.12
 Nodes (31): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+23 more)
 
-### Community 11 - "Community 11"
+### Community 12 - "Community 12"
 Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
-### Community 12 - "Community 12"
+### Community 13 - "Community 13"
 Cohesion: 0.11
 Nodes (20): buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsTransactionSearch(), formatWeekdayDate(), formatWeekdayLabel(), getDailyOperationsMetricLabels(), getLocalDateFromOperatingDate(), getLocalOperatingDate() (+12 more)
 
-### Community 13 - "Community 13"
+### Community 14 - "Community 14"
 Cohesion: 0.08
 Nodes (14): formatInventoryNumber(), formatReservationSourceSummary(), getInventoryItemDisplayName(), getReservationLabels(), getSkuDetailEntries(), getVideoElementStream(), getVideoTracks(), handleDraftChange() (+6 more)
 
-### Community 14 - "Community 14"
+### Community 15 - "Community 15"
+Cohesion: 0.17
+Nodes (31): asRecord(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale(), getPhase() (+23 more)
+
+### Community 16 - "Community 16"
 Cohesion: 0.12
 Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
 
-### Community 15 - "Community 15"
+### Community 17 - "Community 17"
 Cohesion: 0.15
 Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
 
-### Community 16 - "Community 16"
-Cohesion: 0.18
-Nodes (29): asRecord(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale(), getPhase() (+21 more)
-
-### Community 17 - "Community 17"
+### Community 18 - "Community 18"
 Cohesion: 0.15
 Nodes (24): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+16 more)
 
-### Community 18 - "Community 18"
+### Community 19 - "Community 19"
 Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
-
-### Community 19 - "Community 19"
-Cohesion: 0.09
-Nodes (9): collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus(), hasPendingLocalCloseout(), isRuntimeRelevantLocalEvent(), toLocalCloudMappingEntity() (+1 more)
 
 ### Community 20 - "Community 20"
 Cohesion: 0.15
@@ -1851,88 +1851,88 @@ Cohesion: 0.09
 Nodes (7): buildMissingDraftResult(), getApprovalRequestCopy(), handleDecideApprovalRequest(), handleDiscardCycleCountDraft(), handleRefreshCycleCountDraftLineBaseline(), handleSaveCycleCountDraftLine(), handleSubmitCycleCountDraft()
 
 ### Community 23 - "Community 23"
+Cohesion: 0.09
+Nodes (10): createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), normalizeDrawerAuthorityState(), normalizeStaffAuthorityRecord(), normalizeTerminalIntegrityState(), normalizeUsername(), PosLocalStoreSchemaError, preserveWrappedStaffProof() (+2 more)
+
+### Community 24 - "Community 24"
 Cohesion: 0.12
 Nodes (18): ancestorChain(), collectRawMoneyParses(), collectRawMoneyParsesFromSource(), collectRawNumericHelperNames(), collectSourceFiles(), collectStorefrontDirectMoneyFormats(), containsDisallowedRawNumericParse(), containsTerm() (+10 more)
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
 Cohesion: 0.19
 Nodes (23): assertCompoundSolutionCheck(), collectChangedFiles(), collectCompoundSolutionFindings(), collectExistingFiles(), collectMarkdownContents(), collectSourceLineChanges(), countFileLines(), extractFrontmatter() (+15 more)
 
-### Community 25 - "Community 25"
+### Community 26 - "Community 26"
 Cohesion: 0.15
 Nodes (19): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), isLocalGeneratedArtifactPath() (+11 more)
 
-### Community 26 - "Community 26"
+### Community 27 - "Community 27"
 Cohesion: 0.13
 Nodes (18): buildCartSummary(), buildSessionOperationsRow(), expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), loadPosSessionItems(), loadSessionCustomer(), loadSessionOperator() (+10 more)
 
-### Community 27 - "Community 27"
+### Community 28 - "Community 28"
 Cohesion: 0.16
 Nodes (22): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildWeekMetricForDate(), buildWeekMetrics(), emptyCloseSummary(), getCloseItemCounts(), getDailyCloseRecordForDate() (+14 more)
 
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.19
 Nodes (23): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+15 more)
 
-### Community 29 - "Community 29"
+### Community 30 - "Community 30"
 Cohesion: 0.15
 Nodes (19): acquireExpenseQuantityPatchHold(), adjustExpenseQuantityPatchHold(), createDefaultExpenseSessionCommandService(), createExpenseInventoryHoldGateway(), createExpenseSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired() (+11 more)
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.11
 Nodes (13): cancelItemAdjustmentWorkflow(), exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff() (+5 more)
 
-### Community 31 - "Community 31"
+### Community 32 - "Community 32"
 Cohesion: 0.1
 Nodes (4): listCompletedTransactionsForDay(), listSessionItems(), listTransactionItems(), readAllQueryResults()
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.14
 Nodes (15): CashPositionSummary(), cn(), formatCashExposureSupporting(), formatCurrency(), formatStaffByline(), formatStatusLabel(), formatTimestamp(), getSessionActionLabel() (+7 more)
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.15
 Nodes (16): buildGitProcessEnv(), collectCommandsForChangedFiles(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets() (+8 more)
 
-### Community 34 - "Community 34"
+### Community 35 - "Community 35"
 Cohesion: 0.1
 Nodes (2): buildCashControlsDashboardSnapshot(), sumDepositsBySession()
 
-### Community 35 - "Community 35"
+### Community 36 - "Community 36"
 Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
-### Community 36 - "Community 36"
+### Community 37 - "Community 37"
 Cohesion: 0.25
 Nodes (21): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftSubmissionKey(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx(), ensureCycleCountDraftWithCtx(), findOpenCycleCountDraftWithCtx(), getActiveCycleCountDraftSummaryWithCtx() (+13 more)
 
-### Community 37 - "Community 37"
+### Community 38 - "Community 38"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 38 - "Community 38"
+### Community 39 - "Community 39"
 Cohesion: 0.17
 Nodes (17): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionOpeningFloatCorrectionPatch() (+9 more)
 
-### Community 39 - "Community 39"
+### Community 40 - "Community 40"
 Cohesion: 0.18
 Nodes (19): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildSkuActivityEvent(), buildTimeline(), getImpactQuantities() (+11 more)
 
-### Community 40 - "Community 40"
+### Community 41 - "Community 41"
 Cohesion: 0.18
 Nodes (16): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding(), runBindSessionToRegisterSessionCommand() (+8 more)
 
-### Community 41 - "Community 41"
+### Community 42 - "Community 42"
 Cohesion: 0.1
 Nodes (4): handleChange(), isSkuReserved(), parseVariantInputValue(), shouldDisable()
 
-### Community 42 - "Community 42"
+### Community 43 - "Community 43"
 Cohesion: 0.15
 Nodes (11): checkIfItemsHaveChanged(), createOnlineOrder(), createPatchObject(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems() (+3 more)
-
-### Community 43 - "Community 43"
-Cohesion: 0.12
-Nodes (7): createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), normalizeStaffAuthorityRecord(), normalizeUsername(), PosLocalStoreSchemaError, preserveWrappedStaffProof(), staffAuthorityKey()
 
 ### Community 44 - "Community 44"
 Cohesion: 0.15
@@ -1963,48 +1963,48 @@ Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
 ### Community 51 - "Community 51"
+Cohesion: 0.26
+Nodes (14): assertRegisterNumberIsAvailable(), cleanBrowserInfo(), cleanDiagnosticMessage(), cleanDrawerAuthority(), cleanOptionalString(), cleanTerminalIntegrity(), mapRegisterTerminalError(), nonNegativeInteger() (+6 more)
+
+### Community 52 - "Community 52"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 52 - "Community 52"
+### Community 53 - "Community 53"
 Cohesion: 0.29
 Nodes (15): asRecord(), buildPosLocalSyncUploadEvents(), customerInfoFromPayload(), getCompletedSaleItems(), getCompletedServiceLines(), hasLaterCompletedSale(), nullableStringToOptional(), numberOrZero() (+7 more)
 
-### Community 53 - "Community 53"
+### Community 54 - "Community 54"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 55 - "Community 55"
+### Community 56 - "Community 56"
 Cohesion: 0.15
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
-### Community 56 - "Community 56"
+### Community 57 - "Community 57"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.14
 Nodes (4): DailyCloseHistoryView(), getDailyCloseHistoryApi(), getHistoryRecordSnapshot(), normalizeHistorySnapshot()
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
 Cohesion: 0.26
 Nodes (13): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget() (+5 more)
 
-### Community 60 - "Community 60"
+### Community 61 - "Community 61"
 Cohesion: 0.33
 Nodes (14): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+6 more)
-
-### Community 61 - "Community 61"
-Cohesion: 0.26
-Nodes (12): assertRegisterNumberIsAvailable(), cleanBrowserInfo(), cleanDiagnosticMessage(), cleanOptionalString(), mapRegisterTerminalError(), nonNegativeInteger(), normalizeRegisterNumber(), omitUndefined() (+4 more)
 
 ### Community 62 - "Community 62"
 Cohesion: 0.17
@@ -2111,44 +2111,44 @@ Cohesion: 0.24
 Nodes (7): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), useConvexRegisterServiceCatalog(), usePrewarmRegisterCatalogOfflineSnapshots()
 
 ### Community 88 - "Community 88"
+Cohesion: 0.32
+Nodes (9): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), getReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), mapSyncStatus(), normalizeStaffAuthorityStatus(), snapshotAges() (+1 more)
+
+### Community 89 - "Community 89"
 Cohesion: 0.29
 Nodes (10): bestFuzzyTokenScore(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreFuzzySearchEntry(), scoreFuzzyTokenMatch(), scoreQueryTokenForEntry() (+2 more)
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.29
 Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 92 - "Community 92"
+### Community 93 - "Community 93"
 Cohesion: 0.27
 Nodes (6): buildTerminalHealthSummary(), deriveTerminalHealth(), deriveTerminalHealthAttentionReasons(), getTerminalHealthSummary(), resolveAttentionReasonActionTargets(), stripRuntimeStatusIdentity()
 
-### Community 93 - "Community 93"
+### Community 94 - "Community 94"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 94 - "Community 94"
+### Community 95 - "Community 95"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.24
 Nodes (5): blocked(), evaluateLocalPosReadiness(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
-
-### Community 97 - "Community 97"
-Cohesion: 0.35
-Nodes (8): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), getReviewDiagnosticsEvents(), mapSyncStatus(), normalizeStaffAuthorityStatus(), snapshotAges(), toSafeFailureMessage()
 
 ### Community 98 - "Community 98"
 Cohesion: 0.18
@@ -2335,132 +2335,132 @@ Cohesion: 0.25
 Nodes (0):
 
 ### Community 144 - "Community 144"
-Cohesion: 0.46
-Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
-
-### Community 145 - "Community 145"
-Cohesion: 0.43
-Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
-
-### Community 146 - "Community 146"
 Cohesion: 0.25
 Nodes (0):
 
+### Community 145 - "Community 145"
+Cohesion: 0.46
+Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
+
+### Community 146 - "Community 146"
+Cohesion: 0.43
+Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
+
 ### Community 147 - "Community 147"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 148 - "Community 148"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.33
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.33
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 155 - "Community 155"
+### Community 156 - "Community 156"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.33
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.33
 Nodes (2): handlePinChange(), normalizeOtpCode()
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.33
 Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.38
 Nodes (3): handleAttachBarcodeSubmit(), handleClearSearch(), handleQuickAddSubmit()
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 170 - "Community 170"
+### Community 171 - "Community 171"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 171 - "Community 171"
+### Community 172 - "Community 172"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 172 - "Community 172"
+### Community 173 - "Community 173"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 173 - "Community 173"
+### Community 174 - "Community 174"
 Cohesion: 0.33
 Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 175 - "Community 175"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
 
 ### Community 176 - "Community 176"
 Cohesion: 0.29
@@ -2471,36 +2471,36 @@ Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
 ### Community 178 - "Community 178"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 179 - "Community 179"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 182 - "Community 182"
-Cohesion: 0.33
-Nodes (1): ValkeyClient
-
 ### Community 183 - "Community 183"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ValkeyClient
 
 ### Community 184 - "Community 184"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 185 - "Community 185"
-Cohesion: 0.4
-Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 186 - "Community 186"
 Cohesion: 0.33
@@ -2511,72 +2511,72 @@ Cohesion: 0.4
 Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
 ### Community 188 - "Community 188"
+Cohesion: 0.4
+Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
+
+### Community 189 - "Community 189"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.53
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 191 - "Community 191"
+### Community 192 - "Community 192"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 195 - "Community 195"
+### Community 196 - "Community 196"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 197 - "Community 197"
+### Community 198 - "Community 198"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 199 - "Community 199"
+### Community 200 - "Community 200"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 202 - "Community 202"
+### Community 203 - "Community 203"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 203 - "Community 203"
-Cohesion: 0.33
-Nodes (1): ResizeObserverStub
-
 ### Community 204 - "Community 204"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 205 - "Community 205"
 Cohesion: 0.33
@@ -2588,23 +2588,23 @@ Nodes (0):
 
 ### Community 207 - "Community 207"
 Cohesion: 0.33
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 208 - "Community 208"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 209 - "Community 209"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 210 - "Community 210"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 210 - "Community 210"
+### Community 211 - "Community 211"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
-
-### Community 211 - "Community 211"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 212 - "Community 212"
 Cohesion: 0.33
@@ -2623,12 +2623,12 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 216 - "Community 216"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
-
-### Community 217 - "Community 217"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 217 - "Community 217"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 218 - "Community 218"
 Cohesion: 0.33
@@ -2860,23 +2860,23 @@ Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), us
 
 ### Community 275 - "Community 275"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 276 - "Community 276"
 Cohesion: 0.6
-Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 277 - "Community 277"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
 ### Community 278 - "Community 278"
-Cohesion: 0.6
-Nodes (3): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier()
-
-### Community 279 - "Community 279"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 279 - "Community 279"
+Cohesion: 0.6
+Nodes (3): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier()
 
 ### Community 280 - "Community 280"
 Cohesion: 0.4
@@ -2887,88 +2887,88 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 282 - "Community 282"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 283 - "Community 283"
 Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 283 - "Community 283"
+### Community 284 - "Community 284"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 284 - "Community 284"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 285 - "Community 285"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 286 - "Community 286"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 287 - "Community 287"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 288 - "Community 288"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 289 - "Community 289"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
-
-### Community 290 - "Community 290"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 290 - "Community 290"
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 291 - "Community 291"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 292 - "Community 292"
-Cohesion: 0.6
-Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 293 - "Community 293"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 293 - "Community 293"
+Cohesion: 0.6
+Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+
 ### Community 294 - "Community 294"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 295 - "Community 295"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 295 - "Community 295"
+### Community 296 - "Community 296"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 296 - "Community 296"
+### Community 297 - "Community 297"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 297 - "Community 297"
+### Community 298 - "Community 298"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 298 - "Community 298"
+### Community 299 - "Community 299"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 299 - "Community 299"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 300 - "Community 300"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 301 - "Community 301"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
-
-### Community 302 - "Community 302"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 302 - "Community 302"
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 303 - "Community 303"
 Cohesion: 0.5
@@ -2979,72 +2979,72 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 305 - "Community 305"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 306 - "Community 306"
 Cohesion: 0.67
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 306 - "Community 306"
+### Community 307 - "Community 307"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 307 - "Community 307"
+### Community 308 - "Community 308"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 308 - "Community 308"
+### Community 309 - "Community 309"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 309 - "Community 309"
+### Community 310 - "Community 310"
 Cohesion: 0.67
 Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
 
-### Community 310 - "Community 310"
+### Community 311 - "Community 311"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 311 - "Community 311"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 312 - "Community 312"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 313 - "Community 313"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 314 - "Community 314"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 314 - "Community 314"
+### Community 315 - "Community 315"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 315 - "Community 315"
+### Community 316 - "Community 316"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 316 - "Community 316"
+### Community 317 - "Community 317"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 317 - "Community 317"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 318 - "Community 318"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 319 - "Community 319"
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+
+### Community 320 - "Community 320"
 Cohesion: 0.67
 Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
-### Community 320 - "Community 320"
+### Community 321 - "Community 321"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
-
-### Community 321 - "Community 321"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 322 - "Community 322"
 Cohesion: 0.5
@@ -3055,24 +3055,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 324 - "Community 324"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 325 - "Community 325"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 325 - "Community 325"
+### Community 326 - "Community 326"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 326 - "Community 326"
+### Community 327 - "Community 327"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 327 - "Community 327"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 328 - "Community 328"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 329 - "Community 329"
 Cohesion: 0.5
@@ -3087,12 +3087,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 332 - "Community 332"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
-
-### Community 333 - "Community 333"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 333 - "Community 333"
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 334 - "Community 334"
 Cohesion: 0.5
@@ -3115,32 +3115,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 339 - "Community 339"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 340 - "Community 340"
 Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 341 - "Community 341"
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+
+### Community 342 - "Community 342"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 342 - "Community 342"
+### Community 343 - "Community 343"
 Cohesion: 0.67
 Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
-### Community 343 - "Community 343"
+### Community 344 - "Community 344"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 344 - "Community 344"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 345 - "Community 345"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 346 - "Community 346"
 Cohesion: 0.5
@@ -3151,112 +3151,112 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 348 - "Community 348"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 349 - "Community 349"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 349 - "Community 349"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 350 - "Community 350"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 351 - "Community 351"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 352 - "Community 352"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
 
-### Community 352 - "Community 352"
+### Community 353 - "Community 353"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 353 - "Community 353"
-Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 354 - "Community 354"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 355 - "Community 355"
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+
+### Community 356 - "Community 356"
 Cohesion: 1.0
 Nodes (3): canAccessFullAdminSurface(), canAccessStoreDaySurface(), getSurfaceAccess()
 
-### Community 356 - "Community 356"
+### Community 357 - "Community 357"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 357 - "Community 357"
+### Community 358 - "Community 358"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 358 - "Community 358"
+### Community 359 - "Community 359"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 359 - "Community 359"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 360 - "Community 360"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 361 - "Community 361"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 362 - "Community 362"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 363 - "Community 363"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 364 - "Community 364"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 364 - "Community 364"
+### Community 365 - "Community 365"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 365 - "Community 365"
+### Community 366 - "Community 366"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 366 - "Community 366"
-Cohesion: 0.83
-Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
-
 ### Community 367 - "Community 367"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
 ### Community 368 - "Community 368"
 Cohesion: 0.83
-Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
+Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
 ### Community 369 - "Community 369"
-Cohesion: 0.67
-Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 370 - "Community 370"
 Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
+Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
 ### Community 371 - "Community 371"
-Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Cohesion: 0.67
+Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
 ### Community 372 - "Community 372"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 373 - "Community 373"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 374 - "Community 374"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 375 - "Community 375"
 Cohesion: 0.5
@@ -3283,76 +3283,76 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 381 - "Community 381"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 382 - "Community 382"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 383 - "Community 383"
 Cohesion: 0.67
 Nodes (2): useOptionalStoreContext(), useStoreContext()
 
-### Community 382 - "Community 382"
+### Community 384 - "Community 384"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 383 - "Community 383"
+### Community 385 - "Community 385"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 384 - "Community 384"
+### Community 386 - "Community 386"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 385 - "Community 385"
+### Community 387 - "Community 387"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 386 - "Community 386"
+### Community 388 - "Community 388"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 387 - "Community 387"
+### Community 389 - "Community 389"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 388 - "Community 388"
+### Community 390 - "Community 390"
 Cohesion: 0.67
 Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
-### Community 389 - "Community 389"
+### Community 391 - "Community 391"
 Cohesion: 0.67
 Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
-### Community 390 - "Community 390"
+### Community 392 - "Community 392"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 391 - "Community 391"
+### Community 393 - "Community 393"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 392 - "Community 392"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 393 - "Community 393"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 394 - "Community 394"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 395 - "Community 395"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 396 - "Community 396"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 397 - "Community 397"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 398 - "Community 398"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 399 - "Community 399"
 Cohesion: 0.67
@@ -3379,16 +3379,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 405 - "Community 405"
-Cohesion: 1.0
-Nodes (2): buildCtx(), createDb()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 406 - "Community 406"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 407 - "Community 407"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildCtx(), createDb()
 
 ### Community 408 - "Community 408"
 Cohesion: 0.67
@@ -3403,16 +3403,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 411 - "Community 411"
-Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 412 - "Community 412"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 413 - "Community 413"
-Cohesion: 0.67
-Nodes (1): PosServerError
+Cohesion: 1.0
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 414 - "Community 414"
 Cohesion: 0.67
@@ -3420,7 +3420,7 @@ Nodes (0):
 
 ### Community 415 - "Community 415"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 416 - "Community 416"
 Cohesion: 0.67
@@ -3435,28 +3435,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 419 - "Community 419"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 420 - "Community 420"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 421 - "Community 421"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 422 - "Community 422"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 423 - "Community 423"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 424 - "Community 424"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 425 - "Community 425"
 Cohesion: 0.67
@@ -3467,40 +3467,40 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 427 - "Community 427"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 428 - "Community 428"
-Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 429 - "Community 429"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 430 - "Community 430"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 431 - "Community 431"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 432 - "Community 432"
-Cohesion: 1.0
-Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 433 - "Community 433"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 434 - "Community 434"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
 ### Community 435 - "Community 435"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 436 - "Community 436"
 Cohesion: 0.67
@@ -3511,16 +3511,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 438 - "Community 438"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 439 - "Community 439"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 440 - "Community 440"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 441 - "Community 441"
 Cohesion: 0.67
@@ -3528,7 +3528,7 @@ Nodes (0):
 
 ### Community 442 - "Community 442"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 443 - "Community 443"
 Cohesion: 0.67
@@ -3536,23 +3536,23 @@ Nodes (0):
 
 ### Community 444 - "Community 444"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 445 - "Community 445"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 446 - "Community 446"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 447 - "Community 447"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 448 - "Community 448"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 449 - "Community 449"
 Cohesion: 0.67
@@ -3608,83 +3608,83 @@ Nodes (0):
 
 ### Community 462 - "Community 462"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 463 - "Community 463"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (0):
 
 ### Community 464 - "Community 464"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 465 - "Community 465"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 466 - "Community 466"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 467 - "Community 467"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 468 - "Community 468"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TableSkeleton()
 
 ### Community 469 - "Community 469"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
+Cohesion: 0.67
+Nodes (1): TransactionsSkeleton()
 
 ### Community 470 - "Community 470"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (1): NotFound()
 
 ### Community 471 - "Community 471"
-Cohesion: 0.67
-Nodes (1): Badge()
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
 ### Community 472 - "Community 472"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): AppContextMenu()
 
 ### Community 473 - "Community 473"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): Badge()
 
 ### Community 474 - "Community 474"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (0):
 
 ### Community 475 - "Community 475"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): LoadingButton()
 
 ### Community 476 - "Community 476"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): onChange()
 
 ### Community 477 - "Community 477"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): AlertModal()
 
 ### Community 478 - "Community 478"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): OverlayModal()
 
 ### Community 479 - "Community 479"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Skeleton()
 
 ### Community 480 - "Community 480"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 481 - "Community 481"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 482 - "Community 482"
 Cohesion: 0.67
@@ -3712,7 +3712,7 @@ Nodes (0):
 
 ### Community 488 - "Community 488"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 489 - "Community 489"
 Cohesion: 0.67
@@ -3720,27 +3720,27 @@ Nodes (0):
 
 ### Community 490 - "Community 490"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 491 - "Community 491"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 492 - "Community 492"
-Cohesion: 1.0
-Nodes (2): getApprovalGuidance(), presentCommandToast()
-
-### Community 493 - "Community 493"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
-### Community 494 - "Community 494"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 495 - "Community 495"
+### Community 493 - "Community 493"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 494 - "Community 494"
 Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
+Nodes (2): getApprovalGuidance(), presentCommandToast()
+
+### Community 495 - "Community 495"
+Cohesion: 0.67
+Nodes (1): isInMaintenanceMode()
 
 ### Community 496 - "Community 496"
 Cohesion: 0.67
@@ -3748,15 +3748,15 @@ Nodes (0):
 
 ### Community 497 - "Community 497"
 Cohesion: 1.0
-Nodes (2): readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 498 - "Community 498"
-Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
-
-### Community 499 - "Community 499"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 499 - "Community 499"
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 500 - "Community 500"
 Cohesion: 0.67
@@ -3764,67 +3764,67 @@ Nodes (0):
 
 ### Community 501 - "Community 501"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 502 - "Community 502"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 503 - "Community 503"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 504 - "Community 504"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 505 - "Community 505"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 506 - "Community 506"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 507 - "Community 507"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 508 - "Community 508"
 Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Nodes (1): hashPassword()
 
 ### Community 509 - "Community 509"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): createVersionChecker()
 
 ### Community 510 - "Community 510"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 511 - "Community 511"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 512 - "Community 512"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 513 - "Community 513"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 513 - "Community 513"
+### Community 514 - "Community 514"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 514 - "Community 514"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 515 - "Community 515"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 516 - "Community 516"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 517 - "Community 517"
 Cohesion: 0.67
@@ -3839,12 +3839,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 520 - "Community 520"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 521 - "Community 521"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 521 - "Community 521"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 522 - "Community 522"
 Cohesion: 0.67
@@ -3855,12 +3855,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 524 - "Community 524"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 525 - "Community 525"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 525 - "Community 525"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 526 - "Community 526"
 Cohesion: 0.67
@@ -3927,16 +3927,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 542 - "Community 542"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 543 - "Community 543"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 544 - "Community 544"
+### Community 543 - "Community 543"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 544 - "Community 544"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 545 - "Community 545"
 Cohesion: 1.0
@@ -3955,20 +3955,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 549 - "Community 549"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 550 - "Community 550"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 551 - "Community 551"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 552 - "Community 552"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 553 - "Community 553"
 Cohesion: 1.0
@@ -8645,1853 +8645,1851 @@ Nodes (0):
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 552`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 553`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 553`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 554`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 554`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 555`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 555`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 556`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 557`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 558`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 559`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 560`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 561`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 562`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 563`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 564`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 565`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 566`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 567`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 568`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 569`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 570`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 571`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 572`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 573`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 574`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 575`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 576`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 577`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 578`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 579`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 580`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 581`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 582`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 583`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 584`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 585`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 586`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 587`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 588`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 589`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 590`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 591`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 592`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 593`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 594`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 595`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 596`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 597`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 598`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
+- **Thin community `Community 599`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
+- **Thin community `Community 600`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 601`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 602`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 603`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 604`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 605`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
+- **Thin community `Community 606`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 607`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 608`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 609`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 610`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 611`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 612`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 613`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 614`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 615`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 616`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 617`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 618`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 619`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 620`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 621`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 622`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 623`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 624`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 625`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 626`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 627`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 628`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 629`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 630`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 631`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 632`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 633`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 634`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 635`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 636`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 637`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 638`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 639`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 640`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 641`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 642`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 643`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 644`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 645`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 646`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 647`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 648`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 649`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 650`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 651`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 652`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 653`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 654`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 655`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 656`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 657`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 658`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 659`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 660`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 661`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 662`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 663`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 664`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 665`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 666`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 667`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 668`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 669`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 670`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 671`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 672`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 673`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 674`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 675`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 676`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 677`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 678`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 679`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 680`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 681`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 682`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 683`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 684`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 685`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 686`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 687`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 688`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 689`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `cn()`, `CartItems.tsx`
+- **Thin community `Community 690`** (2 nodes): `cn()`, `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
+- **Thin community `Community 691`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 692`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 693`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 694`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 695`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `ProductCard.tsx`, `handleClick()`
+- **Thin community `Community 696`** (2 nodes): `ProductCard.tsx`, `handleClick()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 697`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 698`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 699`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 700`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 701`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 702`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
+- **Thin community `Community 703`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 704`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 705`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 706`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 707`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 708`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 709`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 710`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 711`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 712`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 713`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 714`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 715`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 716`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 717`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 718`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 719`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 720`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 721`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 722`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 723`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 724`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 725`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 726`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 727`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 728`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 729`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 730`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 731`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 732`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 733`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 734`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 735`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 736`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 737`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 738`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
+- **Thin community `Community 739`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 740`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 741`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 742`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 743`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 744`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 745`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 746`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 747`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 748`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 749`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 750`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 751`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 752`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 753`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 754`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 755`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 756`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 757`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 758`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 759`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 760`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 761`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 762`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 763`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 764`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 765`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 766`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 767`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 768`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 769`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 770`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 771`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 772`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 773`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 774`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 775`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 776`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 777`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 778`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 779`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 780`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 781`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 782`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 783`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 784`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 785`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 786`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 787`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 788`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 789`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 790`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 791`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 792`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 793`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 794`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 795`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 796`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 797`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 798`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 799`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 800`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 801`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 802`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 803`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 804`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 805`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 806`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 807`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 808`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 809`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 810`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 811`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 812`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 813`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 814`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 815`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 816`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 817`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 818`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 819`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 820`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 821`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 822`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 823`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 824`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 825`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 826`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 827`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 828`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 829`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 830`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 831`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 832`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 833`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 834`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 835`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 836`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 837`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 838`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 839`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 840`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 841`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 842`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 843`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 844`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 845`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 846`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 847`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 848`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 849`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 850`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 851`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 852`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 853`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 854`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 855`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 856`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 857`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 858`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 859`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 860`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 861`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 862`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 863`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 864`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 865`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 866`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 867`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 868`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 869`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 870`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 871`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 872`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 873`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 874`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 875`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 876`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 877`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 878`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 879`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 880`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 881`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 882`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 883`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 884`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 885`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 886`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 887`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 888`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 889`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 890`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 891`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 892`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 893`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 894`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 895`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 896`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 897`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 898`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 899`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 900`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 901`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 902`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 903`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 904`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 905`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 906`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 907`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 908`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 909`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 910`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 911`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 912`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 913`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 914`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 915`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 916`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 917`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 918`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 919`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 920`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 921`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 922`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 923`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 924`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 925`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 926`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 927`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 928`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 929`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 930`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 931`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 932`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 933`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 934`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 935`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 936`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 937`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 938`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 939`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 940`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 941`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 942`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 943`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 944`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 945`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 946`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 947`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 948`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 949`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 950`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 951`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 952`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 953`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 954`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 955`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 956`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 957`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 958`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 959`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 960`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 961`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 962`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 963`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 964`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 965`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 966`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 967`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 968`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 969`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 970`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (1 nodes): `api.d.ts`
+- **Thin community `Community 971`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `api.js`
+- **Thin community `Community 972`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 973`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `server.d.ts`
+- **Thin community `Community 974`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `server.js`
+- **Thin community `Community 975`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `app.ts`
+- **Thin community `Community 976`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `auth.config.js`
+- **Thin community `Community 977`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `auth.ts`
+- **Thin community `Community 978`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 979`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 980`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 981`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `countries.ts`
+- **Thin community `Community 982`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `email.ts`
+- **Thin community `Community 983`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `ghana.ts`
+- **Thin community `Community 984`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `payment.ts`
+- **Thin community `Community 985`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `crons.ts`
+- **Thin community `Community 986`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 987`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `internal.ts`
+- **Thin community `Community 988`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `public.test.ts`
+- **Thin community `Community 989`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `token.test.ts`
+- **Thin community `Community 990`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 991`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 992`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 993`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 994`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 995`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 996`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 997`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 998`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 999`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `env.ts`
+- **Thin community `Community 1000`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1001`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `auth.ts`
+- **Thin community `Community 1002`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1003`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `colors.ts`
+- **Thin community `Community 1004`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `index.ts`
+- **Thin community `Community 1005`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1006`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `products.ts`
+- **Thin community `Community 1007`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1008`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `stores.ts`
+- **Thin community `Community 1009`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `bag.ts`
+- **Thin community `Community 1010`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `guest.ts`
+- **Thin community `Community 1011`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `index.ts`
+- **Thin community `Community 1012`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `me.ts`
+- **Thin community `Community 1013`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `offers.ts`
+- **Thin community `Community 1014`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1015`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1016`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1017`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1018`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1019`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1020`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1021`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1022`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1023`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `user.ts`
+- **Thin community `Community 1024`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1025`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `index.ts`
+- **Thin community `Community 1026`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1027`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `http.ts`
+- **Thin community `Community 1028`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1029`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1030`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1031`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `categories.ts`
+- **Thin community `Community 1032`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `colors.ts`
+- **Thin community `Community 1033`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1034`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 1035`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1036`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1037`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1038`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1039`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `pos.ts`
+- **Thin community `Community 1040`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1041`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1042`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1043`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1044`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1045`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1046`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1047`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1048`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1049`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1050`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1051`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1052`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1053`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1054`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1055`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1056`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `types.ts`
+- **Thin community `Community 1057`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1058`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1059`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1060`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1061`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1062`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1063`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `dto.ts`
+- **Thin community `Community 1064`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1065`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `posSessionTracing.test.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `types.ts`
+- **Thin community `Community 1066`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1067`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1068`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `customers.ts`
+- **Thin community `Community 1069`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `register.ts`
+- **Thin community `Community 1070`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `sync.ts`
+- **Thin community `Community 1071`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `schema.ts`
+- **Thin community `Community 1072`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1073`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `index.ts`
+- **Thin community `Community 1074`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1075`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1076`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1077`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1078`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1079`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `category.ts`
+- **Thin community `Community 1080`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `color.ts`
+- **Thin community `Community 1081`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1082`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1083`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `index.ts`
+- **Thin community `Community 1084`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1085`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1086`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `organization.ts`
+- **Thin community `Community 1087`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1088`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `product.ts`
+- **Thin community `Community 1089`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1090`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1091`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `store.ts`
+- **Thin community `Community 1092`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1093`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `index.ts`
+- **Thin community `Community 1094`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1095`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1096`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1097`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1098`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1099`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1100`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1101`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `index.ts`
+- **Thin community `Community 1102`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1103`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1104`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1105`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1106`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1107`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1108`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1109`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1110`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1111`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1112`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1113`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `customer.ts`
+- **Thin community `Community 1114`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1115`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1116`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1117`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1118`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `index.ts`
+- **Thin community `Community 1119`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1120`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1121`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1122`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1123`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1124`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1125`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1126`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1127`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1128`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1129`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1130`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1131`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1132`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1133`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1134`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1135`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `index.ts`
+- **Thin community `Community 1136`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1137`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1138`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1139`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1140`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1141`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1142`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `index.ts`
+- **Thin community `Community 1143`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1144`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1145`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1146`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1147`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1148`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1149`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `bag.ts`
+- **Thin community `Community 1150`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1151`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1152`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1153`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `guest.ts`
+- **Thin community `Community 1154`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `index.ts`
+- **Thin community `Community 1155`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `offer.ts`
+- **Thin community `Community 1156`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1157`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1158`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `review.ts`
+- **Thin community `Community 1159`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1160`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1161`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1162`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1163`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1164`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1165`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1166`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1167`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1168`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `bag.ts`
+- **Thin community `Community 1169`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1170`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `customer.ts`
+- **Thin community `Community 1171`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `guest.ts`
+- **Thin community `Community 1172`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1173`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1174`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1175`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1176`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `payment.ts`
+- **Thin community `Community 1177`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1178`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1179`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1180`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `users.ts`
+- **Thin community `Community 1181`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `payment.ts`
+- **Thin community `Community 1182`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1183`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1184`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1185`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1186`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1187`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `index.ts`
+- **Thin community `Community 1188`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1189`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1190`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `auth.ts`
+- **Thin community `Community 1191`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1192`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1193`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1194`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1195`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1196`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1197`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1198`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1199`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1200`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1201`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1202`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1203`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1204`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1205`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `constants.ts`
+- **Thin community `Community 1206`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1207`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1208`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1209`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `types.ts`
+- **Thin community `Community 1210`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1211`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1212`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1213`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1214`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1215`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1216`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1217`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1218`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1219`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1220`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1221`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1222`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1223`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1224`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1225`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1226`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1227`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1228`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1229`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1230`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `constants.ts`
+- **Thin community `Community 1231`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1232`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1233`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1234`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `data.ts`
+- **Thin community `Community 1235`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1236`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1237`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1238`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1239`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1240`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1241`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1242`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1243`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1244`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `constants.ts`
+- **Thin community `Community 1245`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1246`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1247`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1248`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `data.ts`
+- **Thin community `Community 1249`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1250`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1251`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1252`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1253`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1254`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1255`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1256`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1257`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1258`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1259`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `constants.ts`
+- **Thin community `Community 1260`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1261`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1262`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1263`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1264`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1265`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1266`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1267`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1268`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1269`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1270`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1271`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1272`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1273`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1274`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1275`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1276`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1277`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1278`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1279`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1280`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1281`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1282`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1283`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1284`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1285`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1286`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1287`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1288`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1289`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1290`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1291`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1292`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `constants.ts`
+- **Thin community `Community 1293`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1294`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1295`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1296`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `data.ts`
+- **Thin community `Community 1297`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1298`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1299`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `constants.ts`
+- **Thin community `Community 1300`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1301`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1302`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1303`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1304`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `data.ts`
+- **Thin community `Community 1305`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1306`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `constants.ts`
+- **Thin community `Community 1307`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1308`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1309`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1310`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1311`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `data.ts`
+- **Thin community `Community 1312`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1313`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1314`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1315`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1316`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1317`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1318`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1319`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1320`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1321`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1322`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1323`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1324`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1325`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1326`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1327`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1328`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1329`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1330`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1331`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1332`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1333`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1334`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1335`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1336`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1337`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `POSSettingsView.test.tsx`
+- **Thin community `Community 1338`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1339`** (1 nodes): `POSSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `POSTerminalHealthView.test.tsx`
+- **Thin community `Community 1340`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1341`** (1 nodes): `POSTerminalHealthView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1342`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1343`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `types.ts`
+- **Thin community `Community 1344`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1345`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1346`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1347`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1348`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1349`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1350`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1351`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1352`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1353`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1354`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1355`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1356`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1357`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1358`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `data.ts`
+- **Thin community `Community 1359`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1360`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1361`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1362`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1363`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1364`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1365`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1366`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1367`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1368`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1369`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1370`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1371`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `constants.ts`
+- **Thin community `Community 1372`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1373`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1374`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1375`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `data.ts`
+- **Thin community `Community 1376`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `types.ts`
+- **Thin community `Community 1377`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1378`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1379`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1380`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1381`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1382`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `index.tsx`
+- **Thin community `Community 1383`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1384`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1385`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1386`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1387`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1388`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1389`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1390`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1391`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `index.tsx`
+- **Thin community `Community 1392`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1393`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1394`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1395`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `button.tsx`
+- **Thin community `Community 1396`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1397`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `card.tsx`
+- **Thin community `Community 1398`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1399`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1400`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `command.tsx`
+- **Thin community `Community 1401`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1402`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1403`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1404`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `form.tsx`
+- **Thin community `Community 1405`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1406`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1407`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `input.tsx`
+- **Thin community `Community 1408`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1409`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1410`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1411`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1412`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1413`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1414`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `select.tsx`
+- **Thin community `Community 1415`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1416`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1417`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1418`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `table.tsx`
+- **Thin community `Community 1419`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1420`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1421`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1422`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1423`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1424`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1425`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1426`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1427`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `constants.ts`
+- **Thin community `Community 1428`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1429`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1430`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1431`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `data.ts`
+- **Thin community `Community 1432`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1433`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1434`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1435`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1436`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1437`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1438`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1439`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1440`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1441`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1442`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1443`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `index.ts`
+- **Thin community `Community 1444`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1445`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1446`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1447`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1448`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1449`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1450`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1451`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1452`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1453`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1454`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `aws.ts`
+- **Thin community `Community 1455`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `constants.ts`
+- **Thin community `Community 1456`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `countries.ts`
+- **Thin community `Community 1457`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1458`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1459`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1460`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1461`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1462`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1463`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `dto.ts`
+- **Thin community `Community 1464`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `ports.ts`
+- **Thin community `Community 1465`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `constants.ts`
+- **Thin community `Community 1466`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1467`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1468`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `index.ts`
+- **Thin community `Community 1469`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1470`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `types.ts`
+- **Thin community `Community 1471`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1472`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1473`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1474`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `localCommandGateway.test.ts`
+- **Thin community `Community 1475`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1476`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1793
-- Graph nodes: 5879
-- Graph edges: 6236
+- Graph nodes: 5908
+- Graph edges: 6289
 - Communities: 1721
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -19,9 +19,9 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 4) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 4) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 37) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `checkoutSession.ts` (14 edges, Community 58) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
-- `storeConfig.ts` (14 edges, Community 37) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `getStoreConfigV2()` (17 edges, Community 38) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `checkoutSession.ts` (14 edges, Community 59) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `storeConfig.ts` (14 edges, Community 38) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/pos/application/commands/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/terminals.ts
@@ -21,6 +21,8 @@ const REGISTER_NUMBER_REQUIRED_MESSAGE =
   "A register number is required to identify the terminal.";
 const REGISTER_NUMBER_UNIQUE_MESSAGE =
   "A terminal with this register number already exists in this store.";
+const TERMINAL_REACTIVATION_REPROVISION_MESSAGE =
+  "Re-provision this terminal before returning it to service.";
 
 const REGISTER_TERMINAL_VALIDATION_MESSAGES = new Set([
   REGISTER_NUMBER_REQUIRED_MESSAGE,
@@ -187,6 +189,9 @@ export async function updateTerminal(
     updates.displayName = args.displayName;
   }
   if (args.status !== undefined) {
+    if (terminal.status !== "active" && args.status === "active") {
+      throw new Error(TERMINAL_REACTIVATION_REPROVISION_MESSAGE);
+    }
     updates.status = args.status;
   }
   if (args.browserInfo !== undefined) {
@@ -248,12 +253,46 @@ export type TerminalRuntimeStatusInput = {
     staffProfileId?: Id<"staffProfile">;
     expiresAt?: number;
   };
+  terminalIntegrity?: {
+    observedAt: number;
+    reason?: TerminalIntegrityReason;
+    status: TerminalIntegrityStatus;
+  };
+  drawerAuthority?: {
+    cloudRegisterSessionId?: string;
+    localRegisterSessionId: string;
+    observedAt: number;
+    reason?: DrawerAuthorityReason;
+    status: DrawerAuthorityStatus;
+  };
   snapshots: {
     catalogAgeMs?: number;
     availabilityAgeMs?: number;
     registerReadModelAgeMs?: number;
   };
 };
+
+type TerminalIntegrityStatus =
+  | "healthy"
+  | "repairing"
+  | "requires_reprovision"
+  | "reset_required";
+
+type TerminalIntegrityReason =
+  | "authorization_failed"
+  | "ownership_conflict"
+  | "repair_rejected"
+  | "seed_write_failed"
+  | "store_access_missing"
+  | "terminal_revoked"
+  | "unknown";
+
+type DrawerAuthorityStatus = "healthy" | "blocked";
+
+type DrawerAuthorityReason =
+  | "authority_unknown"
+  | "cloud_closed"
+  | "lifecycle_rejected";
 
 const TERMINAL_NOT_ACTIVE_FOR_STORE_MESSAGE =
   "This terminal is not active for this store.";
@@ -357,6 +396,10 @@ export async function submitTerminalRuntimeStatus(
         args.status.snapshots.registerReadModelAgeMs,
       ),
     }),
+    ...omitUndefined({
+      terminalIntegrity: cleanTerminalIntegrity(args.status.terminalIntegrity),
+      drawerAuthority: cleanDrawerAuthority(args.status.drawerAuthority),
+    }),
   });
 
   return ok({
@@ -403,6 +446,73 @@ function cleanDiagnosticMessage(value: string | undefined, maxLength: number) {
     cleaned,
   );
 }
+
+function cleanTerminalIntegrity(
+  terminalIntegrity: TerminalRuntimeStatusInput["terminalIntegrity"],
+) {
+  if (!terminalIntegrity) return undefined;
+
+  return omitUndefined({
+    observedAt: positiveTimestamp(terminalIntegrity.observedAt) ?? Date.now(),
+    reason: terminalIntegrityReasons.has(terminalIntegrity.reason)
+      ? terminalIntegrity.reason
+      : undefined,
+    status: terminalIntegrityStatuses.has(terminalIntegrity.status)
+      ? terminalIntegrity.status
+      : "reset_required",
+  });
+}
+
+function cleanDrawerAuthority(
+  drawerAuthority: TerminalRuntimeStatusInput["drawerAuthority"],
+) {
+  if (!drawerAuthority) return undefined;
+
+  return omitUndefined({
+    cloudRegisterSessionId: cleanOptionalString(
+      drawerAuthority.cloudRegisterSessionId,
+      120,
+    ),
+    localRegisterSessionId:
+      cleanOptionalString(drawerAuthority.localRegisterSessionId, 120) ??
+      "unknown",
+    observedAt: positiveTimestamp(drawerAuthority.observedAt) ?? Date.now(),
+    reason: drawerAuthorityReasons.has(drawerAuthority.reason)
+      ? drawerAuthority.reason
+      : undefined,
+    status: drawerAuthorityStatuses.has(drawerAuthority.status)
+      ? drawerAuthority.status
+      : "blocked",
+  });
+}
+
+const terminalIntegrityStatuses = new Set<TerminalIntegrityStatus>([
+  "healthy",
+  "repairing",
+  "requires_reprovision",
+  "reset_required",
+]);
+
+const terminalIntegrityReasons = new Set<TerminalIntegrityReason | undefined>([
+  "authorization_failed",
+  "ownership_conflict",
+  "repair_rejected",
+  "seed_write_failed",
+  "store_access_missing",
+  "terminal_revoked",
+  "unknown",
+]);
+
+const drawerAuthorityStatuses = new Set<DrawerAuthorityStatus>([
+  "healthy",
+  "blocked",
+]);
+
+const drawerAuthorityReasons = new Set<DrawerAuthorityReason | undefined>([
+  "authority_unknown",
+  "cloud_closed",
+  "lifecycle_rejected",
+]);
 
 function positiveTimestamp(value: number | undefined) {
   return Number.isFinite(value) && value !== undefined && value > 0

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.ts
@@ -46,6 +46,8 @@ export type TerminalHealthAttentionReason = {
     | "local_store_unavailable"
     | "sync_failed"
     | "sync_unavailable"
+    | "terminal_authorization_failed"
+    | "drawer_authority_blocked"
     | "terminal_seed_missing";
 };
 
@@ -243,7 +245,10 @@ function getAttentionReasonActionTarget(
           }
         : { type: "open_work" };
     case "terminal_seed_missing":
+    case "terminal_authorization_failed":
       return { type: "pos_settings" };
+    case "drawer_authority_blocked":
+      return { type: "pos_register" };
     case "local_review":
     case "local_store_unavailable":
     case "sync_failed":
@@ -293,6 +298,27 @@ function deriveTerminalHealthAttentionReasons(input: {
   const reasons: TerminalHealthAttentionReason[] = [];
   const sync = input.runtimeStatus?.sync;
   const latestEvent = input.syncEvidence.latestEvent;
+
+  if (
+    input.runtimeStatus?.terminalIntegrity &&
+    input.runtimeStatus.terminalIntegrity.status !== "healthy"
+  ) {
+    reasons.push({
+      source: "terminal_runtime",
+      summary:
+        "Terminal setup needs repair before this checkout station can record new sales.",
+      type: "terminal_authorization_failed",
+    });
+  }
+
+  if (input.runtimeStatus?.drawerAuthority?.status === "blocked") {
+    reasons.push({
+      source: "terminal_runtime",
+      summary:
+        "Drawer setup needs repair before this checkout station can record new sales.",
+      type: "drawer_authority_blocked",
+    });
+  }
 
   if (sync && (sync.status === "needs_review" || sync.reviewEventCount > 0)) {
     const count = Math.max(1, sync.reviewEventCount);

--- a/packages/athena-webapp/convex/pos/application/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminals.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { Id } from "../../_generated/dataModel";
+import type { Doc, Id } from "../../_generated/dataModel";
 import { userError } from "../../../shared/commandResult";
 import {
   registerTerminal,
   submitTerminalRuntimeStatus,
+  updateTerminal,
 } from "./commands/terminals";
 import {
   getTerminalHealthSummary,
@@ -278,6 +279,31 @@ describe("registerTerminal", () => {
   });
 });
 
+describe("updateTerminal", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not reactivate a non-active terminal with its old sync secret", async () => {
+    vi.mocked(getTerminalById).mockResolvedValue({
+      ...existingTerminal,
+      status: "lost",
+    });
+
+    await expect(
+      updateTerminal({ db: null as never } as never, {
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        status: "active",
+      }),
+    ).rejects.toThrow("Re-provision this terminal before returning it to service.");
+    expect(vi.mocked(patchTerminalRecord)).not.toHaveBeenCalled();
+  });
+});
+
 describe("submitTerminalRuntimeStatus", () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -303,7 +329,19 @@ describe("submitTerminalRuntimeStatus", () => {
         terminalId: "terminal-1" as Id<"posTerminal">,
         status: {
           ...buildRuntimeStatus(),
+          drawerAuthority: {
+            cloudRegisterSessionId: "cloud-register-1",
+            localRegisterSessionId: "local-register-1",
+            observedAt: 112,
+            reason: "cloud_closed",
+            status: "blocked",
+          },
           staffProofToken: "proof-token",
+          terminalIntegrity: {
+            observedAt: 111,
+            reason: "authorization_failed",
+            status: "requires_reprovision",
+          },
           verifierMetadata: { salt: "never" },
           rawLocalEvents: [
             {
@@ -350,6 +388,18 @@ describe("submitTerminalRuntimeStatus", () => {
           pendingEventCount: 2,
           lastFailureMessage: "[redacted] and [redacted]",
         }),
+        terminalIntegrity: {
+          observedAt: 111,
+          reason: "authorization_failed",
+          status: "requires_reprovision",
+        },
+        drawerAuthority: {
+          cloudRegisterSessionId: "cloud-register-1",
+          localRegisterSessionId: "local-register-1",
+          observedAt: 112,
+          reason: "cloud_closed",
+          status: "blocked",
+        },
       }),
     );
   });
@@ -778,6 +828,65 @@ describe("terminal health summaries", () => {
     ]);
   });
 
+  it("surfaces terminal and drawer authority blocks from runtime status", async () => {
+    vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
+    vi.mocked(getLatestRuntimeStatusForTerminal).mockResolvedValue(
+      buildPersistedRuntimeStatus({
+        drawerAuthority: {
+          cloudRegisterSessionId: "cloud-register-1",
+          localRegisterSessionId: "local-register-1",
+          observedAt: 112,
+          reason: "cloud_closed",
+          status: "blocked",
+        },
+        terminalIntegrity: {
+          observedAt: 111,
+          reason: "authorization_failed",
+          status: "requires_reprovision",
+        },
+        sync: {
+          ...buildRuntimeStatus().sync,
+          failedEventCount: 0,
+          pendingEventCount: 0,
+          status: "idle" as never,
+          uploadableEventCount: 0,
+        },
+      }),
+    );
+    vi.mocked(getTerminalSyncEvidence).mockResolvedValue({
+      latestEvent: null,
+      sampledEventCount: 0,
+      acceptedCount: 0,
+      projectedCount: 0,
+      conflictedCount: 0,
+      heldCount: 0,
+      rejectedCount: 0,
+    });
+
+    const result = await getTerminalHealthSummary(
+      { db: null as never } as never,
+      {
+        storeId: "store-1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        now: 220,
+      },
+    );
+
+    expect(result?.health).toBe("needs_attention");
+    expect(result?.attentionReasons).toEqual([
+      expect.objectContaining({
+        actionTarget: { type: "pos_settings" },
+        source: "terminal_runtime",
+        type: "terminal_authorization_failed",
+      }),
+      expect.objectContaining({
+        actionTarget: { type: "pos_register" },
+        source: "terminal_runtime",
+        type: "drawer_authority_blocked",
+      }),
+    ]);
+  });
+
   it.each([
     {
       expectedHealth: "offline",
@@ -958,7 +1067,9 @@ function buildRuntimeStatus() {
 
 function buildPersistedRuntimeStatus(
   overrides: Partial<ReturnType<typeof buildRuntimeStatus>> & {
+    drawerAuthority?: Doc<"posTerminalRuntimeStatus">["drawerAuthority"];
     receivedAt?: number;
+    terminalIntegrity?: Doc<"posTerminalRuntimeStatus">["terminalIntegrity"];
   } = {},
 ) {
   return {

--- a/packages/athena-webapp/convex/pos/public/sync.test.ts
+++ b/packages/athena-webapp/convex/pos/public/sync.test.ts
@@ -226,6 +226,7 @@ describe("POS local sync public mutation", () => {
       error: {
         code: "authorization_failed",
         message: "You do not have access to sync this POS terminal.",
+        metadata: { terminalAuthorizationFailure: true },
       },
     });
     expect(mocks.ingestLocalEventsWithCtx).not.toHaveBeenCalled();
@@ -246,6 +247,7 @@ describe("POS local sync public mutation", () => {
       error: {
         code: "authorization_failed",
         message: "You do not have access to sync this POS terminal.",
+        metadata: { terminalAuthorizationFailure: true },
       },
     });
     expect(mocks.ingestLocalEventsWithCtx).not.toHaveBeenCalled();
@@ -266,6 +268,7 @@ describe("POS local sync public mutation", () => {
       error: {
         code: "authorization_failed",
         message: "You do not have access to sync this POS terminal.",
+        metadata: { terminalAuthorizationFailure: true },
       },
     });
     expect(mocks.ingestLocalEventsWithCtx).not.toHaveBeenCalled();
@@ -290,6 +293,7 @@ describe("POS local sync public mutation", () => {
       error: {
         code: "authorization_failed",
         message: "You do not have access to sync this POS terminal.",
+        metadata: { terminalAuthorizationFailure: true },
       },
     });
     expect(mocks.ingestLocalEventsWithCtx).not.toHaveBeenCalled();

--- a/packages/athena-webapp/convex/pos/public/sync.ts
+++ b/packages/athena-webapp/convex/pos/public/sync.ts
@@ -207,40 +207,43 @@ export const ingestLocalEvents = mutation({
       });
     }
 
-    let submittedByUserId;
+    let athenaUser;
     try {
-      const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
-      submittedByUserId = athenaUser._id;
+      athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
       await requireOrganizationMemberRoleWithCtx(ctx, {
         allowedRoles: ["full_admin", "pos_only"],
         failureMessage: "You do not have access to sync this POS terminal.",
         organizationId: store.organizationId,
         userId: athenaUser._id,
       });
-      const terminal = await ctx.db.get("posTerminal", args.terminalId);
-      const submittedSyncSecretHash = await hashPosTerminalSyncSecret(
-        args.syncSecretHash,
-      );
-      if (
-        !terminal ||
-        terminal.storeId !== args.storeId ||
-        terminal.status !== "active" ||
-        terminal.registeredByUserId !== athenaUser._id ||
-        !terminal.syncSecretHash ||
-        terminal.syncSecretHash !== submittedSyncSecretHash
-      ) {
-        throw new Error("Terminal is not bound to the signed-in user.");
-      }
     } catch {
       return userError({
         code: "authorization_failed",
         message: "You do not have access to sync this POS terminal.",
       });
     }
+    const terminal = await ctx.db.get("posTerminal", args.terminalId);
+    const submittedSyncSecretHash = await hashPosTerminalSyncSecret(
+      args.syncSecretHash,
+    );
+    if (
+      !terminal ||
+      terminal.storeId !== args.storeId ||
+      terminal.status !== "active" ||
+      terminal.registeredByUserId !== athenaUser._id ||
+      !terminal.syncSecretHash ||
+      terminal.syncSecretHash !== submittedSyncSecretHash
+    ) {
+      return userError({
+        code: "authorization_failed",
+        message: "You do not have access to sync this POS terminal.",
+        metadata: { terminalAuthorizationFailure: true },
+      });
+    }
 
     return ingestLocalEventsWithCtx(ctx, {
       ...args,
-      submittedByUserId,
+      submittedByUserId: athenaUser._id,
       submittedAt: args.submittedAt ?? Date.now(),
     });
   },

--- a/packages/athena-webapp/convex/pos/public/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.test.ts
@@ -325,7 +325,19 @@ describe("POS terminal public mutations", () => {
       terminalId: "terminal-1",
       syncSecretHash: "sync-secret-1",
       status: buildRuntimeStatus({
+        drawerAuthority: {
+          cloudRegisterSessionId: "cloud-register-1",
+          localRegisterSessionId: "local-register-1",
+          observedAt: 112,
+          reason: "cloud_closed",
+          status: "blocked",
+        },
         staffProofToken: "proof-token",
+        terminalIntegrity: {
+          observedAt: 111,
+          reason: "authorization_failed",
+          status: "requires_reprovision",
+        },
         verifierMetadata: { salt: "never" },
         rawLocalEvents: [{ payload: { customerInfo: { phone: "never" } } }],
       }),
@@ -352,11 +364,29 @@ describe("POS terminal public mutations", () => {
       expect.objectContaining({
         storeId: "store-1",
         terminalId: "terminal-1",
-        status: expect.not.objectContaining({
-          staffProofToken: expect.anything(),
-          verifierMetadata: expect.anything(),
-          rawLocalEvents: expect.anything(),
+        status: expect.objectContaining({
+          drawerAuthority: {
+            cloudRegisterSessionId: "cloud-register-1",
+            localRegisterSessionId: "local-register-1",
+            observedAt: 112,
+            reason: "cloud_closed",
+            status: "blocked",
+          },
+          terminalIntegrity: {
+            observedAt: 111,
+            reason: "authorization_failed",
+            status: "requires_reprovision",
+          },
         }),
+      }),
+    );
+    expect(
+      mocks.submitTerminalRuntimeStatusCommand.mock.calls[0]?.[1].status,
+    ).not.toEqual(
+      expect.objectContaining({
+        staffProofToken: expect.anything(),
+        verifierMetadata: expect.anything(),
+        rawLocalEvents: expect.anything(),
       }),
     );
   });
@@ -431,6 +461,7 @@ describe("POS terminal public mutations", () => {
       error: {
         code: "authorization_failed",
         message: "You do not have access to update this POS terminal status.",
+        metadata: { terminalAuthorizationFailure: true },
       },
     });
     expect(mocks.submitTerminalRuntimeStatusCommand).not.toHaveBeenCalled();
@@ -498,6 +529,8 @@ describe("POS terminal public mutations", () => {
       "sync_unavailable",
       "local_store_unavailable",
       "terminal_seed_missing",
+      "terminal_authorization_failed",
+      "drawer_authority_blocked",
       "cloud_conflict",
       "cloud_held",
       "cloud_rejected",

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -24,11 +24,13 @@ import {
 import { hashPosTerminalSyncSecret } from "../application/sync/terminalSyncSecret";
 import {
   posTerminalRuntimeBrowserInfoValidator,
+  posTerminalRuntimeDrawerAuthorityValidator,
   posTerminalRuntimeLocalStoreValidator,
   posTerminalRuntimeSnapshotsValidator,
   posTerminalRuntimeStaffAuthorityValidator,
   posTerminalRuntimeStatusSourceValidator,
   posTerminalRuntimeSyncValidator,
+  posTerminalRuntimeTerminalIntegrityValidator,
 } from "../../schemas/pos/posTerminalRuntimeStatus";
 
 const statusValidator = v.union(
@@ -83,6 +85,8 @@ const runtimeStatusInputValidator = v.object({
   sync: posTerminalRuntimeSyncValidator,
   staffAuthority: posTerminalRuntimeStaffAuthorityValidator,
   snapshots: posTerminalRuntimeSnapshotsValidator,
+  terminalIntegrity: v.optional(posTerminalRuntimeTerminalIntegrityValidator),
+  drawerAuthority: v.optional(posTerminalRuntimeDrawerAuthorityValidator),
 });
 
 const runtimeStatusWriteResultValidator = v.object({
@@ -186,6 +190,8 @@ const terminalHealthAttentionReasonReturnValidator = v.object({
     v.literal("local_store_unavailable"),
     v.literal("sync_failed"),
     v.literal("sync_unavailable"),
+    v.literal("terminal_authorization_failed"),
+    v.literal("drawer_authority_blocked"),
     v.literal("terminal_seed_missing"),
   ),
 });
@@ -258,6 +264,22 @@ function stripRuntimeStatusInput(
       staffProfileId: status.staffAuthority.staffProfileId,
       expiresAt: status.staffAuthority.expiresAt,
     },
+    terminalIntegrity: status.terminalIntegrity
+      ? {
+          observedAt: status.terminalIntegrity.observedAt,
+          reason: status.terminalIntegrity.reason,
+          status: status.terminalIntegrity.status,
+        }
+      : undefined,
+    drawerAuthority: status.drawerAuthority
+      ? {
+          cloudRegisterSessionId: status.drawerAuthority.cloudRegisterSessionId,
+          localRegisterSessionId: status.drawerAuthority.localRegisterSessionId,
+          observedAt: status.drawerAuthority.observedAt,
+          reason: status.drawerAuthority.reason,
+          status: status.drawerAuthority.status,
+        }
+      : undefined,
     snapshots: {
       catalogAgeMs: status.snapshots.catalogAgeMs,
       availabilityAgeMs: status.snapshots.availabilityAgeMs,
@@ -372,8 +394,9 @@ export const submitTerminalRuntimeStatus = mutation({
   },
   returns: commandResultValidator(runtimeStatusWriteResultValidator),
   handler: async (ctx, args) => {
+    let athenaUser;
     try {
-      const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
+      athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
       await requireTerminalStoreAccess(ctx, {
         allowedRoles: ["full_admin", "pos_only"],
         failureMessage:
@@ -381,36 +404,36 @@ export const submitTerminalRuntimeStatus = mutation({
         storeId: args.storeId,
         userId: athenaUser._id,
       });
-
-      const terminal = await ctx.db.get("posTerminal", args.terminalId);
-      const submittedSyncSecretHash = await hashPosTerminalSyncSecret(
-        args.syncSecretHash,
-      );
-      if (
-        !terminal ||
-        terminal.storeId !== args.storeId ||
-        terminal.status !== "active" ||
-        terminal.registeredByUserId !== athenaUser._id ||
-        !terminal.syncSecretHash ||
-        terminal.syncSecretHash !== submittedSyncSecretHash
-      ) {
-        return userError({
-          code: "authorization_failed",
-          message: "You do not have access to update this POS terminal status.",
-        });
-      }
-
-      return submitTerminalRuntimeStatusCommand(ctx, {
-        storeId: args.storeId,
-        terminalId: args.terminalId,
-        status: stripRuntimeStatusInput(args.status),
-      });
     } catch {
       return userError({
         code: "authorization_failed",
         message: "You do not have access to update this POS terminal status.",
       });
     }
+    const terminal = await ctx.db.get("posTerminal", args.terminalId);
+    const submittedSyncSecretHash = await hashPosTerminalSyncSecret(
+      args.syncSecretHash,
+    );
+    if (
+      !terminal ||
+      terminal.storeId !== args.storeId ||
+      terminal.status !== "active" ||
+      terminal.registeredByUserId !== athenaUser._id ||
+      !terminal.syncSecretHash ||
+      terminal.syncSecretHash !== submittedSyncSecretHash
+    ) {
+      return userError({
+        code: "authorization_failed",
+        message: "You do not have access to update this POS terminal status.",
+        metadata: { terminalAuthorizationFailure: true },
+      });
+    }
+
+    return submitTerminalRuntimeStatusCommand(ctx, {
+      storeId: args.storeId,
+      terminalId: args.terminalId,
+      status: stripRuntimeStatusInput(args.status),
+    });
   },
 });
 

--- a/packages/athena-webapp/convex/schemas/pos/posTerminalRuntimeStatus.ts
+++ b/packages/athena-webapp/convex/schemas/pos/posTerminalRuntimeStatus.ts
@@ -77,6 +77,41 @@ export const posTerminalRuntimeSnapshotsValidator = v.object({
   registerReadModelAgeMs: v.optional(v.number()),
 });
 
+export const posTerminalRuntimeTerminalIntegrityReasonValidator = v.union(
+  v.literal("authorization_failed"),
+  v.literal("ownership_conflict"),
+  v.literal("repair_rejected"),
+  v.literal("seed_write_failed"),
+  v.literal("store_access_missing"),
+  v.literal("terminal_revoked"),
+  v.literal("unknown"),
+);
+
+export const posTerminalRuntimeDrawerAuthorityReasonValidator = v.union(
+  v.literal("authority_unknown"),
+  v.literal("cloud_closed"),
+  v.literal("lifecycle_rejected"),
+);
+
+export const posTerminalRuntimeTerminalIntegrityValidator = v.object({
+  observedAt: v.number(),
+  reason: v.optional(posTerminalRuntimeTerminalIntegrityReasonValidator),
+  status: v.union(
+    v.literal("healthy"),
+    v.literal("repairing"),
+    v.literal("requires_reprovision"),
+    v.literal("reset_required"),
+  ),
+});
+
+export const posTerminalRuntimeDrawerAuthorityValidator = v.object({
+  cloudRegisterSessionId: v.optional(v.string()),
+  localRegisterSessionId: v.string(),
+  observedAt: v.number(),
+  reason: v.optional(posTerminalRuntimeDrawerAuthorityReasonValidator),
+  status: v.union(v.literal("healthy"), v.literal("blocked")),
+});
+
 export const posTerminalRuntimeStatusSchema = v.object({
   storeId: v.id("store"),
   terminalId: v.id("posTerminal"),
@@ -90,4 +125,6 @@ export const posTerminalRuntimeStatusSchema = v.object({
   sync: posTerminalRuntimeSyncValidator,
   staffAuthority: posTerminalRuntimeStaffAuthorityValidator,
   snapshots: posTerminalRuntimeSnapshotsValidator,
+  terminalIntegrity: v.optional(posTerminalRuntimeTerminalIntegrityValidator),
+  drawerAuthority: v.optional(posTerminalRuntimeDrawerAuthorityValidator),
 });

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx
@@ -141,4 +141,40 @@ describe("RegisterDrawerGate", () => {
 
     expect(onCloseoutSecondaryAction).toHaveBeenCalledTimes(1);
   });
+
+  it("shows terminal repair copy and sign-out action", async () => {
+    const user = userEvent.setup();
+    const onSignOut = vi.fn();
+    renderGate({
+      mode: "terminalRepair",
+      onSignOut,
+    });
+
+    expect(screen.getByText("Setup needed")).toBeInTheDocument();
+    expect(
+      screen.getByText("Terminal setup needs repair"),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Sign out" }));
+
+    expect(onSignOut).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows drawer authority repair copy and sign-out action", async () => {
+    const user = userEvent.setup();
+    const onSignOut = vi.fn();
+    renderGate({
+      mode: "drawerAuthorityRepair",
+      onSignOut,
+    });
+
+    expect(screen.getByText("Setup needed")).toBeInTheDocument();
+    expect(
+      screen.getByText("Drawer needs repair"),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Sign out" }));
+
+    expect(onSignOut).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
@@ -90,6 +90,46 @@ export function RegisterDrawerGate({
   const isCloseoutBlocked = drawerGate.mode === "closeoutBlocked";
   const isOpeningFloatCorrection = drawerGate.mode === "openingFloatCorrection";
   const isRecovery = drawerGate.mode === "recovery";
+  const isAuthorityRepair =
+    drawerGate.mode === "terminalRepair" ||
+    drawerGate.mode === "drawerAuthorityRepair";
+
+  if (isAuthorityRepair) {
+    const isTerminalRepair = drawerGate.mode === "terminalRepair";
+
+    return (
+      <div className="mx-auto max-w-2xl rounded-lg border border-border bg-surface-raised p-8 shadow-surface">
+        <div className="space-y-4">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <p className="text-sm font-medium uppercase tracking-[0.2em] text-muted-foreground">
+              Register {drawerGate.registerNumber}
+            </p>
+            <span className="rounded-full border border-warning/35 bg-warning/10 px-2.5 py-1 text-xs font-medium text-warning-foreground">
+              Setup needed
+            </span>
+          </div>
+          <div className="space-y-2">
+            <h2 className="text-2xl font-semibold text-foreground">
+              {isTerminalRepair
+                ? "Terminal setup needs repair"
+                : "Drawer needs repair"}
+            </h2>
+            <p className="text-sm leading-6 text-muted-foreground">
+              {isTerminalRepair
+                ? `${drawerGate.registerLabel} cannot record new sales until terminal setup is repaired. Existing local activity is preserved for support.`
+                : `${drawerGate.registerLabel} needs a current drawer before sales can continue. Existing local activity is preserved for support.`}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2 pt-2">
+            <Button type="button" variant="outline" onClick={drawerGate.onSignOut}>
+              <LogOutIcon className="mr-2 h-4 w-4" />
+              Sign out
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   if (isOpeningFloatCorrection) {
     const currency = drawerGate.currency ?? "GHS";

--- a/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
@@ -378,6 +378,117 @@ describe("registerAndProvisionPosTerminal", () => {
     );
   });
 
+  it("uses the atomic terminal seed repair path when the local store supports it", async () => {
+    const registerTerminalMutation = vi.fn(async (args) => ({
+      kind: "ok" as const,
+      data: {
+        _id: "terminal-1" as never,
+        _creationTime: 1,
+        browserInfo: args.browserInfo,
+        displayName: args.displayName,
+        fingerprintHash: args.fingerprintHash,
+        registeredAt: 1,
+        registeredByUserId: "user-1" as never,
+        registerNumber: args.registerNumber,
+        status: "active" as const,
+        storeId: args.storeId as never,
+        syncSecretHash: args.syncSecretHash,
+      },
+    }));
+    const writeProvisionedTerminalSeed = vi.fn(async () => ({
+      ok: true,
+      value: null,
+    }));
+    const writeProvisionedTerminalSeedAndClearTerminalIntegrity = vi.fn(
+      async () => ({
+        ok: true,
+        value: null,
+      }),
+    );
+
+    await registerAndProvisionPosTerminal({
+      activeStoreId: "store-1" as never,
+      browserInfo: { userAgent: "test" },
+      displayName: "Front register",
+      fingerprintHash: "fingerprint-1",
+      now: () => 123,
+      registerNumber: "1",
+      registerTerminalMutation,
+      storeFactory: () =>
+        ({
+          writeProvisionedTerminalSeed,
+          writeProvisionedTerminalSeedAndClearTerminalIntegrity,
+        }) as never,
+    });
+
+    expect(writeProvisionedTerminalSeedAndClearTerminalIntegrity).toHaveBeenCalledWith({
+      seed: expect.objectContaining({
+        cloudTerminalId: "terminal-1",
+        syncSecretHash: "01020304",
+        terminalId: "fingerprint-1",
+      }),
+      terminalIntegrity: {
+        storeId: "store-1",
+        terminalId: "fingerprint-1",
+      },
+    });
+    expect(writeProvisionedTerminalSeed).not.toHaveBeenCalled();
+  });
+
+  it("clears terminal integrity after fallback terminal seed repair", async () => {
+    const registerTerminalMutation = vi.fn(async (args) => ({
+      kind: "ok" as const,
+      data: {
+        _id: "terminal-1" as never,
+        _creationTime: 1,
+        browserInfo: args.browserInfo,
+        displayName: args.displayName,
+        fingerprintHash: args.fingerprintHash,
+        registeredAt: 1,
+        registeredByUserId: "user-1" as never,
+        registerNumber: args.registerNumber,
+        status: "active" as const,
+        storeId: args.storeId as never,
+        syncSecretHash: args.syncSecretHash,
+      },
+    }));
+    const writeProvisionedTerminalSeed = vi.fn(async () => ({
+      ok: true,
+      value: null,
+    }));
+    const clearTerminalIntegrityState = vi.fn(async () => ({
+      ok: true,
+      value: null,
+    }));
+
+    await registerAndProvisionPosTerminal({
+      activeStoreId: "store-1" as never,
+      browserInfo: { userAgent: "test" },
+      displayName: "Front register",
+      fingerprintHash: "fingerprint-1",
+      now: () => 123,
+      registerNumber: "1",
+      registerTerminalMutation,
+      storeFactory: () =>
+        ({
+          clearTerminalIntegrityState,
+          writeProvisionedTerminalSeed,
+        }) as never,
+    });
+
+    expect(writeProvisionedTerminalSeed).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cloudTerminalId: "terminal-1",
+        syncSecretHash: "01020304",
+        terminalId: "fingerprint-1",
+      }),
+    );
+    expect(clearTerminalIntegrityState).toHaveBeenCalledWith({
+      storeId: "store-1",
+      terminalId: "fingerprint-1",
+    });
+  });
+
   it("fails provisioning when the local terminal seed cannot be written", async () => {
     const registerTerminalMutation = vi.fn(async (args) => ({
       kind: "ok" as const,

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
@@ -259,6 +259,22 @@ describe("terminal health presentation", () => {
       },
     },
     {
+      expectedLabel: "Setup needed",
+      reason: {
+        source: "terminal_runtime" as const,
+        summary: "Terminal authorization was rejected.",
+        type: "terminal_authorization_failed" as const,
+      },
+    },
+    {
+      expectedLabel: "Drawer repair needed",
+      reason: {
+        source: "terminal_runtime" as const,
+        summary: "Drawer authority is blocked locally.",
+        type: "drawer_authority_blocked" as const,
+      },
+    },
+    {
       expectedLabel: "Needs review",
       reason: {
         source: "cloud_sync" as const,

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
@@ -200,9 +200,16 @@ export function classifyTerminalHealth(
           toneClassName: "border-danger/30 bg-danger/10 text-danger",
         };
       case "terminal_seed_missing":
+      case "terminal_authorization_failed":
         return {
           description: primaryReason.summary,
           label: "Setup needed",
+          toneClassName: "border-warning/30 bg-warning/15 text-warning",
+        };
+      case "drawer_authority_blocked":
+        return {
+          description: primaryReason.summary,
+          label: "Drawer repair needed",
           toneClassName: "border-warning/30 bg-warning/15 text-warning",
         };
     }

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
@@ -161,6 +161,8 @@ export type TerminalHealthAttentionReason = {
     | "local_store_unavailable"
     | "sync_failed"
     | "sync_unavailable"
+    | "terminal_authorization_failed"
+    | "drawer_authority_blocked"
     | "terminal_seed_missing"
     | string;
 };

--- a/packages/athena-webapp/src/lib/pos/application/registerAndProvisionPosTerminal.ts
+++ b/packages/athena-webapp/src/lib/pos/application/registerAndProvisionPosTerminal.ts
@@ -64,12 +64,12 @@ export async function registerAndProvisionPosTerminal(input: {
   });
   if (result.kind === "user_error") return result;
 
-  const seedWrite = await (
+  const store =
     input.storeFactory?.() ??
     createPosLocalStore({
       adapter: createIndexedDbPosLocalStorageAdapter(),
-    })
-  ).writeProvisionedTerminalSeed({
+    });
+  const seed = {
     terminalId: input.fingerprintHash,
     cloudTerminalId: result.data._id,
     syncSecretHash: result.data.syncSecretHash ?? syncSecretToken,
@@ -78,9 +78,30 @@ export async function registerAndProvisionPosTerminal(input: {
     displayName: result.data.displayName,
     provisionedAt: input.now?.() ?? Date.now(),
     schemaVersion: POS_LOCAL_STORE_SCHEMA_VERSION,
-  });
+  };
+  const seedWrite = store.writeProvisionedTerminalSeedAndClearTerminalIntegrity
+    ? await store.writeProvisionedTerminalSeedAndClearTerminalIntegrity({
+        seed,
+        terminalIntegrity: {
+          storeId: input.activeStoreId,
+          terminalId: input.fingerprintHash,
+        },
+      })
+    : await store.writeProvisionedTerminalSeed(seed);
   if (!seedWrite.ok) {
     throw new Error(seedWrite.error.message);
+  }
+  if (
+    !store.writeProvisionedTerminalSeedAndClearTerminalIntegrity &&
+    typeof store.clearTerminalIntegrityState === "function"
+  ) {
+    const integrityClear = await store.clearTerminalIntegrityState({
+      storeId: input.activeStoreId,
+      terminalId: input.fingerprintHash,
+    });
+    if (!integrityClear.ok) {
+      throw new Error(integrityClear.error.message);
+    }
   }
 
   return result;

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts
@@ -6,6 +6,81 @@ import {
   createPosLocalStore,
 } from "./posLocalStore";
 
+function saleCommandInput() {
+  return {
+    terminalId: "terminal-1",
+    storeId: "store-1",
+    registerNumber: "1",
+    localRegisterSessionId: "drawer-1",
+    localPosSessionId: "session-1",
+    staffProfileId: "staff-1",
+  };
+}
+
+async function appendOpenDrawer(store: ReturnType<typeof createPosLocalStore>) {
+  await store.appendEvent({
+    type: "register.opened",
+    terminalId: "terminal-1",
+    storeId: "store-1",
+    registerNumber: "1",
+    localRegisterSessionId: "drawer-1",
+    staffProfileId: "staff-1",
+    payload: { localRegisterSessionId: "drawer-1", openingFloat: 100 },
+  });
+}
+
+async function blockDrawerAuthority(store: ReturnType<typeof createPosLocalStore>) {
+  await store.writeDrawerAuthorityState({
+    cloudRegisterSessionId: "cloud-register-1",
+    localRegisterSessionId: "drawer-1",
+    observedAt: 10_010,
+    reason: "cloud_closed",
+    status: "blocked",
+    storeId: "store-1",
+    terminalId: "terminal-1",
+  });
+}
+
+async function createBlockedSaleGateway() {
+  const store = createPosLocalStore({
+    adapter: createMemoryPosLocalStorageAdapter(),
+  });
+  await appendOpenDrawer(store);
+  await store.appendEvent({
+    type: "session.started",
+    terminalId: "terminal-1",
+    storeId: "store-1",
+    registerNumber: "1",
+    localRegisterSessionId: "drawer-1",
+    localPosSessionId: "session-1",
+    staffProfileId: "staff-1",
+    payload: { localPosSessionId: "session-1" },
+  });
+  await store.appendEvent({
+    type: "cart.item_added",
+    terminalId: "terminal-1",
+    storeId: "store-1",
+    registerNumber: "1",
+    localRegisterSessionId: "drawer-1",
+    localPosSessionId: "session-1",
+    staffProfileId: "staff-1",
+    payload: {
+      localItemId: "item-1",
+      productId: "product-1",
+      productName: "Body Wave",
+      productSkuId: "sku-1",
+      quantity: 1,
+      price: 100,
+    },
+  });
+  await blockDrawerAuthority(store);
+
+  return {
+    gateway: createLocalCommandGateway({ store }),
+    store,
+  };
+}
+
 describe("createLocalCommandGateway", () => {
   it("opens the drawer and starts a sale locally without Convex", async () => {
     let nextId = 1;
@@ -138,6 +213,56 @@ describe("createLocalCommandGateway", () => {
     });
   });
 
+  it("does not reuse a local drawer when drawer authority is blocked", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 10_000,
+    });
+    await store.appendEvent({
+      type: "register.opened",
+      terminalId: "terminal-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      localRegisterSessionId: "local-register-1",
+      staffProfileId: "staff-1",
+      payload: {
+        localRegisterSessionId: "local-register-1",
+        openingFloat: 100,
+      },
+    });
+    await store.writeDrawerAuthorityState({
+      cloudRegisterSessionId: "cloud-register-1",
+      localRegisterSessionId: "local-register-1",
+      observedAt: 10_010,
+      reason: "cloud_closed",
+      status: "blocked",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    });
+    const onEventAppended = vi.fn();
+    const gateway = createLocalCommandGateway({ store, onEventAppended });
+
+    const result = await gateway.openDrawer({
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      staffProfileId: "staff-1" as never,
+      registerNumber: "1",
+      openingFloat: 500,
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: expect.objectContaining({
+        message: "Drawer setup needs repair before selling can continue.",
+      }),
+    });
+    expect(onEventAppended).not.toHaveBeenCalled();
+    await expect(store.listEvents()).resolves.toMatchObject({
+      ok: true,
+      value: [expect.objectContaining({ type: "register.opened" })],
+    });
+  });
+
   it("refuses to start a sale from another store's local drawer", async () => {
     const store = createPosLocalStore({
       adapter: createMemoryPosLocalStorageAdapter(),
@@ -171,6 +296,82 @@ describe("createLocalCommandGateway", () => {
         message: "Open the drawer before starting a sale.",
       }),
     });
+  });
+
+  it("refuses to start a sale when terminal integrity is blocked", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 10_000,
+    });
+    await store.appendEvent({
+      type: "register.opened",
+      terminalId: "terminal-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      localRegisterSessionId: "local-register-1",
+      staffProfileId: "staff-1",
+      payload: {
+        localRegisterSessionId: "local-register-1",
+        openingFloat: 100,
+      },
+    });
+    await store.writeTerminalIntegrityState({
+      observedAt: 10_010,
+      reason: "authorization_failed",
+      status: "requires_reprovision",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    });
+
+    const gateway = createLocalCommandGateway({ store });
+    const result = await gateway.startSession({
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      staffProfileId: "staff-1" as never,
+      registerNumber: "1",
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: expect.objectContaining({
+        message: "Terminal setup needs repair before selling can continue.",
+      }),
+    });
+    await expect(store.listEvents()).resolves.toMatchObject({
+      ok: true,
+      value: [expect.objectContaining({ type: "register.opened" })],
+    });
+  });
+
+  it("does not open a new drawer when terminal integrity is blocked", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 10_000,
+    });
+    await store.writeTerminalIntegrityState({
+      observedAt: 10_010,
+      reason: "authorization_failed",
+      status: "requires_reprovision",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    });
+    const gateway = createLocalCommandGateway({ store });
+
+    const result = await gateway.openDrawer({
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      staffProfileId: "staff-1" as never,
+      registerNumber: "1",
+      openingFloat: 100,
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: expect.objectContaining({
+        message: "Terminal setup needs repair before selling can continue.",
+      }),
+    });
+    await expect(store.listEvents()).resolves.toEqual({ ok: true, value: [] });
   });
 
   it("starts a sale against an explicit usable local register session", async () => {
@@ -369,6 +570,416 @@ describe("createLocalCommandGateway", () => {
       error: expect.objectContaining({
         message: "Open the drawer before starting a sale.",
       }),
+    });
+  });
+
+  it("allows a locally closed register session to be reopened when authority is healthy", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    await store.appendEvent({
+      type: "register.opened",
+      terminalId: "terminal-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      localRegisterSessionId: "local-register-1",
+      staffProfileId: "staff-1",
+      payload: {
+        localRegisterSessionId: "local-register-1",
+        openingFloat: 100,
+      },
+    });
+    await store.appendEvent({
+      type: "register.closeout_started",
+      terminalId: "terminal-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      localRegisterSessionId: "local-register-1",
+      staffProfileId: "staff-1",
+      payload: { countedCash: 100 },
+    });
+
+    const gateway = createLocalCommandGateway({ store });
+
+    await expect(
+      gateway.reopenRegister({
+        storeId: "store-1",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        localRegisterSessionId: "local-register-1",
+        staffProfileId: "staff-1",
+        reason: "Manager correction",
+      }),
+    ).resolves.toBe(true);
+
+    await expect(store.listEvents()).resolves.toMatchObject({
+      ok: true,
+      value: expect.arrayContaining([
+        expect.objectContaining({ type: "register.reopened" }),
+      ]),
+    });
+  });
+
+  it("fails closed when the local projection cannot be read for a sale command", async () => {
+    const appendEvent = vi.fn();
+    const gateway = createLocalCommandGateway({
+      store: {
+        appendEvent,
+        listEvents: async () => ({
+          ok: false as const,
+          error: {
+            code: "write_failed" as const,
+            message: "IndexedDB read failed.",
+          },
+        }),
+      },
+    });
+
+    await expect(
+      gateway.appendCartItem({
+        terminalId: "terminal-1",
+        storeId: "store-1",
+        registerNumber: "1",
+        localRegisterSessionId: "local-register-1",
+        localPosSessionId: "local-pos-session-1",
+        staffProfileId: "staff-1",
+        payload: {
+          localItemId: "item-1",
+          productId: "product-1",
+          productName: "Body Wave",
+          productSkuId: "sku-1",
+          quantity: 1,
+          price: 120,
+        },
+      }),
+    ).resolves.toBe(false);
+    expect(appendEvent).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [
+      "cart item",
+      async (gateway: ReturnType<typeof createLocalCommandGateway>) =>
+        gateway.appendCartItem({
+          ...saleCommandInput(),
+          payload: {
+            localItemId: "item-1",
+            productId: "product-1",
+            productName: "Body Wave",
+            productSkuId: "sku-1",
+            quantity: 1,
+            price: 120,
+          },
+        }),
+    ],
+    [
+      "service line",
+      async (gateway: ReturnType<typeof createLocalCommandGateway>) =>
+        gateway.appendServiceLine({
+          ...saleCommandInput(),
+          payload: {
+            localServiceLineId: "service-line-1",
+            serviceCatalogId: "service-1",
+            name: "Install",
+            amount: 100,
+          },
+        }),
+    ],
+    [
+      "payment state",
+      async (gateway: ReturnType<typeof createLocalCommandGateway>) =>
+        gateway.appendPaymentState({
+          ...saleCommandInput(),
+          checkoutStateVersion: 1,
+          payments: [{ id: "payment-1", method: "cash", amount: 100, timestamp: 1 }],
+          stage: "paymentAdded",
+        }),
+    ],
+    [
+      "transaction completion",
+      async (gateway: ReturnType<typeof createLocalCommandGateway>) =>
+        gateway.completeTransaction({
+          ...saleCommandInput(),
+          localTransactionId: "transaction-1",
+          payload: {
+            localTransactionId: "transaction-1",
+            receiptNumber: "LOCAL-1",
+            subtotal: 100,
+            tax: 0,
+            total: 100,
+            payments: [{ method: "cash", amount: 100, timestamp: 1 }],
+          },
+        }),
+    ],
+    [
+      "clear cart with prior sale activity",
+      async (gateway: ReturnType<typeof createLocalCommandGateway>) =>
+        gateway.clearCart({
+          ...saleCommandInput(),
+          reason: "Cart cleared",
+        }),
+    ],
+  ])("blocks %s when the command points at a stale drawer", async (_label, runCommand) => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    await appendOpenDrawer(store);
+    await store.appendEvent({
+      type: "session.started",
+      terminalId: "terminal-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      localRegisterSessionId: "drawer-1",
+      localPosSessionId: "session-1",
+      staffProfileId: "staff-1",
+      payload: { localPosSessionId: "session-1" },
+    });
+    await store.appendEvent({
+      type: "cart.item_added",
+      terminalId: "terminal-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      localRegisterSessionId: "drawer-1",
+      localPosSessionId: "session-1",
+      staffProfileId: "staff-1",
+      payload: {
+        localItemId: "existing-item-1",
+        productId: "product-1",
+        productName: "Body Wave",
+        productSkuId: "sku-1",
+        quantity: 1,
+        price: 100,
+      },
+    });
+    await store.appendEvent({
+      type: "register.opened",
+      terminalId: "terminal-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      localRegisterSessionId: "drawer-2",
+      staffProfileId: "staff-1",
+      payload: { localRegisterSessionId: "drawer-2", openingFloat: 200 },
+    });
+    const gateway = createLocalCommandGateway({ store });
+
+    await expect(runCommand(gateway)).resolves.toBe(false);
+    await expect(store.listEvents()).resolves.toMatchObject({
+      ok: true,
+      value: [
+        expect.objectContaining({ type: "register.opened" }),
+        expect.objectContaining({ type: "session.started" }),
+        expect.objectContaining({ type: "cart.item_added" }),
+        expect.objectContaining({ type: "register.opened" }),
+      ],
+    });
+  });
+
+  it.each([
+    [
+      "service line",
+      async (gateway: ReturnType<typeof createLocalCommandGateway>) =>
+        gateway.appendServiceLine({
+          ...saleCommandInput(),
+          payload: {
+            localServiceLineId: "service-line-1",
+            serviceCatalogId: "service-1",
+            name: "Install",
+            amount: 100,
+          },
+        }),
+    ],
+    [
+      "payment state",
+      async (gateway: ReturnType<typeof createLocalCommandGateway>) =>
+        gateway.appendPaymentState({
+          ...saleCommandInput(),
+          checkoutStateVersion: 1,
+          payments: [{ id: "payment-1", method: "cash", amount: 100, timestamp: 1 }],
+          stage: "paymentAdded",
+        }),
+    ],
+    [
+      "transaction completion",
+      async (gateway: ReturnType<typeof createLocalCommandGateway>) =>
+        gateway.completeTransaction({
+          ...saleCommandInput(),
+          localTransactionId: "transaction-1",
+          payload: {
+            localTransactionId: "transaction-1",
+            receiptNumber: "LOCAL-1",
+            subtotal: 100,
+            tax: 0,
+            total: 100,
+            payments: [{ method: "cash", amount: 100, timestamp: 1 }],
+          },
+        }),
+    ],
+    [
+      "clear cart with prior sale activity",
+      async (gateway: ReturnType<typeof createLocalCommandGateway>) =>
+        gateway.clearCart({
+          ...saleCommandInput(),
+          reason: "Cart cleared",
+        }),
+    ],
+  ])("blocks %s when drawer authority is blocked", async (_label, runCommand) => {
+    const { gateway, store } = await createBlockedSaleGateway();
+
+    await expect(runCommand(gateway)).resolves.toBe(false);
+    await expect(store.listEvents()).resolves.toMatchObject({
+      ok: true,
+      value: [
+        expect.objectContaining({ type: "register.opened" }),
+        expect.objectContaining({ type: "session.started" }),
+        expect.objectContaining({ type: "cart.item_added" }),
+      ],
+    });
+  });
+
+  it("blocks closeout when drawer authority is blocked", async () => {
+    const { gateway, store } = await createBlockedSaleGateway();
+
+    await expect(
+      gateway.startCloseout({
+        terminalId: "terminal-1",
+        storeId: "store-1",
+        registerNumber: "1",
+        localRegisterSessionId: "drawer-1",
+        staffProfileId: "staff-1",
+        countedCash: 100,
+      }),
+    ).resolves.toEqual({
+      kind: "user_error",
+      error: expect.objectContaining({
+        message: "Drawer setup needs repair before closeout can continue.",
+      }),
+    });
+    await expect(store.listEvents()).resolves.toMatchObject({
+      ok: true,
+      value: expect.not.arrayContaining([
+        expect.objectContaining({ type: "register.closeout_started" }),
+      ]),
+    });
+  });
+
+  it("blocks register reopen when drawer authority is blocked", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    await appendOpenDrawer(store);
+    await store.appendEvent({
+      type: "register.closeout_started",
+      terminalId: "terminal-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      localRegisterSessionId: "drawer-1",
+      staffProfileId: "staff-1",
+      payload: { countedCash: 100 },
+    });
+    await blockDrawerAuthority(store);
+    const gateway = createLocalCommandGateway({ store });
+
+    await expect(
+      gateway.reopenRegister({
+        terminalId: "terminal-1",
+        storeId: "store-1",
+        registerNumber: "1",
+        localRegisterSessionId: "drawer-1",
+        staffProfileId: "staff-1",
+        reason: "Manager correction",
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it("blocks explicit register seeding when drawer authority is blocked before projection", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    await blockDrawerAuthority(store);
+    const gateway = createLocalCommandGateway({
+      allowExplicitRegisterSessionWithoutProjection: true,
+      store,
+    });
+
+    await expect(
+      gateway.seedRegisterSession({
+        terminalId: "terminal-1",
+        storeId: "store-1",
+        registerNumber: "1",
+        localRegisterSessionId: "drawer-1",
+        staffProfileId: "staff-1",
+        openingFloat: 100,
+        expectedCash: 100,
+        status: "open",
+      }),
+    ).resolves.toBe(false);
+    await expect(store.listEvents()).resolves.toEqual({ ok: true, value: [] });
+  });
+
+  it("blocks explicit sale start when drawer authority is blocked before projection", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    await blockDrawerAuthority(store);
+    const gateway = createLocalCommandGateway({
+      allowExplicitRegisterSessionWithoutProjection: true,
+      store,
+    });
+
+    await expect(
+      gateway.startSession({
+        terminalId: "terminal-1" as never,
+        storeId: "store-1" as never,
+        registerNumber: "1",
+        localRegisterSessionId: "drawer-1",
+        staffProfileId: "staff-1" as never,
+      }),
+    ).resolves.toEqual({
+      kind: "user_error",
+      error: expect.objectContaining({
+        message: "Drawer setup needs repair before selling can continue.",
+      }),
+    });
+    await expect(store.listEvents()).resolves.toEqual({ ok: true, value: [] });
+  });
+
+  it("blocks register reopen while drawer lifecycle needs review", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    await appendOpenDrawer(store);
+    const closeout = await store.appendEvent({
+      type: "register.closeout_started",
+      terminalId: "terminal-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      localRegisterSessionId: "drawer-1",
+      staffProfileId: "staff-1",
+      payload: { countedCash: 100 },
+    });
+    if (!closeout.ok) throw new Error("Failed to seed closeout event");
+    await store.markEventsNeedsReview(
+      [closeout.value.localEventId],
+      "Cloud sync needs review before this local event can finish.",
+      { uploaded: true },
+    );
+    const gateway = createLocalCommandGateway({ store });
+
+    await expect(
+      gateway.reopenRegister({
+        terminalId: "terminal-1",
+        storeId: "store-1",
+        registerNumber: "1",
+        localRegisterSessionId: "drawer-1",
+        staffProfileId: "staff-1",
+        reason: "Manager correction",
+      }),
+    ).resolves.toBe(false);
+    await expect(store.listEvents()).resolves.toMatchObject({
+      ok: true,
+      value: expect.not.arrayContaining([
+        expect.objectContaining({ type: "register.reopened" }),
+      ]),
     });
   });
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts
@@ -7,8 +7,11 @@ import { ok, userError, type CommandResult } from "~/shared/commandResult";
 import { readProjectedLocalRegisterModel } from "./localRegisterReader";
 import type {
   PosLocalAppendEventInput,
+  PosDrawerAuthorityState,
   PosLocalEventRecord,
+  PosLocalCloudMapping,
   PosLocalStoreResult,
+  PosTerminalIntegrityState,
   PosProvisionedTerminalSeed,
 } from "./posLocalStore";
 
@@ -17,9 +20,19 @@ type PosLocalCommandStore = {
     input: PosLocalAppendEventInput,
   ): Promise<PosLocalStoreResult<PosLocalEventRecord>>;
   listEvents(): Promise<PosLocalStoreResult<PosLocalEventRecord[]>>;
+  listLocalCloudMappings?(): Promise<PosLocalStoreResult<PosLocalCloudMapping[]>>;
+  readDrawerAuthorityState?(input: {
+    localRegisterSessionId: string;
+    storeId: string;
+    terminalId: string;
+  }): Promise<PosLocalStoreResult<PosDrawerAuthorityState | null>>;
   readProvisionedTerminalSeed?(): Promise<
     PosLocalStoreResult<PosProvisionedTerminalSeed | null>
   >;
+  readTerminalIntegrityState?(input: {
+    storeId: string;
+    terminalId: string;
+  }): Promise<PosLocalStoreResult<PosTerminalIntegrityState | null>>;
 };
 
 type CreateLocalCommandGatewayOptions = {
@@ -98,6 +111,104 @@ export function createLocalCommandGateway(
     return !(await append(input));
   }
 
+  async function readDrawerAuthorityBlock(input: {
+    localRegisterSessionId: string;
+    storeId: string;
+    terminalId: string;
+  }) {
+    const drawerAuthority = options.store.readDrawerAuthorityState
+      ? await options.store.readDrawerAuthorityState(input)
+      : ({ ok: true, value: null } as const);
+    if (!drawerAuthority.ok) return { ok: false as const };
+
+    return {
+      ok: true as const,
+      blocked: drawerAuthority.value?.status === "blocked",
+    };
+  }
+
+  async function canAppendSaleAffectingEvent(input: {
+    localRegisterSessionId?: string;
+    storeId: string;
+    terminalId: string;
+  }) {
+    const model = await readModel(input);
+    if (!model.ok) return false;
+    if (model.value.canSell) {
+      return (
+        Boolean(input.localRegisterSessionId) &&
+        model.value.activeRegisterSession?.localRegisterSessionId ===
+          input.localRegisterSessionId
+      );
+    }
+    if (model.value.saleBlockReason || model.value.activeRegisterSession) {
+      return false;
+    }
+    if (!input.localRegisterSessionId) return false;
+
+    const drawerAuthority = await readDrawerAuthorityBlock({
+      localRegisterSessionId: input.localRegisterSessionId,
+      storeId: input.storeId,
+      terminalId: input.terminalId,
+    });
+    return drawerAuthority.ok && !drawerAuthority.blocked;
+  }
+
+  async function canAppendRegisterReopen(input: ReopenLocalRegisterInput) {
+    const model = await readModel({
+      storeId: input.storeId,
+      terminalId: input.terminalId,
+    });
+    if (!model.ok) return false;
+    if (
+      hasLifecycleReviewForRegisterSession(
+        model.value.sourceEvents,
+        input.localRegisterSessionId,
+      )
+    ) {
+      return false;
+    }
+    if (!model.value.activeRegisterSession) {
+      if (
+        !options.allowExplicitRegisterSessionWithoutProjection ||
+        model.eventCount > 0
+      ) {
+        return false;
+      }
+      const drawerAuthority = await readDrawerAuthorityBlock({
+        localRegisterSessionId: input.localRegisterSessionId,
+        storeId: input.storeId,
+        terminalId: input.terminalId,
+      });
+      return drawerAuthority.ok && !drawerAuthority.blocked;
+    }
+
+    return !model.value.saleBlockReason;
+  }
+
+  async function canSeedRegisterSession(input: SeedLocalRegisterSessionInput) {
+    const model = await readModel({
+      storeId: input.storeId,
+      terminalId: input.terminalId,
+    });
+    if (!model.ok) return false;
+    if (model.value.canSell) return true;
+    if (model.value.saleBlockReason) return false;
+    if (
+      !options.allowExplicitRegisterSessionWithoutProjection ||
+      model.eventCount > 0
+    ) {
+      return false;
+    }
+
+    const drawerAuthority = await readDrawerAuthorityBlock({
+      localRegisterSessionId: input.localRegisterSessionId,
+      storeId: input.storeId,
+      terminalId: input.terminalId,
+    });
+    return drawerAuthority.ok && !drawerAuthority.blocked;
+  }
+
   async function appendWithResult(input: PosLocalAppendEventInput) {
     const result = await options.store.appendEvent(input);
     if (!result.ok) return toLocalUserError(result.error.message);
@@ -106,7 +217,8 @@ export function createLocalCommandGateway(
   }
 
   return {
-    appendCartItem(input: AppendLocalCartItemInput) {
+    async appendCartItem(input: AppendLocalCartItemInput) {
+      if (!(await canAppendSaleAffectingEvent(input))) return false;
       return appendBoolean({
         type: "cart.item_added",
         terminalId: input.terminalId,
@@ -119,7 +231,8 @@ export function createLocalCommandGateway(
       });
     },
 
-    appendServiceLine(input: AppendLocalServiceLineInput) {
+    async appendServiceLine(input: AppendLocalServiceLineInput) {
+      if (!(await canAppendSaleAffectingEvent(input))) return false;
       return appendBoolean({
         type: "cart.service_added",
         terminalId: input.terminalId,
@@ -135,7 +248,8 @@ export function createLocalCommandGateway(
       });
     },
 
-    appendPaymentState(input: AppendLocalPaymentStateInput) {
+    async appendPaymentState(input: AppendLocalPaymentStateInput) {
+      if (!(await canAppendSaleAffectingEvent(input))) return false;
       return appendBoolean({
         type: "session.payments_updated",
         terminalId: input.terminalId,
@@ -171,6 +285,12 @@ export function createLocalCommandGateway(
         model.value.sourceEvents,
         input,
       );
+      if (
+        hasPriorSaleActivity &&
+        !(await canAppendSaleAffectingEvent(input))
+      ) {
+        return false;
+      }
 
       return appendBoolean({
         type: "cart.cleared",
@@ -195,7 +315,8 @@ export function createLocalCommandGateway(
       });
     },
 
-    completeTransaction(input: CompleteLocalTransactionInput) {
+    async completeTransaction(input: CompleteLocalTransactionInput) {
+      if (!(await canAppendSaleAffectingEvent(input))) return false;
       return appendBoolean({
         type: "transaction.completed",
         terminalId: input.terminalId,
@@ -223,12 +344,22 @@ export function createLocalCommandGateway(
       if (!existingModel.ok) {
         return toLocalUserError(existingModel.error.message);
       }
+      if (existingModel.value.saleBlockReason) {
+        return toLocalUserError(
+          blockedSaleMessage(existingModel.value.saleBlockReason),
+        );
+      }
 
       const activeRegisterSession = existingModel.value.activeRegisterSession;
       if (
         activeRegisterSession &&
         isOpenLocalRegisterSessionStatus(activeRegisterSession.status)
       ) {
+        if (!existingModel.value.canSell) {
+          return toLocalUserError(
+            blockedSaleMessage(existingModel.value.saleBlockReason),
+          );
+        }
         if (
           activeRegisterSession.registerNumber &&
           input.registerNumber &&
@@ -290,7 +421,8 @@ export function createLocalCommandGateway(
       });
     },
 
-    reopenRegister(input: ReopenLocalRegisterInput) {
+    async reopenRegister(input: ReopenLocalRegisterInput) {
+      if (!(await canAppendRegisterReopen(input))) return false;
       return appendBoolean({
         type: "register.reopened",
         terminalId: input.terminalId,
@@ -308,7 +440,8 @@ export function createLocalCommandGateway(
       });
     },
 
-    seedRegisterSession(input: SeedLocalRegisterSessionInput) {
+    async seedRegisterSession(input: SeedLocalRegisterSessionInput) {
+      if (!(await canSeedRegisterSession(input))) return false;
       return appendBoolean({
         type: "register.opened",
         terminalId: input.terminalId,
@@ -349,9 +482,25 @@ export function createLocalCommandGateway(
       const explicitlyTrustedBeforeProjection =
         options.allowExplicitRegisterSessionWithoutProjection &&
         explicitRegisterSessionId &&
-        model.eventCount === 0;
+        model.eventCount === 0 &&
+        !model.value.saleBlockReason;
+      if (explicitlyTrustedBeforeProjection) {
+        const drawerAuthority = await readDrawerAuthorityBlock({
+          localRegisterSessionId: explicitRegisterSessionId,
+          storeId: input.storeId.toString(),
+          terminalId: input.terminalId.toString(),
+        });
+        if (!drawerAuthority.ok || drawerAuthority.blocked) {
+          return toLocalUserError(
+            "Drawer setup needs repair before selling can continue.",
+          );
+        }
+      }
       if (!registerSessionCanSell && !explicitlyTrustedBeforeProjection) {
-        return toLocalUserError("Open the drawer before starting a sale.");
+        return toLocalUserError(
+          blockedSaleMessage(model.value.saleBlockReason) ??
+            "Open the drawer before starting a sale.",
+        );
       }
 
       const expiresAt = clock() + SESSION_TTL_MS;
@@ -395,7 +544,12 @@ export function createLocalCommandGateway(
       });
     },
 
-    startCloseout(input: StartLocalCloseoutInput) {
+    async startCloseout(input: StartLocalCloseoutInput) {
+      if (!(await canAppendSaleAffectingEvent(input))) {
+        return toLocalUserError(
+          "Drawer setup needs repair before closeout can continue.",
+        );
+      }
       return appendWithResult({
         type: "register.closeout_started",
         terminalId: input.terminalId,
@@ -455,6 +609,28 @@ function hasLocalSaleActivity(
   });
 }
 
+function hasLifecycleReviewForRegisterSession(
+  events: PosLocalEventRecord[],
+  localRegisterSessionId: string,
+) {
+  return events.some((event) => {
+    if (
+      event.localRegisterSessionId !== localRegisterSessionId ||
+      event.sync.status !== "needs_review" ||
+      !event.sync.uploaded
+    ) {
+      return false;
+    }
+
+    return (
+      event.type === "register.opened" ||
+      event.type === "register.closeout_started" ||
+      event.type === "register.reopened" ||
+      event.type === "transaction.completed"
+    );
+  });
+}
+
 function isOpenLocalRegisterSessionStatus(status: string) {
   return status === "open" || status === "active";
 }
@@ -465,6 +641,19 @@ function toLocalUserError(message: string) {
     message,
     retryable: true,
   });
+}
+
+function blockedSaleMessage(reason?: string) {
+  if (reason === "terminal_integrity") {
+    return "Terminal setup needs repair before selling can continue.";
+  }
+  if (reason === "drawer_authority") {
+    return "Drawer setup needs repair before selling can continue.";
+  }
+  if (reason === "lifecycle_needs_review") {
+    return "Drawer sync needs review before selling can continue.";
+  }
+  return "Open the drawer before starting a sale.";
 }
 
 type LocalCommandContext = {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localRegisterReader.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localRegisterReader.ts
@@ -3,9 +3,11 @@ import {
   type PosLocalRegisterReadModel,
 } from "./registerReadModel";
 import type {
+  PosDrawerAuthorityState,
   PosLocalCloudMapping,
   PosLocalEventRecord,
   PosLocalStoreResult,
+  PosTerminalIntegrityState,
   PosProvisionedTerminalSeed,
 } from "./posLocalStore";
 import {
@@ -17,9 +19,18 @@ import {
 export type PosLocalRegisterReaderStore = {
   listEvents(): Promise<PosLocalStoreResult<PosLocalEventRecord[]>>;
   listLocalCloudMappings?(): Promise<PosLocalStoreResult<PosLocalCloudMapping[]>>;
+  readDrawerAuthorityState?(input: {
+    localRegisterSessionId: string;
+    storeId: string;
+    terminalId: string;
+  }): Promise<PosLocalStoreResult<PosDrawerAuthorityState | null>>;
   readProvisionedTerminalSeed?(): Promise<
     PosLocalStoreResult<PosProvisionedTerminalSeed | null>
   >;
+  readTerminalIntegrityState?(input: {
+    storeId: string;
+    terminalId: string;
+  }): Promise<PosLocalStoreResult<PosTerminalIntegrityState | null>>;
 };
 
 export async function readScopedPosLocalEvents(input: {
@@ -77,6 +88,48 @@ export async function readProjectedLocalRegisterModel(input: {
         value: [] as PosLocalCloudMapping[],
       } as const);
   if (!mappings.ok) return mappings;
+  const scope = resolvePosLocalTerminalScope({
+    storeId: input.storeId,
+    terminal: input.terminal,
+    terminalId: input.terminalId,
+    terminalSeed: scoped.value.terminalSeed,
+  });
+  const scopedTerminalId =
+    scoped.value.terminalSeed?.terminalId ??
+    input.terminal?.localTerminalId ??
+    input.terminalId ??
+    input.terminal?._id ??
+    null;
+  const terminalIntegrity =
+    input.store.readTerminalIntegrityState && scope.storeId && scopedTerminalId
+      ? await input.store.readTerminalIntegrityState({
+          storeId: scope.storeId,
+          terminalId: scopedTerminalId,
+        })
+      : ({ ok: true, value: null } as const);
+  if (!terminalIntegrity.ok) return terminalIntegrity;
+
+  const baseModel = projectLocalRegisterReadModel({
+    events: scoped.value.events,
+    terminalSeed: scoped.value.terminalSeed,
+    mappings: mappings.value,
+    isOnline: input.isOnline,
+    terminalIntegrity: terminalIntegrity.value,
+  });
+  const activeLocalRegisterSessionId =
+    baseModel.activeRegisterSession?.localRegisterSessionId;
+  const drawerAuthority =
+    input.store.readDrawerAuthorityState &&
+    scope.storeId &&
+    activeLocalRegisterSessionId
+      ? await readLatestDrawerAuthorityState({
+          localRegisterSessionId: activeLocalRegisterSessionId,
+          store: input.store,
+          storeId: scope.storeId,
+          terminalIds: scope.terminalIds,
+        })
+      : ({ ok: true, value: null } as const);
+  if (!drawerAuthority.ok) return drawerAuthority;
 
   return {
     ok: true,
@@ -85,6 +138,37 @@ export async function readProjectedLocalRegisterModel(input: {
       terminalSeed: scoped.value.terminalSeed,
       mappings: mappings.value,
       isOnline: input.isOnline,
+      drawerAuthority: drawerAuthority.value,
+      terminalIntegrity: terminalIntegrity.value,
     }),
+  };
+}
+
+async function readLatestDrawerAuthorityState(input: {
+  localRegisterSessionId: string;
+  store: PosLocalRegisterReaderStore;
+  storeId: string;
+  terminalIds: Set<string>;
+}): Promise<PosLocalStoreResult<PosDrawerAuthorityState | null>> {
+  if (!input.store.readDrawerAuthorityState || input.terminalIds.size === 0) {
+    return { ok: true, value: null };
+  }
+
+  const states: PosDrawerAuthorityState[] = [];
+  for (const terminalId of input.terminalIds) {
+    const result = await input.store.readDrawerAuthorityState({
+      localRegisterSessionId: input.localRegisterSessionId,
+      storeId: input.storeId,
+      terminalId,
+    });
+    if (!result.ok) return result;
+    if (result.value) states.push(result.value);
+  }
+
+  return {
+    ok: true,
+    value:
+      states.sort((left, right) => right.observedAt - left.observedAt).at(0) ??
+      null,
   };
 }

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
@@ -10,6 +10,7 @@ import {
   createMemoryPosLocalStorageAdapter,
   createPosLocalStore,
 } from "./posLocalStore";
+import { readProjectedLocalRegisterModel } from "./localRegisterReader";
 
 function buildAuthorityRecord(overrides = {}) {
   return {
@@ -113,6 +114,347 @@ describe("posLocalStore", () => {
         schemaVersion: POS_LOCAL_STORE_SCHEMA_VERSION,
       },
     });
+  });
+
+  it("persists terminal integrity state without storing secret material", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 2_000,
+    });
+
+    const write = await store.writeTerminalIntegrityState({
+      cloudTerminalId: "terminal-cloud-1",
+      message:
+        "syncSecretHash stale-secret staffProofToken proof-token should not persist",
+      observedAt: 1_900,
+      reason: "authorization_failed",
+      registerNumber: "1",
+      status: "requires_reprovision",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+    });
+
+    expect(write).toMatchObject({
+      ok: true,
+      value: {
+        cloudTerminalId: "terminal-cloud-1",
+        message: "Terminal authorization failed. Repair terminal setup.",
+        observedAt: 1_900,
+        reason: "authorization_failed",
+        status: "requires_reprovision",
+      },
+    });
+    await expect(
+      store.readTerminalIntegrityState({
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      value: expect.objectContaining({
+        terminalId: "local-terminal-1",
+        cloudTerminalId: "terminal-cloud-1",
+        status: "requires_reprovision",
+      }),
+    });
+  });
+
+  it("clears terminal integrity state without deleting local events", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+
+    await store.appendEvent({
+      type: "register.opened",
+      terminalId: "local-terminal-1",
+      storeId: "store-1",
+      localRegisterSessionId: "local-register-1",
+      payload: { openingFloat: 100 },
+    });
+    await store.writeTerminalIntegrityState({
+      observedAt: 1_000,
+      reason: "authorization_failed",
+      status: "requires_reprovision",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+    });
+
+    await expect(
+      store.clearTerminalIntegrityState({
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      }),
+    ).resolves.toEqual({ ok: true, value: null });
+    await expect(
+      store.readTerminalIntegrityState({
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      }),
+    ).resolves.toEqual({ ok: true, value: null });
+    await expect(store.listEvents()).resolves.toMatchObject({
+      ok: true,
+      value: [expect.objectContaining({ type: "register.opened" })],
+    });
+  });
+
+  it("persists drawer authority blocks scoped to the active local drawer", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 3_000,
+    });
+
+    await store.writeDrawerAuthorityState({
+      cloudRegisterSessionId: "cloud-register-1",
+      localRegisterSessionId: "local-register-1",
+      observedAt: 2_900,
+      reason: "cloud_closed",
+      registerNumber: "1",
+      status: "blocked",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+    });
+
+    await expect(
+      store.readDrawerAuthorityState({
+        localRegisterSessionId: "local-register-1",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      value: expect.objectContaining({
+        cloudRegisterSessionId: "cloud-register-1",
+        localRegisterSessionId: "local-register-1",
+        reason: "cloud_closed",
+        status: "blocked",
+      }),
+    });
+    await expect(
+      store.readDrawerAuthorityState({
+        localRegisterSessionId: "local-register-other",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      }),
+    ).resolves.toEqual({ ok: true, value: null });
+  });
+
+  it("projects drawer authority written under the cloud terminal id for a provisioned local terminal", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 3_000,
+    });
+
+    await store.writeProvisionedTerminalSeed({
+      terminalId: "local-terminal-1",
+      cloudTerminalId: "terminal-cloud-1",
+      syncSecretHash: "sync-secret-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      displayName: "Front register",
+      provisionedAt: 1_000,
+      schemaVersion: POS_LOCAL_STORE_SCHEMA_VERSION,
+    });
+    await store.appendEvent({
+      type: "register.opened",
+      terminalId: "terminal-cloud-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      localRegisterSessionId: "local-register-1",
+      payload: {
+        localRegisterSessionId: "local-register-1",
+        openingFloat: 100,
+        expectedCash: 100,
+        status: "open",
+      },
+    });
+    await store.writeDrawerAuthorityState({
+      cloudRegisterSessionId: "cloud-register-1",
+      localRegisterSessionId: "local-register-1",
+      observedAt: 2_900,
+      reason: "cloud_closed",
+      status: "blocked",
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+    });
+
+    await expect(
+      readProjectedLocalRegisterModel({
+        store,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      value: {
+        canSell: false,
+        saleBlockReason: "drawer_authority",
+      },
+    });
+  });
+
+  it("atomically writes repaired terminal seed and clears stale integrity state", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+
+    await store.writeTerminalIntegrityState({
+      cloudTerminalId: "terminal-cloud-1",
+      observedAt: 1_000,
+      reason: "authorization_failed",
+      status: "requires_reprovision",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+    });
+
+    await expect(
+      store.writeProvisionedTerminalSeedAndClearTerminalIntegrity({
+        seed: {
+          terminalId: "local-terminal-1",
+          cloudTerminalId: "terminal-cloud-1",
+          syncSecretHash: "sync-secret-2",
+          storeId: "store-1",
+          registerNumber: "1",
+          displayName: "Front register",
+          provisionedAt: 2_000,
+          schemaVersion: POS_LOCAL_STORE_SCHEMA_VERSION,
+        },
+        terminalIntegrity: {
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+      value: {
+        syncSecretHash: "sync-secret-2",
+      },
+    });
+    await expect(store.readProvisionedTerminalSeed()).resolves.toMatchObject({
+      ok: true,
+      value: {
+        syncSecretHash: "sync-secret-2",
+      },
+    });
+    await expect(
+      store.readTerminalIntegrityState({
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      }),
+    ).resolves.toEqual({ ok: true, value: null });
+  });
+
+  it("persists terminal and drawer authority state through the IndexedDB authority store", async () => {
+    const originalIndexedDb = globalThis.indexedDB;
+    const fakeIndexedDb = createControlledIndexedDb();
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: fakeIndexedDb.indexedDB,
+    });
+
+    try {
+      const store = createPosLocalStore({
+        adapter: createIndexedDbPosLocalStorageAdapter({
+          databaseName: "athena-pos-local-authority-test",
+        }),
+      });
+
+      const terminalWrite = store.writeTerminalIntegrityState({
+        cloudTerminalId: "terminal-cloud-1",
+        observedAt: 1_000,
+        reason: "authorization_failed",
+        status: "requires_reprovision",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      });
+      await fakeIndexedDb.waitForTransaction();
+      fakeIndexedDb.completeLastTransaction();
+      await expect(terminalWrite).resolves.toMatchObject({
+        ok: true,
+        value: {
+          status: "requires_reprovision",
+        },
+      });
+
+      const terminalRead = store.readTerminalIntegrityState({
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      });
+      await fakeIndexedDb.waitForTransaction();
+      fakeIndexedDb.completeLastTransaction();
+      await expect(terminalRead).resolves.toMatchObject({
+        ok: true,
+        value: expect.objectContaining({
+          terminalId: "local-terminal-1",
+        }),
+      });
+
+      const drawerWrite = store.writeDrawerAuthorityState({
+        cloudRegisterSessionId: "cloud-register-1",
+        localRegisterSessionId: "local-register-1",
+        observedAt: 2_000,
+        reason: "authority_unknown",
+        status: "blocked",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      });
+      await fakeIndexedDb.waitForTransaction();
+      fakeIndexedDb.completeLastTransaction();
+      await expect(drawerWrite).resolves.toMatchObject({
+        ok: true,
+        value: {
+          reason: "authority_unknown",
+          status: "blocked",
+        },
+      });
+
+      const drawerRead = store.readDrawerAuthorityState({
+        localRegisterSessionId: "local-register-1",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      });
+      await fakeIndexedDb.waitForTransaction();
+      fakeIndexedDb.completeLastTransaction();
+      await expect(drawerRead).resolves.toMatchObject({
+        ok: true,
+        value: expect.objectContaining({
+          cloudRegisterSessionId: "cloud-register-1",
+        }),
+      });
+
+      const drawerClear = store.clearDrawerAuthorityState({
+        localRegisterSessionId: "local-register-1",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      });
+      await fakeIndexedDb.waitForTransaction();
+      fakeIndexedDb.completeLastTransaction();
+      await expect(drawerClear).resolves.toEqual({ ok: true, value: null });
+
+      const drawerReadAfterClear = store.readDrawerAuthorityState({
+        localRegisterSessionId: "local-register-1",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      });
+      await fakeIndexedDb.waitForTransaction();
+      fakeIndexedDb.completeLastTransaction();
+      await expect(drawerReadAfterClear).resolves.toEqual({
+        ok: true,
+        value: null,
+      });
+
+      expect(fakeIndexedDb.database.createObjectStore).toHaveBeenCalledWith(
+        "authority",
+      );
+      expect(fakeIndexedDb.database.transaction).toHaveBeenCalledWith(
+        ["meta", "authority"],
+        "readwrite",
+      );
+    } finally {
+      Object.defineProperty(globalThis, "indexedDB", {
+        configurable: true,
+        value: originalIndexedDb,
+      });
+    }
   });
 
   it("writes and reads a register catalog snapshot for offline lookup", async () => {
@@ -990,6 +1332,10 @@ function createControlledIndexedDb() {
           data.set(storeName, store);
 
           return {
+            delete: (key: string) => {
+              store.delete(key);
+              return createSuccessfulRequest(undefined);
+            },
             get: (key: string) => createSuccessfulRequest(store.get(key)),
             getAll: () => createSuccessfulRequest(Array.from(store.values())),
             put: (value: unknown, key: string) => {
@@ -1057,6 +1403,7 @@ type ControlledIndexedDbTransaction = {
   error: Error | null;
   fail(error: Error): void;
   objectStore(storeName: string): {
+    delete(key: string): IDBRequest<undefined>;
     get(key: string): IDBRequest<unknown>;
     getAll(): IDBRequest<unknown[]>;
     put(value: unknown, key: string): IDBRequest<undefined>;

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
@@ -8,7 +8,7 @@ import type {
   PosServiceCatalogRowDto,
 } from "@/lib/pos/application/dto";
 
-export const POS_LOCAL_STORE_SCHEMA_VERSION = 6;
+export const POS_LOCAL_STORE_SCHEMA_VERSION = 7;
 
 export type PosLocalEntityKind =
   | "registerSession"
@@ -88,6 +88,51 @@ export interface PosLocalCloudMapping {
   mappedAt: number;
 }
 
+export type PosTerminalIntegrityStatus =
+  | "healthy"
+  | "repairing"
+  | "requires_reprovision"
+  | "reset_required";
+
+export type PosTerminalIntegrityReason =
+  | "authorization_failed"
+  | "repair_rejected"
+  | "seed_write_failed"
+  | "terminal_revoked"
+  | "ownership_conflict"
+  | "store_access_missing"
+  | "unknown";
+
+export interface PosTerminalIntegrityState {
+  cloudTerminalId?: string;
+  message?: string;
+  observedAt: number;
+  reason?: PosTerminalIntegrityReason;
+  registerNumber?: string;
+  status: PosTerminalIntegrityStatus;
+  storeId: string;
+  terminalId: string;
+}
+
+export type PosDrawerAuthorityStatus = "healthy" | "blocked";
+
+export type PosDrawerAuthorityBlockReason =
+  | "cloud_closed"
+  | "lifecycle_rejected"
+  | "authority_unknown";
+
+export interface PosDrawerAuthorityState {
+  cloudRegisterSessionId?: string;
+  localRegisterSessionId: string;
+  message?: string;
+  observedAt: number;
+  reason?: PosDrawerAuthorityBlockReason;
+  registerNumber?: string;
+  status: PosDrawerAuthorityStatus;
+  storeId: string;
+  terminalId: string;
+}
+
 export type PosLocalStoreDayReadinessStatus =
   | "started"
   | "not_started"
@@ -163,6 +208,7 @@ export type PosLocalStoreResult<T> =
     };
 
 export type PosLocalObjectStoreName =
+  | "authority"
   | "meta"
   | "terminalSeed"
   | "events"
@@ -219,6 +265,8 @@ const META_SCHEMA_VERSION_KEY = "schemaVersion";
 const META_SEQUENCE_KEY = "sequence";
 const META_UPLOAD_SEQUENCE_PREFIX = "uploadSequence:";
 const TERMINAL_SEED_KEY = "current";
+const TERMINAL_INTEGRITY_PREFIX = "terminalIntegrity:";
+const DRAWER_AUTHORITY_PREFIX = "drawerAuthority:";
 
 class PosLocalStoreSchemaError extends Error {
   readonly code = "unsupported_schema_version" as const;
@@ -380,6 +428,41 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
       }
     },
 
+    async writeProvisionedTerminalSeedAndClearTerminalIntegrity(input: {
+      seed: PosProvisionedTerminalSeed;
+      terminalIntegrity: { storeId: string; terminalId: string };
+    }): Promise<PosLocalStoreResult<PosProvisionedTerminalSeed>> {
+      try {
+        const value = await options.adapter.transaction(
+          "readwrite",
+          ["meta", "terminalSeed", "authority"],
+          async (transaction) => {
+            await ensureSupportedSchema(transaction, "readwrite");
+            const states = await transaction.getAll<unknown>("authority");
+            for (const state of states) {
+              if (
+                isTerminalIntegrityState(state) &&
+                state.storeId === input.terminalIntegrity.storeId &&
+                (state.terminalId === input.terminalIntegrity.terminalId ||
+                  state.cloudTerminalId === input.terminalIntegrity.terminalId)
+              ) {
+                await transaction.delete(
+                  "authority",
+                  terminalIntegrityKey(state.storeId, state.terminalId),
+                );
+              }
+            }
+            await transaction.put("terminalSeed", TERMINAL_SEED_KEY, input.seed);
+            return input.seed;
+          },
+        );
+
+        return { ok: true, value };
+      } catch (error) {
+        return toFailure(error);
+      }
+    },
+
     async readProvisionedTerminalSeed(): Promise<
       PosLocalStoreResult<PosProvisionedTerminalSeed | null>
     > {
@@ -399,6 +482,186 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
         );
 
         return { ok: true, value };
+      } catch (error) {
+        return toFailure(error);
+      }
+    },
+
+    async writeTerminalIntegrityState(
+      state: PosTerminalIntegrityState,
+    ): Promise<PosLocalStoreResult<PosTerminalIntegrityState>> {
+      try {
+        const value = await options.adapter.transaction(
+          "readwrite",
+          ["meta", "authority"],
+          async (transaction) => {
+            await ensureSupportedSchema(transaction, "readwrite");
+            const normalized = normalizeTerminalIntegrityState(state);
+            await transaction.put(
+              "authority",
+              terminalIntegrityKey(normalized.storeId, normalized.terminalId),
+              normalized,
+            );
+            return normalized;
+          },
+        );
+
+        return { ok: true, value };
+      } catch (error) {
+        return toFailure(error);
+      }
+    },
+
+    async readTerminalIntegrityState(input: {
+      storeId: string;
+      terminalId: string;
+    }): Promise<PosLocalStoreResult<PosTerminalIntegrityState | null>> {
+      try {
+        const value = await options.adapter.transaction(
+          "readonly",
+          ["meta", "authority"],
+          async (transaction) => {
+            await ensureSupportedSchema(transaction, "readonly");
+            const states = await transaction.getAll<unknown>("authority");
+            return (
+              states
+                .filter(isTerminalIntegrityState)
+                .filter(
+                  (state) =>
+                    state.storeId === input.storeId &&
+                    (state.terminalId === input.terminalId ||
+                      state.cloudTerminalId === input.terminalId),
+                )
+                .sort((left, right) => right.observedAt - left.observedAt)
+                .at(0) ?? null
+            );
+          },
+        );
+
+        return { ok: true, value };
+      } catch (error) {
+        return toFailure(error);
+      }
+    },
+
+    async clearTerminalIntegrityState(input: {
+      storeId: string;
+      terminalId: string;
+    }): Promise<PosLocalStoreResult<null>> {
+      try {
+        await options.adapter.transaction(
+          "readwrite",
+          ["meta", "authority"],
+          async (transaction) => {
+            await ensureSupportedSchema(transaction, "readwrite");
+            const states = await transaction.getAll<unknown>("authority");
+            for (const state of states) {
+              if (
+                isTerminalIntegrityState(state) &&
+                state.storeId === input.storeId &&
+                (state.terminalId === input.terminalId ||
+                  state.cloudTerminalId === input.terminalId)
+              ) {
+                await transaction.delete(
+                  "authority",
+                  terminalIntegrityKey(state.storeId, state.terminalId),
+                );
+              }
+            }
+          },
+        );
+
+        return { ok: true, value: null };
+      } catch (error) {
+        return toFailure(error);
+      }
+    },
+
+    async writeDrawerAuthorityState(
+      state: PosDrawerAuthorityState,
+    ): Promise<PosLocalStoreResult<PosDrawerAuthorityState>> {
+      try {
+        const value = await options.adapter.transaction(
+          "readwrite",
+          ["meta", "authority"],
+          async (transaction) => {
+            await ensureSupportedSchema(transaction, "readwrite");
+            const normalized = normalizeDrawerAuthorityState(state);
+            await transaction.put(
+              "authority",
+              drawerAuthorityKey(normalized),
+              normalized,
+            );
+            return normalized;
+          },
+        );
+
+        return { ok: true, value };
+      } catch (error) {
+        return toFailure(error);
+      }
+    },
+
+    async readDrawerAuthorityState(input: {
+      localRegisterSessionId: string;
+      storeId: string;
+      terminalId: string;
+    }): Promise<PosLocalStoreResult<PosDrawerAuthorityState | null>> {
+      try {
+        const value = await options.adapter.transaction(
+          "readonly",
+          ["meta", "authority"],
+          async (transaction) => {
+            await ensureSupportedSchema(transaction, "readonly");
+            const states = await transaction.getAll<unknown>("authority");
+            return (
+              states
+                .filter(isDrawerAuthorityState)
+                .filter(
+                  (state) =>
+                    state.storeId === input.storeId &&
+                    state.terminalId === input.terminalId &&
+                    state.localRegisterSessionId ===
+                      input.localRegisterSessionId,
+                )
+                .sort((left, right) => right.observedAt - left.observedAt)
+                .at(0) ?? null
+            );
+          },
+        );
+
+        return { ok: true, value };
+      } catch (error) {
+        return toFailure(error);
+      }
+    },
+
+    async clearDrawerAuthorityState(input: {
+      localRegisterSessionId: string;
+      storeId: string;
+      terminalId: string;
+    }): Promise<PosLocalStoreResult<null>> {
+      try {
+        await options.adapter.transaction(
+          "readwrite",
+          ["meta", "authority"],
+          async (transaction) => {
+            await ensureSupportedSchema(transaction, "readwrite");
+            const states = await transaction.getAll<unknown>("authority");
+            for (const state of states) {
+              if (
+                isDrawerAuthorityState(state) &&
+                state.storeId === input.storeId &&
+                state.terminalId === input.terminalId &&
+                state.localRegisterSessionId === input.localRegisterSessionId
+              ) {
+                await transaction.delete("authority", drawerAuthorityKey(state));
+              }
+            }
+          },
+        );
+
+        return { ok: true, value: null };
       } catch (error) {
         return toFailure(error);
       }
@@ -1018,6 +1281,18 @@ function mappingKey(entity: PosLocalEntityKind, localId: string) {
   return `${entity}:${localId}`;
 }
 
+function terminalIntegrityKey(storeId: string, terminalId: string) {
+  return `${TERMINAL_INTEGRITY_PREFIX}${storeId}:${terminalId}`;
+}
+
+function drawerAuthorityKey(input: {
+  storeId: string;
+  terminalId: string;
+  localRegisterSessionId: string;
+}) {
+  return `${DRAWER_AUTHORITY_PREFIX}${input.storeId}:${input.terminalId}:${input.localRegisterSessionId}`;
+}
+
 function readinessKey(storeId: string, operatingDate: string) {
   return `${storeId}:${operatingDate}`;
 }
@@ -1070,6 +1345,87 @@ function preserveWrappedStaffProof(
   };
 }
 
+function normalizeTerminalIntegrityState(
+  state: PosTerminalIntegrityState,
+): PosTerminalIntegrityState {
+  return {
+    ...state,
+    ...(state.message
+      ? { message: toSafeAuthorityMessage(state.message, state.reason) }
+      : state.reason === "authorization_failed"
+        ? { message: "Terminal authorization failed. Repair terminal setup." }
+        : {}),
+  };
+}
+
+function normalizeDrawerAuthorityState(
+  state: PosDrawerAuthorityState,
+): PosDrawerAuthorityState {
+  return {
+    ...state,
+    ...(state.message
+      ? { message: toSafeAuthorityMessage(state.message) }
+      : state.reason === "cloud_closed"
+        ? { message: "Drawer setup changed. Open a current drawer before selling." }
+        : state.reason === "lifecycle_rejected"
+          ? { message: "Drawer sync needs review before selling can continue." }
+          : {}),
+  };
+}
+
+function toSafeAuthorityMessage(
+  message: string,
+  reason?: PosTerminalIntegrityReason,
+) {
+  if (reason === "authorization_failed") {
+    return "Terminal authorization failed. Repair terminal setup.";
+  }
+
+  const collapsed = message.replace(/\s+/g, " ").trim();
+  if (!collapsed) return undefined;
+
+  return collapsed
+    .replace(
+      /\b(staffProofToken|syncSecretHash|syncSecret|staff proof|sync secret|verifier|credential|credentials|token)\b(?:\s+[^.,;]*)?/gi,
+      (match) => `${match.split(/\s+/)[0]} [redacted]`,
+    )
+    .replace(/[A-Za-z0-9_-]{24,}/g, "[redacted]")
+    .slice(0, 240);
+}
+
+function isTerminalIntegrityState(
+  value: unknown,
+): value is PosTerminalIntegrityState {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.observedAt === "number" &&
+    typeof record.status === "string" &&
+    (record.status === "healthy" ||
+      record.status === "repairing" ||
+      record.status === "requires_reprovision" ||
+      record.status === "reset_required") &&
+    typeof record.storeId === "string" &&
+    typeof record.terminalId === "string" &&
+    (record.cloudTerminalId === undefined ||
+      typeof record.cloudTerminalId === "string")
+  );
+}
+
+function isDrawerAuthorityState(
+  value: unknown,
+): value is PosDrawerAuthorityState {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.localRegisterSessionId === "string" &&
+    typeof record.observedAt === "number" &&
+    (record.status === "healthy" || record.status === "blocked") &&
+    typeof record.storeId === "string" &&
+    typeof record.terminalId === "string"
+  );
+}
+
 function isStaffAuthorityRecord(
   value: unknown,
 ): value is PosLocalStaffAuthorityRecord {
@@ -1119,6 +1475,7 @@ export function createIndexedDbPosLocalStorageAdapter(options?: {
       request.onupgradeneeded = () => {
         const database = request.result;
         for (const storeName of [
+          "authority",
           "meta",
           "terminalSeed",
           "events",
@@ -1286,6 +1643,7 @@ type MemoryStore = Record<PosLocalObjectStoreName, Map<string, unknown>>;
 
 function createEmptyMemoryStore(): MemoryStore {
   return {
+    authority: new Map(),
     meta: new Map(),
     terminalSeed: new Map(),
     events: new Map(),
@@ -1300,6 +1658,7 @@ function createEmptyMemoryStore(): MemoryStore {
 
 function cloneMemoryStore(store: MemoryStore): MemoryStore {
   return {
+    authority: new Map(store.authority),
     meta: new Map(store.meta),
     terminalSeed: new Map(store.terminalSeed),
     events: new Map(store.events),

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts
@@ -749,6 +749,100 @@ describe("projectLocalRegisterReadModel", () => {
       status: "closed_locally",
     });
   });
+
+  it("blocks selling when terminal integrity requires repair", () => {
+    const model = projectLocalRegisterReadModel({
+      terminalIntegrity: {
+        observedAt: 1_010,
+        reason: "authorization_failed",
+        status: "requires_reprovision",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      },
+      events: [
+        event({
+          sequence: 1,
+          type: "register.opened",
+          payload: { openingFloat: 100 },
+        }),
+      ],
+      isOnline: false,
+    });
+
+    expect(model.canSell).toBe(false);
+    expect(model.saleBlockReason).toBe("terminal_integrity");
+    expect(model.syncStatus.state).toBe("synced");
+  });
+
+  it("keeps normal pending offline sync sellable", () => {
+    const model = projectLocalRegisterReadModel({
+      events: [
+        event({
+          sequence: 1,
+          uploadSequence: 1,
+          type: "register.opened",
+          payload: { openingFloat: 100 },
+          sync: { status: "pending" },
+        }),
+      ],
+      isOnline: false,
+    });
+
+    expect(model.canSell).toBe(true);
+    expect(model.saleBlockReason).toBeUndefined();
+    expect(model.syncStatus.state).toBe("offline");
+  });
+
+  it("blocks selling when drawer authority is blocked for the active session", () => {
+    const model = projectLocalRegisterReadModel({
+      drawerAuthority: {
+        cloudRegisterSessionId: "cloud-register-1",
+        localRegisterSessionId: "local-register-1",
+        observedAt: 1_050,
+        reason: "cloud_closed",
+        status: "blocked",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      },
+      mappings: [
+        {
+          entity: "registerSession",
+          localId: "local-register-1",
+          cloudId: "cloud-register-1",
+          mappedAt: 1_001,
+        },
+      ],
+      events: [
+        event({
+          sequence: 1,
+          type: "register.opened",
+          payload: { openingFloat: 100 },
+        }),
+      ],
+    });
+
+    expect(model.canSell).toBe(false);
+    expect(model.saleBlockReason).toBe("drawer_authority");
+  });
+
+  it("blocks selling when an uploaded register lifecycle event needs review", () => {
+    const model = projectLocalRegisterReadModel({
+      events: [
+        event({
+          sequence: 1,
+          uploadSequence: 1,
+          type: "register.opened",
+          payload: { openingFloat: 100 },
+          sync: { status: "needs_review", uploaded: true },
+        }),
+      ],
+      isOnline: true,
+    });
+
+    expect(model.canSell).toBe(false);
+    expect(model.saleBlockReason).toBe("lifecycle_needs_review");
+    expect(model.syncStatus.state).toBe("needs_review");
+  });
 });
 
 function errorCodes(errors: PosLocalRegisterReadModelError[]) {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts
@@ -8,8 +8,15 @@ import { derivePosLocalSyncStatus } from "./syncStatus";
 import type {
   PosLocalCloudMapping,
   PosLocalEventRecord,
+  PosDrawerAuthorityState,
+  PosTerminalIntegrityState,
   PosProvisionedTerminalSeed,
 } from "./posLocalStore";
+
+export type PosLocalSaleBlockReason =
+  | "terminal_integrity"
+  | "drawer_authority"
+  | "lifecycle_needs_review";
 
 export type PosLocalRegisterReadModelErrorCode =
   | "malformed_payload"
@@ -129,6 +136,7 @@ export interface PosLocalRegisterReadModel {
   activeRegisterSession: PosLocalCashDrawerReadModel | null;
   activeSale: PosLocalActiveSaleReadModel | null;
   canSell: boolean;
+  saleBlockReason?: PosLocalSaleBlockReason;
   clearedSaleIds: string[];
   closeoutState: PosLocalCloseoutState;
   completedSales: PosLocalCompletedSaleReadModel[];
@@ -140,6 +148,8 @@ export interface PosLocalRegisterReadModel {
 
 export function projectLocalRegisterReadModel(input: {
   events: PosLocalEventRecord[];
+  drawerAuthority?: PosDrawerAuthorityState | null;
+  terminalIntegrity?: PosTerminalIntegrityState | null;
   terminalSeed?: PosProvisionedTerminalSeed | null;
   mappings?: PosLocalCloudMapping[];
   isOnline?: boolean;
@@ -402,13 +412,22 @@ export function projectLocalRegisterReadModel(input: {
   }
 
   const activeSale = [...sales.values()].at(-1) ?? null;
+  const saleBlockReason = getSaleBlockReason({
+    activeRegisterSession,
+    drawerAuthority: input.drawerAuthority,
+    events: orderedEvents,
+    terminalIntegrity: input.terminalIntegrity,
+  });
   const canSell =
-    Boolean(activeRegisterSession) && activeRegisterSession?.status !== "closing";
+    Boolean(activeRegisterSession) &&
+    activeRegisterSession?.status !== "closing" &&
+    !saleBlockReason;
 
   return {
     activeRegisterSession,
     activeSale,
     canSell,
+    ...(saleBlockReason ? { saleBlockReason } : {}),
     clearedSaleIds: [...clearedSaleIds],
     closeoutState,
     completedSales,
@@ -429,6 +448,55 @@ export function projectLocalRegisterReadModel(input: {
       lastSyncedSequence: input.lastSyncedSequence,
     }),
   };
+}
+
+function getSaleBlockReason(input: {
+  activeRegisterSession: PosLocalCashDrawerReadModel | null;
+  drawerAuthority?: PosDrawerAuthorityState | null;
+  events: PosLocalEventRecord[];
+  terminalIntegrity?: PosTerminalIntegrityState | null;
+}): PosLocalSaleBlockReason | undefined {
+  if (
+    input.terminalIntegrity &&
+    input.terminalIntegrity.status !== "healthy"
+  ) {
+    return "terminal_integrity";
+  }
+
+  if (input.drawerAuthority?.status === "blocked") {
+    return "drawer_authority";
+  }
+
+  const activeRegisterSession = input.activeRegisterSession;
+  if (
+    activeRegisterSession &&
+    input.events.some((event) =>
+      isBlockingLifecycleReviewEvent(event, activeRegisterSession),
+    )
+  ) {
+    return "lifecycle_needs_review";
+  }
+
+  return undefined;
+}
+
+function isBlockingLifecycleReviewEvent(
+  event: PosLocalEventRecord,
+  activeRegisterSession: PosLocalCashDrawerReadModel,
+) {
+  if (event.sync.status !== "needs_review" || !event.sync.uploaded) {
+    return false;
+  }
+  if (
+    event.type !== "register.opened" &&
+    event.type !== "register.closeout_started" &&
+    event.type !== "register.reopened" &&
+    event.type !== "transaction.completed"
+  ) {
+    return false;
+  }
+
+  return registerLifecycleEventMatchesActiveSession(event, activeRegisterSession);
 }
 
 function createMappingIndex(mappings: PosLocalCloudMapping[]) {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts
@@ -75,6 +75,24 @@ describe("terminalRuntimeStatus", () => {
         syncSecretHash: "sync-secret-hash",
         terminalId: "local-terminal-1",
       },
+      terminalIntegrity: {
+        message: "syncSecretHash secret should not leave local storage",
+        observedAt: 1_990,
+        reason: "authorization_failed",
+        status: "requires_reprovision",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      },
+      drawerAuthority: {
+        cloudRegisterSessionId: "cloud-register-1",
+        localRegisterSessionId: "register-1",
+        message: "staffProofToken secret should not leave local storage",
+        observedAt: 1_995,
+        reason: "cloud_closed",
+        status: "blocked",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      },
     });
 
     expect(status).toEqual({
@@ -110,6 +128,18 @@ describe("terminalRuntimeStatus", () => {
         reviewEvents: [],
         status: "pending",
         uploadableEventCount: 2,
+      },
+      terminalIntegrity: {
+        observedAt: 1_990,
+        reason: "authorization_failed",
+        status: "requires_reprovision",
+      },
+      drawerAuthority: {
+        cloudRegisterSessionId: "cloud-register-1",
+        localRegisterSessionId: "register-1",
+        observedAt: 1_995,
+        reason: "cloud_closed",
+        status: "blocked",
       },
     });
 
@@ -156,6 +186,22 @@ describe("terminalRuntimeStatus", () => {
         syncSecretHash: "sync-secret-hash",
         terminalId: "local-terminal-1",
       },
+      terminalIntegrity: {
+        observedAt: 1_900,
+        reason: "authorization_failed",
+        status: "requires_reprovision",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      },
+      drawerAuthority: {
+        cloudRegisterSessionId: "cloud-register-1",
+        localRegisterSessionId: "register-1",
+        observedAt: 1_950,
+        reason: "cloud_closed",
+        status: "blocked",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      },
     });
 
     expect(diagnostics).toEqual(
@@ -165,11 +211,25 @@ describe("terminalRuntimeStatus", () => {
           sync: "token [redacted]",
         },
         labels: {
+          drawerAuthority: "blocked",
           localStore: "unavailable",
           staffAuthority: "expired",
           sync: "failed",
+          terminalIntegrity: "blocked",
         },
         source: "support-diagnostics",
+        authority: {
+          drawer: {
+            cloudRegisterSessionId: "cloud-register-1",
+            localRegisterSessionId: "register-1",
+            reason: "cloud_closed",
+            status: "blocked",
+          },
+          terminal: {
+            reason: "authorization_failed",
+            status: "requires_reprovision",
+          },
+        },
         terminal: {
           cloudTerminalId: "terminal-cloud-1",
           displayName: "Front register",

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts
@@ -5,8 +5,10 @@ import type { Id } from "~/convex/_generated/dataModel";
 
 import {
   POS_LOCAL_STORE_SCHEMA_VERSION,
+  type PosDrawerAuthorityState,
   type PosLocalEventRecord,
   type PosLocalStaffAuthorityReadiness,
+  type PosTerminalIntegrityState,
   type PosProvisionedTerminalSeed,
 } from "./posLocalStore";
 import { derivePosLocalSyncStatus } from "./syncStatus";
@@ -56,12 +58,14 @@ export type PosTerminalRuntimeStatusInput = {
   clock?: () => number;
   events: PosLocalEventRecord[];
   localStoreFailureMessage?: string | null;
+  drawerAuthority?: PosDrawerAuthorityState | null;
   snapshots?: PosTerminalRuntimeSnapshotReadiness;
   source: PosTerminalRuntimeStatusSource;
   staffAuthorityExpiresAt?: number;
   staffAuthorityStatus?: PosLocalStaffAuthorityReadiness | "unknown";
   staffProfileId?: string | null;
   syncDebug?: PosTerminalRuntimeSyncDebugInput;
+  terminalIntegrity?: PosTerminalIntegrityState | null;
   terminalSeed?: PosProvisionedTerminalSeed | null;
 };
 
@@ -80,9 +84,11 @@ export type PosTerminalRuntimeCopyDiagnostics = {
     sync?: string;
   };
   labels: {
+    drawerAuthority: "blocked" | "healthy" | "unknown";
     localStore: "available" | "unavailable";
     staffAuthority: PosTerminalRuntimeStaffAuthorityStatus;
     sync: PosTerminalRuntimeStatusSyncStatus;
+    terminalIntegrity: "blocked" | "healthy" | "repairing" | "unknown";
   };
   reportedAt: number;
   sequences: {
@@ -99,6 +105,20 @@ export type PosTerminalRuntimeCopyDiagnostics = {
     localTerminalId?: string;
     registerNumber?: string;
     storeId?: string;
+  };
+  authority: {
+    drawer?: {
+      cloudRegisterSessionId?: string;
+      localRegisterSessionId: string;
+      reason?: string;
+      registerNumber?: string;
+      status: PosDrawerAuthorityState["status"];
+    };
+    terminal?: {
+      reason?: string;
+      registerNumber?: string;
+      status: PosTerminalIntegrityState["status"];
+    };
   };
   timestamps: {
     availabilitySnapshotRefreshedAt?: number;
@@ -190,6 +210,37 @@ export function buildPosTerminalRuntimeStatus(
         ? { oldestPendingEventAt: sync.oldestPendingEventAt }
         : {}),
     },
+    ...(input.terminalIntegrity &&
+    input.terminalIntegrity.status !== "healthy"
+      ? {
+          terminalIntegrity: {
+            observedAt: input.terminalIntegrity.observedAt,
+            ...(input.terminalIntegrity.reason
+              ? { reason: input.terminalIntegrity.reason }
+              : {}),
+            status: input.terminalIntegrity.status,
+          },
+        }
+      : {}),
+    ...(input.drawerAuthority && input.drawerAuthority.status === "blocked"
+      ? {
+          drawerAuthority: {
+            localRegisterSessionId:
+              input.drawerAuthority.localRegisterSessionId,
+            observedAt: input.drawerAuthority.observedAt,
+            ...(input.drawerAuthority.cloudRegisterSessionId
+              ? {
+                  cloudRegisterSessionId:
+                    input.drawerAuthority.cloudRegisterSessionId,
+                }
+              : {}),
+            ...(input.drawerAuthority.reason
+              ? { reason: input.drawerAuthority.reason }
+              : {}),
+            status: input.drawerAuthority.status,
+          },
+        }
+      : {}),
   };
 }
 
@@ -223,9 +274,13 @@ export function buildPosTerminalRuntimeCopyDiagnostics(
       ...(syncFailure ? { sync: syncFailure } : {}),
     },
     labels: {
+      drawerAuthority: input.drawerAuthority
+        ? input.drawerAuthority.status
+        : "unknown",
       localStore: localStoreFailure ? "unavailable" : "available",
       staffAuthority: staffAuthorityStatus,
       sync: sync.status,
+      terminalIntegrity: getTerminalIntegrityLabel(input.terminalIntegrity),
     },
     reportedAt: now,
     sequences: {
@@ -250,6 +305,42 @@ export function buildPosTerminalRuntimeCopyDiagnostics(
         ? { registerNumber: input.terminalSeed.registerNumber }
         : {}),
       ...(input.terminalSeed?.storeId ? { storeId: input.terminalSeed.storeId } : {}),
+    },
+    authority: {
+      ...(input.drawerAuthority
+        ? {
+            drawer: {
+              ...(input.drawerAuthority.cloudRegisterSessionId
+                ? {
+                    cloudRegisterSessionId:
+                      input.drawerAuthority.cloudRegisterSessionId,
+                  }
+                : {}),
+              localRegisterSessionId:
+                input.drawerAuthority.localRegisterSessionId,
+              ...(input.drawerAuthority.reason
+                ? { reason: input.drawerAuthority.reason }
+                : {}),
+              ...(input.drawerAuthority.registerNumber
+                ? { registerNumber: input.drawerAuthority.registerNumber }
+                : {}),
+              status: input.drawerAuthority.status,
+            },
+          }
+        : {}),
+      ...(input.terminalIntegrity
+        ? {
+            terminal: {
+              ...(input.terminalIntegrity.reason
+                ? { reason: input.terminalIntegrity.reason }
+                : {}),
+              ...(input.terminalIntegrity.registerNumber
+                ? { registerNumber: input.terminalIntegrity.registerNumber }
+                : {}),
+              status: input.terminalIntegrity.status,
+            },
+          }
+        : {}),
     },
     timestamps: {
       ...(input.snapshots?.availabilityRefreshedAt
@@ -360,6 +451,15 @@ function normalizeStaffAuthorityStatus(
     return status;
   }
   return "unknown";
+}
+
+function getTerminalIntegrityLabel(
+  state?: PosTerminalIntegrityState | null,
+): "blocked" | "healthy" | "repairing" | "unknown" {
+  if (!state) return "unknown";
+  if (state.status === "healthy") return "healthy";
+  if (state.status === "repairing") return "repairing";
+  return "blocked";
 }
 
 function snapshotAges(

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -233,6 +233,10 @@ describe("usePosLocalSyncRuntimeStatus", () => {
           terminalId: "local-terminal-1",
         },
       })),
+      writeTerminalIntegrityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
     };
     const storeFactory = () => store as never;
     const onLocalEventsChanged = vi.fn();
@@ -261,7 +265,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
       );
     });
 
-    act(() => {
+    await act(async () => {
       result.current?.onRetrySync?.();
     });
 
@@ -363,6 +367,10 @@ describe("usePosLocalSyncRuntimeStatus", () => {
           storeId: "store-1",
           terminalId: "local-terminal-1",
         },
+      })),
+      writeTerminalIntegrityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
       })),
     };
     const storeFactory = () => store as never;
@@ -541,7 +549,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
         }),
       );
     });
-    act(() => {
+    await act(async () => {
       result.current?.onRetrySync?.();
     });
     await waitFor(() => expect(oldStore.listEvents).toHaveBeenCalled());
@@ -725,6 +733,21 @@ describe("usePosLocalSyncRuntimeStatus", () => {
         ok: true,
         value: [],
       })),
+      clearDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
+      readDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: {
+          localRegisterSessionId: "register-1",
+          observedAt: 1,
+          reason: "lifecycle_rejected",
+          status: "blocked",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
       writeLocalCloudMapping: vi.fn(async () => ({
         ok: true,
         value: {},
@@ -740,6 +763,10 @@ describe("usePosLocalSyncRuntimeStatus", () => {
           storeId: "store-1",
           terminalId: "local-terminal-1",
         },
+      })),
+      writeTerminalIntegrityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
       })),
     };
     const storeFactory = () => store as never;
@@ -784,6 +811,11 @@ describe("usePosLocalSyncRuntimeStatus", () => {
       }),
     );
     expect(store.markEventsNeedsReview).not.toHaveBeenCalled();
+    expect(store.clearDrawerAuthorityState).toHaveBeenCalledWith({
+      localRegisterSessionId: "register-1",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+    });
   });
 
   it("does not manually retry review events that were never uploaded", async () => {
@@ -908,6 +940,10 @@ describe("usePosLocalSyncRuntimeStatus", () => {
         ok: true,
         value: [],
       })),
+      writeDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
       readProvisionedTerminalSeed: vi.fn(async () => ({
         ok: true,
         value: {
@@ -941,6 +977,207 @@ describe("usePosLocalSyncRuntimeStatus", () => {
       ),
     );
     expect(store.markEventsSynced).not.toHaveBeenCalled();
+    expect(store.writeDrawerAuthorityState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        localRegisterSessionId: "register-1",
+        reason: "lifecycle_rejected",
+        status: "blocked",
+        storeId: "store-1",
+      }),
+    );
+  });
+
+  it("persists terminal integrity instead of marking events for review when sync authorization fails", async () => {
+    mocks.ingestLocalEvents.mockResolvedValue({
+      kind: "user_error",
+      error: {
+        code: "authorization_failed",
+        message: "Sync secret is no longer valid.",
+        metadata: { terminalAuthorizationFailure: true },
+      },
+    });
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            localEventId: "event-open",
+            sequence: 1,
+            type: "register.opened",
+            uploadSequence: 1,
+          }),
+        ],
+      })),
+      markEventsNeedsReview: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      markEventsSynced: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          registerNumber: "1",
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+      writeTerminalIntegrityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
+    };
+    const storeFactory = () => store as never;
+
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        storeFactory,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() => expect(mocks.ingestLocalEvents).toHaveBeenCalled());
+    expect(store.writeTerminalIntegrityState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cloudTerminalId: "terminal-cloud-1",
+        reason: "authorization_failed",
+        status: "requires_reprovision",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      }),
+    );
+    expect(store.markEventsNeedsReview).not.toHaveBeenCalled();
+    expect(store.markEventsSynced).not.toHaveBeenCalled();
+  });
+
+  it("does not persist terminal integrity for generic sync authorization failures", async () => {
+    mocks.ingestLocalEvents.mockResolvedValue({
+      kind: "user_error",
+      error: {
+        code: "authorization_failed",
+        message: "User session expired.",
+      },
+    });
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            localEventId: "event-open",
+            sequence: 1,
+            type: "register.opened",
+            uploadSequence: 1,
+          }),
+        ],
+      })),
+      markEventsNeedsReview: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      markEventsSynced: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          registerNumber: "1",
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+      writeDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
+      writeTerminalIntegrityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
+    };
+
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() => expect(mocks.ingestLocalEvents).toHaveBeenCalled());
+    expect(store.markEventsNeedsReview).not.toHaveBeenCalled();
+    expect(store.markEventsSynced).not.toHaveBeenCalled();
+    expect(store.writeDrawerAuthorityState).not.toHaveBeenCalled();
+    expect(store.writeTerminalIntegrityState).not.toHaveBeenCalled();
+  });
+
+  it("skips upload attempts while terminal integrity is blocked", async () => {
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            localEventId: "event-open",
+            sequence: 1,
+            type: "register.opened",
+            uploadSequence: 1,
+          }),
+        ],
+      })),
+      markEventsSynced: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          registerNumber: "1",
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+      readTerminalIntegrityState: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          observedAt: 1,
+          reason: "authorization_failed",
+          status: "requires_reprovision",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+    };
+
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() => expect(store.readTerminalIntegrityState).toHaveBeenCalled());
+    expect(mocks.ingestLocalEvents).not.toHaveBeenCalled();
+    expect(store.markEventsSynced).not.toHaveBeenCalled();
   });
 
   it("returns failure when local cloud mapping persistence fails", async () => {
@@ -973,6 +1210,389 @@ describe("usePosLocalSyncRuntimeStatus", () => {
       cloudId: "session-1",
       mappedAt: 10,
     });
+  });
+
+  it("writes drawer authority when mapping persistence fails during runtime upload", async () => {
+    mocks.ingestLocalEvents.mockResolvedValue({
+      kind: "ok",
+      data: {
+        accepted: [
+          {
+            localEventId: "event-open",
+            sequence: 1,
+            status: "projected",
+          },
+        ],
+        held: [],
+        mappings: [
+          {
+            _id: "mapping-open",
+            storeId: "store-1",
+            terminalId: "terminal-cloud-1",
+            localRegisterSessionId: "register-1",
+            localEventId: "event-open",
+            localIdKind: "registerSession",
+            localId: "register-1",
+            cloudTable: "registerSession",
+            cloudId: "register-session-1",
+            createdAt: 12,
+          },
+        ],
+        conflicts: [],
+        syncCursor: {
+          localRegisterSessionId: "register-1",
+          acceptedThroughSequence: 1,
+        },
+      },
+    });
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            localEventId: "event-open",
+            localRegisterSessionId: "register-1",
+            sequence: 1,
+            type: "register.opened",
+          }),
+        ],
+      })),
+      markEventsNeedsReview: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      markEventsSynced: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          registerNumber: "1",
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+      writeDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
+      writeLocalCloudMapping: vi.fn(async () => ({
+        ok: false,
+        error: { code: "write_failed", message: "mapping write failed" },
+      })),
+    };
+
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(store.markEventsNeedsReview).toHaveBeenCalledWith(
+        ["event-open"],
+        "Cloud sync needs review before this local event can finish.",
+        { uploaded: true },
+      ),
+    );
+    expect(store.writeDrawerAuthorityState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        localRegisterSessionId: "register-1",
+        reason: "authority_unknown",
+        status: "blocked",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      }),
+    );
+    expect(store.markEventsSynced).not.toHaveBeenCalled();
+  });
+
+  it("does not clear hard drawer authority blocks after a blocked closeout sync succeeds", async () => {
+    mocks.ingestLocalEvents.mockResolvedValue({
+      kind: "ok",
+      data: {
+        accepted: [
+          {
+            localEventId: "event-closeout",
+            sequence: 1,
+            status: "projected",
+          },
+        ],
+        held: [],
+        mappings: [],
+        conflicts: [],
+        syncCursor: {
+          localRegisterSessionId: "register-1",
+          acceptedThroughSequence: 1,
+        },
+      },
+    });
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            localEventId: "event-closeout",
+            sequence: 1,
+            sync: { status: "pending" },
+            type: "register.closeout_started",
+          }),
+        ],
+      })),
+      clearDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
+      markEventsSynced: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      readDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: {
+          localRegisterSessionId: "register-1",
+          observedAt: 1,
+          reason: "cloud_closed",
+          status: "blocked",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+      writeLocalCloudMapping: vi.fn(async () => ({
+        ok: true,
+        value: {},
+      })),
+    };
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() => expect(mocks.ingestLocalEvents).toHaveBeenCalled());
+    await waitFor(() => expect(store.markEventsSynced).toHaveBeenCalled());
+    expect(store.clearDrawerAuthorityState).not.toHaveBeenCalled();
+  });
+
+  it("clears recoverable authority-unknown drawer blocks after retry succeeds", async () => {
+    mocks.ingestLocalEvents.mockResolvedValue({
+      kind: "ok",
+      data: {
+        accepted: [
+          {
+            localEventId: "event-closeout",
+            sequence: 1,
+            status: "projected",
+          },
+        ],
+        held: [],
+        mappings: [],
+        conflicts: [],
+        syncCursor: {
+          localRegisterSessionId: "register-1",
+          acceptedThroughSequence: 1,
+        },
+      },
+    });
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            localEventId: "event-closeout",
+            sequence: 1,
+            sync: { status: "pending" },
+            type: "register.closeout_started",
+          }),
+        ],
+      })),
+      clearDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
+      markEventsSynced: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      readDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: {
+          localRegisterSessionId: "register-1",
+          observedAt: 1,
+          reason: "authority_unknown",
+          status: "blocked",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+      writeLocalCloudMapping: vi.fn(async () => ({
+        ok: true,
+        value: {},
+      })),
+    };
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(store.clearDrawerAuthorityState).toHaveBeenCalledWith({
+        localRegisterSessionId: "register-1",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      }),
+    );
+    expect(store.markEventsSynced).toHaveBeenCalledWith(["event-closeout"], {
+      uploaded: true,
+    });
+  });
+
+  it("keeps drawer authority blocked when a same-drawer review event remains", async () => {
+    mocks.ingestLocalEvents.mockResolvedValue({
+      kind: "ok",
+      data: {
+        accepted: [
+          {
+            localEventId: "event-open",
+            sequence: 1,
+            status: "projected",
+          },
+          {
+            localEventId: "event-closeout",
+            sequence: 2,
+            status: "rejected",
+          },
+        ],
+        held: [],
+        mappings: [],
+        conflicts: [],
+        syncCursor: {
+          localRegisterSessionId: "register-1",
+          acceptedThroughSequence: 2,
+        },
+      },
+    });
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            localEventId: "event-open",
+            sequence: 1,
+            type: "register.opened",
+          }),
+          buildLocalEvent({
+            localEventId: "event-closeout",
+            sequence: 2,
+            type: "register.closeout_started",
+          }),
+        ],
+      })),
+      clearDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
+      markEventsNeedsReview: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      markEventsSynced: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      readDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: {
+          localRegisterSessionId: "register-1",
+          observedAt: 1,
+          reason: "lifecycle_rejected",
+          status: "blocked",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+      writeDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
+      writeLocalCloudMapping: vi.fn(async () => ({
+        ok: true,
+        value: {},
+      })),
+    };
+
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(store.markEventsNeedsReview).toHaveBeenCalledWith(
+        ["event-closeout"],
+        "Cloud sync needs review before this local event can finish.",
+        { uploaded: true },
+      ),
+    );
+    expect(store.writeDrawerAuthorityState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        localRegisterSessionId: "register-1",
+        reason: "lifecycle_rejected",
+        status: "blocked",
+      }),
+    );
+    expect(store.clearDrawerAuthorityState).not.toHaveBeenCalled();
   });
 
   it("throws local store write failures before the scheduler can clear sync state", () => {
@@ -1359,6 +1979,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
       error: {
         code: "authorization_failed",
         message: "You do not have access to update this POS terminal status.",
+        metadata: { terminalAuthorizationFailure: true },
       },
     });
     const store = {
@@ -1377,6 +1998,10 @@ describe("usePosLocalSyncRuntimeStatus", () => {
           storeId: "store-1",
           terminalId: "local-terminal-1",
         },
+      })),
+      writeTerminalIntegrityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
       })),
     };
 
@@ -1400,6 +2025,128 @@ describe("usePosLocalSyncRuntimeStatus", () => {
         }),
       ),
     );
+    expect(store.writeTerminalIntegrityState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cloudTerminalId: "terminal-cloud-1",
+        reason: "authorization_failed",
+        status: "requires_reprovision",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      }),
+    );
+  });
+
+  it("publishes drawer authority blocks written under the cloud terminal id", async () => {
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            localEventId: "event-open",
+            localRegisterSessionId: "register-1",
+            sequence: 1,
+            terminalId: "terminal-cloud-1",
+            type: "register.opened",
+          }),
+        ],
+      })),
+      readDrawerAuthorityState: vi.fn(async (input: { terminalId: string }) => ({
+        ok: true,
+        value:
+          input.terminalId === "terminal-cloud-1"
+            ? {
+                localRegisterSessionId: "register-1",
+                observedAt: 1,
+                reason: "cloud_closed",
+                status: "blocked",
+                storeId: "store-1",
+                terminalId: "terminal-cloud-1",
+              }
+            : null,
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+    };
+
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        mode: "status-only",
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.reportTerminalRuntimeStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: expect.objectContaining({
+            drawerAuthority: expect.objectContaining({
+              localRegisterSessionId: "register-1",
+              reason: "cloud_closed",
+              status: "blocked",
+            }),
+          }),
+        }),
+      ),
+    );
+  });
+
+  it("does not persist terminal integrity for generic runtime check-in rejections", async () => {
+    mocks.reportTerminalRuntimeStatus.mockResolvedValue({
+      kind: "user_error",
+      error: {
+        code: "authorization_failed",
+        message: "User session expired.",
+      },
+    });
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+      writeTerminalIntegrityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
+    };
+
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        mode: "status-only",
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.reportTerminalRuntimeStatus).toHaveBeenCalled(),
+    );
+    await Promise.resolve();
+    expect(store.writeTerminalIntegrityState).not.toHaveBeenCalled();
   });
 
   it("clears stale completion time while a fresh runtime check-in publish is pending", async () => {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -8,9 +8,11 @@ import {
   createIndexedDbPosLocalStorageAdapter,
   createPosLocalStore,
   type PosLocalCloudMapping,
+  type PosDrawerAuthorityState,
   type PosLocalEventRecord,
   type PosLocalStaffAuthorityReadiness,
   type PosLocalStoreResult,
+  type PosTerminalIntegrityState,
   type PosProvisionedTerminalSeed,
 } from "./posLocalStore";
 import {
@@ -23,7 +25,10 @@ import {
   type PosLocalSyncTrigger,
 } from "./syncScheduler";
 import { derivePosLocalSyncStatus } from "./syncStatus";
-import { readScopedPosLocalEvents } from "./localRegisterReader";
+import {
+  readProjectedLocalRegisterModel,
+  readScopedPosLocalEvents,
+} from "./localRegisterReader";
 import {
   isPosLocalEventInTerminalScope,
   resolvePosLocalTerminalScope,
@@ -117,8 +122,10 @@ export function usePosLocalSyncRuntimeStatus(input: {
   const [events, setEvents] = useState<PosLocalEventRecord[]>([]);
   const [runtimeReadiness, setRuntimeReadiness] =
     useState<PosTerminalRuntimeReadiness>({
+      drawerAuthority: null,
       snapshots: {},
       staffAuthorityStatus: "unknown",
+      terminalIntegrity: null,
       terminalSeed: null,
     });
   const [readError, setReadError] = useState<string | null>(null);
@@ -201,8 +208,10 @@ export function usePosLocalSyncRuntimeStatus(input: {
         setEvents([]);
         setReadError(null);
         setRuntimeReadiness({
+          drawerAuthority: null,
           snapshots: {},
           staffAuthorityStatus: "unknown",
+          terminalIntegrity: null,
           terminalSeed: null,
         });
         return;
@@ -287,6 +296,25 @@ export function usePosLocalSyncRuntimeStatus(input: {
         isOnline: () =>
           typeof navigator === "undefined" ? true : navigator.onLine,
         loadPendingEvents: async () => {
+          const readTerminalIntegrityState = (
+            store as {
+              readTerminalIntegrityState?: PosLocalRuntimeStore["readTerminalIntegrityState"];
+            }
+          ).readTerminalIntegrityState;
+          if (readTerminalIntegrityState) {
+            const terminalIntegrity = await readTerminalIntegrityState({
+              storeId: syncSeed.storeId,
+              terminalId: syncSeed.cloudTerminalId,
+            });
+            assertPosLocalStoreOk(terminalIntegrity);
+            if (
+              terminalIntegrity.value &&
+              terminalIntegrity.value.status !== "healthy"
+            ) {
+              return [];
+            }
+          }
+
           const pending = await readScopedPosLocalUploadEvents({
             store,
             storeId,
@@ -402,16 +430,41 @@ export function usePosLocalSyncRuntimeStatus(input: {
             return { syncedEventIds: [] };
           }
           if (result.kind !== "ok") {
+            if (isTerminalAuthorizationFailure(result)) {
+              await persistTerminalAuthorizationFailure({
+                message: result.error.message,
+                store,
+                syncSeed,
+              });
+              if (!(await refreshEvents())) {
+                return { syncedEventIds: [] };
+              }
+              if (shouldStop()) {
+                return { syncedEventIds: [] };
+              }
+              onLocalEventsChanged?.();
+              return { syncedEventIds: [] };
+            }
+            if (isRetryableSyncAuthorizationFailure(result)) {
+              throw new Error(result.error.message);
+            }
             setDebug((current) => ({
               ...current,
               lastReviewEventCount: uploadedEvents.length,
             }));
+            const reviewEventIds = collectReviewLocalEventIds(
+              latestEvents.value.events,
+              uploadedEvents.map((event) => event.localEventId),
+            );
+            await persistDrawerAuthorityBlockForReviewEvents({
+              events: latestEvents.value.events,
+              reason: "lifecycle_rejected",
+              reviewEventIds,
+              store,
+            });
             return {
               syncedEventIds: [],
-              reviewEventIds: collectReviewLocalEventIds(
-                latestEvents.value.events,
-                uploadedEvents.map((event) => event.localEventId),
-              ),
+              reviewEventIds,
             };
           }
 
@@ -428,12 +481,19 @@ export function usePosLocalSyncRuntimeStatus(input: {
               ...current,
               lastReviewEventCount: uploadedEvents.length,
             }));
+            const reviewEventIds = collectReviewLocalEventIds(
+              latestEvents.value.events,
+              uploadedEvents.map((event) => event.localEventId),
+            );
+            await persistDrawerAuthorityBlockForReviewEvents({
+              events: latestEvents.value.events,
+              reason: "authority_unknown",
+              reviewEventIds,
+              store,
+            });
             return {
               syncedEventIds: [],
-              reviewEventIds: collectReviewLocalEventIds(
-                latestEvents.value.events,
-                uploadedEvents.map((event) => event.localEventId),
-              ),
+              reviewEventIds,
             };
           }
           const reviewEventIds = collectServerReviewLocalEventIds(
@@ -444,17 +504,31 @@ export function usePosLocalSyncRuntimeStatus(input: {
             lastHeldEventCount: result.data.held.length,
             lastReviewEventCount: reviewEventIds.length,
           }));
+          const localReviewEventIds = collectReviewLocalEventIds(
+            latestEvents.value.events,
+            reviewEventIds,
+          );
+          await persistDrawerAuthorityBlockForReviewEvents({
+            events: latestEvents.value.events,
+            reason: "lifecycle_rejected",
+            reviewEventIds: localReviewEventIds,
+            store,
+          });
+          const syncedEventIds = collectSyncedLocalEventIds(
+            latestEvents.value.events,
+            collectServerSyncedLocalEventIds(result.data.accepted),
+          );
+          await clearRecoverableDrawerAuthorityForSyncedEvents({
+            events: latestEvents.value.events,
+            reviewEventIds: localReviewEventIds,
+            store,
+            syncedEventIds,
+          });
 
           return {
             heldEventIds: collectServerHeldLocalEventIds(result.data.held),
-            syncedEventIds: collectSyncedLocalEventIds(
-              latestEvents.value.events,
-              collectServerSyncedLocalEventIds(result.data.accepted),
-            ),
-            reviewEventIds: collectReviewLocalEventIds(
-              latestEvents.value.events,
-              reviewEventIds,
-            ),
+            syncedEventIds,
+            reviewEventIds: localReviewEventIds,
           };
         },
         markNeedsReview: async (eventIds) => {
@@ -585,10 +659,12 @@ export function usePosLocalSyncRuntimeStatus(input: {
       localStoreFailureMessage: readError,
       snapshots: runtimeReadiness.snapshots,
       source,
+      drawerAuthority: runtimeReadiness.drawerAuthority,
       staffAuthorityStatus:
         input.staffAuthorityStatus ?? runtimeReadiness.staffAuthorityStatus,
       staffProfileId,
       syncDebug: runtimeStatusSyncDebug,
+      terminalIntegrity: runtimeReadiness.terminalIntegrity,
       terminalSeed: runtimeReadiness.terminalSeed,
     }),
     [
@@ -596,8 +672,10 @@ export function usePosLocalSyncRuntimeStatus(input: {
       input.staffAuthorityStatus,
       isOnline,
       readError,
+      runtimeReadiness.drawerAuthority,
       runtimeReadiness.snapshots,
       runtimeReadiness.staffAuthorityStatus,
+      runtimeReadiness.terminalIntegrity,
       runtimeReadiness.terminalSeed,
       runtimeStatusSyncDebug,
       source,
@@ -675,7 +753,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
       syncSecretHash: checkInSyncSecretHash,
       status: runtimeStatus,
     })
-      .then((result) => {
+      .then(async (result) => {
         if (result.kind === "ok") {
           setDebug((current) =>
             withCheckInPublishDebug(current, {
@@ -689,12 +767,55 @@ export function usePosLocalSyncRuntimeStatus(input: {
         }
 
         const error = result.kind === "user_error" ? result.error : null;
+        const terminalAuthorizationRejected =
+          isTerminalAuthorizationUserError(error);
+        if (terminalAuthorizationRejected) {
+          const authorityStore =
+            storeFactory?.() ??
+            (typeof indexedDB === "undefined"
+              ? null
+              : createPosLocalStore({
+                  adapter: createIndexedDbPosLocalStorageAdapter(),
+                }));
+          if (
+            authorityStore &&
+            runtimeReadiness.terminalSeed &&
+            typeof authorityStore.writeTerminalIntegrityState === "function"
+          ) {
+            try {
+              const terminalIntegrity =
+                await persistTerminalAuthorizationFailure({
+                  message: error?.message,
+                  store: authorityStore,
+                  syncSeed: runtimeReadiness.terminalSeed,
+                });
+              lastRuntimeStatusSignatureRef.current =
+                getRuntimeStatusPublishSignature({
+                  observationToken: runtimeStatusObservationToken,
+                  runtimeStatus: buildPosTerminalRuntimeStatus({
+                    ...runtimeStatusInput,
+                    terminalIntegrity,
+                  }),
+                  storeId: checkInStoreId,
+                  terminalId: checkInTerminalId,
+                });
+              setRuntimeReadiness((current) => ({
+                ...current,
+                terminalIntegrity,
+              }));
+            } catch {
+              setReadError(
+                "Terminal setup needs repair before POS can continue.",
+              );
+            }
+          }
+        }
         setDebug((current) =>
           withCheckInPublishDebug(current, {
             checkInPublishCompletedAt: Date.now(),
             checkInPublishMessage: error?.message ?? "Check-in was rejected.",
             checkInPublishReason:
-              error?.code === "authorization_failed"
+              terminalAuthorizationRejected
                 ? "authorization_failed"
                 : "rejected",
             checkInPublishStatus: "rejected",
@@ -717,9 +838,12 @@ export function usePosLocalSyncRuntimeStatus(input: {
     readError,
     runtimeStatus,
     runtimeStatusObservationToken,
+    runtimeReadiness.terminalIntegrity,
     runtimeReadiness.terminalSeed,
+    runtimeStatusInput,
     runtimeStatusSyncSecretHash,
     runtimeStatusTerminalId,
+    storeFactory,
     storeId,
   ]);
 
@@ -768,8 +892,10 @@ export function usePosLocalSyncRuntimeStatus(input: {
 }
 
 type PosTerminalRuntimeReadiness = {
+  drawerAuthority: PosDrawerAuthorityState | null;
   snapshots: PosTerminalRuntimeSnapshotReadiness;
   staffAuthorityStatus: PosLocalStaffAuthorityReadiness | "unknown";
+  terminalIntegrity: PosTerminalIntegrityState | null;
   terminalSeed: PosProvisionedTerminalSeed | null;
 };
 
@@ -782,11 +908,28 @@ async function refreshTerminalRuntimeReadiness(input: {
   const store = input.store as PosLocalRuntimeStore &
     Partial<{
       getStaffAuthorityReadiness: PosLocalRuntimeStore["getStaffAuthorityReadiness"];
+      readTerminalIntegrityState: PosLocalRuntimeStore["readTerminalIntegrityState"];
       readRegisterAvailabilitySnapshot: PosLocalRuntimeStore["readRegisterAvailabilitySnapshot"];
       readRegisterCatalogSnapshot: PosLocalRuntimeStore["readRegisterCatalogSnapshot"];
       readRegisterServiceCatalogSnapshot: PosLocalRuntimeStore["readRegisterServiceCatalogSnapshot"];
     }>;
-  const [catalog, serviceCatalog, availability, staffAuthority] = await Promise.all([
+  const readDrawerAuthorityState = (
+    input.store as {
+      readDrawerAuthorityState?: PosLocalRuntimeStore["readDrawerAuthorityState"];
+    }
+  ).readDrawerAuthorityState;
+  const scope = resolvePosLocalTerminalScope({
+    storeId: input.storeId,
+    terminalId: input.terminalId,
+    terminalSeed: input.terminalSeed,
+  });
+  const [
+    catalog,
+    serviceCatalog,
+    availability,
+    staffAuthority,
+    terminalIntegrity,
+  ] = await Promise.all([
     store.readRegisterCatalogSnapshot
       ? store.readRegisterCatalogSnapshot({ storeId: input.storeId })
       : Promise.resolve({ ok: true as const, value: null }),
@@ -802,9 +945,39 @@ async function refreshTerminalRuntimeReadiness(input: {
           terminalId: input.terminalId,
         })
       : Promise.resolve({ ok: true as const, value: "unknown" as const }),
+    input.terminalId && store.readTerminalIntegrityState
+      ? store.readTerminalIntegrityState({
+          storeId: input.storeId,
+          terminalId: input.terminalId,
+        })
+      : Promise.resolve({ ok: true as const, value: null }),
   ]);
+  const localRegisterModel =
+    input.terminalId && readDrawerAuthorityState
+      ? await readProjectedLocalRegisterModel({
+          store,
+          storeId: input.storeId,
+          terminalId: input.terminalId,
+          isOnline:
+            typeof navigator === "undefined" ? true : navigator.onLine,
+        })
+      : ({ ok: true, value: null } as const);
+  const activeLocalRegisterSessionId =
+    localRegisterModel.ok
+      ? localRegisterModel.value?.activeRegisterSession?.localRegisterSessionId
+      : undefined;
+  const drawerAuthority =
+    activeLocalRegisterSessionId && readDrawerAuthorityState
+      ? await readLatestRuntimeDrawerAuthorityState({
+          localRegisterSessionId: activeLocalRegisterSessionId,
+          readDrawerAuthorityState,
+          storeId: input.storeId,
+          terminalIds: scope.terminalIds,
+        })
+      : ({ ok: true, value: null } as const);
 
   return {
+    drawerAuthority: drawerAuthority.ok ? drawerAuthority.value : null,
     snapshots: {
       ...(catalog.ok && catalog.value
         ? { catalogRefreshedAt: catalog.value.refreshedAt }
@@ -817,8 +990,254 @@ async function refreshTerminalRuntimeReadiness(input: {
         : {}),
     },
     staffAuthorityStatus: staffAuthority.ok ? staffAuthority.value : "unknown",
+    terminalIntegrity: terminalIntegrity.ok ? terminalIntegrity.value : null,
     terminalSeed: input.terminalSeed,
   };
+}
+
+async function persistTerminalAuthorizationFailure(input: {
+  message?: string;
+  store: PosLocalRuntimeStore;
+  syncSeed: PosProvisionedTerminalSeed;
+}): Promise<PosTerminalIntegrityState> {
+  const state: PosTerminalIntegrityState = {
+    cloudTerminalId: input.syncSeed.cloudTerminalId,
+    message: input.message,
+    observedAt: Date.now(),
+    reason: "authorization_failed",
+    registerNumber: input.syncSeed.registerNumber,
+    status: "requires_reprovision",
+    storeId: input.syncSeed.storeId,
+    terminalId: input.syncSeed.terminalId,
+  };
+  const result = await input.store.writeTerminalIntegrityState(state);
+  assertPosLocalStoreOk(result);
+  return state;
+}
+
+function isTerminalAuthorizationFailure(
+  result: { kind: string; error?: { code?: string; metadata?: Record<string, unknown> } },
+): result is {
+  kind: "user_error";
+  error: {
+    code: "authorization_failed";
+    message: string;
+    metadata: { terminalAuthorizationFailure: true };
+  };
+} {
+  return (
+    result.kind === "user_error" &&
+    isTerminalAuthorizationUserError(result.error)
+  );
+}
+
+function isRetryableSyncAuthorizationFailure(result: {
+  kind: string;
+  error?: { code?: string; message?: string; metadata?: Record<string, unknown> };
+}): result is {
+  kind: "user_error";
+  error: { code: "authorization_failed"; message: string };
+} {
+  return (
+    result.kind === "user_error" &&
+    result.error?.code === "authorization_failed" &&
+    !isTerminalAuthorizationUserError(result.error)
+  );
+}
+
+function isTerminalAuthorizationUserError(
+  error: { code?: string; metadata?: Record<string, unknown> } | null | undefined,
+) {
+  return (
+    error?.code === "authorization_failed" &&
+    error.metadata?.terminalAuthorizationFailure === true
+  );
+}
+
+async function persistDrawerAuthorityBlockForReviewEvents(input: {
+  events: PosLocalEventRecord[];
+  reason: NonNullable<PosDrawerAuthorityState["reason"]>;
+  reviewEventIds: string[];
+  store: PosLocalRuntimeStore;
+}) {
+  const writeDrawerAuthorityState = (
+    input.store as {
+      writeDrawerAuthorityState?: PosLocalRuntimeStore["writeDrawerAuthorityState"];
+    }
+  ).writeDrawerAuthorityState;
+  if (
+    input.reviewEventIds.length === 0 ||
+    !writeDrawerAuthorityState
+  ) {
+    return;
+  }
+
+  const reviewEventIds = new Set(input.reviewEventIds);
+  const event = input.events.find(
+    (candidate) =>
+      reviewEventIds.has(candidate.localEventId) &&
+      isDrawerAuthorityLifecycleEvent(candidate) &&
+      candidate.localRegisterSessionId,
+  );
+  if (!event?.localRegisterSessionId) return;
+
+  const mappings = await input.store.listLocalCloudMappings?.();
+  if (mappings && !mappings.ok) return;
+  const cloudRegisterSessionId = mappings?.value.find(
+    (mapping) =>
+      mapping.entity === "registerSession" &&
+      mapping.localId === event.localRegisterSessionId,
+  )?.cloudId;
+
+  const result = await writeDrawerAuthorityState({
+    ...(cloudRegisterSessionId ? { cloudRegisterSessionId } : {}),
+    localRegisterSessionId: event.localRegisterSessionId,
+    message:
+      "Cloud sync needs review before this local drawer can continue.",
+    observedAt: Date.now(),
+    reason: input.reason,
+    registerNumber: event.registerNumber,
+    status: "blocked",
+    storeId: event.storeId,
+    terminalId: event.terminalId,
+  });
+  assertPosLocalStoreOk(result);
+}
+
+async function clearRecoverableDrawerAuthorityForSyncedEvents(input: {
+  events: PosLocalEventRecord[];
+  reviewEventIds: string[];
+  store: PosLocalRuntimeStore;
+  syncedEventIds: string[];
+}) {
+  const clearDrawerAuthorityState = (
+    input.store as {
+      clearDrawerAuthorityState?: PosLocalRuntimeStore["clearDrawerAuthorityState"];
+    }
+  ).clearDrawerAuthorityState;
+  const readDrawerAuthorityState = (
+    input.store as {
+      readDrawerAuthorityState?: PosLocalRuntimeStore["readDrawerAuthorityState"];
+    }
+  ).readDrawerAuthorityState;
+  if (
+    !clearDrawerAuthorityState ||
+    !readDrawerAuthorityState ||
+    input.syncedEventIds.length === 0
+  ) {
+    return;
+  }
+
+  const syncedEventIds = new Set(input.syncedEventIds);
+  const reviewEventIds = new Set(input.reviewEventIds);
+  const remainingReviewDrawers = new Set(
+    input.events
+      .filter(
+        (event) =>
+          ((event.sync.status === "needs_review" && event.sync.uploaded) ||
+            reviewEventIds.has(event.localEventId)) &&
+          !syncedEventIds.has(event.localEventId) &&
+          event.localRegisterSessionId &&
+          isDrawerAuthorityLifecycleEvent(event),
+      )
+      .map((event) =>
+        drawerAuthorityEventKey({
+          localRegisterSessionId: event.localRegisterSessionId!,
+          storeId: event.storeId,
+          terminalId: event.terminalId,
+        }),
+      ),
+  );
+  const cleared = new Set<string>();
+  for (const event of input.events) {
+    if (
+      !syncedEventIds.has(event.localEventId) ||
+      !event.localRegisterSessionId ||
+      !isDrawerAuthorityLifecycleEvent(event)
+    ) {
+      continue;
+    }
+
+    const key = drawerAuthorityEventKey({
+      localRegisterSessionId: event.localRegisterSessionId,
+      storeId: event.storeId,
+      terminalId: event.terminalId,
+    });
+    if (remainingReviewDrawers.has(key)) continue;
+    if (cleared.has(key)) continue;
+    cleared.add(key);
+
+    const drawerAuthority = await readDrawerAuthorityState({
+      localRegisterSessionId: event.localRegisterSessionId,
+      storeId: event.storeId,
+      terminalId: event.terminalId,
+    });
+    assertPosLocalStoreOk(drawerAuthority);
+    if (!isRecoverableDrawerAuthorityReason(drawerAuthority.value?.reason)) {
+      continue;
+    }
+
+    const result: PosLocalStoreResult<null> = await clearDrawerAuthorityState({
+      localRegisterSessionId: event.localRegisterSessionId,
+      storeId: event.storeId,
+      terminalId: event.terminalId,
+    });
+    assertPosLocalStoreOk(result);
+  }
+}
+
+function isRecoverableDrawerAuthorityReason(
+  reason: PosDrawerAuthorityState["reason"] | undefined,
+) {
+  return reason === "lifecycle_rejected" || reason === "authority_unknown";
+}
+
+async function readLatestRuntimeDrawerAuthorityState(input: {
+  localRegisterSessionId: string;
+  readDrawerAuthorityState: NonNullable<
+    PosLocalRuntimeStore["readDrawerAuthorityState"]
+  >;
+  storeId: string;
+  terminalIds: Set<string>;
+}): Promise<PosLocalStoreResult<PosDrawerAuthorityState | null>> {
+  if (input.terminalIds.size === 0) {
+    return { ok: true, value: null };
+  }
+
+  const states: PosDrawerAuthorityState[] = [];
+  for (const terminalId of input.terminalIds) {
+    const result = await input.readDrawerAuthorityState({
+      localRegisterSessionId: input.localRegisterSessionId,
+      storeId: input.storeId,
+      terminalId,
+    });
+    if (!result.ok) return result;
+    if (result.value) states.push(result.value);
+  }
+
+  return {
+    ok: true,
+    value:
+      states.sort((left, right) => right.observedAt - left.observedAt).at(0) ??
+      null,
+  };
+}
+
+function drawerAuthorityEventKey(input: {
+  localRegisterSessionId: string;
+  storeId: string;
+  terminalId: string;
+}) {
+  return `${input.storeId}:${input.terminalId}:${input.localRegisterSessionId}`;
+}
+
+function isDrawerAuthorityLifecycleEvent(event: PosLocalEventRecord) {
+  return (
+    event.type === "register.opened" ||
+    event.type === "register.closeout_started" ||
+    event.type === "register.reopened" ||
+    event.type === "transaction.completed"
+  );
 }
 
 function getRuntimeBrowserInfo(isOnline: boolean) {
@@ -949,7 +1368,9 @@ function toIngestLocalEventArg(
   };
 }
 
-export function assertPosLocalStoreOk<T>(result: PosLocalStoreResult<T>) {
+export function assertPosLocalStoreOk<T>(
+  result: PosLocalStoreResult<T>,
+): asserts result is { ok: true; value: T } {
   if (!result.ok) {
     throw new Error(result.error.message);
   }

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -213,7 +213,9 @@ export interface RegisterDrawerGateState {
     | "initialSetup"
     | "recovery"
     | "closeoutBlocked"
-    | "openingFloatCorrection";
+    | "openingFloatCorrection"
+    | "terminalRepair"
+    | "drawerAuthorityRepair";
   isRecovery?: boolean;
   registerLabel: string;
   registerNumber: string;

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -38,6 +38,9 @@ const mockGetStaffAuthorityReadiness = vi.fn();
 const mockMarkLocalEventsSynced = vi.fn();
 const mockWriteLocalCloudMapping = vi.fn();
 const mockListLocalCloudMappings = vi.fn();
+const mockReadDrawerAuthorityState = vi.fn();
+const mockReadTerminalIntegrityState = vi.fn();
+const mockWriteDrawerAuthorityState = vi.fn();
 
 let mockActiveStore: { _id: Id<"store">; currency: string } | null;
 let mockTerminal:
@@ -304,8 +307,11 @@ vi.mock("@/lib/pos/infrastructure/local/posLocalStore", () => ({
     listEvents: mockListLocalEvents,
     listEventsForUpload: mockListLocalEvents,
     listLocalCloudMappings: mockListLocalCloudMappings,
+    readDrawerAuthorityState: mockReadDrawerAuthorityState,
     readProvisionedTerminalSeed: mockReadProvisionedTerminalSeed,
+    readTerminalIntegrityState: mockReadTerminalIntegrityState,
     markEventsSynced: mockMarkLocalEventsSynced,
+    writeDrawerAuthorityState: mockWriteDrawerAuthorityState,
     writeLocalCloudMapping: mockWriteLocalCloudMapping,
   })),
 }));
@@ -538,6 +544,12 @@ describe("useRegisterViewModel", () => {
     mockWriteLocalCloudMapping.mockResolvedValue({ ok: true, value: {} });
     mockListLocalCloudMappings.mockReset();
     mockListLocalCloudMappings.mockResolvedValue({ ok: true, value: [] });
+    mockReadDrawerAuthorityState.mockReset();
+    mockReadDrawerAuthorityState.mockResolvedValue({ ok: true, value: null });
+    mockReadTerminalIntegrityState.mockReset();
+    mockReadTerminalIntegrityState.mockResolvedValue({ ok: true, value: null });
+    mockWriteDrawerAuthorityState.mockReset();
+    mockWriteDrawerAuthorityState.mockResolvedValue({ ok: true, value: {} });
     (globalThis as typeof globalThis & { indexedDB?: IDBFactory }).indexedDB =
       {} as IDBFactory;
     mockUseMutation.mockReset();
@@ -5497,6 +5509,167 @@ describe("useRegisterViewModel", () => {
     );
     expect(mockAppendLocalEvent).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: "register.opened" }),
+    );
+  });
+
+  it("routes terminal integrity blocks to the terminal repair drawer gate", async () => {
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: [
+        {
+          localEventId: "local-event-open",
+          schemaVersion: 1,
+          sequence: 1,
+          type: "register.opened",
+          terminalId: "local-terminal-1",
+          storeId: "store-1",
+          registerNumber: "1",
+          localRegisterSessionId: "local-register-1",
+          staffProfileId: "staff-1",
+          payload: {
+            localRegisterSessionId: "local-register-1",
+            openingFloat: 5000,
+          },
+          createdAt: 100,
+          sync: { status: "synced" },
+        },
+      ],
+    });
+    mockReadTerminalIntegrityState.mockResolvedValue({
+      ok: true,
+      value: {
+        observedAt: 110,
+        reason: "authorization_failed",
+        status: "requires_reprovision",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      },
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
+
+    await waitFor(() =>
+      expect(result.current.drawerGate?.mode).toBe("terminalRepair"),
+    );
+  });
+
+  it("routes drawer authority blocks to the drawer repair gate", async () => {
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: [
+        {
+          localEventId: "local-event-open",
+          schemaVersion: 1,
+          sequence: 1,
+          type: "register.opened",
+          terminalId: "local-terminal-1",
+          storeId: "store-1",
+          registerNumber: "1",
+          localRegisterSessionId: "local-register-1",
+          staffProfileId: "staff-1",
+          payload: {
+            localRegisterSessionId: "local-register-1",
+            openingFloat: 5000,
+          },
+          createdAt: 100,
+          sync: { status: "synced" },
+        },
+      ],
+    });
+    mockReadDrawerAuthorityState.mockResolvedValue({
+      ok: true,
+      value: {
+        localRegisterSessionId: "local-register-1",
+        observedAt: 110,
+        reason: "cloud_closed",
+        status: "blocked",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      },
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
+
+    await waitFor(() =>
+      expect(result.current.drawerGate?.mode).toBe("drawerAuthorityRepair"),
+    );
+  });
+
+  it("persists drawer authority when a mapped cloud drawer is no longer usable", async () => {
+    mockRegisterState = {
+      ...mockRegisterState!,
+      activeRegisterSession: {
+        _id: "drawer-1",
+        status: "closed",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        openingFloat: 5000,
+        expectedCash: 5000,
+        openedAt: 100,
+      },
+      activeSession: null,
+    };
+    mockActiveSession = null;
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: [
+        {
+          localEventId: "local-event-open",
+          schemaVersion: 1,
+          sequence: 1,
+          type: "register.opened",
+          terminalId: "local-terminal-1",
+          storeId: "store-1",
+          registerNumber: "1",
+          localRegisterSessionId: "local-register-1",
+          staffProfileId: "staff-1",
+          payload: {
+            localRegisterSessionId: "local-register-1",
+            openingFloat: 5000,
+          },
+          createdAt: 100,
+          sync: { status: "synced" },
+        },
+      ],
+    });
+    mockListLocalCloudMappings.mockResolvedValue({
+      ok: true,
+      value: [
+        {
+          entity: "registerSession",
+          localId: "local-register-1",
+          cloudId: "drawer-1",
+          mappedAt: 101,
+        },
+      ],
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    renderHook(() => useRegisterViewModel());
+
+    await waitFor(() =>
+      expect(mockWriteDrawerAuthorityState).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cloudRegisterSessionId: "drawer-1",
+          localRegisterSessionId: "local-register-1",
+          reason: "cloud_closed",
+          status: "blocked",
+        }),
+      ),
     );
   });
 

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -1178,6 +1178,7 @@ export function useRegisterViewModel(): RegisterViewModel {
   const exactAddKeyRef = useRef<string | null>(null);
   const pendingSessionStartKeyRef = useRef<string | null>(null);
   const seededRegisterSessionIdsRef = useRef<Set<string>>(new Set());
+  const persistedDrawerAuthorityBlockRef = useRef<string | null>(null);
   const [optimisticCartQuantities, setOptimisticCartQuantities] = useState<
     Record<string, number>
   >({});
@@ -1552,6 +1553,58 @@ export function useRegisterViewModel(): RegisterViewModel {
       }),
     [],
   );
+  useEffect(() => {
+    const localRegisterSession = localRegisterReadModel?.activeRegisterSession;
+    const cloudRegisterSessionId =
+      registerState?.activeRegisterSession?._id?.toString() ??
+      localRegisterSession?.cloudRegisterSessionId;
+    if (
+      !cloudRegisterSessionBlocksLocalProjection ||
+      !activeStoreId ||
+      !localRegisterSession ||
+      !cloudRegisterSessionId ||
+      localRegisterReadModel?.saleBlockReason === "drawer_authority"
+    ) {
+      return;
+    }
+    const blockKey = `${activeStoreId}:${localRegisterSession.localRegisterSessionId}:${cloudRegisterSessionId}`;
+    if (persistedDrawerAuthorityBlockRef.current === blockKey) {
+      return;
+    }
+
+    void localStore
+      .writeDrawerAuthorityState({
+        cloudRegisterSessionId,
+        localRegisterSessionId: localRegisterSession.localRegisterSessionId,
+        message:
+          "The drawer is already closed. Repair drawer setup before continuing.",
+        observedAt: Date.now(),
+        reason: "cloud_closed",
+        registerNumber: localRegisterSession.registerNumber,
+        status: "blocked",
+        storeId: activeStoreId,
+        terminalId:
+          localRegisterSession.terminalId ??
+          terminal?.localTerminalId ??
+          terminal?._id?.toString() ??
+          "",
+      })
+      .then((result) => {
+        if (result.ok) {
+          persistedDrawerAuthorityBlockRef.current = blockKey;
+          setLocalRegisterReadModelVersion((current) => current + 1);
+        }
+      });
+  }, [
+    activeStoreId,
+    cloudRegisterSessionBlocksLocalProjection,
+    localRegisterReadModel?.activeRegisterSession,
+    localRegisterReadModel?.saleBlockReason,
+    localStore,
+    registerState?.activeRegisterSession?._id,
+    terminal?._id,
+    terminal?.localTerminalId,
+  ]);
   const localCommandGateway = useMemo(
     () =>
       createLocalCommandGateway({
@@ -2113,6 +2166,9 @@ export function useRegisterViewModel(): RegisterViewModel {
       bootstrapState.phase === "resumable" ||
       hasActivePosSession),
   );
+  const localSaleAuthorityBlockReason =
+    localRegisterReadModel?.saleBlockReason ?? null;
+  const hasLocalSaleAuthorityBlock = Boolean(localSaleAuthorityBlockReason);
   const requiresDrawerGate = Boolean(
     activeStoreId &&
     terminal?._id &&
@@ -2121,7 +2177,8 @@ export function useRegisterViewModel(): RegisterViewModel {
     (hasMissingDrawerStartupState ||
       hasCloseoutBlockedDrawerState ||
       hasMissingDrawerRecoveryState ||
-      activeSessionHasBlockedRegisterBinding),
+      activeSessionHasBlockedRegisterBinding ||
+      hasLocalSaleAuthorityBlock),
   ) && !hasCloudBlockedRecoverableLocalSale;
   const closeoutBlockedGateIsRecovery = Boolean(
     hasCloseoutBlockedDrawerState &&
@@ -2180,13 +2237,21 @@ export function useRegisterViewModel(): RegisterViewModel {
     | "initialSetup"
     | "recovery"
     | "closeoutBlocked"
-    | "openingFloatCorrection" = activeOpeningFloatCorrectionRegisterSession
+    | "openingFloatCorrection"
+    | "terminalRepair"
+    | "drawerAuthorityRepair" = activeOpeningFloatCorrectionRegisterSession
     ? "openingFloatCorrection"
-    : hasCloseoutBlockedDrawerState || activeCloseoutRegisterSession
-      ? "closeoutBlocked"
-      : hasMissingDrawerRecoveryState || activeSessionHasBlockedRegisterBinding
-        ? "recovery"
-        : "initialSetup";
+    : localSaleAuthorityBlockReason === "terminal_integrity"
+      ? "terminalRepair"
+      : localSaleAuthorityBlockReason === "drawer_authority" ||
+          localSaleAuthorityBlockReason === "lifecycle_needs_review"
+        ? "drawerAuthorityRepair"
+        : hasCloseoutBlockedDrawerState || activeCloseoutRegisterSession
+          ? "closeoutBlocked"
+          : hasMissingDrawerRecoveryState ||
+              activeSessionHasBlockedRegisterBinding
+            ? "recovery"
+            : "initialSetup";
   const setPaymentState = useCallback((nextPayments: Payment[]) => {
     paymentsRef.current = nextPayments;
     setPayments(nextPayments);
@@ -2703,6 +2768,7 @@ export function useRegisterViewModel(): RegisterViewModel {
           sessionId: operableActiveSession._id,
           stage: args.stage,
         });
+        await refreshLocalRegisterReadModel();
         return false;
       }
 
@@ -2718,6 +2784,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       localCommandGateway,
       noteLocalRegisterEventChanged,
       registerNumber,
+      refreshLocalRegisterReadModel,
       staffProfileId,
       terminal?._id,
     ],


### PR DESCRIPTION
## Summary
- persist terminal integrity and drawer authority state in the local POS store
- fail closed for sale-affecting local commands when terminal binding, drawer mapping, or register lifecycle state is stale
- surface operator-facing terminal/drawer recovery gates and refresh plan/solution artifacts

## Validation
- bun run graphify:rebuild
- bun run pre-commit:generated-artifacts
- bun run harness:review --base origin/main --repo-validation-provided-by pr:athena
- pre-push hook passed, including full @athena/webapp:test, production build, architecture lint, POS workflow/terminal suites, and runtime behavior scenarios

## Linear
- V26-639
- V26-640
- V26-641
- V26-642
- V26-643
- V26-644
- V26-645
