### PR TITLE
Improve POS cashier sale entry workflow

### DIFF
--- a/docs/solutions/logic-errors/athena-pos-idle-lookup-sale-start-2026-06-02.md
+++ b/docs/solutions/logic-errors/athena-pos-idle-lookup-sale-start-2026-06-02.md
@@ -1,0 +1,92 @@
+---
+title: Athena POS Idle Lookup Starts The Sale Workflow
+date: 2026-06-02
+category: logic-errors
+module: athena-webapp
+problem_type: pos_idle_lookup_sale_start_gap
+component: pos-register
+symptoms:
+  - "A signed-in cashier can see product lookup guidance while no sale exists"
+  - "The central lookup target focuses search only after a manual New sale click"
+  - "Cashier sign-in can lose the sale-start intent during local drawer bootstrap"
+root_cause: lookup_readiness_was_treated_as_focus_only_instead_of_sale_workflow_entry
+resolution_type: local_first_intent_preservation
+severity: medium
+tags:
+  - pos
+  - local-first
+  - cashier-flow
+  - terminal-authority
+  - touch-targets
+---
+
+# Athena POS Idle Lookup Starts The Sale Workflow
+
+## Problem
+
+The POS register's idle workspace is a cashier touch target, not just a message.
+When it says the register is ready for product lookup, a cashier expects a scan
+or tap to enter the selling flow. If no sale has started yet, focusing search
+alone leaves the register looking ready while item entry still has no sale to
+write to.
+
+The same gap can happen immediately after cashier authentication. The view model
+may have a valid staff proof and an open drawer, but local drawer bootstrap can
+finish after the first sale-start attempt. Clearing the autostart intent before
+`session.started` is durable leaves the cashier signed in with only a manual
+`New sale` recovery path.
+
+## Solution
+
+Treat idle lookup as the workflow entry point while preserving POS authority
+rules:
+
+- Cashier authentication records a sale-start intent only for a real
+  `StaffAuthenticationResult`. Restored staff ids stay idle so reload, clear,
+  and completion replays do not resurrect sales.
+- The autostart intent remains pending until the local command gateway records
+  `session.started`. Local read-model sequence changes can retry the same
+  intent after drawer bootstrap becomes sellable.
+- The idle product-lookup touch target starts a new sale when the register is
+  signed in, has no active sale, and the normal `New sale` action is enabled.
+  Once the view model reports an active sale, the same target focuses product
+  search.
+- Quantity controls use direct numeric inputs and larger touch targets, but cart
+  writes still go through the same local cart command and trusted availability
+  checks.
+- Terminal access remains store-scoped. Original terminal registrant ownership
+  is not an exclusive guard for staff authentication, runtime status, or
+  re-registration when the current user has store authority.
+
+## Regression Targets
+
+- Register view-model tests should prove cashier sign-in autostarts a local sale
+  after delayed drawer bootstrap and after stale cloud active-session summaries.
+- Register view-model tests should prove autostart does not duplicate starts or
+  resurrect locally completed or cleared sales after reload.
+- POS register view tests should prove the idle lookup workspace starts a sale
+  before focusing search when the register is signed in but idle.
+- Product and cart component tests should prove typed quantities flow into local
+  cart events and reject quantities beyond trusted availability.
+- Terminal command/public tests should prove non-owner authorized store users
+  can authenticate and re-register terminals without exposing sync secrets.
+
+## Prevention
+
+- Do not make product lookup controls depend on a separate manual `New sale`
+  click when the register can start a sale safely.
+- Do not clear a user workflow intent until the local-first command that
+  satisfies it has succeeded.
+- Do not broaden autostart to every signed-in idle state. Tie it to explicit
+  cashier authentication or direct lookup activation to avoid sale resurrection
+  from replayed local history.
+- Keep POS touch-target improvements at the presentation edge. Availability,
+  drawer, staff, and terminal authority remain enforced by the local command
+  gateway and Convex terminal command boundaries.
+
+## Related
+
+- [Athena POS Register Commands Are Always Local First](../architecture/athena-pos-always-local-first-register-2026-05-14.md)
+- [Athena POS Local Staff Authority](../architecture/athena-pos-local-staff-authority-2026-05-14.md)
+- [Athena POS Stale Terminal Sale Blocks](./athena-pos-stale-terminal-sale-block-2026-05-29.md)
+- [Athena POS Terminal Health Visibility](../architecture/athena-pos-terminal-health-visibility-2026-05-20.md)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5964 nodes · 6381 edges · 1726 communities detected
+- 5967 nodes · 6384 edges · 1726 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -3128,28 +3128,28 @@ Cohesion: 0.67
 Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 341 - "Community 341"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 342 - "Community 342"
 Cohesion: 0.67
 Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
-### Community 342 - "Community 342"
+### Community 343 - "Community 343"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 343 - "Community 343"
+### Community 344 - "Community 344"
 Cohesion: 0.67
 Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
-### Community 344 - "Community 344"
+### Community 345 - "Community 345"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 345 - "Community 345"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 346 - "Community 346"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 347 - "Community 347"
 Cohesion: 0.5
@@ -3160,112 +3160,112 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 349 - "Community 349"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 350 - "Community 350"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 350 - "Community 350"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 351 - "Community 351"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 352 - "Community 352"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 353 - "Community 353"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
 
-### Community 353 - "Community 353"
+### Community 354 - "Community 354"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 354 - "Community 354"
-Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 355 - "Community 355"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 356 - "Community 356"
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+
+### Community 357 - "Community 357"
 Cohesion: 1.0
 Nodes (3): canAccessFullAdminSurface(), canAccessStoreDaySurface(), getSurfaceAccess()
 
-### Community 357 - "Community 357"
+### Community 358 - "Community 358"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 358 - "Community 358"
+### Community 359 - "Community 359"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 359 - "Community 359"
+### Community 360 - "Community 360"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 360 - "Community 360"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 361 - "Community 361"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 362 - "Community 362"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 363 - "Community 363"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 364 - "Community 364"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 365 - "Community 365"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 365 - "Community 365"
+### Community 366 - "Community 366"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 366 - "Community 366"
+### Community 367 - "Community 367"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 367 - "Community 367"
+### Community 368 - "Community 368"
 Cohesion: 0.83
 Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 368 - "Community 368"
+### Community 369 - "Community 369"
 Cohesion: 0.83
 Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
-### Community 369 - "Community 369"
+### Community 370 - "Community 370"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 370 - "Community 370"
+### Community 371 - "Community 371"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 371 - "Community 371"
+### Community 372 - "Community 372"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 372 - "Community 372"
+### Community 373 - "Community 373"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 373 - "Community 373"
+### Community 374 - "Community 374"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 374 - "Community 374"
+### Community 375 - "Community 375"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 375 - "Community 375"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 376 - "Community 376"
 Cohesion: 0.5
@@ -3296,59 +3296,59 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 383 - "Community 383"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 384 - "Community 384"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 385 - "Community 385"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 386 - "Community 386"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 386 - "Community 386"
+### Community 387 - "Community 387"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 387 - "Community 387"
-Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 388 - "Community 388"
 Cohesion: 0.83
-Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 389 - "Community 389"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
 ### Community 390 - "Community 390"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 391 - "Community 391"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 392 - "Community 392"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 393 - "Community 393"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 393 - "Community 393"
+### Community 394 - "Community 394"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 394 - "Community 394"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 395 - "Community 395"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 396 - "Community 396"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 397 - "Community 397"
@@ -3356,12 +3356,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 398 - "Community 398"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 399 - "Community 399"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 399 - "Community 399"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 400 - "Community 400"
 Cohesion: 0.67
@@ -3396,12 +3396,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 408 - "Community 408"
-Cohesion: 1.0
-Nodes (2): buildCtx(), createDb()
-
-### Community 409 - "Community 409"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 409 - "Community 409"
+Cohesion: 1.0
+Nodes (2): buildCtx(), createDb()
 
 ### Community 410 - "Community 410"
 Cohesion: 0.67
@@ -3420,20 +3420,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 414 - "Community 414"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 415 - "Community 415"
 Cohesion: 1.0
 Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
-### Community 415 - "Community 415"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 416 - "Community 416"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 417 - "Community 417"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 418 - "Community 418"
 Cohesion: 0.67
@@ -3448,24 +3448,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 421 - "Community 421"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 422 - "Community 422"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 422 - "Community 422"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 423 - "Community 423"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 424 - "Community 424"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 425 - "Community 425"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 425 - "Community 425"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 426 - "Community 426"
 Cohesion: 0.67
@@ -3480,36 +3480,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 429 - "Community 429"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 430 - "Community 430"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 431 - "Community 431"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 432 - "Community 432"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 433 - "Community 433"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 434 - "Community 434"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 435 - "Community 435"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 435 - "Community 435"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 436 - "Community 436"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 437 - "Community 437"
 Cohesion: 0.67
@@ -3524,12 +3524,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 440 - "Community 440"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 441 - "Community 441"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 441 - "Community 441"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 442 - "Community 442"
 Cohesion: 0.67
