### PR TITLE
Deliver POS local sync and service line recovery

### DIFF
--- a/docs/solutions/logic-errors/athena-pos-local-sync-review-and-service-lines-2026-05-29.md
+++ b/docs/solutions/logic-errors/athena-pos-local-sync-review-and-service-lines-2026-05-29.md
@@ -1,0 +1,91 @@
+---
+title: Athena POS Local Sync Review and Service Lines
+date: 2026-05-29
+category: logic-errors
+module: athena-webapp
+problem_type: pos_local_sync_review_service_line_recovery
+component: pos-register
+root_cause: local_service_activity_and_review_state_were_not_projected_as_operator_actions
+resolution_type: local_projection_and_operator_recovery_alignment
+severity: high
+tags:
+  - pos
+  - local-first
+  - service-lines
+  - sync-review
+  - cash-controls
+---
+
+# Athena POS Local Sync Review and Service Lines
+
+## Problem
+
+Local POS activity can settle into states that look synced but remain
+non-actionable for operators. Server-rejected closeout or register review
+activity may be attached to a register session, but the register session view
+does not always surface enough context or a valid recovery action. At the same
+time, service lines added from POS behave differently from product SKUs: they
+need customer attribution, transaction detail visibility, completed-list counts,
+and service-case financial sync without tripping Convex pagination limits.
+
+The result is a mixed cart that can complete locally, but is hard to inspect,
+recover, or trust after sync review.
+
+## Solution
+
+Treat service lines and sync review as first-class POS read-model inputs:
+
+- Keep local service line state in the same register view model surfaces as
+  product items, but make service catalog entries single-add cart lines. Disable
+  duplicate service search results instead of incrementing hidden quantities.
+- Gate payment methods and sale completion when services are in the cart without
+  a customer. The recovery action should open the existing find/add customer
+  flow, not add another disconnected warning.
+- Include service lines in completed transaction detail, transaction summaries,
+  and completed transaction list item counts. The POS list should count product
+  quantity plus service line count so mixed sales are not understated.
+- Persist and project server-rejected synced activity against the associated
+  register session. Register views should surface the rejected activity and
+  expose a recovery route instead of showing a stale "already resolved" action.
+- Avoid multiple paginated queries inside Convex mutations and queries. Load
+  service-case financial context through one paginated path per function and
+  pass derived maps into downstream sync helpers.
+- Keep support diagnostics and terminal health as link-out recovery surfaces
+  when the POS panel itself should stay focused on selling.
+
+## Regression Targets
+
+- Register view-model tests should prove duplicate service additions do not
+  append another local service event or increment a visible service quantity.
+- Product-entry tests should prove service result cards add on card click, show
+  duplicate disabled state, use service icons, and do not render product
+  no-results copy when services match.
+- Cart and transaction tests should prove service lines render alongside product
+  items, use product-card-aligned price placement, and avoid quantity chrome for
+  non-repeatable services.
+- Order summary and checkout tests should prove service checkout requires a
+  customer and that the warning action opens the customer attribution surface.
+- Convex repository and sync tests should prove service-case financial sync uses
+  one paginated query path per function and records service payment totals.
+- Register session and terminal tests should prove rejected synced activity is
+  visible from the associated drawer/register session and can route to terminal
+  health or support trace recovery.
+
+## Prevention
+
+- Do not add service cart behavior by copying product quantity semantics. A
+  service catalog line is a scheduled or case-backed unit of work unless the
+  catalog explicitly models repeatability.
+- Do not show product-only empty states under service search results. Unified
+  search needs result-aware copy so operators are not told nothing was found
+  while service results are present.
+- Do not bury server-rejected local activity in terminal diagnostics only. If it
+  affects a register session, the cash-controls register view needs enough
+  evidence for the operator to decide where to recover it.
+- Do not run separate paginated scans in one Convex function to gather related
+  service data. Build the needed maps from one paginated result set or split the
+  work across separate functions.
+- When a POS change spans local sync, cash controls, services, and transaction
+  history, validate the full path: local append, read-model projection, checkout
+  gate, sync ingest, completed transaction detail, and completed transaction
+  list.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1793 files · ~0 words
+- 1794 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5908 nodes · 6289 edges · 1721 communities detected
+- 5925 nodes · 6311 edges · 1722 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1731,6 +1731,7 @@
 - [[_COMMUNITY_Community 1718|Community 1718]]
 - [[_COMMUNITY_Community 1719|Community 1719]]
 - [[_COMMUNITY_Community 1720|Community 1720]]
+- [[_COMMUNITY_Community 1721|Community 1721]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1779,16 +1780,16 @@ Cohesion: 0.09
 Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
 
 ### Community 5 - "Community 5"
+Cohesion: 0.06
+Nodes (22): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus() (+14 more)
+
+### Community 6 - "Community 6"
 Cohesion: 0.13
 Nodes (40): assertNever(), calculateSalePayments(), canMapExistingCloudRegisterSession(), collectExistingSaleMappings(), collectSaleSkuQuantities(), conflictResult(), createConflict(), createMapping() (+32 more)
 
-### Community 6 - "Community 6"
-Cohesion: 0.07
-Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
-
 ### Community 7 - "Community 7"
 Cohesion: 0.07
-Nodes (21): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus(), drawerAuthorityEventKey() (+13 more)
+Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.08
@@ -1855,36 +1856,36 @@ Cohesion: 0.09
 Nodes (10): createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), normalizeDrawerAuthorityState(), normalizeStaffAuthorityRecord(), normalizeTerminalIntegrityState(), normalizeUsername(), PosLocalStoreSchemaError, preserveWrappedStaffProof() (+2 more)
 
 ### Community 24 - "Community 24"
+Cohesion: 0.1
+Nodes (15): cancelItemAdjustmentWorkflow(), exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff() (+7 more)
+
+### Community 25 - "Community 25"
 Cohesion: 0.12
 Nodes (18): ancestorChain(), collectRawMoneyParses(), collectRawMoneyParsesFromSource(), collectRawNumericHelperNames(), collectSourceFiles(), collectStorefrontDirectMoneyFormats(), containsDisallowedRawNumericParse(), containsTerm() (+10 more)
 
-### Community 25 - "Community 25"
+### Community 26 - "Community 26"
 Cohesion: 0.19
 Nodes (23): assertCompoundSolutionCheck(), collectChangedFiles(), collectCompoundSolutionFindings(), collectExistingFiles(), collectMarkdownContents(), collectSourceLineChanges(), countFileLines(), extractFrontmatter() (+15 more)
 
-### Community 26 - "Community 26"
+### Community 27 - "Community 27"
 Cohesion: 0.15
 Nodes (19): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), isLocalGeneratedArtifactPath() (+11 more)
 
-### Community 27 - "Community 27"
+### Community 28 - "Community 28"
 Cohesion: 0.13
 Nodes (18): buildCartSummary(), buildSessionOperationsRow(), expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), loadPosSessionItems(), loadSessionCustomer(), loadSessionOperator() (+10 more)
 
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.16
 Nodes (22): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildWeekMetricForDate(), buildWeekMetrics(), emptyCloseSummary(), getCloseItemCounts(), getDailyCloseRecordForDate() (+14 more)
 
-### Community 29 - "Community 29"
+### Community 30 - "Community 30"
 Cohesion: 0.19
 Nodes (23): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+15 more)
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.15
 Nodes (19): acquireExpenseQuantityPatchHold(), adjustExpenseQuantityPatchHold(), createDefaultExpenseSessionCommandService(), createExpenseInventoryHoldGateway(), createExpenseSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired() (+11 more)
-
-### Community 31 - "Community 31"
-Cohesion: 0.11
-Nodes (13): cancelItemAdjustmentWorkflow(), exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff() (+5 more)
 
 ### Community 32 - "Community 32"
 Cohesion: 0.1
@@ -2123,24 +2124,24 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 91 - "Community 91"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 92 - "Community 92"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 93 - "Community 93"
+### Community 92 - "Community 92"
 Cohesion: 0.27
 Nodes (6): buildTerminalHealthSummary(), deriveTerminalHealth(), deriveTerminalHealthAttentionReasons(), getTerminalHealthSummary(), resolveAttentionReasonActionTargets(), stripRuntimeStatusIdentity()
 
-### Community 94 - "Community 94"
+### Community 93 - "Community 93"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 95 - "Community 95"
+### Community 94 - "Community 94"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
+
+### Community 95 - "Community 95"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 96 - "Community 96"
 Cohesion: 0.31
@@ -2191,140 +2192,140 @@ Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
 ### Community 108 - "Community 108"
