### PR TITLE
fix(harness): stabilize Athena QA smoke

### DIFF
--- a/docs/solutions/harness/athena-qa-smoke-live-navigation-readiness-2026-06-01.md
+++ b/docs/solutions/harness/athena-qa-smoke-live-navigation-readiness-2026-06-01.md
@@ -1,0 +1,57 @@
+---
+title: Athena QA Live Smoke Should Not Depend On Network Idle
+date: 2026-06-01
+category: harness
+module: runtime-behavior
+problem_type: ci_flake
+component: athena-qa-live-smoke
+resolution_type: navigation_readiness_boundary
+severity: medium
+tags:
+  - ci
+  - github-actions
+  - playwright
+  - qa
+  - smoke-test
+---
+
+# Athena QA Live Smoke Should Not Depend On Network Idle
+
+## Problem
+
+The scheduled Athena QA smoke workflow can fail while the QA page is healthy
+because the live app is a Vite dev server connected to browser runtime services.
+Waiting for Playwright `networkidle` makes the smoke depend on there being no
+active or recently active network traffic for a quiet window. That is a brittle
+condition for a live app with dev-server and backend connections.
+
+The useful smoke signal is not "all network traffic stopped." It is whether the
+document loads, the Athena app mounts, the login form appears, page errors are
+absent, and same-origin document/script/style/fetch/xhr responses do not show
+server failures.
+
+## Solution
+
+Keep `networkidle` as the default for local behavior scenarios where it remains a
+reasonable readiness proxy. Let individual scenarios choose a lighter navigation
+readiness mode when their assertion steps own the meaningful app readiness check.
+
+For `athena-qa-live-smoke`, navigate with `domcontentloaded` and then assert the
+real QA conditions from the scenario:
+
+- wait for the document body
+- wait briefly for the Athena login email field
+- capture same-origin response, request failure, and page error observations
+- fail with diagnostics when Athena content or the login field does not render
+
+This keeps the scheduled workflow sensitive to blank pages and server-side asset
+failures without failing solely because the live app did not become network idle.
+
+## Prevention
+
+- Do not use `networkidle` as the only readiness condition for live smoke checks
+  against dev-server or long-lived backend pages.
+- Prefer scenario-specific DOM and response assertions that describe the user
+  outcome being monitored.
+- When adding a live browser smoke, include a regression test for the navigation
+  readiness mode as well as the final diagnostics.

--- a/docs/solutions/logic-errors/athena-daily-close-store-day-boundary-2026-05-07.md
+++ b/docs/solutions/logic-errors/athena-daily-close-store-day-boundary-2026-05-07.md
@@ -117,6 +117,10 @@ server-side item totals, not from stale client cart state.
 - Keep the snapshot query and completion mutation on the same validated
   operating-day range so the operator does not close against a different window
   than the UI displayed.