@@ -3541,11 +3541,11 @@ Nodes (0):
 
 ### Community 444 - "Community 444"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 445 - "Community 445"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 446 - "Community 446"
 Cohesion: 0.67
@@ -3553,15 +3553,15 @@ Nodes (0):
 
 ### Community 447 - "Community 447"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 448 - "Community 448"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (1): VideoPlayer()
 
 ### Community 449 - "Community 449"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 450 - "Community 450"
 Cohesion: 0.67
@@ -3629,83 +3629,83 @@ Nodes (0):
 
 ### Community 466 - "Community 466"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 467 - "Community 467"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (0):
 
 ### Community 468 - "Community 468"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 469 - "Community 469"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 470 - "Community 470"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 471 - "Community 471"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 472 - "Community 472"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TableSkeleton()
 
 ### Community 473 - "Community 473"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
+Cohesion: 0.67
+Nodes (1): TransactionsSkeleton()
 
 ### Community 474 - "Community 474"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (1): NotFound()
 
 ### Community 475 - "Community 475"
-Cohesion: 0.67
-Nodes (1): Badge()
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
 ### Community 476 - "Community 476"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): AppContextMenu()
 
 ### Community 477 - "Community 477"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): Badge()
 
 ### Community 478 - "Community 478"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (0):
 
 ### Community 479 - "Community 479"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): LoadingButton()
 
 ### Community 480 - "Community 480"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): onChange()
 
 ### Community 481 - "Community 481"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): AlertModal()
 
 ### Community 482 - "Community 482"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): OverlayModal()
 
 ### Community 483 - "Community 483"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Skeleton()
 
 ### Community 484 - "Community 484"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 485 - "Community 485"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 486 - "Community 486"
 Cohesion: 0.67
@@ -3733,7 +3733,7 @@ Nodes (0):
 
 ### Community 492 - "Community 492"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 493 - "Community 493"
 Cohesion: 0.67
@@ -3741,27 +3741,27 @@ Nodes (0):
 
 ### Community 494 - "Community 494"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 495 - "Community 495"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 496 - "Community 496"
-Cohesion: 1.0
-Nodes (2): getApprovalGuidance(), presentCommandToast()
-
-### Community 497 - "Community 497"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
-### Community 498 - "Community 498"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 499 - "Community 499"
+### Community 497 - "Community 497"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 498 - "Community 498"
 Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
+Nodes (2): getApprovalGuidance(), presentCommandToast()
+
+### Community 499 - "Community 499"
+Cohesion: 0.67
+Nodes (1): isInMaintenanceMode()
 
 ### Community 500 - "Community 500"
 Cohesion: 0.67
@@ -3769,63 +3769,63 @@ Nodes (0):
 
 ### Community 501 - "Community 501"
 Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 502 - "Community 502"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 503 - "Community 503"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 504 - "Community 504"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 505 - "Community 505"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 506 - "Community 506"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): App()
 
 ### Community 507 - "Community 507"
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+
+### Community 508 - "Community 508"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 508 - "Community 508"
+### Community 509 - "Community 509"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 510 - "Community 510"
 Cohesion: 1.0
 Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
-### Community 509 - "Community 509"
+### Community 511 - "Community 511"
 Cohesion: 1.0
 Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
-### Community 510 - "Community 510"
+### Community 512 - "Community 512"
 Cohesion: 0.67
 Nodes (1): hashPassword()
 
-### Community 511 - "Community 511"
+### Community 513 - "Community 513"
 Cohesion: 0.67
 Nodes (1): createVersionChecker()
 
-### Community 512 - "Community 512"
+### Community 514 - "Community 514"
 Cohesion: 0.67
 Nodes (1): manualChunks()
 
-### Community 513 - "Community 513"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 514 - "Community 514"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 515 - "Community 515"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 516 - "Community 516"
 Cohesion: 0.67
@@ -3833,19 +3833,19 @@ Nodes (0):
 
 ### Community 517 - "Community 517"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 518 - "Community 518"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 519 - "Community 519"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 520 - "Community 520"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 521 - "Community 521"
 Cohesion: 0.67
@@ -3856,32 +3856,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 523 - "Community 523"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 524 - "Community 524"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 525 - "Community 525"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 526 - "Community 526"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 527 - "Community 527"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 528 - "Community 528"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 529 - "Community 529"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 530 - "Community 530"
 Cohesion: 0.67
@@ -3944,8 +3944,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 545 - "Community 545"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 546 - "Community 546"
 Cohesion: 0.67
@@ -3953,11 +3953,11 @@ Nodes (0):
 
 ### Community 547 - "Community 547"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
 
 ### Community 548 - "Community 548"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 549 - "Community 549"
 Cohesion: 1.0
@@ -3972,24 +3972,24 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 552 - "Community 552"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 553 - "Community 553"
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
+
+### Community 554 - "Community 554"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 554 - "Community 554"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
-
 ### Community 555 - "Community 555"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 556 - "Community 556"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 557 - "Community 557"
 Cohesion: 1.0
@@ -8670,299 +8670,295 @@ Nodes (0):
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 555`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 557`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 556`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 558`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 557`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 559`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 558`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 560`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 559`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 561`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 560`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 562`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 561`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 563`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 562`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 564`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 565`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 566`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 567`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 568`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 569`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 570`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 571`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 572`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 573`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 574`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 575`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 576`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 577`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 578`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 579`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 580`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 581`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 582`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 583`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 584`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 585`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 586`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 587`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 588`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 589`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 590`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 591`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 592`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 593`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 594`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 595`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 596`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 597`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 598`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 599`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 600`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 601`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 602`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 603`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 604`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 605`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
+- **Thin community `Community 606`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
+- **Thin community `Community 607`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 608`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 609`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 610`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 611`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 612`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
+- **Thin community `Community 613`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 614`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 615`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 616`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 617`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 618`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 619`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 620`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 621`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 622`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 623`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 624`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 625`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 626`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 627`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 628`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 629`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 630`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 631`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 632`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 633`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 634`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 635`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 636`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 637`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 638`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 639`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 640`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 641`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 642`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 643`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 644`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 645`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 646`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 647`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 648`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 649`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 650`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 651`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 652`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 653`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 654`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 655`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 656`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 657`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 658`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 659`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 660`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 661`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 662`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 663`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 664`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 665`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 666`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 667`** (2 nodes): `Login()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 668`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 669`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 670`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 671`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 672`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 673`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 674`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 675`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 676`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 677`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 678`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 679`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 680`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 681`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 682`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 683`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 684`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 685`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 686`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 687`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 688`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 689`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 690`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 691`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 692`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 693`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 694`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 695`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 696`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `cn()`, `CartItems.tsx`
+- **Thin community `Community 697`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
+- **Thin community `Community 698`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 699`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 700`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `PinInput.tsx`, `PinInput()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `ProductCard.tsx`, `handleClick()`
+- **Thin community `Community 701`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 702`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1798
-- Graph nodes: 5964
-- Graph edges: 6381
+- Graph nodes: 5967
+- Graph edges: 6384
 - Communities: 1726
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/operations/staffCredentials.test.ts
+++ b/packages/athena-webapp/convex/operations/staffCredentials.test.ts
@@ -1352,7 +1352,7 @@ describe("staff credential operations", () => {
     ).resolves.toBe(proofRows[0]?.tokenHash);
   });
 