+Cohesion: 0.22
+Nodes (2): formatServiceLabel(), formatServiceLineMeta()
+
+### Community 109 - "Community 109"
+Cohesion: 0.29
+Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
+
+### Community 110 - "Community 110"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 109 - "Community 109"
+### Community 111 - "Community 111"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 110 - "Community 110"
+### Community 112 - "Community 112"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 111 - "Community 111"
+### Community 113 - "Community 113"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 112 - "Community 112"
+### Community 114 - "Community 114"
 Cohesion: 0.42
 Nodes (7): getRegisterCatalogPrice(), listRegisterCatalog(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
 
-### Community 113 - "Community 113"
+### Community 115 - "Community 115"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 114 - "Community 114"
+### Community 116 - "Community 116"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 115 - "Community 115"
+### Community 117 - "Community 117"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 116 - "Community 116"
+### Community 118 - "Community 118"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 117 - "Community 117"
+### Community 119 - "Community 119"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 118 - "Community 118"
+### Community 120 - "Community 120"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 119 - "Community 119"
+### Community 121 - "Community 121"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 120 - "Community 120"
+### Community 122 - "Community 122"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 121 - "Community 121"
+### Community 123 - "Community 123"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 122 - "Community 122"
+### Community 124 - "Community 124"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 123 - "Community 123"
+### Community 125 - "Community 125"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 124 - "Community 124"
+### Community 126 - "Community 126"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 125 - "Community 125"
+### Community 127 - "Community 127"
 Cohesion: 0.43
 Nodes (6): sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
-### Community 126 - "Community 126"
+### Community 128 - "Community 128"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 127 - "Community 127"
+### Community 129 - "Community 129"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 128 - "Community 128"
+### Community 130 - "Community 130"
 Cohesion: 0.43
 Nodes (6): assertActiveTerminal(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 129 - "Community 129"
+### Community 131 - "Community 131"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 130 - "Community 130"
+### Community 132 - "Community 132"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 131 - "Community 131"
+### Community 133 - "Community 133"
 Cohesion: 0.5
 Nodes (7): findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), isBarcodeLike(), mapSkuToCatalogResult(), quickAddCatalogItem()
 
-### Community 132 - "Community 132"
-Cohesion: 0.25
-Nodes (0):
-
-### Community 133 - "Community 133"
-Cohesion: 0.25
-Nodes (0):
-
 ### Community 134 - "Community 134"
-Cohesion: 0.39
-Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 135 - "Community 135"
 Cohesion: 0.25
-Nodes (1): DataTableRowActions()
+Nodes (0):
 
 ### Community 136 - "Community 136"
-Cohesion: 0.32
-Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
+Cohesion: 0.39
+Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
 ### Community 137 - "Community 137"
 Cohesion: 0.25
-Nodes (0):
+Nodes (1): DataTableRowActions()
 
 ### Community 138 - "Community 138"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.32
+Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
 ### Community 139 - "Community 139"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 140 - "Community 140"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
-
-### Community 141 - "Community 141"
 Cohesion: 0.25
 Nodes (0):
+
+### Community 141 - "Community 141"
+Cohesion: 0.39
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 142 - "Community 142"
 Cohesion: 0.25
@@ -2339,100 +2340,100 @@ Cohesion: 0.25
 Nodes (0):
 
 ### Community 145 - "Community 145"
-Cohesion: 0.46
-Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
-
-### Community 146 - "Community 146"
-Cohesion: 0.43
-Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
-
-### Community 147 - "Community 147"
 Cohesion: 0.25
 Nodes (0):
 
+### Community 146 - "Community 146"
+Cohesion: 0.46
+Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
+
+### Community 147 - "Community 147"
+Cohesion: 0.43
+Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
+
 ### Community 148 - "Community 148"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 149 - "Community 149"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.33
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.33
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 155 - "Community 155"
+### Community 156 - "Community 156"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.33
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.33
 Nodes (2): handlePinChange(), normalizeOtpCode()
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.33
 Nodes (2): handleKeypadPress(), setAmountFromTouch()
-
-### Community 168 - "Community 168"
-Cohesion: 0.38
-Nodes (3): handleAttachBarcodeSubmit(), handleClearSearch(), handleQuickAddSubmit()
 
 ### Community 169 - "Community 169"
 Cohesion: 0.29
@@ -2607,8 +2608,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 212 - "Community 212"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 213 - "Community 213"
 Cohesion: 0.33
@@ -2627,12 +2628,12 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 217 - "Community 217"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
-
-### Community 218 - "Community 218"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 218 - "Community 218"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 219 - "Community 219"
 Cohesion: 0.33
@@ -2647,40 +2648,40 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 222 - "Community 222"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 223 - "Community 223"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 224 - "Community 224"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 225 - "Community 225"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 226 - "Community 226"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 227 - "Community 227"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 228 - "Community 228"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 230 - "Community 230"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 231 - "Community 231"
 Cohesion: 0.53
@@ -3439,24 +3440,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 420 - "Community 420"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 421 - "Community 421"
 Cohesion: 1.0
 Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+
+### Community 421 - "Community 421"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 422 - "Community 422"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 423 - "Community 423"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 424 - "Community 424"
 Cohesion: 1.0
 Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 424 - "Community 424"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 425 - "Community 425"
 Cohesion: 0.67
@@ -3471,36 +3472,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 428 - "Community 428"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 429 - "Community 429"
 Cohesion: 1.0
 Nodes (2): listBagItems(), loadBagWithItems()
 
-### Community 430 - "Community 430"
+### Community 429 - "Community 429"
 Cohesion: 1.0
 Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
-### Community 431 - "Community 431"
+### Community 430 - "Community 430"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+
+### Community 431 - "Community 431"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 432 - "Community 432"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 433 - "Community 433"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 434 - "Community 434"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 435 - "Community 435"
+### Community 434 - "Community 434"
 Cohesion: 0.67
 Nodes (1): View()
+
+### Community 435 - "Community 435"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 436 - "Community 436"
 Cohesion: 0.67
@@ -3515,12 +3516,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 439 - "Community 439"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 440 - "Community 440"
 Cohesion: 1.0
 Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+
+### Community 440 - "Community 440"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 441 - "Community 441"
 Cohesion: 0.67
@@ -3532,11 +3533,11 @@ Nodes (0):
 
 ### Community 443 - "Community 443"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 444 - "Community 444"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 445 - "Community 445"
 Cohesion: 0.67
@@ -3544,15 +3545,15 @@ Nodes (0):
 
 ### Community 446 - "Community 446"
 Cohesion: 0.67
-Nodes (0):
-
-### Community 447 - "Community 447"
-Cohesion: 0.67
 Nodes (1): VideoPlayer()
 
-### Community 448 - "Community 448"
+### Community 447 - "Community 447"
 Cohesion: 1.0
 Nodes (2): handleRefundOrder(), toast()
+
+### Community 448 - "Community 448"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 449 - "Community 449"
 Cohesion: 0.67
@@ -8642,6 +8643,10 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1721 - "Community 1721"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -8733,2253 +8738,2255 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 596`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 597`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 598`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
+- **Thin community `Community 599`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
+- **Thin community `Community 600`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 601`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 602`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 603`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 604`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 605`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
+- **Thin community `Community 606`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 607`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 608`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 609`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 610`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 611`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 612`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 613`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 614`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 615`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 616`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 617`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 618`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 619`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 620`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 621`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 622`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 623`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 624`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 625`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 626`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 627`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 628`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 629`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 630`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 631`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 632`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 633`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 634`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 635`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 636`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 637`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 638`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 639`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 640`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 641`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 642`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 643`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 644`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 645`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 646`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 647`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 648`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 649`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 650`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 651`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 652`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 653`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 654`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 655`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 656`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 657`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 658`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 659`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 660`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 661`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 662`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 663`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 664`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 665`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 666`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 667`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 668`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 669`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 670`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 671`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 672`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 673`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 674`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 675`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 676`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 677`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 678`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 679`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 680`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 681`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 682`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 683`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 684`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 685`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 686`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 687`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 688`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 689`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `cn()`, `CartItems.tsx`
+- **Thin community `Community 690`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
+- **Thin community `Community 691`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 692`** (2 nodes): `cn()`, `CartItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 693`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 694`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 695`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `ProductCard.tsx`, `handleClick()`
+- **Thin community `Community 696`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 697`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 698`** (2 nodes): `ProductCard.tsx`, `handleClick()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 699`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 700`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 701`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 702`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
+- **Thin community `Community 703`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 704`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 705`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 706`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 707`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 708`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 709`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 710`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 711`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 712`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 713`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 714`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 715`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 716`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 717`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 718`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 719`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 720`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 721`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 722`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 723`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 724`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 725`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 726`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 727`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 728`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 729`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 730`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 731`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 732`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 733`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 734`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 735`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 736`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 737`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 738`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
+- **Thin community `Community 739`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 740`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 741`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 742`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 743`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 744`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 745`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 746`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 747`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 748`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 749`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 750`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 751`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 752`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 753`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 754`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 755`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 756`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 757`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 758`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 759`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 760`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 761`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 762`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 763`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 764`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 765`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 766`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 767`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 768`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 769`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 770`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 771`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 772`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 773`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 774`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 775`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 776`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 777`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 778`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 779`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 780`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 781`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 782`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 783`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 784`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 785`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 786`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 787`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 788`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 789`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 790`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 791`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 792`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 793`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 794`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 795`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 796`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 797`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 798`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 799`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 800`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 801`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 802`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 803`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 804`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 805`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 806`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 807`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 808`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 809`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 810`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 811`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 812`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 813`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 814`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 815`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 816`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 817`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 818`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 819`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 820`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 821`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 822`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 823`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 824`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 825`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 826`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 827`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 828`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 829`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 830`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 831`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 832`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 833`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 834`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 835`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 836`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 837`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 838`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 839`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 840`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 841`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 842`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 843`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 844`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 845`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 846`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 847`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 848`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 849`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 850`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 851`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 852`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 853`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 854`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 855`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 856`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 857`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 858`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 859`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 860`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 861`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 862`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 863`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 864`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 865`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 866`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 867`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 868`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 869`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 870`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 871`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 872`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 873`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 874`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 875`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 876`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 877`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 878`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 879`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 880`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 881`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 882`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 883`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 884`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 885`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 886`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 887`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 888`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 889`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 890`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 891`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 892`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 893`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 894`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 895`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 896`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 897`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 898`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 899`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 900`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 901`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 902`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 903`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 904`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 905`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 906`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 907`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 908`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 909`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 910`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 911`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 912`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 913`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 914`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 915`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 916`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 917`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 918`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 919`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 920`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 921`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 922`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 923`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 924`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 925`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 926`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 927`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 928`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 929`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 930`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 931`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 932`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 933`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 934`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 935`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 936`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 937`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 938`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 939`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 940`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 941`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 942`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 943`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 944`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 945`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 946`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 947`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 948`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 949`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 950`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 951`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 952`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 953`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 954`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 955`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 956`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 957`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 958`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 959`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 960`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 961`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 962`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 963`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 964`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 965`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 966`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 967`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 968`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 969`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 970`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (1 nodes): `api.d.ts`
+- **Thin community `Community 971`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (1 nodes): `api.js`
+- **Thin community `Community 972`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 973`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (1 nodes): `server.d.ts`
+- **Thin community `Community 974`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (1 nodes): `server.js`
+- **Thin community `Community 975`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (1 nodes): `app.ts`
+- **Thin community `Community 976`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (1 nodes): `auth.config.js`
+- **Thin community `Community 977`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (1 nodes): `auth.ts`
+- **Thin community `Community 978`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 979`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 980`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 981`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `countries.ts`
+- **Thin community `Community 982`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `email.ts`
+- **Thin community `Community 983`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `ghana.ts`
+- **Thin community `Community 984`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `payment.ts`
+- **Thin community `Community 985`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `crons.ts`
+- **Thin community `Community 986`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 987`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `internal.ts`
+- **Thin community `Community 988`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `public.test.ts`
+- **Thin community `Community 989`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `token.test.ts`
+- **Thin community `Community 990`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 991`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 992`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 993`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 994`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 995`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 996`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 997`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 998`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 999`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `env.ts`
+- **Thin community `Community 1000`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1001`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `auth.ts`
+- **Thin community `Community 1002`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1003`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `colors.ts`
+- **Thin community `Community 1004`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `index.ts`
+- **Thin community `Community 1005`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1006`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `products.ts`
+- **Thin community `Community 1007`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1008`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `stores.ts`
+- **Thin community `Community 1009`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `bag.ts`
+- **Thin community `Community 1010`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `guest.ts`
+- **Thin community `Community 1011`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `index.ts`
+- **Thin community `Community 1012`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `me.ts`
+- **Thin community `Community 1013`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `offers.ts`
+- **Thin community `Community 1014`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1015`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1016`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1017`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1018`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1019`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1020`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1021`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1022`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1023`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `user.ts`
+- **Thin community `Community 1024`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1025`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `index.ts`
+- **Thin community `Community 1026`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1027`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `http.ts`
+- **Thin community `Community 1028`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1029`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1030`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1031`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `categories.ts`
+- **Thin community `Community 1032`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `colors.ts`
+- **Thin community `Community 1033`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1034`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 1035`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1036`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1037`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1038`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1039`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `pos.ts`
+- **Thin community `Community 1040`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1041`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1042`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1043`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1044`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1045`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1046`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1047`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1048`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1049`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1050`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1051`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1052`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1053`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1054`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1055`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1056`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `types.ts`
+- **Thin community `Community 1057`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1058`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1059`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1060`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1061`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1062`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1063`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `dto.ts`
+- **Thin community `Community 1064`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1065`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1066`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `types.ts`
+- **Thin community `Community 1067`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1068`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1069`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `customers.ts`
+- **Thin community `Community 1070`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `register.ts`
+- **Thin community `Community 1071`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `sync.ts`
+- **Thin community `Community 1072`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `schema.ts`
+- **Thin community `Community 1073`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1074`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `index.ts`
+- **Thin community `Community 1075`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1076`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1077`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1078`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1079`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1080`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `category.ts`
+- **Thin community `Community 1081`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `color.ts`
+- **Thin community `Community 1082`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1083`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1084`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `index.ts`
+- **Thin community `Community 1085`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1086`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1087`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `organization.ts`
+- **Thin community `Community 1088`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1089`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `product.ts`
+- **Thin community `Community 1090`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1091`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1092`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `store.ts`
+- **Thin community `Community 1093`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1094`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `index.ts`
+- **Thin community `Community 1095`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1096`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1097`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1098`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1099`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1100`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1101`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1102`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `index.ts`
+- **Thin community `Community 1103`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1104`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1105`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1106`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1107`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1108`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1109`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1110`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1111`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1112`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1113`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1114`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `customer.ts`
+- **Thin community `Community 1115`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1116`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1117`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1118`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1119`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `index.ts`
+- **Thin community `Community 1120`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1121`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1122`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1123`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1124`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1125`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1126`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1127`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1128`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1129`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1130`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1131`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1132`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1133`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1134`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1135`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1136`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `index.ts`
+- **Thin community `Community 1137`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1138`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1139`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1140`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1141`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1142`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1143`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `index.ts`
+- **Thin community `Community 1144`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1145`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1146`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1147`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1148`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1149`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1150`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `bag.ts`
+- **Thin community `Community 1151`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1152`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1153`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1154`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `guest.ts`
+- **Thin community `Community 1155`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `index.ts`
+- **Thin community `Community 1156`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `offer.ts`
+- **Thin community `Community 1157`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1158`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1159`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `review.ts`
+- **Thin community `Community 1160`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1161`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1162`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1163`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1164`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1165`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1166`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1167`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1168`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1169`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `bag.ts`
+- **Thin community `Community 1170`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1171`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `customer.ts`
+- **Thin community `Community 1172`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `guest.ts`
+- **Thin community `Community 1173`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1174`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1175`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1176`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1177`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `payment.ts`
+- **Thin community `Community 1178`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1179`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1180`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1181`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `users.ts`
+- **Thin community `Community 1182`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `payment.ts`
+- **Thin community `Community 1183`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1184`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1185`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1186`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1187`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1188`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `index.ts`
+- **Thin community `Community 1189`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1190`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1191`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `auth.ts`
+- **Thin community `Community 1192`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1193`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1194`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1195`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1196`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1197`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1198`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1199`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1200`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1201`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1202`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1203`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1204`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1205`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1206`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `constants.ts`
+- **Thin community `Community 1207`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1208`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1209`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1210`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `types.ts`
+- **Thin community `Community 1211`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1212`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1213`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1214`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1215`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1216`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1217`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1218`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1219`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1220`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1221`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1222`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1223`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1224`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1225`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1226`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1227`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1228`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1229`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1230`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1231`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `constants.ts`
+- **Thin community `Community 1232`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1233`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1234`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1235`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `data.ts`
+- **Thin community `Community 1236`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1237`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1238`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1239`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1240`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1241`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1242`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1243`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1244`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1245`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `constants.ts`
+- **Thin community `Community 1246`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1247`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1248`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1249`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `data.ts`
+- **Thin community `Community 1250`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1251`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1252`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1253`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1254`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1255`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1256`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1257`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1258`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1259`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1260`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `constants.ts`
+- **Thin community `Community 1261`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1262`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1263`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1264`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1265`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1266`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1267`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1268`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1269`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1270`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1271`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1272`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1273`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1274`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1275`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1276`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1277`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1278`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1279`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1280`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1281`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1282`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1283`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1284`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1285`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1286`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1287`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1288`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1289`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1290`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1291`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1292`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1293`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `constants.ts`
+- **Thin community `Community 1294`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1295`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1296`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1297`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `data.ts`
+- **Thin community `Community 1298`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1299`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1300`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `constants.ts`
+- **Thin community `Community 1301`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1302`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1303`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1304`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1305`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `data.ts`
+- **Thin community `Community 1306`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1307`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `constants.ts`
+- **Thin community `Community 1308`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1309`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1310`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1311`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1312`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `data.ts`
+- **Thin community `Community 1313`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1314`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1315`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1316`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1317`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1318`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1319`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1320`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1321`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1322`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1323`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1324`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1325`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1326`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1327`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1328`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1329`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1330`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1331`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1332`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1333`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1334`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1335`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1336`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1337`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1338`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `POSSettingsView.test.tsx`
+- **Thin community `Community 1339`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1340`** (1 nodes): `POSSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `POSTerminalHealthView.test.tsx`
+- **Thin community `Community 1341`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1342`** (1 nodes): `POSTerminalHealthView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1343`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1344`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `types.ts`
+- **Thin community `Community 1345`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1346`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1347`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1348`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1349`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1350`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1351`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1352`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1353`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1354`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1355`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1356`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1357`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1358`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1359`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `data.ts`
+- **Thin community `Community 1360`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1361`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1362`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1363`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1364`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1365`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1366`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1367`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1368`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1369`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1370`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1371`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1372`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `constants.ts`
+- **Thin community `Community 1373`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1374`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1375`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1376`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `data.ts`
+- **Thin community `Community 1377`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `types.ts`
+- **Thin community `Community 1378`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1379`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1380`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1381`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1382`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1383`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `index.tsx`
+- **Thin community `Community 1384`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1385`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1386`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1387`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1388`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1389`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1390`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1391`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1392`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `index.tsx`
+- **Thin community `Community 1393`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1394`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1395`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1396`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `button.tsx`
+- **Thin community `Community 1397`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1398`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `card.tsx`
+- **Thin community `Community 1399`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1400`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1401`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `command.tsx`
+- **Thin community `Community 1402`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1403`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1404`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1405`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `form.tsx`
+- **Thin community `Community 1406`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1407`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1408`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `input.tsx`
+- **Thin community `Community 1409`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1410`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1411`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1412`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1413`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1414`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1415`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `select.tsx`
+- **Thin community `Community 1416`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1417`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1418`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1419`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `table.tsx`
+- **Thin community `Community 1420`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1421`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1422`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1423`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1424`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1425`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1426`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1427`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1428`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `constants.ts`
+- **Thin community `Community 1429`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1430`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1431`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1432`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `data.ts`
+- **Thin community `Community 1433`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1434`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1435`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1436`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1437`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1438`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1439`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1440`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1441`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1442`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1443`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1444`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `index.ts`
+- **Thin community `Community 1445`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1446`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1447`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1448`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1449`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1450`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1451`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1452`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1453`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1454`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1455`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `aws.ts`
+- **Thin community `Community 1456`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `constants.ts`
+- **Thin community `Community 1457`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `countries.ts`
+- **Thin community `Community 1458`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1459`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1460`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1461`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1462`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1463`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1464`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `dto.ts`
+- **Thin community `Community 1465`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `ports.ts`
+- **Thin community `Community 1466`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `constants.ts`
+- **Thin community `Community 1467`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1468`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1469`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `index.ts`
+- **Thin community `Community 1470`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1471`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `types.ts`
+- **Thin community `Community 1472`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1473`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1474`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1475`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1476`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1477`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1478`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1479`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1480`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1481`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1482`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `category.ts`
+- **Thin community `Community 1483`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `product.ts`
+- **Thin community `Community 1484`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `store.ts`
+- **Thin community `Community 1485`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1486`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `user.ts`
+- **Thin community `Community 1487`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1488`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1489`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1490`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1491`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1492`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1493`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1494`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `index.tsx`
+- **Thin community `Community 1495`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1496`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1497`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1498`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1499`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1500`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1501`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1502`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `index.tsx`
+- **Thin community `Community 1503`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1504`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1505`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1506`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `home.tsx`
+- **Thin community `Community 1507`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1508`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1509`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1510`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `index.tsx`
+- **Thin community `Community 1511`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1512`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `index.tsx`
+- **Thin community `Community 1513`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1514`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1515`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1516`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `index.tsx`
+- **Thin community `Community 1517`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1518`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1519`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1520`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1521`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1522`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1523`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `index.tsx`
+- **Thin community `Community 1524`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1525`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1526`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1527`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1528`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1529`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1530`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1531`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1532`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1533`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `index.tsx`
+- **Thin community `Community 1534`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1535`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `index.tsx`
+- **Thin community `Community 1536`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `new.tsx`
+- **Thin community `Community 1537`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `index.tsx`
+- **Thin community `Community 1538`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `new.tsx`
+- **Thin community `Community 1539`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1540`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1541`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `index.tsx`
+- **Thin community `Community 1542`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `new.tsx`
+- **Thin community `Community 1543`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `index.tsx`
+- **Thin community `Community 1544`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1545`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1546`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1547`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1548`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `index.tsx`
+- **Thin community `Community 1549`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1550`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1551`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1552`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `index.tsx`
+- **Thin community `Community 1553`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1554`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1555`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1556`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1557`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1558`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1559`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1560`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1561`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1562`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1563`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1564`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1565`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1566`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1567`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1568`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1569`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1570`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1571`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1572`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1573`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1574`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1575`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1576`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1577`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `setup.ts`
+- **Thin community `Community 1578`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1579`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `types.ts`
+- **Thin community `Community 1580`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1581`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1582`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1583`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1584`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1585`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `types.ts`
+- **Thin community `Community 1586`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1587`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1588`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1589`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1590`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1591`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1592`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1593`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1594`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1595`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `schema.ts`
+- **Thin community `Community 1596`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1597`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1598`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1599`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1600`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1601`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1602`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1603`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1604`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1605`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `types.ts`
+- **Thin community `Community 1606`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1607`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1608`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1609`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1610`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1611`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1612`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1613`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `constants.ts`
+- **Thin community `Community 1614`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1615`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `About.tsx`
+- **Thin community `Community 1616`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1617`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1618`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1619`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1620`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1621`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1622`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1623`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1624`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1625`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1626`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `types.ts`
+- **Thin community `Community 1627`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1628`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1629`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1630`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1631`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1632`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1633`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1634`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1635`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1636`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1637`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1638`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `button.tsx`
+- **Thin community `Community 1639`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `card.tsx`
+- **Thin community `Community 1640`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1641`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `command.tsx`
+- **Thin community `Community 1642`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1643`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1644`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1645`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `form.tsx`
+- **Thin community `Community 1646`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1647`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1648`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1649`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1650`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `input.tsx`
+- **Thin community `Community 1651`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `label.tsx`
+- **Thin community `Community 1652`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1653`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1654`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1655`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `index.ts`
+- **Thin community `Community 1656`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `types.ts`
+- **Thin community `Community 1657`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1658`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1659`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1660`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1661`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `select.tsx`
+- **Thin community `Community 1662`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1663`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1664`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `table.tsx`
+- **Thin community `Community 1665`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1666`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1667`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1668`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1669`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1670`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `config.ts`
+- **Thin community `Community 1671`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1672`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1673`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1674`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1675`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `constants.ts`
+- **Thin community `Community 1676`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `countries.ts`
+- **Thin community `Community 1677`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1678`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1679`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1680`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1681`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `index.ts`
+- **Thin community `Community 1682`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `store.ts`
+- **Thin community `Community 1683`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `bag.ts`
+- **Thin community `Community 1684`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1685`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `category.ts`
+- **Thin community `Community 1686`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `organization.ts`
+- **Thin community `Community 1687`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `product.ts`
+- **Thin community `Community 1688`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `store.ts`
+- **Thin community `Community 1689`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1690`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `user.ts`
+- **Thin community `Community 1691`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `states.ts`
+- **Thin community `Community 1692`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1693`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1694`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1695`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1696`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1697`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1698`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1699`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `index.tsx`
+- **Thin community `Community 1700`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1701`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `index.tsx`
+- **Thin community `Community 1702`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1703`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1704`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1705`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1706`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1707`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `index.tsx`
+- **Thin community `Community 1708`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1709`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1710`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1711`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1712`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1713`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `index.js`
+- **Thin community `Community 1714`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1715`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1716`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1717`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1718`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1719`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1720`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1721`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -10998,4 +11005,4 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 4` be split into smaller, more focused modules?**
   _Cohesion score 0.09 - nodes in this community are weakly interconnected._
 - **Should `Community 5` be split into smaller, more focused modules?**
-  _Cohesion score 0.13 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.06 - nodes in this community are weakly interconnected._

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,20 +7,20 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1793
-- Graph nodes: 5908
-- Graph edges: 6289
-- Communities: 1721
+- Code files discovered: 1794
+- Graph nodes: 5925
+- Graph edges: 6311
+- Communities: 1722
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (82 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `useRegisterViewModel.ts` (51 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
+- `useRegisterViewModel.ts` (52 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `harness-inferential-review.ts` (46 edges, Community 3) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `storefrontJourneyEvents.ts` (45 edges, Community 4) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `ProcurementView.tsx` (41 edges, Community 6) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
-- `projectLocalEvents.ts` (41 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
-- `createJourneyEvent()` (40 edges, Community 4) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `usePosLocalSyncRuntime.ts` (44 edges, Community 5) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
+- `ProcurementView.tsx` (41 edges, Community 7) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
+- `projectLocalEvents.ts` (41 edges, Community 6) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 
 ## Registered Packages
 - [Athena Webapp](packages/athena-webapp.md)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -19,9 +19,9 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 ## Graph Hotspots
 - `DailyCloseView.tsx` (82 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `useRegisterViewModel.ts` (51 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
-- `ProcurementView.tsx` (41 edges, Community 6) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
-- `projectLocalEvents.ts` (41 edges, Community 5) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `useRegisterViewModel.ts` (52 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
+- `usePosLocalSyncRuntime.ts` (44 edges, Community 5) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
+- `ProcurementView.tsx` (41 edges, Community 7) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (14 edges, Community 65) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 120) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 122) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 65) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `createRedisCluster()` (3 edges, Community 65) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `deleteKeysIndividually()` (3 edges, Community 65) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/cashControls/deposits.test.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.test.ts
@@ -1103,6 +1103,63 @@ describe("cash control deposits", () => {
     ).resolves.toEqual(new Map());
   });
 
+  it("surfaces rejected sync events as register-session evidence when requested", async () => {
+    const ctx = createQueryCtx({
+      posLocalSyncConflict: [],
+      posLocalSyncEvent: [
+        {
+          _id: "sync_event_rejected",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_1",
+          sequence: 1,
+          eventType: "sale_completed",
+          occurredAt: 2,
+          staffProfileId: "staff_1",
+          payload: {},
+          rejectionMessage: "Register was closed before this sale synced.",
+          status: "rejected",
+          submittedAt: 3,
+        },
+      ],
+      posLocalSyncMapping: [
+        {
+          _id: "sync_mapping_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localIdKind: "registerSession",
+          localId: "local-register-1",
+          cloudTable: "registerSession",
+          cloudId: "session_open",
+        },
+      ],
+      registerSession: [{ _id: "session_open" }],
+    });
+
+    await expect(
+      listOpenLocalSyncConflictsByRegisterSession(
+        ctx as never,
+        "store_1" as Id<"store">,
+        { includeRejectedEvidence: true },
+      ),
+    ).resolves.toEqual(
+      new Map([
+        [
+          "session_open",
+          [
+            expect.objectContaining({
+              _id: "sync_event_rejected",
+              status: "rejected",
+              summary: "Register was closed before this sale synced.",
+            }),
+          ],
+        ],
+      ]),
+    );
+  });
+
   it("keeps resolved sync conflicts reviewable when the source event is still conflicted", async () => {
     const conflict = {
       _id: "sync_conflict_1",
@@ -1164,7 +1221,94 @@ describe("cash control deposits", () => {
       ),
     ).resolves.toEqual(
       new Map([
-        ["session_open", [expect.objectContaining({ _id: "sync_conflict_1" })]],
+        [
+          "session_open",
+          [
+            expect.objectContaining({
+              _id: "sync_conflict_1",
+              status: "needs_review",
+            }),
+          ],
+        ],
+      ]),
+    );
+  });
+
+  it("surfaces resolved sync conflicts as rejected evidence when the source event is rejected", async () => {
+    const conflict = {
+      _id: "sync_conflict_1",
+      storeId: "store_1",
+      terminalId: "terminal_1",
+      localRegisterSessionId: "local-register-1",
+      localEventId: "event_1",
+      sequence: 1,
+      conflictType: "permission",
+      status: "resolved",
+      summary:
+        "Register closeout variance requires manager review before synced closeout can be applied.",
+      details: {},
+      createdAt: 1,
+    };
+    const ctx = createQueryCtx({
+      posLocalSyncConflict: [conflict],
+      posLocalSyncEvent: [
+        {
+          _id: "sync_event_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_1",
+          sequence: 1,
+          eventType: "register_closed",
+          occurredAt: 2,
+          staffProfileId: "staff_1",
+          payload: { countedCash: 45000 },
+          rejectionMessage:
+            "Manager rejected synced register activity during cash-controls review.",
+          status: "rejected",
+          submittedAt: 3,
+        },
+      ],
+      posLocalSyncMapping: [
+        {
+          _id: "sync_mapping_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localIdKind: "registerSession",
+          localId: "local-register-1",
+          cloudTable: "registerSession",
+          cloudId: "session_open",
+        },
+      ],
+      registerSession: [
+        {
+          _id: "session_open",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+        },
+      ],
+    });
+
+    await expect(
+      listOpenLocalSyncConflictsByRegisterSession(
+        ctx as never,
+        "store_1" as Id<"store">,
+        { includeRejectedEvidence: true },
+      ),
+    ).resolves.toEqual(
+      new Map([
+        [
+          "session_open",
+          [
+            expect.objectContaining({
+              _id: "sync_conflict_1",
+              status: "rejected",
+              summary:
+                "Manager rejected synced register activity during cash-controls review.",
+            }),
+          ],
+        ],
       ]),
     );
   });

--- a/packages/athena-webapp/convex/cashControls/deposits.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.ts
@@ -660,7 +660,9 @@ export const getDashboardSnapshot = query({
         .order("desc")
         .take(SESSION_LIMIT),
       listStoreDeposits(ctx, args.storeId),
-      listRegisterSessionSyncReviewConflicts(ctx, args.storeId),
+      listRegisterSessionSyncReviewConflicts(ctx, args.storeId, {
+        includeRejectedEvidence: true,
+      }),
     ]);
 
     const dashboardRegisterSessions =
@@ -749,7 +751,9 @@ export const getRegisterSessionSnapshot = query({
             registerSession.managerApprovalRequestId,
           )
         : Promise.resolve(null),
-      listRegisterSessionSyncReviewConflicts(ctx, args.storeId),
+      listRegisterSessionSyncReviewConflicts(ctx, args.storeId, {
+        includeRejectedEvidence: true,
+      }),
       resolveRegisterSessionWorkflowTraceId(ctx, registerSession),
     ]);
     const registerSessionWithTraceId = {
@@ -1283,11 +1287,15 @@ export const resolveRegisterSessionSyncReview = mutation({
 
     await Promise.all(
       conflicts.map((conflict) =>
-        ctx.db.patch("posLocalSyncConflict", conflict._id, {
-          resolvedAt,
-          resolvedByStaffProfileId: args.actorStaffProfileId,
-          status: "resolved",
-        }),
+        ctx.db.patch(
+          "posLocalSyncConflict",
+          conflict._id as Id<"posLocalSyncConflict">,
+          {
+            resolvedAt,
+            resolvedByStaffProfileId: args.actorStaffProfileId,
+            status: "resolved",
+          },
+        ),
       ),
     );
 

--- a/packages/athena-webapp/convex/pos/application/commands/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/terminals.ts
@@ -242,6 +242,9 @@ export type TerminalRuntimeStatusInput = {
     failedEventCount: number;
     reviewEventCount: number;
     localOnlyEventCount: number;
+    reviewEvents?: NonNullable<
+      Doc<"posTerminalRuntimeStatus">["sync"]["reviewEvents"]
+    >;
     oldestPendingEventAt?: number;
     nextPendingUploadSequence?: number;
     lastSyncedSequence?: number;

--- a/packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts
@@ -3,22 +3,19 @@ import type { QueryCtx } from "../../../_generated/server";
 
 const SYNC_CONFLICT_LIMIT = 500;
 
-export type RegisterSessionSyncConflict = Pick<
-  Doc<"posLocalSyncConflict">,
-  | "_id"
-  | "conflictType"
-  | "createdAt"
-  | "localEventId"
-  | "sequence"
-  | "status"
-  | "summary"
-> &
-  Partial<
-    Pick<
-      Doc<"posLocalSyncConflict">,
-      "details" | "localRegisterSessionId" | "storeId" | "terminalId"
-    >
-  >;
+export type RegisterSessionSyncConflict = {
+  _id: string;
+  conflictType?: string;
+  createdAt: number;
+  details?: Record<string, unknown>;
+  localEventId: string;
+  localRegisterSessionId?: string;
+  sequence: number;
+  status: string;
+  storeId?: Id<"store">;
+  summary?: string;
+  terminalId?: Id<"posTerminal">;
+};
 
 export type RegisterSessionLocalSyncStatus = {
   status: "needs_review";
@@ -53,7 +50,7 @@ function getSyncConflictReconciliationType(
     return "register_closeout";
   }
 
-  return conflict.conflictType;
+  return conflict.conflictType ?? null;
 }
 
 function numberDetail(
@@ -92,8 +89,9 @@ export function buildRegisterSessionLocalSyncStatus(
 export async function listOpenLocalSyncConflictsByRegisterSession(
   ctx: Pick<QueryCtx, "db">,
   storeId: Id<"store">,
+  options: { includeRejectedEvidence?: boolean } = {},
 ) {
-  const [needsReviewConflicts, resolvedConflicts] = await Promise.all([
+  const [needsReviewConflicts, resolvedConflicts, rejectedEvents] = await Promise.all([
     ctx.db
       .query("posLocalSyncConflict")
       .withIndex("by_store_status", (q) =>
@@ -106,6 +104,14 @@ export async function listOpenLocalSyncConflictsByRegisterSession(
         q.eq("storeId", storeId).eq("status", "resolved"),
       )
       .take(SYNC_CONFLICT_LIMIT),
+    options.includeRejectedEvidence
+      ? ctx.db
+          .query("posLocalSyncEvent")
+          .withIndex("by_store_status", (q) =>
+            q.eq("storeId", storeId).eq("status", "rejected"),
+          )
+          .take(SYNC_CONFLICT_LIMIT)
+      : Promise.resolve([]),
   ]);
   const staleResolvedConflicts = await Promise.all(
     resolvedConflicts.map(async (conflict) => {
@@ -119,27 +125,70 @@ export async function listOpenLocalSyncConflictsByRegisterSession(
         )
         .unique();
 
-      return syncEvent?.status === "conflicted" ? conflict : null;
+      if (syncEvent?.status === "conflicted") {
+        return { ...conflict, status: "needs_review" };
+      }
+
+      if (options.includeRejectedEvidence && syncEvent?.status === "rejected") {
+        return {
+          ...conflict,
+          conflictType: "server_rejected",
+          status: "rejected",
+          summary:
+            syncEvent.rejectionMessage ??
+            "Server rejected synced register activity for this drawer.",
+        };
+      }
+
+      return null;
     }),
   );
-  const conflicts: Doc<"posLocalSyncConflict">[] = [
+  const conflicts: RegisterSessionSyncConflict[] = [
     ...needsReviewConflicts,
     ...staleResolvedConflicts.filter(
       (conflict): conflict is Doc<"posLocalSyncConflict"> => conflict !== null,
     ),
   ];
+  const includedConflictKeys = new Set(
+    conflicts.map((conflict) =>
+      [conflict.terminalId, conflict.localEventId].join(":"),
+    ),
+  );
+  if (options.includeRejectedEvidence) {
+    for (const event of rejectedEvents) {
+      const key = [event.terminalId, event.localEventId].join(":");
+      if (includedConflictKeys.has(key)) continue;
+
+      conflicts.push({
+        _id: event._id,
+        conflictType: "server_rejected",
+        createdAt: event.acceptedAt ?? event.submittedAt,
+        details: {},
+        localEventId: event.localEventId,
+        localRegisterSessionId: event.localRegisterSessionId,
+        sequence: event.sequence,
+        status: event.status,
+        storeId: event.storeId,
+        summary:
+          event.rejectionMessage ??
+          "Server rejected synced register activity for this drawer.",
+        terminalId: event.terminalId,
+      });
+    }
+  }
   const entries = await Promise.all(
     conflicts.map(async (conflict) => {
       const { terminalId, localRegisterSessionId } = conflict;
       if (!terminalId || !localRegisterSessionId) {
         return null;
       }
+      const conflictStoreId = conflict.storeId ?? storeId;
 
       const registerSessionMapping = await ctx.db
         .query("posLocalSyncMapping")
         .withIndex("by_store_terminal_local", (q) =>
           q
-            .eq("storeId", conflict.storeId)
+            .eq("storeId", conflictStoreId)
             .eq("terminalId", terminalId)
             .eq("localRegisterSessionId", localRegisterSessionId)
             .eq("localIdKind", "registerSession")
@@ -171,7 +220,7 @@ export async function listOpenLocalSyncConflictsByRegisterSession(
         );
         if (!registerSession) return null;
         if (
-          registerSession.storeId === conflict.storeId &&
+          registerSession.storeId === conflictStoreId &&
           registerSession.terminalId === terminalId
         ) {
           return [cloudRegisterSessionId, conflict] as const;

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.test.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const projectRoot = process.cwd();
+const readProjectFile = (...segments: string[]) =>
+  readFileSync(join(projectRoot, ...segments), "utf8");
+
+describe("createConvexLocalSyncRepository", () => {
+  it("does not use paginated reads while syncing service-case financials", () => {
+    const source = readProjectFile(
+      "convex",
+      "pos",
+      "infrastructure",
+      "repositories",
+      "localSyncRepository.ts",
+    );
+    const financialSyncSource = source.slice(
+      source.indexOf("async syncServiceCaseFinancials(serviceCaseId)"),
+      source.indexOf("async createTransaction(input)"),
+    );
+
+    expect(financialSyncSource).toContain(".collect()");
+    expect(financialSyncSource).not.toContain(".paginate(");
+  });
+});

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
@@ -22,32 +22,6 @@ import type {
 } from "../../application/sync/types";
 import { hashPosLocalStaffProofToken } from "../../application/sync/staffProof";
 
-const SERVICE_CASE_FINANCIALS_PAGE_SIZE = 100;
-
-type PaginatedPage<TItem> = {
-  page: TItem[];
-  isDone: boolean;
-  continueCursor: string;
-};
-
-async function collectAllPages<TItem>(
-  loadPage: (cursor: string | null) => Promise<PaginatedPage<TItem>>,
-): Promise<TItem[]> {
-  const items: TItem[] = [];
-  let cursor: string | null = null;
-
-  while (true) {
-    const page = await loadPage(cursor);
-    items.push(...page.page);
-
-    if (page.isDone) {
-      return items;
-    }
-
-    cursor = page.continueCursor;
-  }
-}
-
 export function createConvexLocalSyncRepository(
   ctx: MutationCtx,
 ): LocalSyncRepository {
@@ -489,25 +463,23 @@ export function createConvexLocalSyncRepository(
     async syncServiceCaseFinancials(serviceCaseId) {
       const serviceCase = await ctx.db.get("serviceCase", serviceCaseId);
       if (!serviceCase) return;
-      const lineItems = await collectAllPages((cursor) =>
-        ctx.db
-          .query("serviceCaseLineItem")
-          .withIndex("by_serviceCaseId", (q) =>
-            q.eq("serviceCaseId", serviceCaseId),
-          )
-          .paginate({ cursor, numItems: SERVICE_CASE_FINANCIALS_PAGE_SIZE }),
-      );
-      const paymentAllocations = await collectAllPages((cursor) =>
-        ctx.db
-          .query("paymentAllocation")
-          .withIndex("by_storeId_target", (q) =>
-            q
-              .eq("storeId", serviceCase.storeId)
-              .eq("targetType", "service_case")
-              .eq("targetId", serviceCaseId),
-          )
-          .paginate({ cursor, numItems: SERVICE_CASE_FINANCIALS_PAGE_SIZE }),
-      );
+      // eslint-disable-next-line @convex-dev/no-collect-in-query -- Service-case financial sync runs inside local sync ingestion, where Convex forbids paginated-query fanout; this read is scoped to one service case.
+      const lineItems = await ctx.db
+        .query("serviceCaseLineItem")
+        .withIndex("by_serviceCaseId", (q) =>
+          q.eq("serviceCaseId", serviceCaseId),
+        )
+        .collect();
+      // eslint-disable-next-line @convex-dev/no-collect-in-query -- Service-case payment allocations are scoped to one service case and cannot use pagination inside local sync ingestion.
+      const paymentAllocations = await ctx.db
+        .query("paymentAllocation")
+        .withIndex("by_storeId_target", (q) =>
+          q
+            .eq("storeId", serviceCase.storeId)
+            .eq("targetType", "service_case")
+            .eq("targetId", serviceCaseId),
+        )
+        .collect();
       const totalAmount =
         lineItems.length > 0
           ? lineItems.reduce((sum, lineItem) => sum + lineItem.amount, 0)

--- a/packages/athena-webapp/convex/pos/public/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.test.ts
@@ -332,6 +332,23 @@ describe("POS terminal public mutations", () => {
           reason: "cloud_closed",
           status: "blocked",
         },
+        sync: {
+          ...buildRuntimeStatus().sync,
+          reviewEventCount: 1,
+          reviewEvents: [
+            {
+              createdAt: 101,
+              localEventId: "event-review-1",
+              localRegisterSessionId: "local-register-1",
+              sequence: 9,
+              status: "needs_review",
+              type: "transaction.completed",
+              uploaded: true,
+              uploadSequence: 9,
+            },
+          ],
+          status: "needs_review",
+        },
         staffProofToken: "proof-token",
         terminalIntegrity: {
           observedAt: 111,
@@ -372,6 +389,15 @@ describe("POS terminal public mutations", () => {
             reason: "cloud_closed",
             status: "blocked",
           },
+          sync: expect.objectContaining({
+            reviewEvents: [
+              expect.objectContaining({
+                localEventId: "event-review-1",
+                localRegisterSessionId: "local-register-1",
+                status: "needs_review",
+              }),
+            ],
+          }),
           terminalIntegrity: {
             observedAt: 111,
             reason: "authorization_failed",

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -253,6 +253,7 @@ function stripRuntimeStatusInput(
       failedEventCount: status.sync.failedEventCount,
       reviewEventCount: status.sync.reviewEventCount,
       localOnlyEventCount: status.sync.localOnlyEventCount,
+      reviewEvents: status.sync.reviewEvents,
       oldestPendingEventAt: status.sync.oldestPendingEventAt,
       nextPendingUploadSequence: status.sync.nextPendingUploadSequence,
       lastSyncedSequence: status.sync.lastSyncedSequence,

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -22,7 +22,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/stockOps`](../../convex/stockOps) — Stock-adjustment, procurement, replenishment, receiving, and vendor flows layered over inventory state. Currently 14 file(s); key children: access.test.ts, access.ts, adjustments.test.ts, adjustments.ts, cycleCountDrafts.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 6 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCases.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 11 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 464 file(s); key children: README.md, _generated, app.ts, auth.config.js, auth.ts.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 465 file(s); key children: README.md, _generated, app.ts, auth.config.js, auth.ts.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 6 file(s); key children: README.md, SUMMARY.md, pos.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -95,6 +95,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`convex/pos/application/transactionAdjustmentPlanner.test.ts`](../../convex/pos/application/transactionAdjustmentPlanner.test.ts)
 - [`convex/pos/application/transactionAdjustments.test.ts`](../../convex/pos/application/transactionAdjustments.test.ts)
 - [`convex/pos/infrastructure/integrations/inventoryHoldGateway.test.ts`](../../convex/pos/infrastructure/integrations/inventoryHoldGateway.test.ts)