+- Open operating-date picker calendars on the selected operating date, not the
+  browser's current month. Historical end of day reviews must let operators move
+  to adjacent historical store days even when today's future-date guard would
+  disable the same day number in the current month.
 - Test local-day boundary cases with a completed transaction after UTC midnight
   but before the local operating day ends.
 - Test expense transactions with the same local-day boundary, store filtering,

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -2458,6 +2458,7 @@ function OperatingDatePicker({
       </PopoverTrigger>
       <PopoverContent align="end" className="w-auto p-0">
         <Calendar
+          defaultMonth={selectedDate}
           disabled={{ after: latestSelectableDate }}
           mode="single"
           onSelect={(date) => {

--- a/scripts/harness-behavior-scenarios.test.ts
+++ b/scripts/harness-behavior-scenarios.test.ts
@@ -387,6 +387,7 @@ describe("HARNESS_BEHAVIOR_SCENARIOS", () => {
 
   it("runs the Athena QA live smoke scenario through browser observations", async () => {
     const listeners = new Map<string, ((payload: any) => void)[]>();
+    let observedWaitUntil: string | undefined;
     const page = {
       on(event: string, listener: (payload: any) => void) {
         listeners.set(event, [...(listeners.get(event) ?? []), listener]);
@@ -396,7 +397,8 @@ describe("HARNESS_BEHAVIOR_SCENARIOS", () => {
     };
 
     const browserResult = await ATHENA_QA_LIVE_SMOKE_SCENARIO.browser({
-      runPlaywrightFlow: async ({ setupPage, steps }) => {
+      runPlaywrightFlow: async ({ setupPage, steps, waitUntil }) => {
+        observedWaitUntil = waitUntil;
         await setupPage?.({ page } as any);
         for (const listener of listeners.get("response") ?? []) {
           listener({
@@ -429,6 +431,7 @@ describe("HARNESS_BEHAVIOR_SCENARIOS", () => {
     } as any);
 
     expect(browserResult.observedText).toContain("LOG IN");
+    expect(observedWaitUntil).toBe("domcontentloaded");
     expect(browserResult.hasEmailField).toBe(true);
     expect(browserResult.observations).toHaveLength(3);
     expect(browserResult.diagnostics).toEqual([

--- a/scripts/harness-behavior-scenarios.ts
+++ b/scripts/harness-behavior-scenarios.ts
@@ -1301,6 +1301,7 @@ export const ATHENA_QA_LIVE_SMOKE_SCENARIO: HarnessBehaviorScenario<AthenaQaLive
 
       const flowResult = await runPlaywrightFlow({
         url: qaUrl,
+        waitUntil: "domcontentloaded",
         setupPage: ({ page }) => {
           page.on("pageerror", (error) => {
             observations.push({

--- a/scripts/harness-behavior.test.ts
+++ b/scripts/harness-behavior.test.ts
@@ -491,6 +491,24 @@ describe("runPlaywrightFlow", () => {
     ]);
   });
 
+  it("lets scenarios choose a lighter navigation readiness mode", async () => {
+    let observedWaitUntil: string | undefined;
+    const browser = createBrowser({
+      goto: async (_url: string, options?: { waitUntil?: string }) => {
+        observedWaitUntil = options?.waitUntil;
+      },
+    });
+
+    await runPlaywrightFlow({
+      url: "https://athena-qa.wigclub.store/",
+      waitUntil: "domcontentloaded",
+      playwrightModule: createPlaywrightModule(async () => browser),
+      steps: async () => ({ loaded: true }),
+    });
+
+    expect(observedWaitUntil).toBe("domcontentloaded");
+  });
+
   it("does not auto-install missing Chromium in CI", async () => {
     let installCount = 0;
 

--- a/scripts/harness-behavior.ts
+++ b/scripts/harness-behavior.ts
@@ -78,6 +78,7 @@ export type HarnessBehaviorRuntimeSignalResult = {
 export type HarnessBehaviorPlaywrightFlowOptions<TStepResult> = {
   url: string;
   headless?: boolean;
+  waitUntil?: "load" | "domcontentloaded" | "networkidle";
   recordVideo?: boolean;
   videoDir?: string;
   videoSize?: {
@@ -1035,7 +1036,7 @@ export async function runPlaywrightFlow<TStepResult>(
     });
     await options.setupPage?.({ page });
     await page.goto(options.url, {
-      waitUntil: "networkidle",
+      waitUntil: options.waitUntil ?? "networkidle",
     });
 
     stepResult = await options.steps({ page });


### PR DESCRIPTION
## Summary

This fixes the scheduled Athena QA smoke workflow failure by making the live QA browser scenario stop waiting for `networkidle` on a Vite/Convex-backed page. The scenario now navigates on `domcontentloaded` and still verifies the meaningful smoke signals: Athena content, the login email field, same-origin HTTP failures, request failures, and page errors.

It also closes the validation gap exposed during the full gate by making the Daily Close operating-date picker open on the selected operating date instead of the browser's current month. That keeps historical EOD Review navigation usable when today's future-date guard would disable the same day number in the current month.

## Validation

- `ATHENA_QA_URL=https://athena-qa.wigclub.store/ bun run harness:behavior --scenario athena-qa-live-smoke`
- `bun run --filter '@athena/webapp' test` (279 files, 2413 tests)
- `bun run pr:athena`

## Notes

- Added solution notes for the QA live-smoke readiness boundary and the Daily Close calendar month boundary.
- Rebuilt Graphify artifacts.