-  it("rejects public terminal authentication when the signed-in user does not own the terminal", async () => {
+  it("allows public terminal authentication when the signed-in POS user did not register the terminal", async () => {
     const { ctx } = createStaffCredentialsMutationCtx({
       posTerminals: [
         {
@@ -1406,15 +1406,14 @@ describe("staff credential operations", () => {
         username: "frontdesk",
       })
     ).resolves.toEqual({
-      kind: "user_error",
-      error: {
-        code: "authorization_failed",
-        message: "This terminal is not available for staff authentication.",
-      },
+      kind: "ok",
+      data: expect.objectContaining({
+        staffProfileId: "staff_profile_1",
+      }),
     });
   });
 
-  it("requires the terminal owner to have POS access before public terminal authentication", async () => {
+  it("requires the signed-in user to have POS access before public terminal authentication", async () => {
     const { ctx } = createStaffCredentialsMutationCtx({
       credentials: [
         {
@@ -1479,7 +1478,7 @@ describe("staff credential operations", () => {
     );
   });
 
-  it("checks the terminal owner's POS access before minting a public local staff proof", async () => {
+  it("checks the signed-in user's POS access before minting a public local staff proof", async () => {
     const { ctx } = createStaffCredentialsMutationCtx({
       credentials: [
         {

--- a/packages/athena-webapp/convex/operations/staffCredentials.ts
+++ b/packages/athena-webapp/convex/operations/staffCredentials.ts
@@ -207,9 +207,6 @@ async function requirePosTerminalAuthorityWithCtx(
       return terminalAuthorizationFailedResult();
     }
     const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
-    if (terminal.registeredByUserId !== athenaUser._id) {
-      return terminalAuthorizationFailedResult();
-    }
     await requireOrganizationMemberRoleWithCtx(ctx, {
       allowedRoles: ["full_admin", "pos_only"],
       failureMessage: "You do not have access to this POS terminal.",

--- a/packages/athena-webapp/convex/pos/application/commands/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/terminals.ts
@@ -108,14 +108,6 @@ export async function registerTerminal(
         });
       }
 
-      if (existing.registeredByUserId !== args.registeredByUserId) {
-        return userError({
-          code: "authorization_failed",
-          message:
-            "This terminal is already registered to another signed-in user.",
-        });
-      }
-
       if (existing.registerNumber !== nextRegisterNumber) {
         return userError({
           code: "validation_failed",

--- a/packages/athena-webapp/convex/pos/application/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminals.test.ts
@@ -155,28 +155,41 @@ describe("registerTerminal", () => {
     );
   });
 
-  it("does not rebind an existing terminal to a different signed-in user", async () => {
+  it("rebinds an existing terminal to a different signed-in full-admin user", async () => {
     vi.mocked(getTerminalByFingerprint).mockResolvedValue(existingTerminal);
     vi.mocked(getTerminalByStoreIdAndRegisterNumber).mockResolvedValue(null);
 
     const result = await registerTerminal({ db: null as never } as never, {
       storeId: "store-1" as Id<"store">,
       fingerprintHash: "fingerprint-1",
-      syncSecretHash: "sync-secret-1",
+      syncSecretHash: "sync-secret-rotated",
       displayName: "Updated Terminal",
       registerNumber: "A1",
       registeredByUserId: "user-2" as Id<"athenaUser">,
       browserInfo,
     });
 
-    expect(result).toEqual(
-      userError({
-        code: "authorization_failed",
-        message:
-          "This terminal is already registered to another signed-in user.",
+    expect(vi.mocked(patchTerminalRecord)).toHaveBeenCalledWith(
+      expect.anything(),
+      existingTerminal._id,
+      expect.objectContaining({
+        browserInfo,
+        displayName: "Updated Terminal",
+        registeredByUserId: "user-2",
+        registerNumber: "A1",
+        status: "active",
+        syncSecretHash: "sync-secret-rotated",
       }),
     );
-    expect(vi.mocked(patchTerminalRecord)).not.toHaveBeenCalled();
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "ok",
+        data: expect.objectContaining({
+          registeredByUserId: "user-2",
+          syncSecretHash: "sync-secret-rotated",
+        }),
+      }),
+    );
   });
 
   it("does not reassign an existing terminal to another register number", async () => {

--- a/packages/athena-webapp/convex/pos/public/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.test.ts
@@ -317,8 +317,16 @@ describe("POS terminal public mutations", () => {
     );
   });
 
-  it("accepts redacted runtime status from the terminal owner only", async () => {
-    const ctx = buildCtx();
+  it("accepts redacted runtime status from an authorized store member", async () => {
+    const ctx = buildCtx({
+      terminal: {
+        _id: "terminal-1",
+        storeId: "store-1",
+        status: "active",
+        registeredByUserId: "athena-user-2",
+        syncSecretHash: SYNC_SECRET_HASH,
+      },
+    });
 
     const result = await getHandler(submitTerminalRuntimeStatus)(ctx as never, {
       storeId: "store-1",
@@ -439,16 +447,6 @@ describe("POS terminal public mutations", () => {
         storeId: "store-2",
         status: "active",
         registeredByUserId: "athena-user-1",
-        syncSecretHash: SYNC_SECRET_HASH,
-      },
-    },
-    {
-      name: "wrong registered user",
-      terminal: {
-        _id: "terminal-1",
-        storeId: "store-1",
-        status: "active",
-        registeredByUserId: "athena-user-2",
         syncSecretHash: SYNC_SECRET_HASH,
       },
     },

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -451,7 +451,6 @@ export const submitTerminalRuntimeStatus = mutation({
       !terminal ||
       terminal.storeId !== args.storeId ||
       terminal.status !== "active" ||
-      terminal.registeredByUserId !== athenaUser._id ||
       !terminal.syncSecretHash ||
       terminal.syncSecretHash !== submittedSyncSecretHash
     ) {

--- a/packages/athena-webapp/src/components/pos/CartItems.test.tsx
+++ b/packages/athena-webapp/src/components/pos/CartItems.test.tsx
@@ -124,4 +124,42 @@ describe("CartItems service lines", () => {
 
     expect(onRemoveService).toHaveBeenCalledWith("service-line-1");
   });
+
+  it("gives compact product quantity controls larger touch targets and accepts typed quantities", async () => {
+    const user = userEvent.setup();
+    const onUpdateQuantity = vi.fn();
+
+    render(
+      <CartItems
+        density="compact"
+        cartItems={[
+          {
+            id: "item-1" as never,
+            barcode: "4739394883944",
+            name: "Nicca",
+            price: 6500,
+            quantity: 6,
+            sku: "6N2Y-WMA",
+          },
+        ]}
+        onUpdateQuantity={onUpdateQuantity}
+      />,
+    );
+
+    const quantityInput = screen.getByRole("spinbutton", {
+      name: /quantity for nicca/i,
+    });
+    expect(quantityInput).toHaveClass("h-11", "w-14");
+    await user.click(
+      screen.getByRole("button", { name: /increase quantity for nicca/i }),
+    );
+
+    expect(onUpdateQuantity).toHaveBeenCalledWith("item-1", 7);
+
+    await user.clear(quantityInput);
+    await user.type(quantityInput, "9");
+    await user.tab();
+
+    expect(onUpdateQuantity).toHaveBeenCalledWith("item-1", 9);
+  });
 });

--- a/packages/athena-webapp/src/components/pos/CartItems.tsx
+++ b/packages/athena-webapp/src/components/pos/CartItems.tsx
@@ -19,6 +19,7 @@ import {
 } from "~/src/lib/pos/displayAmounts";
 import type { RegisterServiceLineState } from "@/lib/pos/presentation/register/registerUiState";
 import { Input } from "@/components/ui/input";
+import { useEffect, useState } from "react";
 
 interface CartItemsProps {
   cartItems: CartItem[];
@@ -34,6 +35,114 @@ interface CartItemsProps {
   readOnly?: boolean;
   density?: "comfortable" | "compact";
   className?: string;
+}
+
+function normalizeCartQuantityInput(value: string | number) {
+  const parsed =
+    typeof value === "number" ? value : Number.parseInt(value, 10);
+
+  if (!Number.isFinite(parsed)) {
+    return 1;
+  }
+
+  return Math.max(1, Math.trunc(parsed));
+}
+
+function CartItemQuantityControl({
+  isCompact,
+  item,
+  onUpdateQuantity,
+}: {
+  isCompact: boolean;
+  item: CartItem;
+  onUpdateQuantity: NonNullable<CartItemsProps["onUpdateQuantity"]>;
+}) {
+  const [draftQuantity, setDraftQuantity] = useState(String(item.quantity));
+
+  useEffect(() => {
+    setDraftQuantity(String(item.quantity));
+  }, [item.id, item.quantity]);
+
+  const updateQuantity = (quantity: number) => {
+    setDraftQuantity(String(quantity));
+    if (quantity !== item.quantity) {
+      onUpdateQuantity(
+        item.id as Id<"posSessionItem"> | Id<"expenseSessionItem">,
+        quantity,
+      );
+    }
+  };
+
+  const commitDraftQuantity = () => {
+    updateQuantity(normalizeCartQuantityInput(draftQuantity));
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex items-center rounded-md border border-border bg-background p-1.5 shadow-sm",
+        isCompact ? "gap-2" : "gap-3",
+      )}
+    >
+      <Button
+        variant="outline"
+        size="icon"
+        className={cn(
+          "rounded-md",
+          isCompact ? "h-11 w-11" : "h-12 w-12",
+        )}
+        aria-label={`Decrease quantity for ${item.name}`}
+        onClick={() =>
+          updateQuantity(
+            Math.max(1, normalizeCartQuantityInput(draftQuantity) - 1),
+          )
+        }
+      >
+        <Minus className="h-4 w-4" />
+      </Button>
+      <label className="sr-only" htmlFor={`cart-quantity-${item.id}`}>
+        Quantity for {item.name}
+      </label>
+      <Input
+        id={`cart-quantity-${item.id}`}
+        type="number"
+        inputMode="numeric"
+        pattern="[0-9]*"
+        min={1}
+        value={draftQuantity}
+        className={cn(
+          "px-2 text-center font-numeric font-semibold tabular-nums text-foreground [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none",
+          isCompact ? "h-11 w-14 text-base" : "h-12 w-16 text-lg",
+        )}
+        onBlur={commitDraftQuantity}
+        onChange={(event) => setDraftQuantity(event.target.value)}
+        onFocus={(event) => event.currentTarget.select()}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.currentTarget.blur();
+          }
+          if (event.key === "Escape") {
+            setDraftQuantity(String(item.quantity));
+            event.currentTarget.blur();
+          }
+        }}
+      />
+      <Button
+        variant="outline"
+        size="icon"
+        className={cn(
+          "rounded-md",
+          isCompact ? "h-11 w-11" : "h-12 w-12",
+        )}
+        aria-label={`Increase quantity for ${item.name}`}
+        onClick={() =>
+          updateQuantity(normalizeCartQuantityInput(draftQuantity) + 1)
+        }
+      >
+        <Plus className="h-4 w-4" />
+      </Button>
+    </div>
+  );
 }
 
 export function CartItems({
@@ -380,43 +489,13 @@ export function CartItems({
                     )}
                   >
                     {!readOnly && (
-                      <div className="flex items-center gap-2">
-                        <Button
-                          variant="outline"
-                          size="icon"
-                          className="h-10 w-10"
-                          onClick={() =>
-                            onUpdateQuantity &&
-                            onUpdateQuantity(
-                              item.id as
-                                | Id<"posSessionItem">
-                                | Id<"expenseSessionItem">,
-                              item.quantity - 1,
-                            )
-                          }
-                        >
-                          <Minus className="w-4 h-4" />
-                        </Button>
-                        <span className="w-10 text-center font-medium text-sm">
-                          {item.quantity}
-                        </span>
-                        <Button
-                          variant="outline"
-                          size="icon"
-                          className="h-10 w-10"
-                          onClick={() =>
-                            onUpdateQuantity &&
-                            onUpdateQuantity(
-                              item.id as
-                                | Id<"posSessionItem">
-                                | Id<"expenseSessionItem">,
-                              item.quantity + 1,
-                            )
-                          }
-                        >
-                          <Plus className="w-4 h-4" />
-                        </Button>
-                      </div>
+                      onUpdateQuantity && (
+                        <CartItemQuantityControl
+                          isCompact={isCompact}
+                          item={item}
+                          onUpdateQuantity={onUpdateQuantity}
+                        />
+                      )
                     )}
                   </div>
 

--- a/packages/athena-webapp/src/components/pos/ProductCard.tsx
+++ b/packages/athena-webapp/src/components/pos/ProductCard.tsx
@@ -1,14 +1,36 @@
 import { Badge } from "@/components/ui/badge";
-import { Package } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Minus, Package, Plus, ShoppingCart } from "lucide-react";
 import { Product } from "./types";
 import { capitalizeWords } from "~/src/lib/utils";
 import { toDisplayAmount } from "~/convex/lib/currency";
+import { useEffect, useMemo, useState } from "react";
 
 interface ProductCardProps {
   product: Product;
-  onAddProduct: (product: Product) => boolean | Promise<boolean>;
+  onAddProduct: (
+    product: Product,
+    quantity?: number,
+  ) => boolean | Promise<boolean>;
   formatter: Intl.NumberFormat;
   onAfterAdd?: () => void;
+}
+
+function normalizeQuantity(value: string | number, maxQuantity?: number) {
+  const parsed =
+    typeof value === "number" ? value : Number.parseInt(value, 10);
+
+  if (!Number.isFinite(parsed)) {
+    return 1;
+  }
+
+  const quantity = Math.max(1, Math.trunc(parsed));
+  if (maxQuantity === undefined || maxQuantity <= 0) {
+    return quantity;
+  }
+
+  return Math.min(quantity, maxQuantity);
 }
 
 export function ProductCard({
@@ -17,10 +39,29 @@ export function ProductCard({
   formatter,
   onAfterAdd,
 }: ProductCardProps) {
-  const isAvailable = product.inStock;
-  const handleClick = async () => {
+  const [quantityInput, setQuantityInput] = useState("1");
+  const maxQuantity = useMemo(() => {
+    if (typeof product.quantityAvailable !== "number") {
+      return undefined;
+    }
+
+    return Math.max(0, Math.trunc(product.quantityAvailable));
+  }, [product.quantityAvailable]);
+  const selectedQuantity = normalizeQuantity(quantityInput, maxQuantity);
+  const isAvailable =
+    product.inStock && (maxQuantity === undefined || maxQuantity > 0);
+  const canDecreaseQuantity = selectedQuantity > 1;
+  const canIncreaseQuantity =
+    maxQuantity === undefined || selectedQuantity < maxQuantity;
+
+  useEffect(() => {
+    setQuantityInput("1");
+  }, [product.id]);
+
+  const handleAddSelectedQuantity = async () => {
     if (isAvailable) {
-      const added = await onAddProduct(product);
+      setQuantityInput(String(selectedQuantity));
+      const added = await onAddProduct(product, selectedQuantity);
       if (added !== false) {
         onAfterAdd?.();
       }
@@ -30,12 +71,12 @@ export function ProductCard({
   return (
     <div
       aria-disabled={!isAvailable}
-      className={`group flex items-center gap-4 p-4 border rounded-lg transition-all duration-200 bg-white/80 backdrop-blur-sm ${
+      className={`group flex flex-col gap-4 rounded-lg border p-4 transition-all duration-200 sm:flex-row sm:items-center ${
         !isAvailable
-          ? "cursor-not-allowed opacity-95 border-gray-200"
-          : "border-gray-200 hover:border-blue-200 hover:shadow-md hover:shadow-blue-100/50"
+          ? "cursor-not-allowed border-border/70 bg-surface/80 opacity-95"
+          : "border-border bg-surface/80 hover:border-signal/30 hover:shadow-surface"
       }`}
-      onClick={handleClick}
+      onClick={handleAddSelectedQuantity}
     >
       {/* Product Image */}
       <div className="w-16 h-16 bg-muted rounded flex items-center justify-center flex-shrink-0 overflow-hidden">
@@ -51,14 +92,14 @@ export function ProductCard({
       </div>
 
       {/* Product Details */}
-      <div className="flex-1 min-w-0">
+      <div className="min-w-0 flex-1">
         {/* Name and Price */}
         <div className="flex items-start justify-between gap-2">
-          <h4 className="font-semibold text-md text-gray-600 truncate group-hover:text-gray-900">
+          <h4 className="text-md truncate font-semibold text-foreground/80 group-hover:text-foreground">
             {capitalizeWords(product.name)}
           </h4>
           <div className="flex items-center gap-2 flex-shrink-0">
-            <p className="text-lg font-medium px-4">
+            <p className="px-4 font-numeric text-lg font-medium">
               {formatter.format(toDisplayAmount(product.price))}
             </p>
           </div>
@@ -67,12 +108,12 @@ export function ProductCard({
         {/* SKU and Barcode */}
         <div className="flex items-center gap-2 mt-1">
           {product.sku && (
-            <span className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded">
+            <span className="rounded bg-muted px-2 py-1 font-mono text-xs text-muted-foreground">
               {product.sku}
             </span>
           )}
           {product.barcode && (
-            <span className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded">
+            <span className="rounded bg-muted px-2 py-1 font-mono text-xs text-muted-foreground">
               {product.barcode}
             </span>
           )}
@@ -104,16 +145,81 @@ export function ProductCard({
           </div>
         )}
 
-        {/* Availability */}
-        <p className="text-xs text-gray-500 mt-4">
-          {product.availabilityMessage ? (
-            product.availabilityMessage
-          ) : (
-            <>
-              <b>{product.quantityAvailable ?? 0}</b> available
-            </>
-          )}
-        </p>
+        <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          {/* Availability */}
+          <p className="text-xs text-muted-foreground">
+            {product.availabilityMessage ? (
+              product.availabilityMessage
+            ) : (
+              <>
+                <b>{product.quantityAvailable ?? 0}</b> available
+              </>
+            )}
+          </p>
+
+          <div
+            className="flex items-center rounded-md border border-border bg-background p-1.5 shadow-sm"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="h-11 w-11 rounded-md"
+                disabled={!isAvailable || !canDecreaseQuantity}
+                aria-label={`Decrease quantity for ${product.name}`}
+                onClick={() =>
+                  setQuantityInput(String(Math.max(1, selectedQuantity - 1)))
+                }
+              >
+                <Minus className="h-4 w-4" />
+              </Button>
+              <label className="sr-only" htmlFor={`quantity-${product.id}`}>
+                Quantity for {product.name}
+              </label>
+              <Input
+                id={`quantity-${product.id}`}
+                type="number"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                min={1}
+                max={maxQuantity}
+                value={quantityInput}
+                disabled={!isAvailable}
+                className="h-11 w-14 px-2 text-center font-numeric text-base font-semibold tabular-nums [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                onBlur={() => setQuantityInput(String(selectedQuantity))}
+                onChange={(event) => setQuantityInput(event.target.value)}
+                onFocus={(event) => event.currentTarget.select()}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="h-11 w-11 rounded-md"
+                disabled={!isAvailable || !canIncreaseQuantity}
+                aria-label={`Increase quantity for ${product.name}`}
+                onClick={() => setQuantityInput(String(selectedQuantity + 1))}
+              >
+                <Plus className="h-4 w-4" />
+              </Button>
+            </div>
+            <div className="ml-3 flex border-l border-border/80 pl-3">
+              <Button
+                type="button"
+                size="sm"
+                className="h-11 px-4"
+                disabled={!isAvailable}
+                onClick={handleAddSelectedQuantity}
+              >
+                <ShoppingCart className="mr-1.5 h-4 w-4" />
+                <span>
+                  Add{selectedQuantity > 1 ? ` ${selectedQuantity}` : ""}
+                </span>
+              </Button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/packages/athena-webapp/src/components/pos/ProductEntry.test.tsx
+++ b/packages/athena-webapp/src/components/pos/ProductEntry.test.tsx
@@ -61,7 +61,10 @@ function buildQuickAddedProduct(): Product {
 }
 
 function renderProductEntry(input: {
-  onAddProduct: (product: Product) => boolean | Promise<boolean>;
+  onAddProduct: (
+    product: Product,
+    quantity?: number,
+  ) => boolean | Promise<boolean>;
   setProductSearchQuery: (query: string) => void;
 }) {
   function Harness() {

--- a/packages/athena-webapp/src/components/pos/ProductEntry.tsx
+++ b/packages/athena-webapp/src/components/pos/ProductEntry.tsx
@@ -57,7 +57,10 @@ interface ProductSearchInputProps {
 interface ProductEntryProps extends ProductSearchInputProps {
   showProductLookup: boolean;
   setShowProductLookup: (value: boolean) => void;
-  onAddProduct: (product: Product) => boolean | Promise<boolean>;
+  onAddProduct: (
+    product: Product,
+    quantity?: number,
+  ) => boolean | Promise<boolean>;
   searchResults: Product[];
   isSearchLoading: boolean;
   isSearchReady: boolean;

--- a/packages/athena-webapp/src/components/pos/SearchResultsSection.test.tsx
+++ b/packages/athena-webapp/src/components/pos/SearchResultsSection.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import { SearchResultsSection } from "./SearchResultsSection";
@@ -60,9 +61,15 @@ describe("SearchResultsSection", () => {
   it("shows the shortcut hint on the add-variant action", () => {
     renderSearchResults();
 
-    expect(
-      screen.getByRole("button", { name: /add variant for this product/i }),
-    ).toHaveAttribute("aria-keyshortcuts", "Meta+Enter Control+Enter");
+    const addVariantButton = screen.getByRole("button", {
+      name: /add variant for this product/i,
+    });
+
+    expect(addVariantButton).toHaveAttribute(
+      "aria-keyshortcuts",
+      "Meta+Enter Control+Enter",
+    );
+    expect(addVariantButton).toHaveClass("bg-action-workflow");
     expect(screen.getByText("⌘+↵")).toBeInTheDocument();
   });
 
@@ -81,9 +88,15 @@ describe("SearchResultsSection", () => {
       products: [],
     });
 
-    expect(
-      screen.getByRole("button", { name: /quick add product/i }),
-    ).toHaveAttribute("aria-keyshortcuts", "Meta+Enter Control+Enter");
+    const quickAddButton = screen.getByRole("button", {
+      name: /quick add product/i,
+    });
+
+    expect(quickAddButton).toHaveAttribute(
+      "aria-keyshortcuts",
+      "Meta+Enter Control+Enter",
+    );
+    expect(quickAddButton).toHaveClass("bg-action-workflow");
     expect(screen.getByText("⌘+↵")).toBeInTheDocument();
   });
 
@@ -159,5 +172,57 @@ describe("SearchResultsSection", () => {
     fireEvent.click(screen.getByText("Club"));
 
     expect(onAddProduct).not.toHaveBeenCalled();
+  });
+
+  it("adds the selected quantity from a product result", async () => {
+    const user = userEvent.setup();
+    const product = buildProduct({
+      id: "sku-quantity",
+      name: "Nicca",
+      quantityAvailable: 12,
+    });
+    const onAddProduct = vi.fn(async () => true);
+    const onClearSearch = vi.fn();
+
+    renderSearchResults({
+      products: [product],
+      onAddProduct,
+      onClearSearch,
+    });
+
+    const quantityInput = screen.getByRole("spinbutton", {
+      name: /quantity for nicca/i,
+    });
+    expect(quantityInput).toHaveClass("h-11", "w-14");
+    await user.clear(quantityInput);
+    await user.type(quantityInput, "3");
+    await user.click(screen.getByRole("button", { name: /add 3/i }));
+
+    expect(onAddProduct).toHaveBeenCalledWith(product, 3);
+    expect(onClearSearch).toHaveBeenCalled();
+  });
+
+  it("clamps result quantity entry to available stock", async () => {
+    const user = userEvent.setup();
+    const product = buildProduct({
+      id: "sku-limited",
+      name: "Limited wig",
+      quantityAvailable: 4,
+    });
+    const onAddProduct = vi.fn(async () => true);
+
+    renderSearchResults({
+      products: [product],
+      onAddProduct,
+    });
+
+    const quantityInput = screen.getByRole("spinbutton", {
+      name: /quantity for limited wig/i,
+    });
+    await user.clear(quantityInput);
+    await user.type(quantityInput, "99");
+    await user.click(screen.getByRole("button", { name: /add 4/i }));
+
+    expect(onAddProduct).toHaveBeenCalledWith(product, 4);
   });
 });

--- a/packages/athena-webapp/src/components/pos/SearchResultsSection.tsx
+++ b/packages/athena-webapp/src/components/pos/SearchResultsSection.tsx
@@ -8,7 +8,10 @@ import { useEffect } from "react";
 interface SearchResultsSectionProps {
   isLoading: boolean;
   products: Product[];
-  onAddProduct: (product: Product) => boolean | Promise<boolean>;
+  onAddProduct: (
+    product: Product,
+    quantity?: number,
+  ) => boolean | Promise<boolean>;
   formatter: Intl.NumberFormat;
   onClearSearch: () => void;
   onQuickAddProduct?: (product?: Product) => void;
@@ -121,6 +124,7 @@ export function SearchResultsSection({
             <Button
               type="button"
               size="sm"
+              variant="workflow"
               className="mt-5"
               aria-keyshortcuts="Meta+Enter Control+Enter"
               onClick={() => onQuickAddProduct?.()}
@@ -157,6 +161,7 @@ export function SearchResultsSection({
             <Button
               type="button"
               size="sm"
+              variant="workflow"
               className="w-full sm:w-auto"
               aria-keyshortcuts="Meta+Enter Control+Enter"
               onClick={() => onQuickAddProduct(variantSourceProduct)}

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -108,13 +108,16 @@ vi.mock("@/components/pos/ProductEntry", async () => {
           onAddProduct,
           serviceEntry,
         }: {
-          onAddProduct?: (product: {
-            id: string;
-            name: string;
-            price: number;
-            productId: string;
-            skuId: string;
-          }) => boolean | Promise<boolean>;
+          onAddProduct?: (
+            product: {
+              id: string;
+              name: string;
+              price: number;
+              productId: string;
+              skuId: string;
+            },
+            quantity?: number,
+          ) => boolean | Promise<boolean>;
           serviceEntry?: {
             onAddService?: (
               service: {
@@ -959,6 +962,73 @@ describe("POSRegisterView", () => {
 
     expect(setShowProductLookup).toHaveBeenCalledWith(true);
     expect(screen.getByLabelText("product search input")).toHaveFocus();
+  });
+
+  it("starts a new sale before focusing product lookup from the idle lookup workspace", async () => {
+    const setShowProductLookup = vi.fn();
+    let isSessionActive = false;
+    const onStartNewSession = vi.fn(async () => {
+      isSessionActive = true;
+    });
+    mockUseRegisterViewModel.mockImplementation(() => ({
+      hasActiveStore: true,
+      header: {
+        title: "POS",
+        isSessionActive,
+      },
+      registerInfo: {
+        customerName: "Ama Serwa",
+        registerLabel: "Front Counter",
+        hasTerminal: true,
+      },
+      customerPanel: {},
+      productEntry: {
+        disabled: false,
+        productSearchQuery: "",
+        setProductSearchQuery: vi.fn(),
+        setShowProductLookup,
+        onBarcodeSubmit: vi.fn(),
+        canQuickAddProduct: false,
+      },
+      cart: {
+        items: [],
+      },
+      checkout: {
+        isTransactionCompleted: false,
+      },
+      sessionPanel: {
+        disableNewSession: false,
+        onStartNewSession,
+      },
+      cashierCard: {},
+      closeoutControl: {
+        canCloseout: true,
+        canShowOpeningFloatCorrection: true,
+        canCorrectOpeningFloat: true,
+        onRequestCloseout: vi.fn(),
+        onRequestOpeningFloatCorrection: vi.fn(),
+      },
+      authDialog: {
+        open: false,
+      },
+      drawerGate: null,
+      onNavigateBack: vi.fn(),
+    }));
+
+    const { POSRegisterView } = await import("./POSRegisterView");
+    const { rerender } = render(<POSRegisterView />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Ready for product lookup/i }),
+    );
+    expect(onStartNewSession).toHaveBeenCalledTimes(1);
+
+    rerender(<POSRegisterView />);
+
+    await waitFor(() => {
+      expect(setShowProductLookup).toHaveBeenCalledWith(true);
+      expect(screen.getByLabelText("product search input")).toHaveFocus();
+    });
   });
 
   it("returns focus to the header product search after an item is added", async () => {

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -89,7 +89,7 @@ function ProductLookupEmptyState({
   workflowMode,
 }: {
   canQuickAddProduct?: boolean;
-  onActivate?: () => void;
+  onActivate?: () => void | Promise<void>;
   onQuickAddProduct?: () => void;
   workflowMode: RegisterWorkflowMode;
 }) {
@@ -973,6 +973,7 @@ export function POSRegisterView({
     useState(false);
   const productEntryRef = useRef<ProductEntryHandle>(null);
   const pendingEmptyStateQuickAddRef = useRef(false);
+  const pendingProductLookupFocusAfterSaleStartRef = useRef(false);
   const headerProductSearchInputRef = useRef<HTMLInputElement>(null);
   const isDebugPanelVisible = usePosDebugPanelToggle();
 
@@ -1033,6 +1034,14 @@ export function POSRegisterView({
     !isResolvingRegisterSetup;
   const isHeaderProductSearchSupported =
     isSessionActive && canSearchProducts && !viewModel.productEntry.disabled;
+  const canStartSaleFromProductLookup =
+    isPosWorkflow &&
+    canSearchProducts &&
+    !isSessionActive &&
+    Boolean(viewModel.sessionPanel) &&
+    !viewModel.sessionPanel?.disableNewSession;
+  const canActivateProductLookup =
+    isHeaderProductSearchSupported || canStartSaleFromProductLookup;
   const isRegisterOperable =
     isPosWorkflow && isHeaderProductSearchSupported && !viewModel.drawerGate;
   const shouldRenderSaleSurface = isPosWorkflow
@@ -1161,15 +1170,39 @@ export function POSRegisterView({
     viewModel.serviceEntry,
   ]);
 
+  const focusProductLookupSearch = useCallback(() => {
+    viewModel.productEntry?.setShowProductLookup?.(true);
+
+    window.setTimeout(() => {
+      const didFocusProductEntryInput =
+        productEntryRef.current?.focusProductSearchInput() ?? false;
+      if (didFocusProductEntryInput) {
+        return;
+      }
+
+      headerProductSearchInputRef.current?.focus();
+      headerProductSearchInputRef.current?.select();
+    }, 0);
+  }, [viewModel.productEntry]);
+
   const handleProductLookupEmptyStateActivate = useCallback(() => {
-    if (!isHeaderProductSearchSupported) {
+    if (isHeaderProductSearchSupported) {
+      focusProductLookupSearch();
       return;
     }
 
-    viewModel.productEntry?.setShowProductLookup?.(true);
-    headerProductSearchInputRef.current?.focus();
-    headerProductSearchInputRef.current?.select();
-  }, [isHeaderProductSearchSupported, viewModel.productEntry]);
+    if (!canStartSaleFromProductLookup || !viewModel.sessionPanel) {
+      return;
+    }
+
+    pendingProductLookupFocusAfterSaleStartRef.current = true;
+    void viewModel.sessionPanel.onStartNewSession();
+  }, [
+    canStartSaleFromProductLookup,
+    focusProductLookupSearch,
+    isHeaderProductSearchSupported,
+    viewModel.sessionPanel,
+  ]);
 
   const handleProductLookupEmptyStateQuickAdd = useCallback(() => {
     if (
@@ -1210,6 +1243,18 @@ export function POSRegisterView({
     }
   }, [isEmptyStateQuickAddActive]);
 
+  useEffect(() => {
+    if (
+      !pendingProductLookupFocusAfterSaleStartRef.current ||
+      !isHeaderProductSearchSupported
+    ) {
+      return;
+    }
+
+    pendingProductLookupFocusAfterSaleStartRef.current = false;
+    focusProductLookupSearch();
+  }, [focusProductLookupSearch, isHeaderProductSearchSupported]);
+
   const focusHeaderProductSearch = useCallback(() => {
     if (!isHeaderProductSearchSupported) {
       return;
@@ -1222,8 +1267,11 @@ export function POSRegisterView({
   }, [isHeaderProductSearchSupported]);
 
   const handleAddProduct = useCallback(
-    async (product: Product) => {
-      const added = await viewModel.productEntry.onAddProduct(product);
+    async (product: Product, quantity?: number) => {
+      const added = await viewModel.productEntry.onAddProduct(
+        product,
+        quantity,
+      );
       if (added !== false) {
         focusHeaderProductSearch();
       }
@@ -1456,7 +1504,7 @@ export function POSRegisterView({
                         viewModel.productEntry.canQuickAddProduct
                       }
                       onActivate={
-                        isHeaderProductSearchSupported
+                        canActivateProductLookup
                           ? handleProductLookupEmptyStateActivate
                           : undefined
                       }
@@ -1494,7 +1542,7 @@ export function POSRegisterView({
                         viewModel.productEntry.canQuickAddProduct
                       }
                       onActivate={
-                        isHeaderProductSearchSupported
+                        canActivateProductLookup
                           ? handleProductLookupEmptyStateActivate
                           : undefined
                       }

--- a/packages/athena-webapp/src/components/services/ServiceIntakeView.test.tsx
+++ b/packages/athena-webapp/src/components/services/ServiceIntakeView.test.tsx
@@ -175,7 +175,7 @@ describe("ServiceIntakeViewContent", () => {
     expect(
       screen.getByRole("combobox", { name: /service title/i }),
     ).toHaveTextContent("Select service");
-  });
+  }, 10_000);
 
   it("renders safe user_error copy inline and clears stale validation errors before submit", async () => {
     const user = userEvent.setup();

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -40,7 +40,7 @@ export interface RegisterProductEntryState {
   productSearchQuery: string;
   setProductSearchQuery: (query: string) => void;
   onBarcodeSubmit: (event: FormEvent) => Promise<void>;
-  onAddProduct: (product: Product) => Promise<boolean>;
+  onAddProduct: (product: Product, quantity?: number) => Promise<boolean>;
   searchResults: Product[];
   isSearchLoading: boolean;
   isSearchReady: boolean;

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -787,6 +787,208 @@ describe("useRegisterViewModel", () => {
     expect(toast.success).not.toHaveBeenCalledWith("Sale started");
   });
 
+  it("starts a new sale when cashier sign-in beats the local drawer bootstrap", async () => {
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: null,
+      activeRegisterSession: null,
+      activeSession: null,
+      activeSessionConflict: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+    const pendingLocalEvents = deferred<{
+      ok: true;
+      value: Array<ReturnType<typeof buildLocalEvent>>;
+    }>();
+    mockListLocalEvents.mockImplementation(() => pendingLocalEvents.promise);
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      await result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
+
+    expect(
+      mockAppendLocalEvent.mock.calls.filter(
+        ([event]) => event.type === "session.started",
+      ),
+    ).toHaveLength(0);
+
+    await act(async () => {
+      pendingLocalEvents.resolve({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            sequence: 1,
+            staffProofToken: "staff-proof-token",
+            type: "register.opened",
+            payload: {
+              expectedCash: 5_000,
+              localRegisterSessionId: "drawer-1",
+              openingFloat: 5_000,
+              status: "open",
+            },
+          }),
+        ],
+      });
+      await pendingLocalEvents.promise;
+    });
+
+    await waitFor(() =>
+      expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "session.started",
+          localRegisterSessionId: "drawer-1",
+          staffProfileId: "staff-1",
+        }),
+      ),
+    );
+    expect(result.current.productEntry.disabled).toBe(false);
+  });
+
+  it("keeps cashier autostart pending until the local drawer is sellable", async () => {
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: null,
+      activeRegisterSession: {
+        _id: "drawer-1",
+        status: "open",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        openingFloat: 5_000,
+        expectedCash: 5_000,
+        openedAt: Date.now(),
+      },
+      activeSession: null,
+      activeSessionConflict: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+    mockAppendLocalEvent.mockImplementation((input: { type: string }) =>
+      input.type === "register.opened"
+        ? Promise.resolve(
+            userError({
+              code: "unavailable",
+              message: "Local drawer seed not ready.",
+            }),
+          )
+        : Promise.resolve({
+            ok: true,
+            value: { localEventId: "local-event-1" },
+          }),
+    );
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      await result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
+
+    await waitFor(() =>
+      expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "register.opened",
+          localRegisterSessionId: "drawer-1",
+          staffProfileId: "staff-1",
+        }),
+      ),
+    );
+    expect(
+      mockAppendLocalEvent.mock.calls.filter(
+        ([event]) => event.type === "session.started",
+      ),
+    ).toHaveLength(0);
+
+    mockAppendLocalEvent.mockResolvedValue({
+      ok: true,
+      value: { localEventId: "local-event-2" },
+    });
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: [
+        buildLocalEvent({
+          sequence: 1,
+          staffProofToken: "staff-proof-token",
+          type: "register.opened",
+          payload: {
+            expectedCash: 5_000,
+            localRegisterSessionId: "drawer-1",
+            openingFloat: 5_000,
+            status: "open",
+          },
+        }),
+      ],
+    });
+
+    const runtimeInput = mockUsePosLocalSyncRuntimeStatus.mock.calls.at(-1)?.[0] as
+      | { onLocalEventsChanged?: () => void }
+      | undefined;
+    await act(async () => {
+      runtimeInput?.onLocalEventsChanged?.();
+    });
+
+    await waitFor(() =>
+      expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "session.started",
+          localRegisterSessionId: "drawer-1",
+          staffProfileId: "staff-1",
+        }),
+      ),
+    );
+    expect(result.current.productEntry.disabled).toBe(false);
+  });
+
+  it("starts a new sale when the active-session summary is stale but no sale is operable", async () => {
+    mockRegisterState = {
+      phase: "readyToStart",
+      terminal: { _id: "terminal-1", displayName: "Front Counter" },
+      cashier: null,
+      activeRegisterSession: {
+        _id: "drawer-1",
+        status: "open",
+        terminalId: "terminal-1",
+        registerNumber: "1",
+        openingFloat: 5_000,
+        expectedCash: 5_000,
+        openedAt: Date.now(),
+      },
+      activeSession: { _id: "stale-session-1", sessionNumber: "POS-OLD" },
+      activeSessionConflict: null,
+      resumableSession: null,
+    };
+    mockActiveSession = null;
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      await result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
+
+    await waitFor(() =>
+      expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "session.started",
+          localRegisterSessionId: "drawer-1",
+          staffProfileId: "staff-1",
+        }),
+      ),
+    );
+    expect(result.current.sessionPanel?.disableNewSession).toBe(false);
+  });
+
   it("does not start duplicate local sales when cashier sign-in completes twice", async () => {
     mockRegisterState = {
       phase: "readyToStart",
@@ -5069,6 +5271,127 @@ describe("useRegisterViewModel", () => {
         ([event]) => event?.type === "cart.item_added",
       ),
     ).toHaveLength(1);
+    expect(toast.error).toHaveBeenCalledWith(
+      "No trusted availability remains for this item on this terminal.",
+    );
+  });
+
+  it("adds the requested product quantity through the local cart event", async () => {
+    mockRegisterCatalogRows = [buildRegisterCatalogRow()];
+    mockRegisterCatalogAvailabilityRows = [
+      buildRegisterCatalogAvailabilityRow({
+        availabilitySource: "local",
+        quantityAvailable: 5,
+      }),
+    ];
+    const localEvents = [
+      buildLocalEvent({
+        sequence: 1,
+        type: "register.opened",
+        payload: {
+          localRegisterSessionId: "drawer-1",
+          openingFloat: 5_000,
+          expectedCash: 5_000,
+          status: "open",
+        },
+      }),
+    ];
+    mockListLocalEvents.mockImplementation(async () => ({
+      ok: true,
+      value: [...localEvents],
+    }));
+    mockAppendLocalEvent.mockImplementation(async (event) => {
+      localEvents.push(
+        buildLocalEvent({
+          ...event,
+          sequence: localEvents.length + 1,
+        }),
+      );
+
+      return { ok: true, value: { localEventId: "local-event-1" } };
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    const product = {
+      id: "sku-2",
+      name: "Deep Wave",
+      price: 10_000,
+      barcode: "1234567890123",
+      productId: "product-2" as Id<"product">,
+      skuId: "sku-2" as Id<"productSku">,
+      sku: "DW-18",
+      category: "Hair",
+      description: "Deep wave bundle",
+      image: null,
+      inStock: true,
+      quantityAvailable: 5,
+    };
+    let added = false;
+    await act(async () => {
+      added = await result.current.productEntry.onAddProduct(product, 3);
+    });
+
+    expect(added).toBe(true);
+    const cartEvent = mockAppendLocalEvent.mock.calls.find(
+      ([event]) => event?.type === "cart.item_added",
+    )?.[0];
+    expect(cartEvent?.payload).toEqual(
+      expect.objectContaining({
+        productSkuId: "sku-2",
+        quantity: 3,
+      }),
+    );
+  });
+
+  it("rejects requested product quantity beyond trusted availability", async () => {
+    mockRegisterCatalogRows = [buildRegisterCatalogRow()];
+    mockRegisterCatalogAvailabilityRows = [
+      buildRegisterCatalogAvailabilityRow({
+        availabilitySource: "local",
+        quantityAvailable: 2,
+      }),
+    ];
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    const product = {
+      id: "sku-2",
+      name: "Deep Wave",
+      price: 10_000,
+      barcode: "1234567890123",
+      productId: "product-2" as Id<"product">,
+      skuId: "sku-2" as Id<"productSku">,
+      sku: "DW-18",
+      category: "Hair",
+      description: "Deep wave bundle",
+      image: null,
+      inStock: true,
+      quantityAvailable: 2,
+    };
+    let added = true;
+    await act(async () => {
+      added = await result.current.productEntry.onAddProduct(product, 3);
+    });
+
+    expect(added).toBe(false);
+    expect(mockAppendLocalEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "cart.item_added" }),
+    );
     expect(toast.error).toHaveBeenCalledWith(
       "No trusted availability remains for this item on this terminal.",
     );

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -1173,6 +1173,8 @@ export function useRegisterViewModel(): RegisterViewModel {
   staffProofTokenRef.current = staffProofToken;
   const [localAuthenticatedStaff, setLocalAuthenticatedStaff] =
     useState<LocalAuthenticatedStaff>(null);
+  const [autoStartRequestedStaffProfileId, setAutoStartRequestedStaffProfileId] =
+    useState<Id<"staffProfile"> | null>(null);
   const terminalRegisterNumber = terminal?.registerNumber
     ? trimOptional(terminal.registerNumber)
     : undefined;
@@ -2384,6 +2386,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       }
 
       if (!options?.keepCashier) {
+        setAutoStartRequestedStaffProfileId(null);
         setStaffProfileId(null);
         setStaffProofToken(null);
         setLocalAuthenticatedStaff(null);
@@ -3210,6 +3213,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       const localPosSessionId = result.data.localPosSessionId;
       keepSessionStartGuard = true;
       noteLocalRegisterEventChanged();
+      setAutoStartRequestedStaffProfileId(null);
       resetDraftState({
         keepCashier: true,
       });
@@ -3312,6 +3316,7 @@ export function useRegisterViewModel(): RegisterViewModel {
 
     const localRegisterSessionId = result.data.localRegisterSessionId;
     noteLocalRegisterEventChanged();
+    setAutoStartRequestedStaffProfileId(null);
     setLocalOperableRegisterSession({
       expectedCash: parsedOpeningFloat,
       localRegisterSessionId,
@@ -3519,6 +3524,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     noteLocalRegisterEventChanged();
     setCloseoutCountedCash("");
     setCloseoutNotes("");
+    setAutoStartRequestedStaffProfileId(null);
     setLocalOperableRegisterSession({
       expectedCash: closeoutBlockedRegisterSession.expectedCash,
       localRegisterSessionId: registerSessionId,
@@ -4007,7 +4013,11 @@ export function useRegisterViewModel(): RegisterViewModel {
   ]);
 
   const handleAddProduct = useCallback(
-    async (product: Product) => {
+    async (product: Product, quantity = 1) => {
+      const requestedQuantity = Number.isFinite(quantity)
+        ? Math.max(1, Math.trunc(quantity))
+        : 1;
+
       if (!staffProfileId) {
         toast.error("Register sign-in required. Sign in before adding items.");
         return false;
@@ -4042,108 +4052,113 @@ export function useRegisterViewModel(): RegisterViewModel {
       }
 
       return enqueueCartMutation(async () => {
-      const localPosSessionId = await ensureLocalPosSessionId();
-      if (!localPosSessionId) {
-        return false;
-      }
-
-      const queuedReadModel = await readCurrentLocalRegisterModel();
-      if (registerCatalogSkuIds.has(productSkuId)) {
-        const availability = registerCatalogAvailabilityBySkuId.get(productSkuId);
-        const localConsumption =
-          localAvailabilityConsumptionFromReadModel(queuedReadModel).get(
-            productSkuId,
-          ) ?? 0;
-        const quantityAvailable =
-          availability !== undefined
-            ? Math.trunc(availability.quantityAvailable)
-            : availabilityStatus === "available" &&
-                typeof product.quantityAvailable === "number"
-              ? Math.trunc(product.quantityAvailable)
-              : undefined;
-        const isInStock =
-          availability !== undefined ? availability.inStock : product.inStock;
-
-        if (quantityAvailable === undefined) {
-          toast.error(POS_AVAILABILITY_NOT_READY_MESSAGE);
+        const localPosSessionId = await ensureLocalPosSessionId();
+        if (!localPosSessionId) {
           return false;
         }
 
-        if (!isInStock || quantityAvailable - localConsumption <= 0) {
-          toast.error(POS_NO_TRUSTED_AVAILABILITY_REMAINING_MESSAGE);
-          return false;
+        const queuedReadModel = await readCurrentLocalRegisterModel();
+        if (registerCatalogSkuIds.has(productSkuId)) {
+          const availability =
+            registerCatalogAvailabilityBySkuId.get(productSkuId);
+          const localConsumption =
+            localAvailabilityConsumptionFromReadModel(queuedReadModel).get(
+              productSkuId,
+            ) ?? 0;
+          const quantityAvailable =
+            availability !== undefined
+              ? Math.trunc(availability.quantityAvailable)
+              : availabilityStatus === "available" &&
+                  typeof product.quantityAvailable === "number"
+                ? Math.trunc(product.quantityAvailable)
+                : undefined;
+          const isInStock =
+            availability !== undefined ? availability.inStock : product.inStock;
+
+          if (quantityAvailable === undefined) {
+            toast.error(POS_AVAILABILITY_NOT_READY_MESSAGE);
+            return false;
+          }
+
+          if (
+            !isInStock ||
+            quantityAvailable - localConsumption < requestedQuantity
+          ) {
+            toast.error(POS_NO_TRUSTED_AVAILABILITY_REMAINING_MESSAGE);
+            return false;
+          }
         }
-      }
 
-      const localSaleItem = queuedReadModel?.activeSale?.items.find(
-        (item) => item.productSkuId === productSkuId,
-      );
-      const existingItem = activeCartItems.find(
-        (item) => item.skuId === productSkuId,
-      );
-      const nextQuantity =
-        (localSaleItem?.quantity ?? existingItem?.quantity ?? 0) + 1;
-      const localItemId =
-        localSaleItem?.localItemId ??
-        existingItem?.id.toString() ??
-        createLocalFallbackId("local-item");
-      const optimisticProductKey = productSkuId;
-      const previousOptimisticProduct = optimisticCartProducts[productSkuId];
-      const isExistingOptimisticProduct = existingItem?.id
-        .toString()
-        .startsWith("optimistic:");
-      if (existingItem && !isExistingOptimisticProduct) {
-        setOptimisticCartQuantities((current) => ({
-          ...current,
-          [existingItem.id]: nextQuantity,
-        }));
-      } else {
-        setOptimisticCartProducts((current) => ({
-          ...current,
-          [optimisticProductKey]: mapProductToOptimisticCartItem(
-            product,
-            nextQuantity,
-          ),
-        }));
-      }
-
-      const savedLocally = await appendLocalCartItem({
-        localPosSessionId,
-        payload: buildLocalCartItemPayload({
-          localItemId,
-          product,
-          quantity: nextQuantity,
-        }),
-      });
-
-      if (!savedLocally) {
+        const localSaleItem = queuedReadModel?.activeSale?.items.find(
+          (item) => item.productSkuId === productSkuId,
+        );
+        const existingItem = activeCartItems.find(
+          (item) => item.skuId === productSkuId,
+        );
+        const nextQuantity =
+          (localSaleItem?.quantity ?? existingItem?.quantity ?? 0) +
+          requestedQuantity;
+        const localItemId =
+          localSaleItem?.localItemId ??
+          existingItem?.id.toString() ??
+          createLocalFallbackId("local-item");
+        const optimisticProductKey = productSkuId;
+        const previousOptimisticProduct = optimisticCartProducts[productSkuId];
+        const isExistingOptimisticProduct = existingItem?.id
+          .toString()
+          .startsWith("optimistic:");
         if (existingItem && !isExistingOptimisticProduct) {
-          setOptimisticCartQuantities((current) => {
-            const next = { ...current };
-            delete next[existingItem.id];
-            return next;
-          });
+          setOptimisticCartQuantities((current) => ({
+            ...current,
+            [existingItem.id]: nextQuantity,
+          }));
         } else {
-          setOptimisticCartProducts((current) => {
-            if (previousOptimisticProduct) {
-              return {
-                ...current,
-                [optimisticProductKey]: previousOptimisticProduct,
-              };
-            }
-
-            const next = { ...current };
-            delete next[optimisticProductKey];
-            return next;
-          });
+          setOptimisticCartProducts((current) => ({
+            ...current,
+            [optimisticProductKey]: mapProductToOptimisticCartItem(
+              product,
+              nextQuantity,
+            ),
+          }));
         }
-        presentOperatorError("Unable to add this item. Try again.");
-        return false;
-      }
 
-      noteLocalRegisterEventChanged();
-      setProductSearchQuery("");
-      return true;
+        const savedLocally = await appendLocalCartItem({
+          localPosSessionId,
+          payload: buildLocalCartItemPayload({
+            localItemId,
+            product,
+            quantity: nextQuantity,
+          }),
+        });
+
+        if (!savedLocally) {
+          if (existingItem && !isExistingOptimisticProduct) {
+            setOptimisticCartQuantities((current) => {
+              const next = { ...current };
+              delete next[existingItem.id];
+              return next;
+            });
+          } else {
+            setOptimisticCartProducts((current) => {
+              if (previousOptimisticProduct) {
+                return {
+                  ...current,
+                  [optimisticProductKey]: previousOptimisticProduct,
+                };
+              }
+
+              const next = { ...current };
+              delete next[optimisticProductKey];
+              return next;
+            });
+          }
+          presentOperatorError("Unable to add this item. Try again.");
+          return false;
+        }
+
+        noteLocalRegisterEventChanged();
+        setProductSearchQuery("");
+        return true;
       });
     },
     [
@@ -4588,7 +4603,6 @@ export function useRegisterViewModel(): RegisterViewModel {
   const handleCashierAuthenticated = useCallback(
     (result: StaffAuthenticationResult | Id<"staffProfile">) => {
       let authenticatedStaffProfileId: Id<"staffProfile">;
-      let canAutoStartSale = false;
       if (typeof result === "string") {
         authenticatedStaffProfileId = result as Id<"staffProfile">;
         staffProfileIdRef.current = authenticatedStaffProfileId;
@@ -4596,8 +4610,8 @@ export function useRegisterViewModel(): RegisterViewModel {
         setStaffProfileId(authenticatedStaffProfileId);
         setStaffProofToken(null);
         setLocalAuthenticatedStaff(null);
+        setAutoStartRequestedStaffProfileId(null);
       } else {
-        canAutoStartSale = true;
         authenticatedStaffProfileId = result.staffProfileId;
         const authenticatedStaffProofToken = readStaffProofFromAuthResult(result);
         staffProfileIdRef.current = authenticatedStaffProfileId;
@@ -4608,38 +4622,43 @@ export function useRegisterViewModel(): RegisterViewModel {
           activeRoles: result.activeRoles ?? [],
           displayName: getStaffDisplayNameFromAuthResult(result),
         });
+        setAutoStartRequestedStaffProfileId(authenticatedStaffProfileId);
       }
       requestBootstrap();
-
-      if (
-        canAutoStartSale &&
-        activeStoreId &&
-        terminal?._id &&
-        localEventRegisterSessionId &&
-        !projectedLocalActiveSale &&
-        !operableActiveSession &&
-        !registerState?.activeSession &&
-        !activeSessionConflict &&
-        !isTransactionCompleted
-      ) {
-        void handleStartNewSession({
-          staffProfileId: authenticatedStaffProfileId,
-        });
-      }
     },
-    [
-      activeSessionConflict,
-      activeStoreId,
-      handleStartNewSession,
-      isTransactionCompleted,
-      localEventRegisterSessionId,
-      operableActiveSession,
-      projectedLocalActiveSale,
-      registerState?.activeSession,
-      requestBootstrap,
-      terminal?._id,
-    ],
+    [requestBootstrap],
   );
+
+  useEffect(() => {
+    const autoStartStaffProfileId = autoStartRequestedStaffProfileId;
+    if (
+      !autoStartStaffProfileId ||
+      !activeStoreId ||
+      !terminal?._id ||
+      !localEventRegisterSessionId ||
+      projectedLocalActiveSale ||
+      operableActiveSession ||
+      activeSessionConflict ||
+      isTransactionCompleted
+    ) {
+      return;
+    }
+
+    void handleStartNewSession({
+      staffProfileId: autoStartStaffProfileId,
+    });
+  }, [
+    activeSessionConflict,
+    activeStoreId,
+    autoStartRequestedStaffProfileId,
+    handleStartNewSession,
+    isTransactionCompleted,
+    localRegisterReadModel?.syncStatus.lastLocalSequence,
+    localEventRegisterSessionId,
+    operableActiveSession,
+    projectedLocalActiveSale,
+    terminal?._id,
+  ]);
 
   const handleNavigateBack = useCallback(async () => {
     if (


### PR DESCRIPTION
## Summary
- make idle POS lookup act as the sale-start trigger for authenticated cashier flow, preserving autostart intent until the local register session is actually started
- add direct quantity inputs and larger touch targets across POS product and cart quantity controls
- remove terminal owner-only constraints so authorized staff can use store-scoped POS terminal flows
- add a solution note for the idle lookup/new sale pattern and stabilize the unrelated service intake full-suite timeout

## Validation
- `bun run --filter '@athena/webapp' test -- src/lib/pos/presentation/register/useRegisterViewModel.test.ts src/components/pos/register/POSRegisterView.test.tsx src/components/pos/CartItems.test.tsx src/components/pos/ProductEntry.test.tsx src/components/pos/SearchResultsSection.test.tsx`
- `bun run --filter '@athena/webapp' lint:frontend:changed`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `bun run --filter '@athena/webapp' lint:convex:changed`
- `bun run --filter '@athena/webapp' test -- convex/operations/staffCredentials.test.ts convex/pos/application/terminals.test.ts convex/pos/public/terminals.test.ts`
- `bun run pr:athena`
- pre-push validation suite from `git push`