+- [`convex/pos/infrastructure/repositories/localSyncRepository.test.ts`](../../convex/pos/infrastructure/repositories/localSyncRepository.test.ts)
 - [`convex/pos/infrastructure/repositories/registerSessionRepository.test.ts`](../../convex/pos/infrastructure/repositories/registerSessionRepository.test.ts)
 - [`convex/pos/infrastructure/repositories/sessionCommandRepository.test.ts`](../../convex/pos/infrastructure/repositories/sessionCommandRepository.test.ts)
 - [`convex/pos/infrastructure/repositories/sessionRepository.test.ts`](../../convex/pos/infrastructure/repositories/sessionRepository.test.ts)

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
@@ -460,6 +460,100 @@ describe("RegisterSessionViewContent", () => {
     ).toBeInTheDocument();
   });
 
+  it("surfaces rejected server sync activity without review actions", () => {
+    render(
+      <RegisterSessionViewContent
+        currency="GHS"
+        isLoading={false}
+        onRecordDeposit={vi.fn()}
+        {...closeoutHandlers}
+        onResolveSyncReview={vi.fn()}
+        orgUrlSlug="org"
+        registerSessionSnapshot={{
+          ...baseSnapshot,
+          registerSession: {
+            ...baseSnapshot.registerSession,
+            localSyncStatus: {
+              status: "needs_review",
+              reconciliationItems: [
+                {
+                  localEventId: "event-rejected-sale",
+                  sequence: 10,
+                  status: "rejected",
+                  summary: "Register was closed before this sale synced.",
+                  type: "server_rejected",
+                },
+              ],
+            },
+          },
+        }}
+        storeUrlSlug="store"
+      />,
+    );
+
+    expect(screen.getByText("Synced activity rejected")).toBeInTheDocument();
+    expect(
+      screen.getByText("Register was closed before this sale synced."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /approve synced sales/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /reject synced activity/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open POS sync" })).toHaveAttribute(
+      "href",
+      expect.stringContaining("/pos/register"),
+    );
+  });
+
+  it("does not offer closeout review actions for already rejected closeout evidence", () => {
+    render(
+      <RegisterSessionViewContent
+        currency="GHS"
+        isLoading={false}
+        onRecordDeposit={vi.fn()}
+        {...closeoutHandlers}
+        onResolveSyncReview={vi.fn()}
+        orgUrlSlug="org"
+        registerSessionSnapshot={{
+          ...baseSnapshot,
+          registerSession: {
+            ...baseSnapshot.registerSession,
+            localSyncStatus: {
+              status: "needs_review",
+              reconciliationItems: [
+                {
+                  localEventId: "event-register-closeout-1",
+                  sequence: 10,
+                  status: "rejected",
+                  summary:
+                    "Manager rejected synced register activity during cash-controls review.",
+                  type: "register_closeout",
+                  variance: 2500,
+                },
+              ],
+            },
+          },
+        }}
+        storeUrlSlug="store"
+      />,
+    );
+
+    expect(screen.getByText("Synced activity rejected")).toBeInTheDocument();
+    expect(screen.getByText("Closeout variance review")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /reject synced closeout/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /approve synced closeout/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open POS sync" })).toHaveAttribute(
+      "href",
+      expect.stringContaining("/pos/register"),
+    );
+  });
+
   it("communicates synced closeout variance review as closeout work", () => {
     render(
       <RegisterSessionViewContent

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -518,12 +518,16 @@ function RegisterSessionSyncNotice({
   errorMessage,
   isResolving,
   onReviewDecision,
+  orgUrlSlug,
+  storeUrlSlug,
   syncStatus,
 }: {
   currency: string;
   errorMessage?: string;
   isResolving?: boolean;
   onReviewDecision?: (decision: "approved" | "rejected") => void;
+  orgUrlSlug?: string;
+  storeUrlSlug?: string;
   syncStatus: PosSyncStatusPresentation;
 }) {
   if (syncStatus.status === "synced") {
@@ -531,6 +535,10 @@ function RegisterSessionSyncNotice({
   }
 
   const reconciliationItems = syncStatus.reconciliationItems;
+  const hasOnlyRejectedReviewItems =
+    syncStatus.status === "needs_review" &&
+    reconciliationItems.length > 0 &&
+    reconciliationItems.every((item) => item.status === "rejected");
   const hasClosedRegisterSyncedCloseout = reconciliationItems.some(
     isClosedRegisterSyncedCloseoutReviewItem,
   );
@@ -539,6 +547,8 @@ function RegisterSessionSyncNotice({
   );
   const noticeLabel = hasClosedRegisterSyncedCloseout
     ? "Synced closeout cannot be applied"
+    : hasOnlyRejectedReviewItems
+      ? "Synced activity rejected"
     : syncStatus.status === "locally_closed_pending_sync"
       ? "Pending reconciliation"
       : hasCloseoutReview
@@ -546,6 +556,8 @@ function RegisterSessionSyncNotice({
         : syncStatus.label;
   const noticeDescription = hasClosedRegisterSyncedCloseout
     ? "This register is already closed. Reject the duplicate synced activity to clear the review."
+    : hasOnlyRejectedReviewItems
+      ? "Server-rejected sync activity is recorded for this register session. Retry pending sync in POS to settle the local queue."
     : syncStatus.description;
   const approveLabel = hasCloseoutReview
     ? "Approve synced closeout"
@@ -667,7 +679,28 @@ function RegisterSessionSyncNotice({
           ) : null}
         </div>
         <div className="flex flex-wrap items-center justify-end gap-layout-sm">
-          {syncStatus.status === "needs_review" && onReviewDecision ? (
+          {syncStatus.status === "needs_review" &&
+          hasOnlyRejectedReviewItems &&
+          orgUrlSlug &&
+          storeUrlSlug ? (
+            <Button
+              asChild
+              className="border-border bg-background text-foreground hover:bg-muted"
+              size="sm"
+              variant="outline"
+            >
+              <Link
+                params={{ orgUrlSlug, storeUrlSlug }}
+                search={{ o: getOrigin() }}
+                to="/$orgUrlSlug/store/$storeUrlSlug/pos/register"
+              >
+                Open POS sync
+              </Link>
+            </Button>
+          ) : null}
+          {syncStatus.status === "needs_review" &&
+          !hasOnlyRejectedReviewItems &&
+          onReviewDecision ? (
             <>
               {canApproveSyncReview ? (
                 <LoadingButton
@@ -1970,6 +2003,8 @@ export function RegisterSessionViewContent({
               onReviewDecision={
                 canResolveSyncReview ? requestResolveSyncReview : undefined
               }
+              orgUrlSlug={orgUrlSlug}
+              storeUrlSlug={storeUrlSlug}
               syncStatus={syncStatus}
             />
           ) : null}

--- a/packages/athena-webapp/src/components/pos/CartItems.test.tsx
+++ b/packages/athena-webapp/src/components/pos/CartItems.test.tsx
@@ -54,6 +54,51 @@ describe("CartItems service lines", () => {
     expect(screen.getByText("BW-18")).toBeInTheDocument();
   });
 
+  it("shows service totals without a quantity count", () => {
+    render(
+      <CartItems
+        cartItems={[]}
+        serviceItems={[buildServiceLine({ price: 40000, quantity: 2 })]}
+        onRemoveService={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("x2")).not.toBeInTheDocument();
+    expect(screen.queryByText("2 x GH₵400")).not.toBeInTheDocument();
+    expect(screen.queryByText("2")).not.toBeInTheDocument();
+    expect(screen.getByText("GH₵800")).toBeInTheDocument();
+    expect(screen.getByText("GH₵800").closest(".col-span-2")).toHaveClass(
+      "col-span-2",
+      "justify-end",
+    );
+    expect(screen.getByRole("button").closest(".col-span-1")).toHaveClass(
+      "col-span-1",
+    );
+  });
+
+  it("aligns compact service pricing like compact product rows", () => {
+    render(
+      <CartItems
+        cartItems={[]}
+        density="compact"
+        serviceItems={[
+          buildServiceLine({
+            price: 40000,
+            pricingModel: "fixed",
+            quantity: 2,
+            serviceMode: "revamp",
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText(/revamp · fixed price/i)).toBeInTheDocument();
+    expect(screen.getByText("GH₵400")).toBeInTheDocument();
+    expect(screen.getByText("GH₵800")).toBeInTheDocument();
+    expect(screen.queryByText("2")).not.toBeInTheDocument();
+    expect(screen.queryByText("2 x GH₵400")).not.toBeInTheDocument();
+  });
+
   it("updates editable service amounts and removes service lines", async () => {
     const user = userEvent.setup();
     const onUpdateServiceAmount = vi.fn();

--- a/packages/athena-webapp/src/components/pos/CartItems.tsx
+++ b/packages/athena-webapp/src/components/pos/CartItems.tsx
@@ -6,7 +6,7 @@ import {
   Minus,
   ShoppingBasket,
   Package,
-  Wrench,
+  Scissors,
 } from "lucide-react";
 import { CartItem } from "./types";
 import { currencyFormatter } from "~/convex/utils";
@@ -125,6 +125,7 @@ export function CartItems({
                   : item.pricingModel === "starting_at"
                     ? "Entered amount"
                     : "Quoted amount";
+              const lineTotal = item.price * item.quantity;
 
               return (
                 <div
@@ -139,7 +140,7 @@ export function CartItems({
                   <div
                     className={cn(
                       "flex items-start gap-4",
-                      !isCompact && "col-span-7",
+                      !isCompact && "col-span-5",
                     )}
                   >
                     <div
@@ -148,24 +149,46 @@ export function CartItems({
                         isCompact ? "w-12 h-12" : "w-16 h-16",
                       )}
                     >
-                      <Wrench className="h-5 w-5 text-muted-foreground" />
+                      <Scissors className="h-5 w-5 text-muted-foreground" />
                     </div>
 
-                    <div className="min-w-0 flex-1 space-y-2">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <h4 className="truncate text-sm font-medium leading-tight">
-                          {capitalizeWords(item.name)}
-                        </h4>
-                        <span className="rounded-full border border-border bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
-                          Service
-                        </span>
+                    <div
+                      className={cn(
+                        "flex min-w-0 flex-1",
+                        isCompact
+                          ? "items-start justify-between gap-3"
+                          : "block space-y-2",
+                      )}
+                    >
+                      <div className="min-w-0 space-y-2">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <h4 className="truncate text-sm font-medium leading-tight">
+                            {capitalizeWords(item.name)}
+                          </h4>
+                          <span className="rounded-full border border-border bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+                            Service
+                          </span>
+                        </div>
+                        <div className="space-y-2">
+                          <p className="text-xs capitalize text-muted-foreground">
+                            {item.serviceMode.replace(/_/g, " ")} · {amountLabel}
+                          </p>
+                          {!canEditAmount ? (
+                            <p className="text-sm font-medium">
+                              {formatStoredAmount(formatter, item.price)}
+                            </p>
+                          ) : null}
+                        </div>
+                        {item.amountRequired ? (
+                          <p className="text-xs font-medium text-amber-700">
+                            Enter an amount before checkout.
+                          </p>
+                        ) : null}
                       </div>
-                      <p className="text-xs capitalize text-muted-foreground">
-                        {item.serviceMode.replace(/_/g, " ")} · {amountLabel}
-                      </p>
-                      {item.amountRequired ? (
-                        <p className="text-xs font-medium text-amber-700">
-                          Enter an amount before checkout.
+
+                      {isCompact && !canEditAmount ? (
+                        <p className="shrink-0 text-right text-sm font-semibold">
+                          {formatStoredAmount(formatter, lineTotal)}
                         </p>
                       ) : null}
                     </div>
@@ -177,10 +200,11 @@ export function CartItems({
                       isCompact ? "justify-between pt-3" : "contents",
                     )}
                   >
+                    {!isCompact ? <div className="col-span-4" /> : null}
                     <div
                       className={cn(
                         "flex items-center",
-                        isCompact ? "justify-start" : "col-span-3 justify-end",
+                        isCompact ? "justify-start" : "col-span-2 justify-end",
                       )}
                     >
                       {canEditAmount ? (
@@ -201,10 +225,14 @@ export function CartItems({
                             }
                           }}
                         />
+                      ) : isCompact ? (
+                        null
                       ) : (
-                        <p className="text-sm font-medium">
-                          {formatStoredAmount(formatter, item.price)}
-                        </p>
+                        <div className="text-right">
+                          <p className="text-sm font-medium">
+                            {formatStoredAmount(formatter, lineTotal)}
+                          </p>
+                        </div>
                       )}
                     </div>
 
@@ -212,7 +240,7 @@ export function CartItems({
                       <div
                         className={cn(
                           "flex justify-center",
-                          !isCompact && "col-span-2",
+                          !isCompact && "col-span-1",
                         )}
                       >
                         <Button

--- a/packages/athena-webapp/src/components/pos/OrderSummary.test.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.test.tsx
@@ -319,10 +319,10 @@ describe("OrderSummary completed transaction summary", () => {
           serviceLines: [
             {
               id: "service-line-1",
-              name: "Closure repair",
+              name: "tokin",
               quantity: 1,
               serviceCaseId: "case-1",
-              serviceCaseTitle: "Repair for Ama",
+              serviceCaseTitle: "tokin",
               serviceMode: "repair",
               servicePaymentStatus: "partially_paid",
               serviceStatus: "intake",
@@ -344,8 +344,10 @@ describe("OrderSummary completed transaction summary", () => {
     );
 
     expect(screen.getByText("Service lines")).toBeInTheDocument();
-    expect(screen.getByText("Closure repair")).toBeInTheDocument();
-    expect(screen.getByText(/Repair for Ama/i)).toBeInTheDocument();
+    expect(screen.getByText("Tokin")).toBeInTheDocument();
+    expect(
+      screen.getByText("Tokin • Intake • Partially Paid"),
+    ).toBeInTheDocument();
     expect(screen.getByText("2 items")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /Print receipt/i }));
@@ -365,8 +367,8 @@ describe("OrderSummary completed transaction summary", () => {
     expect(receiptElement.props.items).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          attributes: expect.stringContaining("Payment: partially paid"),
-          name: "Closure repair",
+          attributes: expect.stringContaining("Payment: Partially Paid"),
+          name: "Tokin",
           totalPrice: "GH₵150",
         }),
       ]),
@@ -682,6 +684,77 @@ describe("OrderSummary completed transaction summary", () => {
     expect(
       screen.queryByRole("button", { name: "Complete Sale" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("keeps the service checkout blocker beside disabled payment methods", async () => {
+    const user = userEvent.setup();
+    const onPaymentEntryStart = vi.fn();
+    const onCompletionBlockAction = vi.fn();
+
+    render(
+      <OrderSummary
+        cartItems={[
+          {
+            id: "item-1",
+            name: "Hair",
+            barcode: "123456789012",
+            price: 1700,
+            quantity: 1,
+            productId: "product-1",
+            skuId: "sku-1",
+          } as never,
+        ]}
+        total={1700}
+        completionBlockMessage="Customer required. Add a customer before checking out services."
+        onPaymentEntryStart={onPaymentEntryStart}
+        onCompletionBlockAction={onCompletionBlockAction}
+      />,
+    );
+
+    const blocker = screen.getByText("Customer required");
+    expect(blocker).toBeInTheDocument();
+    expect(blocker.closest("button")).toBeInTheDocument();
+    expect(
+      screen.getByText("Add a customer before checking out services"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Find/add")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cash" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Card" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Mobile Money" })).toBeDisabled();
+
+    await user.click(blocker);
+
+    expect(onCompletionBlockAction).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "Cash" }));
+
+    expect(onPaymentEntryStart).not.toHaveBeenCalled();
+  });
+
+  it("disables the service checkout blocker action when no customer lookup handler is available", () => {
+    render(
+      <OrderSummary
+        cartItems={[
+          {
+            id: "item-1",
+            name: "Hair",
+            barcode: "123456789012",
+            price: 1700,
+            quantity: 1,
+            productId: "product-1",
+            skuId: "sku-1",
+          } as never,
+        ]}
+        total={1700}
+        completionBlockMessage="Customer required. Add a customer before checking out services."
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "Customer required",
+      ).closest("button"),
+    ).toBeDisabled();
   });
 
   it("keeps item count out of the payment summary when the cart already owns it", () => {

--- a/packages/athena-webapp/src/components/pos/OrderSummary.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.tsx
@@ -8,6 +8,7 @@ import {
   Plus,
   Printer,
   Smartphone,
+  UserPlus,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -67,6 +68,25 @@ function parseReceiptLocation(location?: string) {
   };
 }
 
+function formatServiceLabel(value?: string | null) {
+  const label = value?.replaceAll("_", " ").trim();
+  return label ? capitalizeWords(label) : null;
+}
+
+function formatServiceLineMeta(line: PosServiceReceiptLine) {
+  if (line.serviceCaseUnavailable) {
+    return "Service Case Unavailable";
+  }
+
+  return [
+    formatServiceLabel(line.serviceCaseTitle),
+    formatServiceLabel(line.serviceStatus),
+    formatServiceLabel(line.servicePaymentStatus),
+  ]
+    .filter(Boolean)
+    .join(" • ");
+}
+
 interface OrderSummaryProps {
   cartItems: CartItem[];
   customerInfo?: {
@@ -83,6 +103,7 @@ interface OrderSummaryProps {
   isTransactionCompleted?: boolean;
   readOnly?: boolean;
   completedOrderNumber?: string | null;
+  completionBlockMessage?: string;
   completedTransactionData?: {
     paymentMethod: string;
     payments?: Payment[];
@@ -127,6 +148,7 @@ interface OrderSummaryProps {
   onVoidTransaction?: () => void | Promise<void>;
   onPaymentFlowChange?: (isActive: boolean) => void;
   onPaymentEntryStart?: () => void;
+  onCompletionBlockAction?: () => void;
   onEditingPaymentChange?: (isEditing: boolean) => void;
   hidePaymentItemCountSummary?: boolean;
   hideActiveSummaryCards?: boolean;
@@ -145,6 +167,7 @@ export function OrderSummary({
   isTransactionCompleted = false,
   readOnly = false,
   completedOrderNumber,
+  completionBlockMessage,
   completedTransactionData,
   completedAdjustmentSummary,
   presentation = "workspace",
@@ -161,6 +184,7 @@ export function OrderSummary({
   onVoidTransaction,
   onPaymentFlowChange,
   onPaymentEntryStart,
+  onCompletionBlockAction,
   onEditingPaymentChange,
   hidePaymentItemCountSummary = false,
   hideActiveSummaryCards = false,
@@ -333,6 +357,8 @@ export function OrderSummary({
     !isEditingPaymentAmount &&
     selectedPaymentMethod === null &&
     (payments.length === 0 || remainingDue > 0);
+  const paymentMethodsDisabled =
+    cartItemsCount === 0 || Boolean(completionBlockMessage);
   const showPaymentEditor =
     !readOnly &&
     !isTransactionCompleted &&
@@ -365,6 +391,15 @@ export function OrderSummary({
   const balanceDueLabelClass = isPaymentAmountOverpaying
     ? "text-success"
     : "text-transaction-signal";
+  const [completionBlockTitle, completionBlockDetail] = completionBlockMessage
+    ? (() => {
+        const [title, ...detailParts] = completionBlockMessage.split(". ");
+        return [
+          title.replace(/\.$/, ""),
+          detailParts.join(". ").replace(/\.$/, "") || "Add a customer to continue.",
+        ];
+      })()
+    : [null, null];
 
   const completedAdjustmentSettlementLabel =
     completedAdjustmentSummary?.settlementDirection === "refund"
@@ -399,6 +434,16 @@ export function OrderSummary({
 
     onPaymentFlowChange?.(isPaymentEntryActive);
   }, [isPaymentEntryActive, onPaymentFlowChange, selectedPaymentMethod]);
+
+  useEffect(() => {
+    if (!completionBlockMessage || selectedPaymentMethod === null) {
+      return;
+    }
+
+    setSelectedPaymentMethod(null);
+    setPaymentAmountDraft(undefined);
+    onPaymentFlowChange?.(false);
+  }, [completionBlockMessage, onPaymentFlowChange, selectedPaymentMethod]);
 
   useEffect(() => {
     return () => onPaymentFlowChange?.(false);
@@ -488,7 +533,7 @@ export function OrderSummary({
       });
       const receiptServiceItems = (completedData.serviceLines ?? []).map(
         (line) => ({
-          name: line.name,
+          name: formatServiceLabel(line.name) ?? line.name,
           totalPrice: formatStoredAmount(formatter, line.totalPrice),
           quantityLabel: `${line.quantity ?? 1} × ${formatStoredAmount(
             formatter,
@@ -499,10 +544,10 @@ export function OrderSummary({
             : undefined,
           attributes: [
             line.serviceMode
-              ? `Service mode: ${line.serviceMode.replaceAll("_", " ")}`
+              ? `Service mode: ${formatServiceLabel(line.serviceMode)}`
               : null,
             line.servicePaymentStatus
-              ? `Payment: ${line.servicePaymentStatus.replaceAll("_", " ")}`
+              ? `Payment: ${formatServiceLabel(line.servicePaymentStatus)}`
               : null,
           ]
             .filter(Boolean)
@@ -644,32 +689,30 @@ export function OrderSummary({
                 Service lines
               </p>
               <div className="space-y-4">
-                {completedServiceLines.map((line) => (
-                  <div
-                    className="grid gap-1"
-                    key={`${line.id}-${line.serviceCaseId ?? "service"}`}
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <span className="min-w-0 text-foreground">
-                        {line.name}
-                      </span>
-                      <span className="font-medium text-foreground">
-                        {formatStoredAmount(formatter, line.totalPrice)}
-                      </span>
+                {completedServiceLines.map((line) => {
+                  const serviceMeta = formatServiceLineMeta(line);
+
+                  return (
+                    <div
+                      className="grid gap-1"
+                      key={`${line.id}-${line.serviceCaseId ?? "service"}`}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <span className="min-w-0 text-foreground">
+                          {formatServiceLabel(line.name) ?? line.name}
+                        </span>
+                        <span className="font-medium text-foreground">
+                          {formatStoredAmount(formatter, line.totalPrice)}
+                        </span>
+                      </div>
+                      {serviceMeta ? (
+                        <p className="text-xs text-muted-foreground">
+                          {serviceMeta}
+                        </p>
+                      ) : null}
                     </div>
-                    <p className="text-xs text-muted-foreground">
-                      {line.serviceCaseUnavailable
-                        ? "Service case unavailable"
-                        : [
-                            line.serviceCaseTitle,
-                            line.serviceStatus?.replaceAll("_", " "),
-                            line.servicePaymentStatus?.replaceAll("_", " "),
-                          ]
-                            .filter(Boolean)
-                            .join(" • ")}
-                    </p>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             </div>
           ) : null}
@@ -975,35 +1018,30 @@ export function OrderSummary({
                     Service lines
                   </p>
                   <div className="space-y-3">
-                    {completedServiceLines.map((line) => (
-                      <div
-                        className="grid gap-1"
-                        key={`${line.id}-${line.serviceCaseId ?? "service"}`}
-                      >
-                        <div className="flex items-start justify-between gap-3">
-                          <span className="min-w-0 text-foreground">
-                            {line.name}
-                          </span>
-                          <span className="font-medium text-foreground">
-                            {formatStoredAmount(formatter, line.totalPrice)}
-                          </span>
+                    {completedServiceLines.map((line) => {
+                      const serviceMeta = formatServiceLineMeta(line);
+
+                      return (
+                        <div
+                          className="grid gap-1"
+                          key={`${line.id}-${line.serviceCaseId ?? "service"}`}
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <span className="min-w-0 text-foreground">
+                              {formatServiceLabel(line.name) ?? line.name}
+                            </span>
+                            <span className="font-medium text-foreground">
+                              {formatStoredAmount(formatter, line.totalPrice)}
+                            </span>
+                          </div>
+                          {serviceMeta ? (
+                            <p className="text-xs text-muted-foreground">
+                              {serviceMeta}
+                            </p>
+                          ) : null}
                         </div>
-                        <p className="text-xs text-muted-foreground">
-                          {line.serviceCaseUnavailable
-                            ? "Service case unavailable"
-                            : [
-                                line.serviceCaseTitle,
-                                line.serviceStatus?.replaceAll("_", " "),
-                                line.servicePaymentStatus?.replaceAll(
-                                  "_",
-                                  " ",
-                                ),
-                              ]
-                                .filter(Boolean)
-                                .join(" • ")}
-                        </p>
-                      </div>
-                    ))}
+                      );
+                    })}
                   </div>
                 </div>
               ) : null}
@@ -1209,6 +1247,33 @@ export function OrderSummary({
               </div>
             )}
 
+            {completionBlockMessage ? (
+              <button
+                type="button"
+                disabled={!onCompletionBlockAction}
+                onClick={onCompletionBlockAction}
+                className={cn(
+                  "flex w-full items-center gap-3 rounded-xl border border-action-workflow-border bg-action-workflow-soft px-3.5 py-3 text-left text-action-workflow transition-colors hover:bg-action-workflow-soft/75 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-default disabled:hover:bg-action-workflow-soft",
+                  !shouldDockPaymentButtons && "col-span-2",
+                )}
+              >
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-white/70 text-action-workflow">
+                  <UserPlus className="h-4 w-4" aria-hidden="true" />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-semibold">
+                    {completionBlockTitle}
+                  </span>
+                  <span className="mt-0.5 block text-xs leading-5 text-action-workflow/80">
+                    {completionBlockDetail}
+                  </span>
+                </span>
+                <span className="shrink-0 rounded-md border border-action-workflow-border/80 bg-white/70 px-2.5 py-1 text-xs font-semibold text-action-workflow">
+                  Find/add
+                </span>
+              </button>
+            ) : null}
+
             <div
               className={cn(
                 "grid grid-cols-2 gap-3",
@@ -1220,7 +1285,7 @@ export function OrderSummary({
                   onPaymentEntryStart?.();
                   setSelectedPaymentMethod("cash");
                 }}
-                disabled={cartItemsCount === 0}
+                disabled={paymentMethodsDisabled}
                 className="flex h-28 flex-col items-start justify-between rounded-xl bg-transaction-signal p-4 text-left text-transaction-signal-foreground shadow-md shadow-transaction-signal/20 hover:bg-transaction-signal/90 hover:text-transaction-signal-foreground"
                 size="lg"
                 variant="outline"
@@ -1233,7 +1298,7 @@ export function OrderSummary({
                   onPaymentEntryStart?.();
                   setSelectedPaymentMethod("card");
                 }}
-                disabled={cartItemsCount === 0}
+                disabled={paymentMethodsDisabled}
                 variant="outline"
                 className="flex h-28 flex-col items-start justify-between rounded-xl border-border bg-surface-raised p-4 text-left text-foreground shadow-surface hover:bg-muted/30"
                 size="lg"
@@ -1246,7 +1311,7 @@ export function OrderSummary({
                   onPaymentEntryStart?.();
                   setSelectedPaymentMethod("mobile_money");
                 }}
-                disabled={cartItemsCount === 0}
+                disabled={paymentMethodsDisabled}
                 variant="outline"
                 className="col-span-2 flex h-24 items-center justify-between rounded-xl bg-yellow-200 p-4 text-left text-yellow-950 shadow-sm shadow-yellow-200/70 hover:bg-yellow-100 hover:text-yellow-950"
                 size="lg"
@@ -1277,6 +1342,7 @@ export function OrderSummary({
               }
               onPaymentAmountChange={setPaymentAmountDraft}
               onComplete={handleCompleteTransaction}
+              completionBlockMessage={completionBlockMessage}
               isCompleting={isCompleting}
             />
           </div>

--- a/packages/athena-webapp/src/components/pos/PaymentView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/PaymentView.test.tsx
@@ -73,6 +73,36 @@ describe("PaymentView", () => {
       expect(onComplete).toHaveBeenCalledTimes(1);
     });
 
+    it("does not show Complete Sale when checkout completion is blocked", async () => {
+      const onAddPayment = vi.fn().mockResolvedValue(true);
+      const onComplete = vi.fn().mockResolvedValue(true);
+      const user = userEvent.setup();
+
+      render(
+        <PaymentView
+          cartItemCount={1}
+          totalPaid={0}
+          remainingDue={5000}
+          amountDue={5000}
+          formatter={formatter}
+          selectedPaymentMethod={method}
+          setSelectedPaymentMethod={vi.fn()}
+          onAddPayment={onAddPayment}
+          onComplete={onComplete}
+          completionBlockMessage="Customer required. Add a customer before checking out services."
+        />,
+      );
+
+      expect(
+        screen.queryByRole("button", { name: "Complete Sale" }),
+      ).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Add Payment" }));
+
+      expect(onAddPayment).toHaveBeenCalledWith(method, expectedAmount);
+      expect(onComplete).not.toHaveBeenCalled();
+    });
+
     it("waits for durable payment save before completing the sale", async () => {
       let resolvePayment!: (value: boolean) => void;
       const onAddPayment = vi.fn(

--- a/packages/athena-webapp/src/components/pos/PaymentView.tsx
+++ b/packages/athena-webapp/src/components/pos/PaymentView.tsx
@@ -39,6 +39,7 @@ interface PaymentViewProps {
     amount: number,
   ) => boolean | Promise<boolean>;
   onComplete: () => void | Promise<boolean | void>;
+  completionBlockMessage?: string;
   onPaymentAmountChange?: (amount: number | undefined) => void;
   isCompleting?: boolean;
 }
@@ -99,6 +100,7 @@ export const PaymentView = ({
   setSelectedPaymentMethod,
   onAddPayment,
   onComplete,
+  completionBlockMessage,
   onPaymentAmountChange,
   isCompleting = false,
 }: PaymentViewProps) => {
@@ -108,7 +110,9 @@ export const PaymentView = ({
   const [displayValue, setDisplayValue] = useState("");
   const [keypadValue, setKeypadValue] = useState("");
 
-  const canComplete = canCompleteTransaction(totalPaid, amountDue);
+  const completionBlocked = Boolean(completionBlockMessage);
+  const canComplete =
+    canCompleteTransaction(totalPaid, amountDue) && !completionBlocked;
   const enteredAmount = currentAmount ?? 0;
   const shouldCompleteWithCurrentAmount =
     Boolean(selectedPaymentMethod) &&
@@ -212,7 +216,7 @@ export const PaymentView = ({
       return;
     }
 
-    if (shouldCompleteWithCurrentAmount) {
+    if (shouldCompleteWithCurrentAmount && !completionBlocked) {
       const isCompleted = await onComplete();
       if (isCompleted === false) {
         return;
@@ -423,7 +427,8 @@ export const PaymentView = ({
       </div>
 
       <div className="shrink-0 space-y-3">
-        {shouldCompleteWithCurrentAmount || isCompleting ? (
+        {(shouldCompleteWithCurrentAmount && !completionBlocked) ||
+        isCompleting ? (
           <Button
             variant="outline"
             className={cn(

--- a/packages/athena-webapp/src/components/pos/ProductEntry.test.tsx
+++ b/packages/athena-webapp/src/components/pos/ProductEntry.test.tsx
@@ -95,7 +95,8 @@ function buildServiceResult(
 ): RegisterServiceSearchResult {
   return {
     id: "service-1",
-    serviceCatalogId: "service-1" as RegisterServiceSearchResult["serviceCatalogId"],
+    serviceCatalogId:
+      "service-1" as RegisterServiceSearchResult["serviceCatalogId"],
     name: "Closure Repair",
     serviceMode: "repair",
     pricingModel: "fixed",
@@ -166,9 +167,9 @@ describe("ProductEntry", () => {
       expect(onAddProduct).toHaveBeenCalledWith(quickAddedProduct),
     );
     expect(setProductSearchQuery).toHaveBeenCalledWith("");
-    expect(
-      setProductSearchQuery.mock.invocationCallOrder.at(-1),
-    ).toBeLessThan(onAddProduct.mock.invocationCallOrder[0]);
+    expect(setProductSearchQuery.mock.invocationCallOrder.at(-1)).toBeLessThan(
+      onAddProduct.mock.invocationCallOrder[0],
+    );
   });
 
   it("creates additional SKU variants before adding the primary quick-add product to the cart", async () => {
@@ -201,7 +202,9 @@ describe("ProductEntry", () => {
       screen.getByRole("button", { name: /add product variants/i }),
     );
 
-    await waitFor(() => expect(quickAddProductSkuMock).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(quickAddProductSkuMock).toHaveBeenCalledTimes(2),
+    );
     expect(quickAddProductSkuMock).toHaveBeenNthCalledWith(1, {
       storeId: "store-1",
       createdByUserId: "user-1",
@@ -305,7 +308,7 @@ describe("ProductEntry", () => {
     renderProductEntryWithServices({ serviceEntry, setProductSearchQuery });
 
     await user.type(
-      screen.getByPlaceholderText(/lookup product by name/i),
+      screen.getByPlaceholderText(/lookup product or service by name/i),
       "closure",
     );
 
@@ -315,7 +318,7 @@ describe("ProductEntry", () => {
 
   it("adds a fixed-price service from explicit service lookup", async () => {
     const user = userEvent.setup();
-    const service = buildServiceResult();
+    const service = buildServiceResult({ name: "tokin" });
     const serviceEntry: RegisterServiceEntryState = {
       disabled: false,
       serviceSearchQuery: "closure",
@@ -334,10 +337,95 @@ describe("ProductEntry", () => {
       serviceEntry,
     });
 
-    await user.click(screen.getByRole("button", { name: /add service/i }));
+    expect(screen.getByText("Tokin")).toBeInTheDocument();
+    expect(document.querySelector(".lucide-scissors")).toBeInTheDocument();
+    expect(screen.queryByText("Add service")).not.toBeInTheDocument();
+    expect(screen.queryByText("No products found")).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /add tokin service/i }),
+    );
 
     expect(serviceEntry.onAddService).toHaveBeenCalledWith(service, undefined);
     expect(serviceEntry.setServiceSearchQuery).toHaveBeenCalledWith("");
+  });
+
+  it("disables service search results already in the cart", async () => {
+    const user = userEvent.setup();
+    const service = buildServiceResult({ name: "tokin" });
+    const serviceEntry: RegisterServiceEntryState = {
+      disabled: false,
+      serviceSearchQuery: "tokin",
+      setServiceSearchQuery: vi.fn(),
+      searchResults: [service],
+      isSearchLoading: false,
+      isSearchReady: true,
+      items: [
+        {
+          id: "service-line-1",
+          serviceCatalogId: service.serviceCatalogId,
+          name: service.name,
+          serviceMode: service.serviceMode,
+          pricingModel: service.pricingModel,
+          price: service.basePrice ?? 0,
+          quantity: 1,
+          amountRequired: false,
+        },
+      ],
+      onAddService: vi.fn(async () => true),
+      onUpdateServiceAmount: vi.fn(),
+      onRemoveService: vi.fn(),
+    };
+
+    renderProductEntryWithServices({
+      lookupMode: "service",
+      serviceEntry,
+    });
+
+    const serviceCard = screen.getByRole("button", {
+      name: /add tokin service/i,
+    });
+    expect(serviceCard).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByText("Already added")).toBeInTheDocument();
+
+    await user.click(serviceCard);
+
+    expect(serviceEntry.onAddService).not.toHaveBeenCalled();
+    expect(serviceEntry.setServiceSearchQuery).not.toHaveBeenCalled();
+  });
+
+  it("adds a fixed-price service from the unified register search", async () => {
+    const user = userEvent.setup();
+    const service = buildServiceResult();
+    const serviceEntry: RegisterServiceEntryState = {
+      disabled: false,
+      serviceSearchQuery: "closure",
+      setServiceSearchQuery: vi.fn(),
+      searchResults: [service],
+      isSearchLoading: false,
+      isSearchReady: true,
+      items: [],
+      onAddService: vi.fn(async () => true),
+      onUpdateServiceAmount: vi.fn(),
+      onRemoveService: vi.fn(),
+    };
+
+    renderProductEntryWithServices({
+      serviceEntry,
+    });
+
+    expect(screen.queryByText("Add service")).not.toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: /add closure repair service/i }),
+    );
+
+    expect(serviceEntry.onAddService).toHaveBeenCalledWith(service, undefined);
+    expect(serviceEntry.setServiceSearchQuery).toHaveBeenCalledWith("");
+    await waitFor(() =>
+      expect(
+        screen.getByPlaceholderText(/lookup product or service by name/i),
+      ).toHaveFocus(),
+    );
   });
 
   it("requires an entered amount before adding a starting-at service", async () => {
@@ -364,12 +452,15 @@ describe("ProductEntry", () => {
       serviceEntry,
     });
 
-    const addButton = screen.getByRole("button", { name: /add service/i });
-    expect(addButton).toBeDisabled();
+    const serviceCard = screen.getByRole("button", {
+      name: /add closure repair service/i,
+    });
+    expect(serviceCard).toHaveAttribute("aria-disabled", "true");
+    expect(screen.queryByText("Add service")).not.toBeInTheDocument();
 
     await user.type(screen.getByLabelText(/closure repair amount/i), "65");
-    expect(addButton).toBeEnabled();
-    await user.click(addButton);
+    expect(serviceCard).toHaveAttribute("aria-disabled", "false");
+    await user.click(serviceCard);
 
     expect(serviceEntry.onAddService).toHaveBeenCalledWith(service, 6500);
   });

--- a/packages/athena-webapp/src/components/pos/ProductEntry.tsx
+++ b/packages/athena-webapp/src/components/pos/ProductEntry.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/components/product/QuickAddProductDialog";
 import { normalizeQuickAddInitialLookupCode } from "@/components/product/quickAddProductDialogUtils";
 import type { QuickAddProductSubmitPayload } from "@/components/product/QuickAddProductDialog";
-import { ScanBarcode, Search, Wrench } from "lucide-react";
+import { ScanBarcode, Scissors, Search } from "lucide-react";
 import type { Product } from "./types";
 import type {
   RegisterLookupMode,
@@ -36,7 +36,7 @@ import {
   useState,
 } from "react";
 import { SearchResultsSection } from "./SearchResultsSection";
-import { cn } from "@/lib/utils";
+import { capitalizeWords, cn } from "@/lib/utils";
 import { useAuth } from "@/hooks/useAuth";
 import { toast } from "sonner";
 import {
@@ -89,13 +89,41 @@ const pricingModelLabels: Record<RegisterServicePricingModel, string> = {
   quote_after_consultation: "Quote after consultation",
 };
 
+function serviceSearchResultIsInCart(
+  serviceEntry: RegisterServiceEntryState,
+  service: RegisterServiceSearchResult,
+) {
+  const serviceCatalogId = service.serviceCatalogId?.toString();
+  const normalizedName = service.name.trim().toLowerCase();
+
+  return serviceEntry.items.some((item) => {
+    const itemCatalogId = item.serviceCatalogId?.toString();
+
+    if (serviceCatalogId && itemCatalogId) {
+      return serviceCatalogId === itemCatalogId;
+    }
+
+    if (serviceCatalogId || itemCatalogId) {
+      return false;
+    }
+
+    return (
+      item.name.trim().toLowerCase() === normalizedName &&
+      item.serviceMode === service.serviceMode &&
+      item.pricingModel === service.pricingModel
+    );
+  });
+}
+
 function ServiceSearchResults({
   formatter,
   isLoading,
+  onServiceAdded,
   serviceEntry,
 }: {
   formatter: Intl.NumberFormat;
   isLoading: boolean;
+  onServiceAdded?: () => void;
   serviceEntry: RegisterServiceEntryState;
 }) {
   const [amountInputs, setAmountInputs] = useState<Record<string, string>>({});
@@ -121,6 +149,7 @@ function ServiceSearchResults({
         delete next[service.id];
         return next;
       });
+      onServiceAdded?.();
     }
   };
 
@@ -133,7 +162,7 @@ function ServiceSearchResults({
       <div className="max-h-[586px] space-y-1 overflow-y-auto scrollbar-hide">
         <div className="flex h-full flex-col items-center justify-center py-8 text-center text-gray-500">
           <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-gray-100">
-            <Wrench className="h-6 w-6 text-gray-400" />
+            <Scissors className="h-6 w-6 text-gray-400" />
           </div>
           <p className="text-sm font-medium">No services found</p>
           <p className="mt-1 text-xs text-gray-400">
@@ -145,96 +174,135 @@ function ServiceSearchResults({
   }
 
   return (
-    <div className="max-h-[586px] space-y-2 overflow-y-auto pr-1 scrollbar-hide">
-      {serviceEntry.searchResults.map((service) => {
-        const requiresAmount =
-          service.pricingModel === "starting_at" ||
-          service.pricingModel === "quote_after_consultation";
-        const amountInput = amountInputs[service.id] ?? "";
-        const parsedAmount = amountInput.trim()
-          ? parseDisplayAmountInput(amountInput)
-          : undefined;
-        const canAdd = !requiresAmount || (parsedAmount ?? 0) > 0;
-        const priceLabel =
-          service.basePrice === undefined
-            ? pricingModelLabels[service.pricingModel]
-            : `${pricingModelLabels[service.pricingModel]} · ${formatStoredAmount(
-                formatter,
-                service.basePrice,
-              )}`;
-        const amountHelp =
-          service.pricingModel === "starting_at"
-            ? "Enter the service amount before adding."
-            : service.pricingModel === "quote_after_consultation"
-              ? "Enter the quoted amount before adding."
-              : null;
+    <div className="max-h-[586px] overflow-y-auto scrollbar-hide">
+      <div className="space-y-8 py-8">
+        {serviceEntry.searchResults.map((service) => {
+          const requiresAmount =
+            service.pricingModel === "starting_at" ||
+            service.pricingModel === "quote_after_consultation";
+          const amountInput = amountInputs[service.id] ?? "";
+          const parsedAmount = amountInput.trim()
+            ? parseDisplayAmountInput(amountInput)
+            : undefined;
+          const isAlreadyAdded = serviceSearchResultIsInCart(
+            serviceEntry,
+            service,
+          );
+          const canAdd =
+            !isAlreadyAdded && (!requiresAmount || (parsedAmount ?? 0) > 0);
+          const isDisabled = serviceEntry.disabled || isAlreadyAdded || !canAdd;
+          const priceLabel = pricingModelLabels[service.pricingModel];
+          const amountHelp =
+            service.pricingModel === "starting_at"
+              ? "Enter the service amount before adding."
+              : service.pricingModel === "quote_after_consultation"
+                ? "Enter the quoted amount before adding."
+                : null;
+          const handleCardClick = () => {
+            if (isDisabled) {
+              return;
+            }
+            void handleAddService(service);
+          };
+          const handleCardKeyDown = (
+            event: React.KeyboardEvent<HTMLDivElement>,
+          ) => {
+            if (event.key !== "Enter" && event.key !== " ") {
+              return;
+            }
+            event.preventDefault();
+            handleCardClick();
+          };
 
-        return (
-          <div
-            key={service.id}
-            className="rounded-lg border border-border bg-white p-4 shadow-sm"
-          >
-            <div className="flex items-start justify-between gap-3">
-              <div className="min-w-0 space-y-1">
-                <div className="flex flex-wrap items-center gap-2">
-                  <p className="truncate text-sm font-semibold text-foreground">
-                    {service.name}
-                  </p>
-                  <span className="rounded-full border border-border bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
-                    {serviceModeLabels[service.serviceMode]}
-                  </span>
+          return (
+            <div
+              key={service.id}
+              role="button"
+              tabIndex={isDisabled ? -1 : 0}
+              aria-disabled={isDisabled}
+              aria-label={`Add ${service.name} service`}
+              className={cn(
+                "group rounded-lg border bg-white/80 p-4 shadow-sm backdrop-blur-sm transition-all duration-200",
+                isDisabled
+                  ? "cursor-not-allowed border-gray-200 opacity-75"
+                  : "cursor-pointer border-gray-200 hover:border-blue-200 hover:shadow-md hover:shadow-blue-100/50",
+              )}
+              onClick={handleCardClick}
+              onKeyDown={handleCardKeyDown}
+            >
+              <div className="flex items-center gap-4">
+                <div className="flex h-16 w-16 flex-shrink-0 items-center justify-center overflow-hidden rounded bg-muted">
+                  <Scissors className="h-5 w-5 text-muted-foreground" />
                 </div>
-                <p className="text-xs text-muted-foreground">{priceLabel}</p>
-                {service.description ? (
-                  <p className="line-clamp-2 text-xs text-muted-foreground">
-                    {service.description}
-                  </p>
-                ) : null}
-              </div>
-              {!requiresAmount ? (
-                <Button
-                  type="button"
-                  size="sm"
-                  disabled={serviceEntry.disabled}
-                  onClick={() => void handleAddService(service)}
-                >
-                  Add service
-                </Button>
-              ) : null}
-            </div>
 
-            {requiresAmount ? (
-              <div className="mt-4 grid gap-2 sm:grid-cols-[minmax(0,1fr)_auto]">
-                <div className="space-y-1">
-                  <Input
-                    aria-label={`${service.name} amount`}
-                    inputMode="decimal"
-                    placeholder="Amount"
-                    value={amountInput}
-                    disabled={serviceEntry.disabled}
-                    onChange={(event) =>
-                      handleAmountChange(service.id, event.target.value)
-                    }
-                  />
-                  {amountHelp ? (
-                    <p className="text-xs text-muted-foreground">
-                      {amountHelp}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="truncate text-md font-semibold text-gray-600 group-hover:text-gray-900">
+                          {capitalizeWords(service.name)}
+                        </p>
+                        <span className="rounded-full border border-border bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+                          {serviceModeLabels[service.serviceMode]}
+                        </span>
+                        {isAlreadyAdded ? (
+                          <span className="rounded-full border border-action-workflow-border bg-action-workflow-soft px-2 py-0.5 text-[11px] font-medium text-action-workflow">
+                            Already added
+                          </span>
+                        ) : null}
+                      </div>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {priceLabel}
+                      </p>
+                    </div>
+                    {service.basePrice !== undefined ? (
+                      <p className="flex-shrink-0 px-4 text-lg font-medium">
+                        {formatStoredAmount(formatter, service.basePrice)}
+                      </p>
+                    ) : null}
+                  </div>
+                  {service.description ? (
+                    <p className="mt-2 line-clamp-2 text-xs text-muted-foreground">
+                      {service.description}
                     </p>
                   ) : null}
                 </div>
-                <Button
-                  type="button"
-                  size="sm"
-                  disabled={serviceEntry.disabled || !canAdd}
-                  onClick={() => void handleAddService(service)}
-                >
-                  Add service
-                </Button>
               </div>
-            ) : null}
-          </div>
-        );
-      })}
+
+              {requiresAmount ? (
+                <div
+                  className="mt-4 pl-20"
+                  onClick={(event) => event.stopPropagation()}
+                >
+                  <div className="space-y-1">
+                    <Input
+                      aria-label={`${service.name} amount`}
+                      inputMode="decimal"
+                      placeholder="Amount"
+                      value={amountInput}
+                      disabled={serviceEntry.disabled || isAlreadyAdded}
+                      onChange={(event) =>
+                        handleAmountChange(service.id, event.target.value)
+                      }
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" && canAdd) {
+                          event.preventDefault();
+                          void handleAddService(service);
+                        }
+                      }}
+                    />
+                    {amountHelp ? (
+                      <p className="text-xs text-muted-foreground">
+                        {amountHelp}
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }
@@ -250,7 +318,7 @@ export const ProductSearchInput = forwardRef<
     onBarcodeSubmit,
     className,
     inputClassName,
-    placeholder = "Lookup product by name, bar/qr code, sku, or product url...",
+    placeholder = "Lookup product or service by name, bar/qr code, sku, or product url...",
   },
   ref,
 ) {
@@ -337,8 +405,6 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
       resultsClassName,
       onQuickAddOpenChange,
       forceQuickAddHost = false,
-      lookupMode = "product",
-      setLookupMode,
       serviceEntry,
     },
     ref,
@@ -358,16 +424,17 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
     const inputIsUrlOrBarcode = isUrlOrBarcode(productSearchQuery);
 
     const formatter = currencyFormatter(activeStore?.currency || "GHS");
-    const activeLookupMode: RegisterLookupMode =
-      serviceEntry && lookupMode === "service" ? "service" : "product";
-    const activeSearchQuery =
-      activeLookupMode === "service"
-        ? serviceEntry?.serviceSearchQuery ?? ""
-        : productSearchQuery;
-    const setActiveSearchQuery =
-      activeLookupMode === "service" && serviceEntry
-        ? serviceEntry.setServiceSearchQuery
-        : setProductSearchQuery;
+    const serviceSearchQuery = serviceEntry?.serviceSearchQuery ?? "";
+    const shouldShowServiceResults =
+      Boolean(serviceEntry) &&
+      serviceSearchQuery.trim().length > 0 &&
+      serviceEntry!.searchResults.length > 0 &&
+      !inputIsUrlOrBarcode;
+    const shouldShowProductResults =
+      Boolean(productSearchQuery) &&
+      (!shouldShowServiceResults ||
+        searchResults.length > 0 ||
+        isSearchLoading);
 
     // Handler to clear search after adding product
     const handleClearSearch = () => {
@@ -400,31 +467,39 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
       [formatter, registerCatalog],
     );
 
-    const handleOpenQuickAdd = useCallback((selectedProduct?: Product) => {
-      if (!canQuickAddProduct) {
-        return;
-      }
+    const handleOpenQuickAdd = useCallback(
+      (selectedProduct?: Product) => {
+        if (!canQuickAddProduct) {
+          return;
+        }
 
-      const rawQuery = productSearchQuery.trim();
-      const extractedQuery = extractBarcodeFromInput(rawQuery).value.trim();
+        const rawQuery = productSearchQuery.trim();
+        const extractedQuery = extractBarcodeFromInput(rawQuery).value.trim();
 
-      setQuickAddInitialName(
-        selectedProduct?.name || (inputIsUrlOrBarcode ? "" : rawQuery),
-      );
-      setQuickAddInitialLookupCode(
-        normalizeQuickAddInitialLookupCode(extractedQuery),
-      );
-      setQuickAddSourceProduct(
-        selectedProduct && selectedProduct.productId ? selectedProduct : null,
-      );
-      setIsQuickAddOpen(true);
-      onQuickAddOpenChange?.(true);
-    }, [
-      canQuickAddProduct,
-      inputIsUrlOrBarcode,
-      onQuickAddOpenChange,
-      productSearchQuery,
-    ]);
+        setQuickAddInitialName(
+          selectedProduct?.name || (inputIsUrlOrBarcode ? "" : rawQuery),
+        );
+        setQuickAddInitialLookupCode(
+          normalizeQuickAddInitialLookupCode(extractedQuery),
+        );
+        setQuickAddSourceProduct(
+          selectedProduct && selectedProduct.productId ? selectedProduct : null,
+        );
+        setIsQuickAddOpen(true);
+        onQuickAddOpenChange?.(true);
+      },
+      [
+        canQuickAddProduct,
+        inputIsUrlOrBarcode,
+        onQuickAddOpenChange,
+        productSearchQuery,
+      ],
+    );
+
+    const refocusProductSearchInput = useCallback(() => {
+      productSearchInputRef.current?.focus();
+      productSearchInputRef.current?.select();
+    }, []);
 
     useImperativeHandle(
       ref,
@@ -564,7 +639,7 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
       !showProductLookup ||
       (!showSearchInput &&
         !productSearchQuery &&
-        !serviceEntry?.serviceSearchQuery &&
+        !serviceSearchQuery &&
         !isQuickAddOpen &&
         !forceQuickAddHost)
     ) {
@@ -583,64 +658,26 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
           >
             {showSearchInput && (
               <div className="space-y-3">
-                {serviceEntry ? (
-                  <div className="inline-flex rounded-lg border border-border bg-white p-1">
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant={
-                        activeLookupMode === "product" ? "default" : "ghost"
-                      }
-                      onClick={() => setLookupMode?.("product")}
-                    >
-                      Products
-                    </Button>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant={
-                        activeLookupMode === "service" ? "default" : "ghost"
-                      }
-                      onClick={() => setLookupMode?.("service")}
-                    >
-                      Services
-                    </Button>
-                  </div>
-                ) : null}
                 <ProductSearchInput
                   ref={productSearchInputRef}
-                  disabled={
-                    activeLookupMode === "service"
-                      ? serviceEntry?.disabled
-                      : disabled || isQuickAddOpen
-                  }
-                  productSearchQuery={activeSearchQuery}
-                  setProductSearchQuery={setActiveSearchQuery}
-                  onBarcodeSubmit={
-                    activeLookupMode === "service"
-                      ? (event) => event.preventDefault()
-                      : onBarcodeSubmit
-                  }
-                  placeholder={
-                    activeLookupMode === "service"
-                      ? "Search services by name or service type..."
-                      : undefined
-                  }
+                  disabled={disabled || isQuickAddOpen}
+                  productSearchQuery={productSearchQuery}
+                  setProductSearchQuery={setProductSearchQuery}
+                  onBarcodeSubmit={onBarcodeSubmit}
                 />
               </div>
             )}
 
-            {activeLookupMode === "service" &&
-            serviceEntry &&
-            activeSearchQuery ? (
+            {shouldShowServiceResults && serviceEntry ? (
               <ServiceSearchResults
                 formatter={formatter}
                 isLoading={serviceEntry.isSearchLoading}
+                onServiceAdded={refocusProductSearchInput}
                 serviceEntry={serviceEntry}
               />
             ) : null}
 
-            {activeLookupMode === "product" && productSearchQuery && (
+            {shouldShowProductResults ? (
               <SearchResultsSection
                 isLoading={isSearchLoading}
                 products={searchResults}
@@ -656,7 +693,7 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
                 quickAddShortcutDisabled={isQuickAddOpen}
                 className={resultsClassName}
               />
-            )}
+            ) : null}
           </div>
         </div>
 

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -52,12 +52,12 @@ vi.mock("@tanstack/react-router", () => ({
             orgUrlSlug: "$orgUrlSlug",
             sessionId: "$sessionId",
             storeUrlSlug: "$storeUrlSlug",
+            terminalId: "$terminalId",
           })
         : params;
-    const href = to.replace(
-      "$sessionId",
-      resolvedParams?.sessionId ?? "$sessionId",
-    );
+    const href = to
+      .replace("$sessionId", resolvedParams?.sessionId ?? "$sessionId")
+      .replace("$terminalId", resolvedParams?.terminalId ?? "$terminalId");
     const query = search ? `?${new URLSearchParams(search)}` : "";
 
     return <a href={`${href}${query}`}>{children}</a>;
@@ -106,6 +106,7 @@ vi.mock("@/components/pos/ProductEntry", async () => {
       (
         {
           onAddProduct,
+          serviceEntry,
         }: {
           onAddProduct?: (product: {
             id: string;
@@ -114,6 +115,17 @@ vi.mock("@/components/pos/ProductEntry", async () => {
             productId: string;
             skuId: string;
           }) => boolean | Promise<boolean>;
+          serviceEntry?: {
+            onAddService?: (
+              service: {
+                id: string;
+                name: string;
+                serviceMode: "repair";
+                pricingModel: "fixed";
+              },
+              amount?: number,
+            ) => boolean | Promise<boolean>;
+          };
         },
         ref,
       ) => {
@@ -139,6 +151,21 @@ vi.mock("@/components/pos/ProductEntry", async () => {
                 }
               >
                 mock-add-product
+              </button>
+            ) : null}
+            {serviceEntry?.onAddService ? (
+              <button
+                type="button"
+                onClick={() =>
+                  void serviceEntry.onAddService?.({
+                    id: "service-1",
+                    name: "Repair",
+                    serviceMode: "repair",
+                    pricingModel: "fixed",
+                  })
+                }
+              >
+                mock-add-service
               </button>
             ) : null}
           </div>
@@ -343,6 +370,77 @@ describe("POSRegisterView", () => {
     expect(screen.queryByText("cashier-auth-dialog")).not.toBeInTheDocument();
   });
 
+  it("returns focus to the header product search after adding a service", async () => {
+    const onAddService = vi.fn(async () => true);
+    mockUseRegisterViewModel.mockReturnValue({
+      hasActiveStore: true,
+      header: {
+        title: "POS",
+        isSessionActive: true,
+      },
+      registerInfo: {
+        registerLabel: "Front Counter",
+        hasTerminal: true,
+      },
+      customerPanel: {},
+      productEntry: {
+        disabled: false,
+        productSearchQuery: "repair",
+        setProductSearchQuery: vi.fn(),
+        onBarcodeSubmit: vi.fn(),
+        onAddProduct: vi.fn(async () => true),
+        searchResults: [],
+        isSearchLoading: false,
+        isSearchReady: true,
+        canQuickAddProduct: false,
+      },
+      serviceEntry: {
+        disabled: false,
+        serviceSearchQuery: "repair",
+        setServiceSearchQuery: vi.fn(),
+        searchResults: [],
+        isSearchLoading: false,
+        isSearchReady: true,
+        items: [],
+        onAddService,
+        onUpdateServiceAmount: vi.fn(),
+        onRemoveService: vi.fn(),
+      },
+      cart: {
+        items: [],
+      },
+      checkout: {
+        isTransactionCompleted: false,
+      },
+      sessionPanel: {},
+      cashierCard: {
+        cashierName: "Ato K.",
+        onSignOut: vi.fn(),
+      },
+      closeoutControl: null,
+      authDialog: {
+        open: false,
+      },
+      drawerGate: null,
+      onNavigateBack: vi.fn(),
+    });
+
+    const { POSRegisterView } = await import("./POSRegisterView");
+    render(<POSRegisterView />);
+
+    const searchInput = screen.getByLabelText("product search input");
+    searchInput.blur();
+    expect(searchInput).not.toHaveFocus();
+
+    await userEvent.click(screen.getByRole("button", { name: "mock-add-service" }));
+
+    await waitFor(() => expect(searchInput).toHaveFocus());
+    expect(onAddService).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "service-1" }),
+      undefined,
+    );
+  });
+
   it("renders local-only register context with debug state instead of the blank shell", async () => {
     mockUseRegisterViewModel.mockReturnValue({
       hasActiveStore: true,
@@ -518,9 +616,15 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("next sync step")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Use pending sync retry to settle uploaded review events; resolve any remaining server review, then retry again.",
+        "Use pending sync retry to settle uploaded review events; if the count stays put, open terminal health to review server conflicts.",
       ),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /open terminal health/i }),
+    ).toHaveAttribute(
+      "href",
+      expect.stringContaining("/pos/terminals/terminal-1"),
+    );
     expect(screen.getByText("runtime mode")).toBeInTheDocument();
     expect(screen.getByText("Status only")).toBeInTheDocument();
     expect(screen.getByText("check-in publish")).toBeInTheDocument();
@@ -844,6 +948,9 @@ describe("POSRegisterView", () => {
     );
 
     expect(screen.getByText("Ready for product lookup")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /add service/i }),
+    ).not.toBeInTheDocument();
     expect(setShowProductLookup).toHaveBeenCalledWith(true);
     await waitFor(() => expect(mockOpenQuickAddProduct).toHaveBeenCalled());
   });
@@ -896,6 +1003,9 @@ describe("POSRegisterView", () => {
 
     expect(
       screen.queryByRole("button", { name: /quick add product/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /add service/i }),
     ).not.toBeInTheDocument();
   });
 

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -28,15 +28,14 @@ import {
   ScanBarcode,
   Search,
   ShoppingBasket,
-  Wrench,
   Settings,
   Users,
 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
-  type RegisterLookupMode,
+  type RegisterServiceSearchResult,
   type RegisterViewModel,
   type RegisterWorkflowMode,
 } from "@/lib/pos/presentation/register/registerUiState";
@@ -87,13 +86,11 @@ function ProductLookupEmptyState({
   canQuickAddProduct = false,
   onActivate,
   onQuickAddProduct,
-  onServiceLookup,
   workflowMode,
 }: {
   canQuickAddProduct?: boolean;
   onActivate?: () => void;
   onQuickAddProduct?: () => void;
-  onServiceLookup?: () => void;
   workflowMode: RegisterWorkflowMode;
 }) {
   const isExpenseWorkflow = workflowMode === "expense";
@@ -144,18 +141,6 @@ function ProductLookupEmptyState({
           >
             <PackagePlus className="h-3.5 w-3.5" />
             Quick add product
-          </Button>
-        ) : null}
-        {!isExpenseWorkflow && onServiceLookup ? (
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="h-7 gap-1.5 rounded-full bg-surface px-3 text-xs"
-            onClick={onServiceLookup}
-          >
-            <Wrench className="h-3.5 w-3.5" />
-            Add service
           </Button>
         ) : null}
       </div>
@@ -422,7 +407,7 @@ function getDebugSyncNextStep(debug: NonNullable<RegisterViewModel["debug"]>) {
   const retryableCount = debug.syncFlow.pendingUploadEventCount ?? 0;
 
   if (debug.syncFlow.status === "needs_review" && retryableCount > 0) {
-    return "Use pending sync retry to settle uploaded review events; resolve any remaining server review, then retry again.";
+    return "Use pending sync retry to settle uploaded review events; if the count stays put, open terminal health to review server conflicts.";
   }
 
   if (debug.syncFlow.status === "needs_review") {
@@ -695,6 +680,25 @@ function POSLocalDebugStrip({
           </div>
         ))}
       </div>
+      {debug.terminalId ? (
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <Button asChild size="sm" variant="utility">
+            <Link
+              params={(params) => ({
+                ...params,
+                orgUrlSlug: params.orgUrlSlug!,
+                storeUrlSlug: params.storeUrlSlug!,
+                terminalId: debug.terminalId!,
+              })}
+              search={{ o: getOrigin() }}
+              to="/$orgUrlSlug/store/$storeUrlSlug/pos/terminals/$terminalId"
+            >
+              Open terminal health
+              <ArrowRight aria-hidden className="h-3.5 w-3.5" />
+            </Link>
+          </Button>
+        </div>
+      ) : null}
       <dl className="mt-2 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
         {rows.map(([label, value]) => (
           <div key={label} className="min-w-0">
@@ -920,7 +924,6 @@ export function POSRegisterView({
   const [isPaymentsListExpanded, setIsPaymentsListExpanded] = useState(false);
   const [isEmptyStateQuickAddActive, setIsEmptyStateQuickAddActive] =
     useState(false);
-  const [lookupMode, setLookupMode] = useState<RegisterLookupMode>("product");
   const productEntryRef = useRef<ProductEntryHandle>(null);
   const pendingEmptyStateQuickAddRef = useRef(false);
   const headerProductSearchInputRef = useRef<HTMLInputElement>(null);
@@ -937,12 +940,7 @@ export function POSRegisterView({
   const hasProductSearchIntent =
     (viewModel.productEntry?.productSearchQuery ?? "").trim().length > 0;
   const hasServiceSearchIntent =
-    lookupMode === "service" &&
     (viewModel.serviceEntry?.serviceSearchQuery ?? "").trim().length > 0;
-  const shouldShowServiceLookup =
-    isPosWorkflow &&
-    lookupMode === "service" &&
-    viewModel.productEntry?.showProductLookup;
   const hasLookupIntent = hasProductSearchIntent || hasServiceSearchIntent;
   const cartItemCount =
     (viewModel.cart?.items?.reduce((sum, item) => sum + item.quantity, 0) ??
@@ -1001,7 +999,6 @@ export function POSRegisterView({
     shouldRenderSaleSurface &&
     cartItemCount > 0 &&
     !hasLookupIntent &&
-    !shouldShowServiceLookup &&
     !shouldShowPaymentWorkspace &&
     !isPaymentEditActive &&
     !isPaymentsListExpanded &&
@@ -1112,24 +1109,10 @@ export function POSRegisterView({
       return;
     }
 
-    setLookupMode("product");
     viewModel.productEntry?.setShowProductLookup?.(true);
     headerProductSearchInputRef.current?.focus();
     headerProductSearchInputRef.current?.select();
   }, [isHeaderProductSearchSupported, viewModel.productEntry]);
-
-  const handleServiceLookupEmptyStateActivate = useCallback(() => {
-    if (!isHeaderProductSearchSupported || !viewModel.serviceEntry) {
-      return;
-    }
-
-    setLookupMode("service");
-    viewModel.productEntry?.setShowProductLookup?.(true);
-  }, [
-    isHeaderProductSearchSupported,
-    viewModel.productEntry,
-    viewModel.serviceEntry,
-  ]);
 
   const handleProductLookupEmptyStateQuickAdd = useCallback(() => {
     if (
@@ -1155,6 +1138,10 @@ export function POSRegisterView({
     isHeaderProductSearchSupported,
     viewModel.productEntry,
   ]);
+
+  const handleCompletionBlockAction = useCallback(() => {
+    viewModel.customerPanel.onOpenChange(true);
+  }, [viewModel.customerPanel]);
 
   useEffect(() => {
     if (!pendingEmptyStateQuickAddRef.current || !isEmptyStateQuickAddActive) {
@@ -1189,6 +1176,33 @@ export function POSRegisterView({
     [focusHeaderProductSearch, viewModel.productEntry],
   );
 
+  const handleAddService = useCallback(
+    async (service: RegisterServiceSearchResult, amount?: number) => {
+      if (!viewModel.serviceEntry) {
+        return false;
+      }
+
+      const added = await viewModel.serviceEntry.onAddService(service, amount);
+      if (added !== false) {
+        focusHeaderProductSearch();
+      }
+
+      return added;
+    },
+    [focusHeaderProductSearch, viewModel.serviceEntry],
+  );
+
+  const productEntryServiceEntry = useMemo(
+    () =>
+      viewModel.serviceEntry
+        ? {
+            ...viewModel.serviceEntry,
+            onAddService: handleAddService,
+          }
+        : undefined,
+    [handleAddService, viewModel.serviceEntry],
+  );
+
   const renderProductEntry = ({
     containerClassName = "h-full min-h-0",
     forceQuickAddHost = false,
@@ -1215,10 +1229,8 @@ export function POSRegisterView({
       canQuickAddProduct={viewModel.productEntry.canQuickAddProduct}
       onQuickAddOpenChange={setIsEmptyStateQuickAddActive}
       forceQuickAddHost={forceQuickAddHost}
-      lookupMode={lookupMode}
-      setLookupMode={setLookupMode}
-      serviceEntry={viewModel.serviceEntry}
-      showSearchInput={lookupMode === "service"}
+      serviceEntry={productEntryServiceEntry}
+      showSearchInput={false}
       containerClassName={containerClassName}
       lookupPanelClassName={lookupPanelClassName}
       resultsClassName={resultsClassName}
@@ -1294,10 +1306,7 @@ export function POSRegisterView({
                   ref={headerProductSearchInputRef}
                   disabled={!isHeaderProductSearchSupported}
                   productSearchQuery={viewModel.productEntry.productSearchQuery}
-                  setProductSearchQuery={(query) => {
-                    setLookupMode("product");
-                    viewModel.productEntry.setProductSearchQuery(query);
-                  }}
+                  setProductSearchQuery={viewModel.productEntry.setProductSearchQuery}
                   onBarcodeSubmit={viewModel.productEntry.onBarcodeSubmit}
                   className="max-w-[800px] flex-1"
                   inputClassName="h-14"
@@ -1374,7 +1383,7 @@ export function POSRegisterView({
                     clearCart={viewModel.cart.onClearCart}
                     density="comfortable"
                   />
-                ) : hasLookupIntent || shouldShowServiceLookup ? (
+                ) : hasLookupIntent ? (
                   <div className="min-h-0 flex-1">
                     {renderProductEntry()}
                   </div>
@@ -1393,11 +1402,6 @@ export function POSRegisterView({
                         isHeaderProductSearchSupported &&
                         viewModel.productEntry.canQuickAddProduct
                           ? handleProductLookupEmptyStateQuickAdd
-                          : undefined
-                      }
-                      onServiceLookup={
-                        viewModel.serviceEntry
-                          ? handleServiceLookupEmptyStateActivate
                           : undefined
                       }
                       workflowMode={effectiveWorkflowMode}
@@ -1436,11 +1440,6 @@ export function POSRegisterView({
                         isHeaderProductSearchSupported &&
                         viewModel.productEntry.canQuickAddProduct
                           ? handleProductLookupEmptyStateQuickAdd
-                          : undefined
-                      }
-                      onServiceLookup={
-                        viewModel.serviceEntry
-                          ? handleServiceLookupEmptyStateActivate
                           : undefined
                       }
                       workflowMode={effectiveWorkflowMode}
@@ -1498,16 +1497,12 @@ export function POSRegisterView({
                           : "shrink-0",
                       )}
                     >
-                      {viewModel.serviceEntry?.checkoutBlockMessage ? (
-                        <div className="mb-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
-                          {viewModel.serviceEntry.checkoutBlockMessage}
-                        </div>
-                      ) : null}
                       {isPosWorkflow ? (
                         <RegisterCheckoutPanel
                           checkout={viewModel.checkout}
                           onPaymentFlowChange={handlePaymentFlowChange}
                           onPaymentEntryStart={handlePaymentEntryStart}
+                          onCompletionBlockAction={handleCompletionBlockAction}
                           onEditingPaymentChange={handleEditingPaymentChange}
                           hidePaymentItemCountSummary={
                             shouldShowCartSummarySidebar

--- a/packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterCheckoutPanel.tsx
@@ -12,6 +12,7 @@ interface RegisterCheckoutPanelProps {
   checkout: RegisterCheckoutState;
   onPaymentFlowChange?: (isActive: boolean) => void;
   onPaymentEntryStart?: () => void;
+  onCompletionBlockAction?: () => void;
   onEditingPaymentChange?: (isEditing: boolean) => void;
   hidePaymentItemCountSummary?: boolean;
   hideActiveSummaryCards?: boolean;
@@ -23,6 +24,7 @@ export function RegisterCheckoutPanel({
   checkout,
   onPaymentFlowChange,
   onPaymentEntryStart,
+  onCompletionBlockAction,
   onEditingPaymentChange,
   hidePaymentItemCountSummary = false,
   hideActiveSummaryCards = false,
@@ -60,6 +62,7 @@ export function RegisterCheckoutPanel({
         hasTerminal={checkout.hasTerminal}
         isTransactionCompleted={checkout.isTransactionCompleted}
         completedOrderNumber={checkout.completedOrderNumber}
+        completionBlockMessage={checkout.completionBlockMessage}
         completedTransactionData={checkout.completedTransactionData}
         cashierName={checkout.cashierName}
         actorStaffProfileId={checkout.actorStaffProfileId}
@@ -74,6 +77,7 @@ export function RegisterCheckoutPanel({
         }
         onPaymentFlowChange={onPaymentFlowChange}
         onPaymentEntryStart={onPaymentEntryStart}
+        onCompletionBlockAction={onCompletionBlockAction}
         onEditingPaymentChange={onEditingPaymentChange}
         hidePaymentItemCountSummary={hidePaymentItemCountSummary}
         hideActiveSummaryCards={hideActiveSummaryCards}

--- a/packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.test.tsx
@@ -113,6 +113,27 @@ describe("RegisterCustomerAttribution", () => {
     ).toBeInTheDocument();
   });
 
+  it("opens the customer lookup from a controlled parent state", () => {
+    render(
+      <RegisterCustomerAttribution
+        customerInfo={{
+          customerProfileId: undefined,
+          name: "",
+          email: "",
+          phone: "",
+        }}
+        isOpen
+        onOpenChange={vi.fn()}
+        onCustomerCommitted={vi.fn().mockResolvedValue(undefined)}
+        setCustomerInfo={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByPlaceholderText("Name, phone, or email"),
+    ).toBeInTheDocument();
+  });
+
   it("disables the entire attribution flow when active store session is not active", async () => {
     const user = userEvent.setup();
 
@@ -144,6 +165,10 @@ describe("RegisterCustomerAttribution", () => {
     expect(
       screen.getByRole("button", { name: /Ama Serwa/ }),
     ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Ama Serwa/ })).toHaveClass(
+      "min-h-12",
+      "py-3",
+    );
     expect(
       screen.getByRole("button", { name: 'Add "ama"' }),
     ).toBeInTheDocument();

--- a/packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterCustomerAttribution.tsx
@@ -12,9 +12,7 @@ import {
   Plus,
   Search,
   User,
-  User2,
   UserCheck,
-  UserRound,
   X,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -27,6 +25,8 @@ interface RegisterCustomerAttributionProps {
     customer: CustomerInfo | ((currentCustomer: CustomerInfo) => CustomerInfo),
   ) => void;
   disabled?: boolean;
+  isOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 const EMPTY_CUSTOMER_INFO: CustomerInfo = {
@@ -90,13 +90,17 @@ export function RegisterCustomerAttribution({
   onCustomerCommitted,
   setCustomerInfo,
   disabled = false,
+  isOpen,
+  onOpenChange,
 }: RegisterCustomerAttributionProps) {
   const { activeStore } = useGetActiveStore();
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [uncontrolledIsExpanded, setUncontrolledIsExpanded] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [isAddingCustomer, setIsAddingCustomer] = useState(false);
   const [inlineError, setInlineError] = useState<string | null>(null);
   const addOperationVersionRef = useRef(0);
+  const isExpanded = isOpen ?? uncontrolledIsExpanded;
+  const setIsExpanded = onOpenChange ?? setUncontrolledIsExpanded;
 
   const normalizedCustomer = useMemo(
     () => trimCustomerInfo(customerInfo),
@@ -266,6 +270,7 @@ export function RegisterCustomerAttribution({
               className="h-8 px-3 text-xs"
               disabled={disabled}
               onClick={() => setIsExpanded(true)}
+              variant="workflow-soft"
             >
               <Search className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
               Find or add customer
@@ -352,7 +357,7 @@ export function RegisterCustomerAttribution({
           )}
 
           {trimmedSearchQuery && searchResults.length > 0 && (
-            <div className="mt-2 grid gap-1">
+            <div className="mt-2 grid gap-2">
               {searchResults.map((customer) => {
                 const customerIdentifier = customer.email || customer.phone;
 
@@ -361,7 +366,7 @@ export function RegisterCustomerAttribution({
                     key={customer._id}
                     type="button"
                     className={cn(
-                      "flex min-w-0 items-center justify-between gap-3 rounded-md border border-transparent px-3 py-2 text-left text-sm hover:border-border hover:bg-white focus:outline-none focus:ring-2 focus:ring-ring",
+                      "flex min-h-12 min-w-0 items-center justify-between gap-3 rounded-lg border border-transparent px-3.5 py-3 text-left text-sm hover:border-border hover:bg-white focus:outline-none focus:ring-2 focus:ring-ring",
                       disabled && "opacity-60",
                     )}
                     disabled={disabled}

--- a/packages/athena-webapp/src/components/pos/register/RegisterCustomerPanel.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterCustomerPanel.tsx
@@ -13,6 +13,8 @@ export function RegisterCustomerPanel({
   return (
     <RegisterCustomerAttribution
       customerInfo={customerPanel.customerInfo}
+      isOpen={customerPanel.isOpen}
+      onOpenChange={customerPanel.onOpenChange}
       onCustomerCommitted={customerPanel.onCustomerCommitted}
       setCustomerInfo={customerPanel.setCustomerInfo}
       disabled={disabled}

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx
@@ -163,8 +163,10 @@ describe("RegisterDrawerGate", () => {
   it("shows drawer authority repair copy and sign-out action", async () => {
     const user = userEvent.setup();
     const onSignOut = vi.fn();
+    const onRetrySync = vi.fn();
     renderGate({
       mode: "drawerAuthorityRepair",
+      onRetrySync,
       onSignOut,
     });
 
@@ -172,6 +174,9 @@ describe("RegisterDrawerGate", () => {
     expect(
       screen.getByText("Drawer needs repair"),
     ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Retry sync" }));
+    expect(onRetrySync).toHaveBeenCalledTimes(1);
 
     await user.click(screen.getByRole("button", { name: "Sign out" }));
 

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
@@ -1,5 +1,10 @@
 import type { FormEvent } from "react";
-import { ArrowRightIcon, Clock3Icon, LogOutIcon } from "lucide-react";
+import {
+  ArrowRightIcon,
+  Clock3Icon,
+  LogOutIcon,
+  RefreshCwIcon,
+} from "lucide-react";
 import { Link } from "@tanstack/react-router";
 
 import { Button } from "@/components/ui/button";
@@ -121,6 +126,16 @@ export function RegisterDrawerGate({
             </p>
           </div>
           <div className="flex flex-wrap gap-2 pt-2">
+            {!isTerminalRepair && drawerGate.onRetrySync ? (
+              <Button
+                type="button"
+                variant="default"
+                onClick={drawerGate.onRetrySync}
+              >
+                <RefreshCwIcon className="mr-2 h-4 w-4" />
+                Retry sync
+              </Button>
+            ) : null}
             <Button type="button" variant="outline" onClick={drawerGate.onSignOut}>
               <LogOutIcon className="mr-2 h-4 w-4" />
               Sign out

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.test.tsx
@@ -343,13 +343,21 @@ vi.mock("../OrderSummary", () => ({
 vi.mock("../CartItems", () => ({
   CartItems: ({
     cartItems,
+    serviceItems = [],
   }: {
     cartItems: Array<{ name: string; price: number; quantity: number }>;
+    serviceItems?: Array<{ name: string; price: number; quantity: number }>;
   }) => (
     <div data-testid="cart-items">
       {cartItems.map((item) => (
         <span key={item.name}>
           {item.name} qty {item.quantity} total {item.price * item.quantity}
+        </span>
+      ))}
+      {serviceItems.map((item) => (
+        <span key={`service-${item.name}`}>
+          {item.name} service qty {item.quantity} total{" "}
+          {item.price * item.quantity}
         </span>
       ))}
     </div>
@@ -598,6 +606,47 @@ describe("TransactionView", () => {
     expect(screen.getByText("Customer")).toBeInTheDocument();
     expect(screen.getByText("Ama Mensah")).toBeInTheDocument();
     expect(screen.getByText("ama@example.com • 0240000000")).toBeInTheDocument();
+  });
+
+  it("renders service lines in the main transaction items list", () => {
+    useParamsMock.mockReturnValue({ transactionId: "txn_service_items" });
+    useQueryMock.mockReturnValue({
+      ...baseTransaction,
+      _id: "txn_service_items",
+      items: [
+        {
+          _id: "item_1",
+          productId: "product_1",
+          productName: "Bacca",
+          productSku: "6N2Y-D3-4RC",
+          productSkuId: "sku_1",
+          quantity: 1,
+          totalPrice: 150,
+          unitPrice: 150,
+        },
+      ],
+      serviceLines: [
+        {
+          id: "service_line_1",
+          name: "tokin",
+          quantity: 2,
+          serviceMode: "revamp",
+          servicePaymentStatus: "paid",
+          totalPrice: 800,
+          unitPrice: 400,
+        },
+      ],
+    });
+
+    render(<TransactionView />);
+
+    expect(screen.getByTestId("cart-items")).toHaveTextContent(
+      "Bacca qty 1 total 150",
+    );
+    expect(screen.getByTestId("cart-items")).toHaveTextContent(
+      "tokin service qty 2 total 800",
+    );
+    expect(screen.queryByText("Service lines")).not.toBeInTheDocument();
   });
 
   it("renders fallback customer info without an email and phone separator", () => {

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionView.tsx
@@ -29,6 +29,7 @@ import type { ReceiptDeliveryHistoryEntry } from "../receipt/PosReceiptShareCont
 import { CartItems } from "../CartItems";
 import type { CartItem, PosServiceReceiptLine } from "../types";
 import type { Id } from "~/convex/_generated/dataModel";
+import type { RegisterServiceLineState } from "~/src/lib/pos/presentation/register/registerUiState";
 import { CardContent, CardHeader } from "../../ui/card";
 import { WorkflowTraceRouteLink } from "../../traces/WorkflowTraceRouteLink";
 import { Button } from "../../ui/button";
@@ -123,6 +124,41 @@ const PAYMENT_METHOD_OPTIONS = [
 const ghsCurrencyFormatter = currencyFormatter("GHS");
 const REGISTER_EXPECTED_CASH_ERROR =
   "Register session expected cash cannot be negative.";
+
+function normalizeReceiptServiceMode(
+  value: PosServiceReceiptLine["serviceMode"],
+): RegisterServiceLineState["serviceMode"] {
+  if (
+    value === "consultation" ||
+    value === "repair" ||
+    value === "revamp" ||
+    value === "same_day"
+  ) {
+    return value;
+  }
+
+  return "same_day";
+}
+
+function receiptServiceLineToCartServiceLine(
+  line: PosServiceReceiptLine,
+): RegisterServiceLineState {
+  const quantity = line.quantity && line.quantity > 0 ? line.quantity : 1;
+  const unitPrice =
+    line.unitPrice && line.unitPrice > 0
+      ? line.unitPrice
+      : Math.round(line.totalPrice / quantity);
+
+  return {
+    id: line.id,
+    name: line.name,
+    serviceMode: normalizeReceiptServiceMode(line.serviceMode),
+    pricingModel: "fixed",
+    price: unitPrice,
+    quantity,
+    amountRequired: false,
+  };
+}
 
 function isAdjustedLineItem(line: {
   adjustedQuantity?: number;
@@ -563,10 +599,18 @@ export function TransactionView() {
   const displayCartItems = hasAppliedItemAdjustment
     ? adjustedCartItems
     : cartItems;
-  const serviceLines = (
-    ((transaction as { serviceLines?: PosServiceReceiptLine[] } | null)
-      ?.serviceLines ?? []) as PosServiceReceiptLine[]
-  ).filter((line) => line.totalPrice > 0 || line.serviceCaseUnavailable);
+  const serviceLines = useMemo(
+    () =>
+      (
+        ((transaction as { serviceLines?: PosServiceReceiptLine[] } | null)
+          ?.serviceLines ?? []) as PosServiceReceiptLine[]
+      ).filter((line) => line.totalPrice > 0 || line.serviceCaseUnavailable),
+    [transaction],
+  );
+  const displayServiceItems = useMemo(
+    () => serviceLines.map(receiptServiceLineToCartServiceLine),
+    [serviceLines],
+  );
   const effectiveSaleTotal =
     transaction?.adjustmentSummary?.effectiveNetTotal ??
     transaction?.effectiveNetTotal ??
@@ -2331,56 +2375,6 @@ export function TransactionView() {
                 </section>
               ) : null}
 
-              {serviceLines.length > 0 ? (
-                <section className="space-y-4 overflow-hidden rounded-[calc(var(--radius)*1.35)] border border-border/80 bg-surface-raised p-5 shadow-surface">
-                  <div className="space-y-1">
-                    <h2 className="font-display text-xl font-semibold text-foreground">
-                      Service lines
-                    </h2>
-                    <p className="text-sm text-muted-foreground">
-                      POS-collected service payments are linked to service cases
-                      while retail product lines stay on the sale.
-                    </p>
-                  </div>
-                  <div className="divide-y divide-border/70 rounded-lg border border-border bg-background">
-                    {serviceLines.map((line) => (
-                      <div
-                        className="grid gap-2 px-4 py-3"
-                        key={`${line.id}-${line.serviceCaseId ?? "service"}`}
-                      >
-                        <div className="flex items-start justify-between gap-3">
-                          <div className="min-w-0">
-                            <p className="truncate text-sm font-medium text-foreground">
-                              {line.name}
-                            </p>
-                            <p className="mt-1 text-xs text-muted-foreground">
-                              {line.serviceCaseUnavailable
-                                ? "Service case unavailable"
-                                : [
-                                    line.serviceCaseTitle,
-                                    line.serviceStatus?.replaceAll("_", " "),
-                                    line.servicePaymentStatus?.replaceAll(
-                                      "_",
-                                      " ",
-                                    ),
-                                  ]
-                                    .filter(Boolean)
-                                    .join(" • ")}
-                            </p>
-                          </div>
-                          <p className="shrink-0 font-medium text-foreground">
-                            {formatStoredAmount(
-                              ghsCurrencyFormatter,
-                              line.totalPrice,
-                            )}
-                          </p>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </section>
-              ) : null}
-
               <OrderSummary
                 cartItems={displayCartItems}
                 readOnly
@@ -2429,6 +2423,7 @@ export function TransactionView() {
 
             <CartItems
               cartItems={displayCartItems}
+              serviceItems={displayServiceItems}
               readOnly
               className="h-full min-h-0"
             />

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx
@@ -52,6 +52,7 @@ vi.mock("../../base/table/data-table", () => ({
     data,
   }: {
     data: Array<{
+      itemCount?: number;
       transactionNumber: string;
       sessionTraceId: string | null;
       status?: string;
@@ -61,6 +62,11 @@ vi.mock("../../base/table/data-table", () => ({
       {data.map((row) => (
         <div key={row.transactionNumber}>
           <span>{row.transactionNumber}</span>
+          {row.itemCount !== undefined ? (
+            <span>
+              {row.itemCount} {row.itemCount === 1 ? "item" : "items"}
+            </span>
+          ) : null}
           {row.sessionTraceId ? (
             <span data-testid={`session-trace-${row.transactionNumber}`}>
               trace
@@ -168,6 +174,36 @@ describe("TransactionsView", () => {
 
     expect(screen.getByText("POS-VOID")).toBeInTheDocument();
     expect(screen.getByText("Voided")).toBeInTheDocument();
+  });
+
+  it("includes service lines in completed transaction item counts", () => {
+    getActiveStoreMock.mockReturnValue({
+      activeStore: {
+        _id: "store-1",
+        currency: "GHS",
+      },
+    });
+    useQueryMock.mockReturnValue([
+      {
+        _id: "txn-service-count",
+        transactionNumber: "POS-SERVICE-COUNT",
+        total: 1000,
+        paymentMethod: "cash",
+        paymentMethods: ["cash"],
+        cashierName: "Ada L.",
+        customerName: null,
+        itemCount: 2,
+        serviceLineCount: 1,
+        completedAt: Date.now(),
+        hasTrace: false,
+        sessionTraceId: null,
+      },
+    ]);
+
+    render(<TransactionsView />);
+
+    expect(screen.getByText("POS-SERVICE-COUNT")).toBeInTheDocument();
+    expect(screen.getByText("3 items")).toBeInTheDocument();
   });
 
   it("passes the register session filter to the completed transactions query", () => {

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx
@@ -73,6 +73,7 @@ type CompletedTransaction = {
   cashierName: string | null;
   customerName: string | null;
   itemCount: number;
+  serviceLineCount?: number;
   completedAt: number;
   hasTrace: boolean;
   sessionTraceId: string | null;
@@ -166,7 +167,7 @@ export function TransactionsView() {
       hasMultiplePaymentMethods: Boolean(transaction.hasMultiplePaymentMethods),
       cashierName: transaction.cashierName,
       customerName: transaction.customerName,
-      itemCount: transaction.itemCount,
+      itemCount: transaction.itemCount + (transaction.serviceLineCount ?? 0),
       completedAt: transaction.completedAt,
       hasTrace: transaction.hasTrace,
       sessionTraceId: null,

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts
@@ -213,7 +213,7 @@ describe("createLocalCommandGateway", () => {
     });
   });
 
-  it("does not reuse a local drawer when drawer authority is blocked", async () => {
+  it("does not reuse a local drawer when recoverable drawer authority is blocked", async () => {
     const store = createPosLocalStore({
       adapter: createMemoryPosLocalStorageAdapter(),
       clock: () => 10_000,
@@ -234,7 +234,7 @@ describe("createLocalCommandGateway", () => {
       cloudRegisterSessionId: "cloud-register-1",
       localRegisterSessionId: "local-register-1",
       observedAt: 10_010,
-      reason: "cloud_closed",
+      reason: "lifecycle_rejected",
       status: "blocked",
       storeId: "store-1",
       terminalId: "terminal-1",
@@ -260,6 +260,74 @@ describe("createLocalCommandGateway", () => {
     await expect(store.listEvents()).resolves.toMatchObject({
       ok: true,
       value: [expect.objectContaining({ type: "register.opened" })],
+    });
+  });
+
+  it("opens a replacement drawer when the mapped local drawer is cloud-closed", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 10_000,
+    });
+    await store.appendEvent({
+      type: "register.opened",
+      terminalId: "terminal-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      localRegisterSessionId: "local-register-1",
+      staffProfileId: "staff-1",
+      payload: {
+        localRegisterSessionId: "local-register-1",
+        openingFloat: 100,
+      },
+    });
+    await store.writeLocalCloudMapping({
+      entity: "registerSession",
+      localId: "local-register-1",
+      cloudId: "cloud-register-1",
+      mappedAt: 10_001,
+    });
+    await store.writeDrawerAuthorityState({
+      cloudRegisterSessionId: "cloud-register-1",
+      localRegisterSessionId: "local-register-1",
+      observedAt: 10_010,
+      reason: "cloud_closed",
+      status: "blocked",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    });
+    const gateway = createLocalCommandGateway({
+      store,
+      clock: () => 20_000,
+      createLocalId: (kind) => `${kind}-2`,
+    });
+
+    const result = await gateway.openDrawer({
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      staffProfileId: "staff-1" as never,
+      registerNumber: "1",
+      openingFloat: 500,
+    });
+
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        localRegisterSessionId: "local-register-session-2",
+        openingFloat: 500,
+      },
+    });
+    await expect(store.listEvents()).resolves.toMatchObject({
+      ok: true,
+      value: [
+        expect.objectContaining({
+          localRegisterSessionId: "local-register-1",
+          type: "register.opened",
+        }),
+        expect.objectContaining({
+          localRegisterSessionId: "local-register-session-2",
+          type: "register.opened",
+        }),
+      ],
     });
   });
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts
@@ -111,6 +111,42 @@ export function createLocalCommandGateway(
     return !(await append(input));
   }
 
+  async function appendNewDrawer(input: PosOpenDrawerInput) {
+    const localRegisterSessionId = createLocalId("local-register-session");
+    const openedAt = clock();
+    const appendError = await append({
+      type: "register.opened",
+      terminalId: input.terminalId.toString(),
+      storeId: input.storeId.toString(),
+      registerNumber: input.registerNumber,
+      localRegisterSessionId,
+      staffProfileId: input.staffProfileId.toString(),
+      staffProofToken: resolveStaffProofToken(
+        options.staffProofToken,
+        input.staffProfileId.toString(),
+      ),
+      payload: {
+        localRegisterSessionId,
+        openingFloat: input.openingFloat,
+        expectedCash: input.openingFloat,
+        notes: input.notes ?? null,
+        status: "open",
+      },
+    });
+    if (appendError) return appendError;
+
+    return ok({
+      localRegisterSessionId,
+      status: "open" as const,
+      terminalId: input.terminalId.toString(),
+      registerNumber: input.registerNumber,
+      openingFloat: input.openingFloat,
+      expectedCash: input.openingFloat,
+      openedAt,
+      notes: input.notes,
+    });
+  }
+
   async function readDrawerAuthorityBlock(input: {
     localRegisterSessionId: string;
     storeId: string;
@@ -344,7 +380,10 @@ export function createLocalCommandGateway(
       if (!existingModel.ok) {
         return toLocalUserError(existingModel.error.message);
       }
-      if (existingModel.value.saleBlockReason) {
+      const isClosedCloudDrawerBlock =
+        existingModel.value.saleBlockReason === "drawer_authority" &&
+        existingModel.value.drawerAuthorityReason === "cloud_closed";
+      if (existingModel.value.saleBlockReason && !isClosedCloudDrawerBlock) {
         return toLocalUserError(
           blockedSaleMessage(existingModel.value.saleBlockReason),
         );
@@ -355,6 +394,9 @@ export function createLocalCommandGateway(
         activeRegisterSession &&
         isOpenLocalRegisterSessionStatus(activeRegisterSession.status)
       ) {
+        if (isClosedCloudDrawerBlock) {
+          return appendNewDrawer(input);
+        }
         if (!existingModel.value.canSell) {
           return toLocalUserError(
             blockedSaleMessage(existingModel.value.saleBlockReason),
@@ -386,39 +428,7 @@ export function createLocalCommandGateway(
         });
       }
 
-      const localRegisterSessionId = createLocalId("local-register-session");
-      const openedAt = clock();
-      const appendError = await append({
-        type: "register.opened",
-        terminalId: input.terminalId.toString(),
-        storeId: input.storeId.toString(),
-        registerNumber: input.registerNumber,
-        localRegisterSessionId,
-        staffProfileId: input.staffProfileId.toString(),
-        staffProofToken: resolveStaffProofToken(
-          options.staffProofToken,
-          input.staffProfileId.toString(),
-        ),
-        payload: {
-          localRegisterSessionId,
-          openingFloat: input.openingFloat,
-          expectedCash: input.openingFloat,
-          notes: input.notes ?? null,
-          status: "open",
-        },
-      });
-      if (appendError) return appendError;
-
-      return ok({
-        localRegisterSessionId,
-        status: "open",
-        terminalId: input.terminalId.toString(),
-        registerNumber: input.registerNumber,
-        openingFloat: input.openingFloat,
-        expectedCash: input.openingFloat,
-        openedAt,
-        notes: input.notes,
-      });
+      return appendNewDrawer(input);
     },
 
     async reopenRegister(input: ReopenLocalRegisterInput) {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts
@@ -823,6 +823,7 @@ describe("projectLocalRegisterReadModel", () => {
 
     expect(model.canSell).toBe(false);
     expect(model.saleBlockReason).toBe("drawer_authority");
+    expect(model.drawerAuthorityReason).toBe("cloud_closed");
   });
 
   it("blocks selling when an uploaded register lifecycle event needs review", () => {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts
@@ -136,6 +136,7 @@ export interface PosLocalRegisterReadModel {
   activeRegisterSession: PosLocalCashDrawerReadModel | null;
   activeSale: PosLocalActiveSaleReadModel | null;
   canSell: boolean;
+  drawerAuthorityReason?: PosDrawerAuthorityState["reason"];
   saleBlockReason?: PosLocalSaleBlockReason;
   clearedSaleIds: string[];
   closeoutState: PosLocalCloseoutState;
@@ -427,6 +428,9 @@ export function projectLocalRegisterReadModel(input: {
     activeRegisterSession,
     activeSale,
     canSell,
+    ...(input.drawerAuthority?.status === "blocked"
+      ? { drawerAuthorityReason: input.drawerAuthority.reason }
+      : {}),
     ...(saleBlockReason ? { saleBlockReason } : {}),
     clearedSaleIds: [...clearedSaleIds],
     closeoutState,

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -26,9 +26,11 @@ vi.mock("~/convex/_generated/api", () => ({
 
 import {
   assertPosLocalStoreOk,
+  collectLocallySettledSkippedReviewEventIds,
   collectSyncedLocalEventIds,
   collectServerHeldLocalEventIds,
   collectServerReviewLocalEventIds,
+  collectServerSettledLocalEventIds,
   collectServerSyncedLocalEventIds,
   derivePosLocalRuntimeSyncStatus,
   getRuntimeStatusSignature,
@@ -36,6 +38,7 @@ import {
   writeReturnedLocalCloudMappings,
 } from "./usePosLocalSyncRuntime";
 import type { PosLocalEventRecord } from "./posLocalStore";
+import { buildPosLocalSyncUploadEvents } from "./syncContract";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -884,6 +887,47 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     expect(store.markEventsNeedsReview).not.toHaveBeenCalled();
   });
 
+  it("identifies superseded review rows that are skipped when retrying the later sale", () => {
+    const events = [
+      buildLocalEvent({
+        localEventId: "event-clear",
+        localPosSessionId: "local-session-1",
+        payload: {
+          localPosSessionId: "local-session-1",
+          stage: "cartCleared",
+        },
+        sequence: 1,
+        sync: { status: "needs_review", uploaded: true },
+        type: "cart.cleared",
+      }),
+      buildLocalEvent({
+        localEventId: "event-checkout",
+        localPosSessionId: "local-session-1",
+        localTransactionId: "local-txn-1",
+        payload: {
+          localPosSessionId: "local-session-1",
+          localTransactionId: "local-txn-1",
+          receiptNumber: "LOCAL-1-000001",
+          subtotal: 25,
+          tax: 0,
+          total: 25,
+          payments: [{ method: "cash", amount: 25, timestamp: 2 }],
+        },
+        sequence: 2,
+        sync: { status: "needs_review", uploaded: true },
+        type: "transaction.completed",
+      }),
+    ];
+    const uploadEvents = buildPosLocalSyncUploadEvents(events, events);
+
+    expect(uploadEvents.map((event) => event.localEventId)).toEqual([
+      "event-checkout",
+    ]);
+    expect(
+      collectLocallySettledSkippedReviewEventIds(events, uploadEvents),
+    ).toEqual(["event-clear"]);
+  });
+
   it("marks uploaded events for review when the server rejects the batch", async () => {
     mocks.ingestLocalEvents.mockResolvedValue({
       kind: "user_error",
@@ -968,7 +1012,9 @@ describe("usePosLocalSyncRuntimeStatus", () => {
       }),
     );
 
-    await waitFor(() => expect(mocks.ingestLocalEvents).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.ingestLocalEvents).toHaveBeenCalled(), {
+      timeout: 5000,
+    });
     await waitFor(() =>
       expect(store.markEventsNeedsReview).toHaveBeenCalledWith(
         ["event-checkout", "event-session", "event-cart"],
@@ -1484,6 +1530,72 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     });
   });
 
+  it("clears stale recoverable drawer blocks when lifecycle events are already settled", async () => {
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            localEventId: "event-open",
+            localRegisterSessionId: "register-1",
+            sequence: 1,
+            sync: { status: "synced" },
+            type: "register.opened",
+          }),
+          buildLocalEvent({
+            localEventId: "event-closeout",
+            localRegisterSessionId: "register-1",
+            sequence: 2,
+            sync: { status: "synced", uploaded: true },
+            type: "register.closeout_started",
+          }),
+        ],
+      })),
+      clearDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
+      readDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: {
+          localRegisterSessionId: "register-1",
+          observedAt: 1,
+          reason: "lifecycle_rejected",
+          status: "blocked",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+    };
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(store.clearDrawerAuthorityState).toHaveBeenCalledWith({
+        localRegisterSessionId: "register-1",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      }),
+    );
+  });
+
   it("keeps drawer authority blocked when a same-drawer review event remains", async () => {
     mocks.ingestLocalEvents.mockResolvedValue({
       kind: "ok",
@@ -1497,7 +1609,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
           {
             localEventId: "event-closeout",
             sequence: 2,
-            status: "rejected",
+            status: "conflicted",
           },
         ],
         held: [],
@@ -2543,7 +2655,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
       .toEqual([1, 2]);
   });
 
-  it("marks server-conflicted accepted events for local review instead of sync retry", () => {
+  it("keeps server-conflicted events in review and settles server-rejected events locally", () => {
     expect(
       collectServerSyncedLocalEventIds([
         { localEventId: "event-checkout", status: "conflicted" },
@@ -2559,7 +2671,15 @@ describe("usePosLocalSyncRuntimeStatus", () => {
         { localEventId: "event-held", status: "held" },
         { localEventId: "event-rejected", status: "rejected" },
       ]),
-    ).toEqual(["event-checkout", "event-rejected"]);
+    ).toEqual(["event-checkout"]);
+    expect(
+      collectServerSettledLocalEventIds([
+        { localEventId: "event-checkout", status: "conflicted" },
+        { localEventId: "event-open", status: "projected" },
+        { localEventId: "event-held", status: "held" },
+        { localEventId: "event-rejected", status: "rejected" },
+      ]),
+    ).toEqual(["event-open", "event-rejected"]);
     expect(
       collectServerHeldLocalEventIds([
         { localEventId: "event-held" },
@@ -2608,7 +2728,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     );
   });
 
-  it("marks rejected runtime sale responses and embedded local events for review", async () => {
+  it("marks rejected runtime sale responses and embedded local events as settled", async () => {
     mocks.ingestLocalEvents.mockResolvedValue({
       kind: "ok",
       data: {
@@ -2727,13 +2847,12 @@ describe("usePosLocalSyncRuntimeStatus", () => {
 
     await waitFor(() => expect(mocks.ingestLocalEvents).toHaveBeenCalled());
     await waitFor(() =>
-      expect(store.markEventsNeedsReview).toHaveBeenCalledWith(
+      expect(store.markEventsSynced).toHaveBeenCalledWith(
         ["event-checkout", "event-session", "event-cart", "event-payment"],
-        "Cloud sync needs review before this local event can finish.",
         { uploaded: true },
       ),
     );
-    expect(store.markEventsSynced).not.toHaveBeenCalled();
+    expect(store.markEventsNeedsReview).not.toHaveBeenCalled();
   });
 
   it("presents unsynced closeout events as locally closed pending sync", () => {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -412,11 +412,17 @@ export function usePosLocalSyncRuntimeStatus(input: {
             eventsToUpload,
             latestEvents.value.events,
           );
+          const locallySettledEventIds = collectLocallySettledSkippedReviewEventIds(
+            eventsToUpload,
+            uploadedEvents,
+          );
           setDebug((current) => ({
             ...current,
             lastBatchEventCount: uploadedEvents.length,
           }));
-          if (uploadedEvents.length === 0) return { syncedEventIds: [] };
+          if (uploadedEvents.length === 0) {
+            return { syncedEventIds: locallySettledEventIds };
+          }
 
           const result = await ingestLocalEvents(
             toIngestLocalEventsArgs({
@@ -456,15 +462,19 @@ export function usePosLocalSyncRuntimeStatus(input: {
               latestEvents.value.events,
               uploadedEvents.map((event) => event.localEventId),
             );
+            const localReviewEventIds = withoutEventIds(
+              reviewEventIds,
+              locallySettledEventIds,
+            );
             await persistDrawerAuthorityBlockForReviewEvents({
               events: latestEvents.value.events,
               reason: "lifecycle_rejected",
-              reviewEventIds,
+              reviewEventIds: localReviewEventIds,
               store,
             });
             return {
-              syncedEventIds: [],
-              reviewEventIds,
+              syncedEventIds: locallySettledEventIds,
+              reviewEventIds: localReviewEventIds,
             };
           }
 
@@ -485,15 +495,19 @@ export function usePosLocalSyncRuntimeStatus(input: {
               latestEvents.value.events,
               uploadedEvents.map((event) => event.localEventId),
             );
+            const localReviewEventIds = withoutEventIds(
+              reviewEventIds,
+              locallySettledEventIds,
+            );
             await persistDrawerAuthorityBlockForReviewEvents({
               events: latestEvents.value.events,
               reason: "authority_unknown",
-              reviewEventIds,
+              reviewEventIds: localReviewEventIds,
               store,
             });
             return {
-              syncedEventIds: [],
-              reviewEventIds,
+              syncedEventIds: locallySettledEventIds,
+              reviewEventIds: localReviewEventIds,
             };
           }
           const reviewEventIds = collectServerReviewLocalEventIds(
@@ -516,19 +530,26 @@ export function usePosLocalSyncRuntimeStatus(input: {
           });
           const syncedEventIds = collectSyncedLocalEventIds(
             latestEvents.value.events,
-            collectServerSyncedLocalEventIds(result.data.accepted),
+            collectServerSettledLocalEventIds(result.data.accepted),
+          );
+          const localSyncedEventIds = mergeEventIds(
+            locallySettledEventIds,
+            syncedEventIds,
           );
           await clearRecoverableDrawerAuthorityForSyncedEvents({
             events: latestEvents.value.events,
             reviewEventIds: localReviewEventIds,
             store,
-            syncedEventIds,
+            syncedEventIds: localSyncedEventIds,
           });
 
           return {
             heldEventIds: collectServerHeldLocalEventIds(result.data.held),
-            syncedEventIds,
-            reviewEventIds: localReviewEventIds,
+            syncedEventIds: localSyncedEventIds,
+            reviewEventIds: withoutEventIds(
+              localReviewEventIds,
+              locallySettledEventIds,
+            ),
           };
         },
         markNeedsReview: async (eventIds) => {
@@ -966,7 +987,7 @@ async function refreshTerminalRuntimeReadiness(input: {
     localRegisterModel.ok
       ? localRegisterModel.value?.activeRegisterSession?.localRegisterSessionId
       : undefined;
-  const drawerAuthority =
+  let drawerAuthority =
     activeLocalRegisterSessionId && readDrawerAuthorityState
       ? await readLatestRuntimeDrawerAuthorityState({
           localRegisterSessionId: activeLocalRegisterSessionId,
@@ -975,6 +996,16 @@ async function refreshTerminalRuntimeReadiness(input: {
           terminalIds: scope.terminalIds,
         })
       : ({ ok: true, value: null } as const);
+  if (drawerAuthority.ok && drawerAuthority.value && localRegisterModel.ok) {
+    const clearResult = await clearSettledRecoverableDrawerAuthorityBlock({
+      drawerAuthority: drawerAuthority.value,
+      events: localRegisterModel.value?.sourceEvents ?? [],
+      store: input.store,
+    });
+    if (clearResult.ok && clearResult.value) {
+      drawerAuthority = { ok: true, value: null };
+    }
+  }
 
   return {
     drawerAuthority: drawerAuthority.ok ? drawerAuthority.value : null,
@@ -1190,6 +1221,62 @@ function isRecoverableDrawerAuthorityReason(
   reason: PosDrawerAuthorityState["reason"] | undefined,
 ) {
   return reason === "lifecycle_rejected" || reason === "authority_unknown";
+}
+
+async function clearSettledRecoverableDrawerAuthorityBlock(input: {
+  drawerAuthority: PosDrawerAuthorityState;
+  events: PosLocalEventRecord[];
+  store: PosLocalRuntimeStore;
+}): Promise<PosLocalStoreResult<boolean>> {
+  const clearDrawerAuthorityState = (
+    input.store as {
+      clearDrawerAuthorityState?: PosLocalRuntimeStore["clearDrawerAuthorityState"];
+    }
+  ).clearDrawerAuthorityState;
+  if (
+    !clearDrawerAuthorityState ||
+    input.drawerAuthority.status !== "blocked" ||
+    !isRecoverableDrawerAuthorityReason(input.drawerAuthority.reason)
+  ) {
+    return { ok: true, value: false };
+  }
+
+  const drawerLifecycleEvents = input.events.filter(
+    (event) =>
+      event.localRegisterSessionId ===
+        input.drawerAuthority.localRegisterSessionId &&
+      event.storeId === input.drawerAuthority.storeId &&
+      event.terminalId === input.drawerAuthority.terminalId &&
+      isDrawerAuthorityLifecycleEvent(event),
+  );
+  if (drawerLifecycleEvents.length === 0) {
+    return { ok: true, value: false };
+  }
+
+  const hasUnsettledLifecycleEvent = drawerLifecycleEvents.some(
+    (event) => event.sync.status !== "synced",
+  );
+  if (hasUnsettledLifecycleEvent) {
+    return { ok: true, value: false };
+  }
+
+  const hasRemainingLifecycleReview = drawerLifecycleEvents.some(
+    (event) =>
+      event.sync.status === "needs_review" &&
+      event.sync.uploaded,
+  );
+  if (hasRemainingLifecycleReview) {
+    return { ok: true, value: false };
+  }
+
+  const result = await clearDrawerAuthorityState({
+    localRegisterSessionId: input.drawerAuthority.localRegisterSessionId,
+    storeId: input.drawerAuthority.storeId,
+    terminalId: input.drawerAuthority.terminalId,
+  });
+  if (!result.ok) return result;
+
+  return { ok: true, value: true };
 }
 
 async function readLatestRuntimeDrawerAuthorityState(input: {
@@ -1477,7 +1564,7 @@ export function collectServerSyncedLocalEventIds(
     .map((event) => event.localEventId);
 }
 
-export function collectServerReviewLocalEventIds(
+export function collectServerSettledLocalEventIds(
   acceptedEvents: Array<{
     localEventId: string;
     status: string;
@@ -1485,8 +1572,19 @@ export function collectServerReviewLocalEventIds(
 ) {
   return acceptedEvents
     .filter(
-      (event) => event.status === "conflicted" || event.status === "rejected",
+      (event) => event.status === "projected" || event.status === "rejected",
     )
+    .map((event) => event.localEventId);
+}
+
+export function collectServerReviewLocalEventIds(
+  acceptedEvents: Array<{
+    localEventId: string;
+    status: string;
+  }>,
+) {
+  return acceptedEvents
+    .filter((event) => event.status === "conflicted")
     .map((event) => event.localEventId);
 }
 
@@ -1544,6 +1642,64 @@ function collectReviewLocalEventIds(
   acceptedReviewEventIds: string[],
 ) {
   return collectAcceptedEventIdsWithLocalPrecursors(events, acceptedReviewEventIds);
+}
+
+export function collectLocallySettledSkippedReviewEventIds(
+  eventsToUpload: PosLocalEventRecord[],
+  uploadedEvents: PosLocalUploadEvent[],
+) {
+  const uploadedEventIds = new Set(
+    uploadedEvents.map((event) => event.localEventId),
+  );
+
+  return eventsToUpload
+    .filter(
+      (event) =>
+        event.type === "cart.cleared" &&
+        event.sync.status === "needs_review" &&
+        event.sync.uploaded &&
+        !uploadedEventIds.has(event.localEventId) &&
+        hasLaterLocalCompletedSale(
+          event,
+          eventsToUpload,
+          event.localPosSessionId ??
+            stringValueFromPayload(event.payload, "localPosSessionId"),
+        ),
+    )
+    .map((event) => event.localEventId);
+}
+
+function hasLaterLocalCompletedSale(
+  event: PosLocalEventRecord,
+  events: PosLocalEventRecord[],
+  localPosSessionId: string,
+) {
+  if (!localPosSessionId) return false;
+
+  return events.some(
+    (candidate) =>
+      candidate.sequence > event.sequence &&
+      candidate.type === "transaction.completed" &&
+      (candidate.localPosSessionId ??
+        stringValueFromPayload(candidate.payload, "localPosSessionId")) ===
+        localPosSessionId,
+  );
+}
+
+function stringValueFromPayload(payload: unknown, key: string) {
+  if (!payload || typeof payload !== "object") return "";
+  const value = (payload as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : "";
+}
+
+function mergeEventIds(left: string[], right: string[]) {
+  return Array.from(new Set([...left, ...right]));
+}
+
+function withoutEventIds(eventIds: string[], excludedEventIds: string[]) {
+  if (excludedEventIds.length === 0) return eventIds;
+  const excluded = new Set(excludedEventIds);
+  return eventIds.filter((eventId) => !excluded.has(eventId));
 }
 
 function collectAcceptedEventIdsWithLocalPrecursors(

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -79,7 +79,7 @@ export interface RegisterServiceLineState {
   serviceMode: RegisterServiceMode;
   pricingModel: RegisterServicePricingModel;
   price: number;
-  quantity: 1;
+  quantity: number;
   amountRequired: boolean;
   catalogUpdatedAt?: number;
 }
@@ -163,6 +163,7 @@ export interface RegisterCheckoutState {
   hasTerminal: boolean;
   isTransactionCompleted: boolean;
   completedOrderNumber: string | null;
+  completionBlockMessage?: string;
   completedTransactionData?: {
     paymentMethod: string;
     payments?: Payment[];
@@ -253,6 +254,7 @@ export interface RegisterDrawerGateState {
   onSubmitOpeningFloatCorrection?: () => Promise<void>;
   onSubmitCloseout?: () => Promise<void>;
   onReopenRegister?: () => Promise<void>;
+  onRetrySync?: () => void;
   onSubmit?: () => Promise<void>;
   onSignOut: () => Promise<void>;
 }

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -3597,12 +3597,13 @@ describe("useRegisterViewModel", () => {
     });
 
     act(() => {
-      result.current.serviceEntry?.setServiceSearchQuery("closure");
+      result.current.productEntry.setProductSearchQuery("closure");
     });
 
     await waitFor(() =>
       expect(result.current.serviceEntry?.searchResults).toHaveLength(1),
     );
+    expect(result.current.serviceEntry?.serviceSearchQuery).toBe("closure");
 
     await act(async () => {
       await result.current.serviceEntry?.onAddService(
@@ -3621,6 +3622,9 @@ describe("useRegisterViewModel", () => {
     expect(result.current.serviceEntry?.checkoutBlockMessage).toBe(
       "Customer required. Add a customer before checking out services.",
     );
+    expect(result.current.checkout.completionBlockMessage).toBe(
+      "Customer required. Add a customer before checking out services.",
+    );
 
     await act(async () => {
       await result.current.checkout.onCompleteTransaction();
@@ -3628,6 +3632,65 @@ describe("useRegisterViewModel", () => {
 
     expect(toast.error).toHaveBeenCalledWith(
       "Customer required. Add a customer before checking out services.",
+    );
+  });
+
+  it("does not add the same service twice", async () => {
+    mockRegisterServiceCatalogRows = [
+      {
+        serviceCatalogId: "service-1" as Id<"serviceCatalog">,
+        name: "Closure Repair",
+        description: "Repair a closure install.",
+        serviceMode: "repair",
+        pricingModel: "fixed",
+        basePrice: 4500,
+        status: "active",
+      },
+    ];
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    act(() => {
+      result.current.productEntry.setProductSearchQuery("closure");
+    });
+
+    await waitFor(() =>
+      expect(result.current.serviceEntry?.searchResults).toHaveLength(1),
+    );
+    const service = result.current.serviceEntry?.searchResults[0];
+    expect(service).toBeDefined();
+
+    await act(async () => {
+      await result.current.serviceEntry?.onAddService(service!);
+      await result.current.serviceEntry?.onAddService(service!);
+    });
+
+    expect(result.current.cart.serviceItems).toEqual([
+      expect.objectContaining({
+        name: "Closure Repair",
+        pricingModel: "fixed",
+        price: 4500,
+        quantity: 1,
+      }),
+    ]);
+
+    const serviceEvents = mockAppendLocalEvent.mock.calls.filter(
+      ([event]) => event.type === "cart.service_added",
+    );
+    expect(serviceEvents).toHaveLength(1);
+    expect(serviceEvents[0]?.[0].payload).toEqual(
+      expect.objectContaining({
+        quantity: 1,
+        unitPrice: 4500,
+        totalPrice: 4500,
+      }),
     );
   });
 
@@ -5560,7 +5623,57 @@ describe("useRegisterViewModel", () => {
     );
   });
 
-  it("routes drawer authority blocks to the drawer repair gate", async () => {
+  it("routes recoverable drawer authority blocks to the drawer repair gate", async () => {
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: [
+        {
+          localEventId: "local-event-open",
+          schemaVersion: 1,
+          sequence: 1,
+          type: "register.opened",
+          terminalId: "local-terminal-1",
+          storeId: "store-1",
+          registerNumber: "1",
+          localRegisterSessionId: "local-register-1",
+          staffProfileId: "staff-1",
+          payload: {
+            localRegisterSessionId: "local-register-1",
+            openingFloat: 5000,
+          },
+          createdAt: 100,
+          sync: { status: "synced" },
+        },
+      ],
+    });
+    mockReadDrawerAuthorityState.mockResolvedValue({
+      ok: true,
+      value: {
+        localRegisterSessionId: "local-register-1",
+        observedAt: 110,
+        reason: "lifecycle_rejected",
+        status: "blocked",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      },
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
+
+    await waitFor(() =>
+      expect(result.current.drawerGate?.mode).toBe("drawerAuthorityRepair"),
+    );
+    expect(result.current.drawerGate?.onRetrySync).toBeTypeOf("function");
+  });
+
+  it("routes closed drawer authority blocks to the open-drawer gate", async () => {
     mockListLocalEvents.mockResolvedValue({
       ok: true,
       value: [
@@ -5605,8 +5718,10 @@ describe("useRegisterViewModel", () => {
     });
 
     await waitFor(() =>
-      expect(result.current.drawerGate?.mode).toBe("drawerAuthorityRepair"),
+      expect(result.current.drawerGate?.mode).toBe("initialSetup"),
     );
+    expect(result.current.drawerGate?.onSubmit).toBeTypeOf("function");
+    expect(result.current.drawerGate?.onRetrySync).toBeUndefined();
   });
 
   it("persists drawer authority when a mapped cloud drawer is no longer usable", async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -695,13 +695,41 @@ function mapLocalServiceLineToState(
     serviceMode: line.serviceMode,
     pricingModel: line.pricingModel,
     price: line.unitPrice,
-    quantity: 1,
+    quantity: line.quantity,
     amountRequired:
       (line.pricingModel === "starting_at" ||
         line.pricingModel === "quote_after_consultation") &&
       line.unitPrice <= 0,
     catalogUpdatedAt: line.catalogUpdatedAt,
   };
+}
+
+function matchingServiceLineDraft(
+  drafts: RegisterServiceLineState[],
+  service: RegisterServiceSearchResult,
+) {
+  const serviceCatalogId = service.serviceCatalogId?.toString();
+  const normalizedName = service.name.trim().toLowerCase();
+
+  return drafts.find(
+    (line) => {
+      const lineCatalogId = line.serviceCatalogId?.toString();
+
+      if (serviceCatalogId && lineCatalogId) {
+        return serviceCatalogId === lineCatalogId;
+      }
+
+      if (serviceCatalogId || lineCatalogId) {
+        return false;
+      }
+
+      return (
+        line.name.trim().toLowerCase() === normalizedName &&
+        line.serviceMode === service.serviceMode &&
+        line.pricingModel === service.pricingModel
+      );
+    },
+  );
 }
 
 function serviceLineStateToLocalPayload(line: RegisterServiceLineState) {
@@ -1126,10 +1154,13 @@ export function useRegisterViewModel(): RegisterViewModel {
   const [showCustomerPanel, setShowCustomerPanel] = useState(false);
   const [showProductEntry, setShowProductEntry] = useState(true);
   const [productSearchQuery, setProductSearchQuery] = useState("");
-  const [serviceSearchQuery, setServiceSearchQuery] = useState("");
   const [serviceLineDrafts, setServiceLineDrafts] = useState<
     RegisterServiceLineState[]
   >([]);
+  const serviceLineDraftsRef = useRef<RegisterServiceLineState[]>([]);
+  useEffect(() => {
+    serviceLineDraftsRef.current = serviceLineDrafts;
+  }, [serviceLineDrafts]);
   const [customerInfo, setCustomerInfo] = useState<CustomerInfo>(
     EMPTY_REGISTER_CUSTOMER_INFO,
   );
@@ -2075,7 +2106,7 @@ export function useRegisterViewModel(): RegisterViewModel {
           .filter((row) => row.status === undefined || row.status === "active")
           .map(mapServiceCatalogRowToSearchRow),
       );
-      return searchRegisterServiceCatalog(index, serviceSearchQuery, {
+      return searchRegisterServiceCatalog(index, productSearchQuery, {
         limit: 25,
       }).results.map((result) =>
         mapServiceCatalogRowToRegisterSearchResult({
@@ -2096,7 +2127,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         }),
       );
     },
-    [serviceCatalogRows, serviceSearchQuery],
+    [productSearchQuery, serviceCatalogRows],
   );
   const serviceSubtotal = useMemo(
     () =>
@@ -2168,6 +2199,11 @@ export function useRegisterViewModel(): RegisterViewModel {
   );
   const localSaleAuthorityBlockReason =
     localRegisterReadModel?.saleBlockReason ?? null;
+  const localDrawerAuthorityReason =
+    localRegisterReadModel?.drawerAuthorityReason ?? null;
+  const hasRecoverableDrawerAuthorityBlock =
+    localDrawerAuthorityReason === "authority_unknown" ||
+    localDrawerAuthorityReason === "lifecycle_rejected";
   const hasLocalSaleAuthorityBlock = Boolean(localSaleAuthorityBlockReason);
   const requiresDrawerGate = Boolean(
     activeStoreId &&
@@ -2243,7 +2279,8 @@ export function useRegisterViewModel(): RegisterViewModel {
     ? "openingFloatCorrection"
     : localSaleAuthorityBlockReason === "terminal_integrity"
       ? "terminalRepair"
-      : localSaleAuthorityBlockReason === "drawer_authority" ||
+      : (localSaleAuthorityBlockReason === "drawer_authority" &&
+            hasRecoverableDrawerAuthorityBlock) ||
           localSaleAuthorityBlockReason === "lifecycle_needs_review"
         ? "drawerAuthorityRepair"
         : hasCloseoutBlockedDrawerState || activeCloseoutRegisterSession
@@ -2282,7 +2319,6 @@ export function useRegisterViewModel(): RegisterViewModel {
       setShowCustomerPanel(false);
       setShowProductEntry(true);
       setProductSearchQuery("");
-      setServiceSearchQuery("");
       setServiceLineDrafts([]);
       setCustomerInfo(EMPTY_REGISTER_CUSTOMER_INFO);
       setPaymentState([]);
@@ -2594,9 +2630,11 @@ export function useRegisterViewModel(): RegisterViewModel {
       return;
     }
 
-    setServiceLineDrafts(
-      projectedLocalServiceLines.map(mapLocalServiceLineToState),
+    const nextServiceLineDrafts = projectedLocalServiceLines.map(
+      mapLocalServiceLineToState,
     );
+    serviceLineDraftsRef.current = nextServiceLineDrafts;
+    setServiceLineDrafts(nextServiceLineDrafts);
   }, [
     isProjectedLocalActiveSaleOwnedByCurrentStaff,
     projectedLocalSaleId,
@@ -3693,6 +3731,16 @@ export function useRegisterViewModel(): RegisterViewModel {
             return false;
           }
 
+          const currentServiceLineDrafts = serviceLineDraftsRef.current;
+          const existingServiceLine = matchingServiceLineDraft(
+            currentServiceLineDrafts,
+            service,
+          );
+
+          if (existingServiceLine) {
+            return false;
+          }
+
           const serviceLine: RegisterServiceLineState = {
             id: createLocalFallbackId("local-service-line"),
             serviceCatalogId: service.serviceCatalogId,
@@ -3719,9 +3767,11 @@ export function useRegisterViewModel(): RegisterViewModel {
             return false;
           }
 
-          setServiceLineDrafts((current) => [...current, serviceLine]);
+          const nextServiceLineDrafts = [...currentServiceLineDrafts, serviceLine];
+          serviceLineDraftsRef.current = nextServiceLineDrafts;
+          setServiceLineDrafts(nextServiceLineDrafts);
           setShowProductEntry(true);
-          setServiceSearchQuery("");
+          setProductSearchQuery("");
           return true;
         });
       serviceMutationQueueRef.current = queued.then(
@@ -5007,6 +5057,21 @@ export function useRegisterViewModel(): RegisterViewModel {
     activeCloseoutRegisterSession ||
     activeOpeningFloatCorrectionRegisterSession,
   );
+  const localRuntimeSyncSource = usePosLocalSyncRuntimeStatus({
+    drainOnAppend: true,
+    eventAppendToken: localSyncEventAppendToken,
+    mode: "status-only",
+    onLocalEventsChanged: noteLocalRegisterEventChanged,
+    storeId: activeStoreId,
+    staffProfileId,
+    terminalId: terminal?._id,
+    onRetrySync: requestBootstrap,
+    storeFactory: localRuntimeStoreFactory,
+  });
+  const handleRetryLocalSync = useCallback(() => {
+    localRuntimeSyncSource?.onRetrySync?.();
+    requestBootstrap();
+  }, [localRuntimeSyncSource, requestBootstrap]);
 
   const drawerGate =
     activeStoreId && terminal?._id && staffProfileId && shouldShowDrawerGate
@@ -5124,6 +5189,10 @@ export function useRegisterViewModel(): RegisterViewModel {
                 setDrawerErrorMessage(null);
               },
               onSubmit: handleOpenDrawer,
+              onRetrySync:
+                drawerGateMode === "drawerAuthorityRepair"
+                  ? handleRetryLocalSync
+                  : undefined,
               onSignOut: handleCashierSignOut,
             }
       : null;
@@ -5173,17 +5242,6 @@ export function useRegisterViewModel(): RegisterViewModel {
           },
         }
       : null;
-  const localRuntimeSyncSource = usePosLocalSyncRuntimeStatus({
-    drainOnAppend: true,
-    eventAppendToken: localSyncEventAppendToken,
-    mode: "status-only",
-    onLocalEventsChanged: noteLocalRegisterEventChanged,
-    storeId: activeStoreId,
-    staffProfileId,
-    terminalId: terminal?._id,
-    onRetrySync: requestBootstrap,
-    storeFactory: localRuntimeStoreFactory,
-  });
   const localRuntimeStatusSource = localRuntimeSyncSource?.status
     ? localRuntimeSyncSource
     : null;
@@ -5251,7 +5309,7 @@ export function useRegisterViewModel(): RegisterViewModel {
           ...buildPosSyncStatusPresentation(localSyncSource),
           onRetrySync: () => {
             localSyncSource?.onRetrySync?.();
-            requestBootstrap();
+            handleRetryLocalSync();
           },
         }
       : null;
@@ -5393,8 +5451,8 @@ export function useRegisterViewModel(): RegisterViewModel {
         cloudRegisterSessionBlocksLocalProjection ||
         activeSessionHasBlockedRegisterBinding ||
         isOpeningDrawer,
-      serviceSearchQuery,
-      setServiceSearchQuery,
+      serviceSearchQuery: productSearchQuery,
+      setServiceSearchQuery: setProductSearchQuery,
       searchResults: serviceSearchResults,
       isSearchLoading: serviceCatalogResult === undefined,
       isSearchReady: serviceCatalogResult !== undefined,
@@ -5435,6 +5493,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       hasTerminal: Boolean(terminal),
       isTransactionCompleted,
       completedOrderNumber,
+      completionBlockMessage: serviceCheckoutBlockMessage,
       completedTransactionData,
       cashierName: getCashierDisplayName(cashier),
       actorStaffProfileId: staffProfileId,


### PR DESCRIPTION
## Summary
- recover POS local sync review handling, drawer retry flow, and register health visibility
- add service-line support across POS search, cart, checkout gating, transaction detail, and transaction list counts
- fix Convex local sync service-case financial sync to avoid multiple paginated queries

## Validation
- bun run pr:athena
- bun run --filter '@athena/webapp' test:coverage -- src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
- bun run graphify:rebuild
- pre-push validation: full tests, coverage, focused POS/cash-controls/terminal suites, build, Convex audit, changed-file lint, harness behavior