### PR TITLE
fix(operations): recover stock filters and terminal repair

### DIFF
--- a/docs/solutions/logic-errors/athena-stock-adjustment-category-filter-and-terminal-repair-2026-06-02.md
+++ b/docs/solutions/logic-errors/athena-stock-adjustment-category-filter-and-terminal-repair-2026-06-02.md
@@ -1,0 +1,82 @@
+---
+title: Athena Stock Adjustment Filters Should Not Become Count Scope
+date: 2026-06-02
+category: logic-errors
+module: athena-webapp
+problem_type: filter_state_and_local_terminal_repair
+component: stock-adjustments-and-pos-register
+symptoms:
+  - "Stock adjustment search could return no rows when a category filter was active even though matching SKUs existed in another category"
+  - "Cycle count draft selection treated category scope as an operator workflow choice instead of deriving it from the selected SKU"
+  - "A terminal integrity repair path could identify a locally provisioned terminal but did not offer an operator repair action"
+root_cause: operator_filter_state_was_mixed_with_workflow_authority_state
+resolution_type: url_filter_boundary_and_repair_command
+severity: medium
+tags:
+  - operations
+  - stock-adjustments
+  - category-filter
+  - pos
+  - terminal-repair
+---
+
+# Athena Stock Adjustment Filters Should Not Become Count Scope
+
+## Problem
+
+Stock adjustment category state is useful for browsing, but it should not be
+the authority for which inventory group is counted. When the category was
+treated as a count scope, operators could combine a search query with the wrong
+category and see an empty table even though matching SKUs existed elsewhere.
+
+The same branch also exposed a related POS repair boundary: terminal setup
+repair is an operator action, not a passive blocked state. When local terminal
+integrity required reprovisioning and the browser fingerprint still matched the
+local seed, the UI needed a repair command that re-registers the terminal and
+clears the integrity block.
+
+## Solution
+
+Keep filter state and durable workflow state separate:
+
+- Store stock adjustment category as a URL-backed `category` filter, not as a
+  count `scope`.
+- Infer the cycle-count draft scope from the selected SKU. If no SKU is
+  selected, default to the first inventory item while staying out of manual
+  adjustment mode.
+- Apply category, query, and availability as table filters only.
+- When a query has matches outside the active category, show those matching
+  rows with calm recovery copy and an explicit action to switch category or
+  show all categories.
+- When an operator selects an outside-category result, move the category filter
+  to that SKU's category so the URL, selected row, and detail rail agree.
+
+For terminal repair, keep the operator action explicit:
+
+- Detect the local terminal fingerprint before attempting reprovisioning.
+- Use the existing terminal registration/provisioning command path to repair the
+  setup when the fingerprint matches the local seed.
+- Persist the repaired terminal seed and clear terminal integrity state in the
+  same local-store write.
+- Render a loading repair action in the drawer gate so the operator can see the
+  command and its progress.
+
+## Prevention
+
+- Do not use category filters as durable cycle-count scope selection. Category
+  filters should narrow visible rows only.
+- Do not hide search matches merely because the active category filter excludes
+  them. Show the matches and make the category switch explicit.
+- Do not auto-clear operator filters without visible context; prefer a recovery
+  state that explains which filter is excluding results.
+- Do not clear POS terminal integrity state without writing the repaired
+  provisioned terminal seed in the same operation.
+
+## Related Validation
+
+- `bun run --filter '@athena/webapp' test -- src/components/operations/StockAdjustmentWorkspace.test.tsx`
+- `bun run --filter '@athena/webapp' test -- src/components/operations/OperationsQueueView.test.tsx`
+- `bun run --filter '@athena/webapp' test -- src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- `bun run --filter '@athena/webapp' lint:frontend:changed`
+- `bun run --filter '@athena/webapp' typecheck`
+- `bun run pr:athena`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5967 nodes · 6384 edges · 1726 communities detected
+- 5968 nodes · 6387 edges · 1726 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1812,12 +1812,12 @@ Cohesion: 0.12
 Nodes (31): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+23 more)
 
 ### Community 12 - "Community 12"
-Cohesion: 0.15
-Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
+Cohesion: 0.08
+Nodes (18): formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getReservationLabels(), getSkuDetailEntries(), getStockAdjustmentCategoryKey(), getStockAdjustmentCategoryLabel() (+10 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.08
-Nodes (14): formatInventoryNumber(), formatReservationSourceSummary(), getInventoryItemDisplayName(), getReservationLabels(), getSkuDetailEntries(), getVideoElementStream(), getVideoTracks(), handleDraftChange() (+6 more)
+Cohesion: 0.15
+Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
 ### Community 14 - "Community 14"
 Cohesion: 0.17
@@ -2148,20 +2148,20 @@ Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
 ### Community 96 - "Community 96"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 97 - "Community 97"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.24
 Nodes (5): blocked(), evaluateLocalPosReadiness(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.18
 Nodes (0):
-
-### Community 99 - "Community 99"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 100 - "Community 100"
 Cohesion: 0.18
@@ -2728,52 +2728,52 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 241 - "Community 241"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
-
-### Community 242 - "Community 242"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 243 - "Community 243"
+### Community 242 - "Community 242"
 Cohesion: 0.5
 Nodes (2): buildOperationalEvent(), recordOperationalEventWithCtx()
+
+### Community 243 - "Community 243"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 244 - "Community 244"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 245 - "Community 245"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 246 - "Community 246"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+
+### Community 246 - "Community 246"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 247 - "Community 247"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 248 - "Community 248"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 249 - "Community 249"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 250 - "Community 250"
+### Community 249 - "Community 249"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 251 - "Community 251"
+### Community 250 - "Community 250"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 252 - "Community 252"
+### Community 251 - "Community 251"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+
+### Community 252 - "Community 252"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 253 - "Community 253"
 Cohesion: 0.4
@@ -2792,12 +2792,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 257 - "Community 257"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 258 - "Community 258"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 258 - "Community 258"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 259 - "Community 259"
 Cohesion: 0.4
@@ -2812,12 +2812,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 262 - "Community 262"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 263 - "Community 263"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
+
+### Community 263 - "Community 263"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 264 - "Community 264"
 Cohesion: 0.4
@@ -2829,11 +2829,11 @@ Nodes (0):
 
 ### Community 266 - "Community 266"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 267 - "Community 267"
 Cohesion: 0.4
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 268 - "Community 268"
 Cohesion: 0.4
@@ -2844,48 +2844,48 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 270 - "Community 270"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 271 - "Community 271"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 272 - "Community 272"
+### Community 271 - "Community 271"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 273 - "Community 273"
+### Community 272 - "Community 272"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 274 - "Community 274"
+### Community 273 - "Community 273"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 275 - "Community 275"
+### Community 274 - "Community 274"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 276 - "Community 276"
+### Community 275 - "Community 275"
 Cohesion: 0.6
 Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
-### Community 277 - "Community 277"
+### Community 276 - "Community 276"
 Cohesion: 0.6
 Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
-### Community 278 - "Community 278"
+### Community 277 - "Community 277"
 Cohesion: 0.6
 Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
-### Community 279 - "Community 279"
+### Community 278 - "Community 278"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 280 - "Community 280"
+### Community 279 - "Community 279"
 Cohesion: 0.6
 Nodes (3): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier()
+
+### Community 280 - "Community 280"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 281 - "Community 281"
 Cohesion: 0.4
@@ -2896,36 +2896,36 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 283 - "Community 283"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 284 - "Community 284"
 Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 285 - "Community 285"
+### Community 284 - "Community 284"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 286 - "Community 286"
+### Community 285 - "Community 285"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 287 - "Community 287"
+### Community 286 - "Community 286"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 288 - "Community 288"
+### Community 287 - "Community 287"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 288 - "Community 288"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 289 - "Community 289"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 290 - "Community 290"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 291 - "Community 291"
 Cohesion: 0.7

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1798
-- Graph nodes: 5967
-- Graph edges: 6384
+- Graph nodes: 5968
+- Graph edges: 6387
 - Communities: 1726
 
 ## Graph Hotspots

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.test.tsx
@@ -995,7 +995,7 @@ describe("OperationsQueueViewContent", () => {
     );
   });
 
-  it("loads or creates the selected cycle-count draft", async () => {
+  it("loads or creates the default SKU cycle-count draft", async () => {
     const ensureCycleCountDraft = vi.fn().mockResolvedValue(ok({}));
 
     mockedHooks.useMutation.mockReset();
@@ -1023,13 +1023,12 @@ describe("OperationsQueueViewContent", () => {
       <OperationsQueueView
         stockAdjustmentSearch={{
           mode: "cycle_count",
-          scope: "Hair",
         }}
       />,
     );
 
     expect(mockedHooks.useQuery.mock.calls[2]?.[1]).toEqual({
-      scopeKey: "Hair",
+      scopeKey: "__uncategorized",
       storeId: "store-1",
     });
     expect(mockedHooks.useQuery.mock.calls[3]?.[1]).toEqual({
@@ -1037,13 +1036,13 @@ describe("OperationsQueueViewContent", () => {
     });
     await waitFor(() =>
       expect(ensureCycleCountDraft).toHaveBeenCalledWith({
-        scopeKey: "Hair",
+        scopeKey: "__uncategorized",
         storeId: "store-1",
       }),
     );
   });
 
-  it("infers the cycle-count scope from a selected SKU when the route has no scope", async () => {
+  it("infers the cycle-count scope from a selected SKU", async () => {
     const ensureCycleCountDraft = vi.fn().mockResolvedValue(ok({}));
     const inventoryItems = [
       {
@@ -1092,9 +1091,7 @@ describe("OperationsQueueViewContent", () => {
         storeId: "store-1",
       }),
     );
-    expect(
-      screen.getByRole("button", { name: /pos quick add 1 sku/i }),
-    ).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getAllByText("POS quick add").length).toBeGreaterThan(0);
   });
 
   it("skips cycle-count draft loading in manual mode", () => {
@@ -1113,7 +1110,6 @@ describe("OperationsQueueViewContent", () => {
       <OperationsQueueView
         stockAdjustmentSearch={{
           mode: "manual",
-          scope: "Hair",
         }}
       />,
     );

--- a/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsQueueView.tsx
@@ -1713,38 +1713,21 @@ export function OperationsQueueView({
     stockOpsApi.adjustments.listInventorySnapshot,
     canQueryProtectedData ? { storeId: activeStore!._id } : "skip",
   ) as InventorySnapshotItem[] | undefined;
-  const inferredCycleCountScopeKey = useMemo(() => {
+  const selectedCycleCountScopeKey = useMemo(() => {
     if (stockAdjustmentSearch?.mode === "manual") return undefined;
-    if (stockAdjustmentSearch?.scope?.trim()) return undefined;
-    if (!stockAdjustmentSearch?.sku || !inventoryItems) return undefined;
+    if (!inventoryItems) return undefined;
 
-    const selectedItem = inventoryItems.find(
-      (item) => String(item._id) === stockAdjustmentSearch.sku,
-    );
+    const selectedItem =
+      stockAdjustmentSearch?.sku !== undefined
+        ? inventoryItems.find(
+            (item) => String(item._id) === stockAdjustmentSearch.sku,
+          )
+        : inventoryItems[0];
 
     return selectedItem
       ? getCountScopeKeyForInventoryItem(selectedItem)
       : undefined;
-  }, [
-    inventoryItems,
-    stockAdjustmentSearch?.mode,
-    stockAdjustmentSearch?.scope,
-    stockAdjustmentSearch?.sku,
-  ]);
-  const effectiveStockAdjustmentSearch = useMemo(
-    () =>
-      inferredCycleCountScopeKey
-        ? {
-            ...stockAdjustmentSearch,
-            scope: inferredCycleCountScopeKey,
-          }
-        : stockAdjustmentSearch,
-    [inferredCycleCountScopeKey, stockAdjustmentSearch],
-  );
-  const selectedCycleCountScopeKey =
-    effectiveStockAdjustmentSearch?.mode === "manual"
-      ? undefined
-      : effectiveStockAdjustmentSearch?.scope?.split(",")[0]?.trim();
+  }, [inventoryItems, stockAdjustmentSearch?.mode, stockAdjustmentSearch?.sku]);
   const canUseCycleCountDraft =
     canQueryProtectedData &&
     Boolean(activeStore?._id) &&
@@ -1878,7 +1861,7 @@ export function OperationsQueueView({
   }) => {
     if (!cycleCountDraft) {
       return buildMissingDraftResult(
-        "Select a count scope before saving a draft.",
+        "Select a SKU before saving a count draft.",
       );
     }
 
@@ -1900,7 +1883,7 @@ export function OperationsQueueView({
   const handleDiscardCycleCountDraft = async () => {
     if (!cycleCountDraft) {
       return buildMissingDraftResult(
-        "Select a count scope before discarding a draft.",
+        "Select a SKU before discarding a count draft.",
       );
     }
 
@@ -2165,7 +2148,7 @@ export function OperationsQueueView({
         showBackButton={typeof search.o === "string" && search.o.length > 0}
         storeId={activeStore._id}
         storeUrlSlug={routeParams?.storeUrlSlug}
-        stockAdjustmentSearch={effectiveStockAdjustmentSearch}
+        stockAdjustmentSearch={stockAdjustmentSearch}
         workItems={queue?.workItems ?? []}
       />
       <StaffAuthenticationDialog

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
@@ -300,9 +300,9 @@ describe("StockAdjustmentWorkspaceContent", () => {
     expect(mockedToast.success).toHaveBeenCalledWith("Product added");
     expect(onSearchStateChange).toHaveBeenCalledWith({
       availability: undefined,
+      category: undefined,
       page: 1,
       query: "skillz",
-      scope: undefined,
       sku: "sku-quick",
     });
   });
@@ -349,9 +349,9 @@ describe("StockAdjustmentWorkspaceContent", () => {
     expect(mockedToast.success).toHaveBeenCalledWith("Barcode attached to SKU");
     expect(onSearchStateChange).toHaveBeenCalledWith({
       availability: undefined,
+      category: undefined,
       page: 1,
       query: "123212312",
-      scope: undefined,
       sku: "sku-2",
     });
   });
@@ -389,7 +389,7 @@ describe("StockAdjustmentWorkspaceContent", () => {
       screen.getByLabelText(/counted quantity for .*closure wig/i),
     ).toHaveValue(5);
     expect(
-      screen.getByText(/saved count: 1 SKU across 1 scope/i),
+      screen.getByText(/saved count: 1 SKU across 1 category/i),
     ).toBeInTheDocument();
   });
 
@@ -450,7 +450,7 @@ describe("StockAdjustmentWorkspaceContent", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("summarizes saved draft SKUs across all scopes in the batch rail", () => {
+  it("summarizes saved draft SKUs across all categories in the batch rail", () => {
     renderStockAdjustmentWorkspace({
       cycleCountDraft: {
         _id: "draft-1" as Id<"cycleCountDraft">,
@@ -489,13 +489,13 @@ describe("StockAdjustmentWorkspaceContent", () => {
     });
 
     expect(
-      screen.getByText(/saved count: 5 SKUs across 3 scopes/i),
+      screen.getByText(/saved count: 5 SKUs across 3 categories/i),
     ).toBeInTheDocument();
     expect(screen.getByText(/current: hair, 2 SKUs/i)).toBeInTheDocument();
-    expect(screen.getByText(/scopes: beverages, hair/i)).toBeInTheDocument();
+    expect(screen.getByText(/categories: beverages, hair/i)).toBeInTheDocument();
     expect(screen.getByText("Count metrics")).toBeInTheDocument();
     expect(screen.getByText("All saved counts")).toBeInTheDocument();
-    expect(screen.getByText("Selected scope")).toBeInTheDocument();
+    expect(screen.getByText("Active category")).toBeInTheDocument();
     expect(screen.getByText("5")).toBeInTheDocument();
     expect(screen.getByText("-9")).toBeInTheDocument();
     expect(screen.getAllByText("SKUs").length).toBeGreaterThan(0);
@@ -504,7 +504,7 @@ describe("StockAdjustmentWorkspaceContent", () => {
     expect(screen.getAllByText("4").length).toBeGreaterThan(0);
   });
 
-  it("submits the overall cycle count draft when the current scope has no changes", async () => {
+  it("submits the overall cycle count draft when the current category has no changes", async () => {
     const user = userEvent.setup();
     const onSubmitCycleCountDraft = vi.fn().mockResolvedValue(ok({}));
 
@@ -552,7 +552,6 @@ describe("StockAdjustmentWorkspaceContent", () => {
       searchState: {
         mode: "cycle_count",
         page: 1,
-        scope: "Hair",
         sku: "sku-1",
       },
     });
@@ -808,8 +807,9 @@ describe("StockAdjustmentWorkspaceContent", () => {
     expect(resetButton).toBeDisabled();
   });
 
-  it("orients cycle counts around a selected category scope", async () => {
+  it("filters stock rows by category without changing the count model", async () => {
     const user = userEvent.setup();
+    const onSearchStateChange = vi.fn();
 
     renderStockAdjustmentWorkspace({
       inventoryItems: [
@@ -830,51 +830,34 @@ describe("StockAdjustmentWorkspaceContent", () => {
           sku: "BOOK-1",
         },
       ],
+      onSearchStateChange,
     });
 
-    expect(
-      screen.getByRole("button", { name: /books 1 sku/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /hair 1 sku/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /books 1 sku/i }),
-    ).toHaveAttribute("aria-pressed", "false");
-    expect(
-      screen.getByRole("button", { name: /show all scopes/i }),
-    ).toBeDisabled();
     const table = screen.getByRole("table");
 
+    expect(
+      screen.getByRole("button", { name: /all categories, 2 skus/i }),
+    ).toHaveAttribute("aria-pressed", "true");
     expect(within(table).getByText("Ai Engineering")).toBeInTheDocument();
     expect(within(table).getByText("Closure Wig")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /hair 1 sku/i }));
+    await user.click(screen.getByRole("button", { name: /hair, 1 sku/i }));
 
-    expect(screen.getByRole("button", { name: /hair 1 sku/i })).toHaveAttribute(
-      "aria-pressed",
-      "true",
-    );
+    expect(onSearchStateChange).toHaveBeenLastCalledWith({
+      availability: undefined,
+      category: "Hair",
+      page: 1,
+      query: undefined,
+      sku: "sku-1",
+    });
     expect(
-      screen.getByRole("button", { name: /show all scopes/i }),
-    ).toBeEnabled();
+      screen.getByRole("button", { name: /hair, 1 sku/i }),
+    ).toHaveAttribute("aria-pressed", "true");
     expect(within(table).getByText("Closure Wig")).toBeInTheDocument();
     expect(within(table).queryByText("Ai Engineering")).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: /hair 1 sku/i }));
-
-    expect(screen.getByRole("button", { name: /hair 1 sku/i })).toHaveAttribute(
-      "aria-pressed",
-      "false",
-    );
-    expect(
-      screen.getByRole("button", { name: /show all scopes/i }),
-    ).toBeDisabled();
-    expect(within(table).getByText("Closure Wig")).toBeInTheDocument();
-    expect(within(table).getByText("Ai Engineering")).toBeInTheDocument();
   });
 
-  it("shows stock scopes in manual adjustment mode", async () => {
+  it("filters category matches through the SKU search", async () => {
     const user = userEvent.setup();
 
     renderStockAdjustmentWorkspace({
@@ -897,27 +880,22 @@ describe("StockAdjustmentWorkspaceContent", () => {
         },
       ],
       searchState: {
-        mode: "manual",
+        mode: "cycle_count",
       },
     });
-
-    expect(
-      screen.getByRole("button", { name: /books 1 sku/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /hair 1 sku/i }),
-    ).toBeInTheDocument();
 
     const table = screen.getByRole("table");
 
     expect(within(table).getByText("Ai Engineering")).toBeInTheDocument();
     expect(within(table).getByText("Closure Wig")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /books 1 sku/i }));
+    await user.type(
+      screen.getByRole("textbox", {
+        name: /search products, skus, or barcodes/i,
+      }),
+      "books",
+    );
 
-    expect(
-      screen.getByRole("button", { name: /books 1 sku/i }),
-    ).toHaveAttribute("aria-pressed", "true");
     expect(within(table).getByText("Ai Engineering")).toBeInTheDocument();
     expect(within(table).queryByText("Closure Wig")).not.toBeInTheDocument();
   });
@@ -931,7 +909,9 @@ describe("StockAdjustmentWorkspaceContent", () => {
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/9 of 11 units are available to sell\. Choose a scope/i),
+      screen.getByText(
+        /9 of 11 units are available to sell\. Select a SKU/i,
+      ),
     ).toBeInTheDocument();
     expect(screen.getAllByText("On hand").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Available").length).toBeGreaterThan(0);
@@ -1057,6 +1037,218 @@ describe("StockAdjustmentWorkspaceContent", () => {
       within(table).queryByText("Body Wave Bundle"),
     ).not.toBeInTheDocument();
     expect(screen.getByText("Showing 1 of 2 SKUs.")).toBeInTheDocument();
+  });
+
+  it("shows search matches across categories", async () => {
+    const user = userEvent.setup();
+    const onSearchStateChange = vi.fn();
+
+    renderStockAdjustmentWorkspace({
+      inventoryItems: [
+        {
+          _id: "sku-beverage" as Id<"productSku">,
+          inventoryCount: 2,
+          productCategory: "Beverages",
+          productName: "sparkling water",
+          quantityAvailable: 2,
+          sku: "DRINK-1",
+        },
+        {
+          _id: "sku-hair-vibes" as Id<"productSku">,
+          inventoryCount: 4,
+          productCategory: "Hair",
+          productName: "vibes closure",
+          quantityAvailable: 4,
+          sku: "VIBES-18",
+        },
+        {
+          _id: "sku-books-vibes" as Id<"productSku">,
+          inventoryCount: 3,
+          productCategory: "Books",
+          productName: "vibes workbook",
+          quantityAvailable: 3,
+          sku: "VIBES-BOOK",
+        },
+      ],
+      onSearchStateChange,
+      searchState: {
+        mode: "cycle_count",
+        sku: "sku-beverage",
+      },
+    });
+
+    const table = screen.getByRole("table");
+
+    await user.type(
+      screen.getByRole("textbox", {
+        name: /search products, skus, or barcodes/i,
+      }),
+      "vibes",
+    );
+
+    expect(onSearchStateChange).toHaveBeenLastCalledWith({
+      availability: undefined,
+      category: undefined,
+      page: 1,
+      query: "vibes",
+      sku: "sku-hair-vibes",
+    });
+    expect(screen.getByText("Showing 2 of 3 SKUs.")).toBeInTheDocument();
+    expect(within(table).getByText("Vibes Closure")).toBeInTheDocument();
+    expect(within(table).getByText("Vibes Workbook")).toBeInTheDocument();
+    expect(
+      within(table).queryByText("Sparkling Water"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows matching SKUs from other categories when the active category has no results", async () => {
+    const user = userEvent.setup();
+    const onSearchStateChange = vi.fn();
+
+    renderStockAdjustmentWorkspace({
+      inventoryItems: [
+        {
+          _id: "sku-hair" as Id<"productSku">,
+          inventoryCount: 4,
+          productCategory: "Hair",
+          productName: "closure wig",
+          quantityAvailable: 4,
+          sku: "CW-18",
+        },
+        {
+          _id: "sku-makeup" as Id<"productSku">,
+          inventoryCount: 6,
+          productCategory: "Makeup",
+          productName: "zara lip gloss",
+          quantityAvailable: 6,
+          sku: "ZA-LIP",
+        },
+      ],
+      onSearchStateChange,
+      searchState: {
+        category: "Hair",
+        mode: "cycle_count",
+        query: "za",
+        sku: "sku-hair",
+      },
+    });
+
+    const table = screen.getByRole("table");
+
+    expect(
+      screen.getByText("No Hair matches. Showing 1 match in Makeup."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Matches are in Makeup."),
+    ).toBeInTheDocument();
+    expect(within(table).getByText("Zara Lip Gloss")).toBeInTheDocument();
+    expect(within(table).queryByText("Closure Wig")).not.toBeInTheDocument();
+    expect(within(table).queryByText("No results.")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /switch to makeup/i }));
+
+    expect(onSearchStateChange).toHaveBeenLastCalledWith({
+      availability: undefined,
+      category: "Makeup",
+      page: 1,
+      query: "za",
+      sku: "sku-makeup",
+    });
+  });
+
+  it("moves the category filter when selecting an outside-category match", async () => {
+    const user = userEvent.setup();
+    const onSearchStateChange = vi.fn();
+
+    renderStockAdjustmentWorkspace({
+      inventoryItems: [
+        {
+          _id: "sku-hair" as Id<"productSku">,
+          inventoryCount: 4,
+          productCategory: "Hair",
+          productName: "closure wig",
+          quantityAvailable: 4,
+          sku: "CW-18",
+        },
+        {
+          _id: "sku-makeup" as Id<"productSku">,
+          inventoryCount: 6,
+          productCategory: "Makeup",
+          productName: "zara lip gloss",
+          quantityAvailable: 6,
+          sku: "ZA-LIP",
+        },
+      ],
+      onSearchStateChange,
+      searchState: {
+        category: "Hair",
+        mode: "cycle_count",
+        query: "za",
+      },
+    });
+
+    await user.click(
+      within(screen.getByRole("table")).getByText("Zara Lip Gloss"),
+    );
+
+    expect(onSearchStateChange).toHaveBeenLastCalledWith({
+      category: "Makeup",
+      page: 1,
+      sku: "sku-makeup",
+    });
+  });
+
+  it("clears the search and category filters", async () => {
+    const user = userEvent.setup();
+    const onSearchStateChange = vi.fn();
+
+    renderStockAdjustmentWorkspace({
+      inventoryItems: [
+        {
+          _id: "sku-beverage" as Id<"productSku">,
+          inventoryCount: 2,
+          productCategory: "Beverages",
+          productName: "sparkling water",
+          quantityAvailable: 2,
+          sku: "DRINK-1",
+        },
+        {
+          _id: "sku-hair-vibes" as Id<"productSku">,
+          inventoryCount: 4,
+          productCategory: "Hair",
+          productName: "vibes closure",
+          quantityAvailable: 4,
+          sku: "VIBES-18",
+        },
+      ],
+      onSearchStateChange,
+      searchState: {
+        category: "Hair",
+        mode: "cycle_count",
+        query: "vibes",
+        sku: "sku-hair-vibes",
+      },
+    });
+
+    const table = screen.getByRole("table");
+
+    expect(within(table).queryByText("Sparkling Water")).not.toBeInTheDocument();
+    expect(within(table).getByText("Vibes Closure")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /^clear$/i }));
+
+    expect(onSearchStateChange).toHaveBeenLastCalledWith({
+      availability: undefined,
+      category: undefined,
+      page: 1,
+      query: undefined,
+      sku: "sku-beverage",
+    });
+    expect(
+      screen.getByText("Showing 2 of 2 SKUs."),
+    ).toBeInTheDocument();
+    expect(within(table).getByText("Sparkling Water")).toBeInTheDocument();
+    expect(within(table).getByText("Vibes Closure")).toBeInTheDocument();
   });
 
   it("fuzzy matches stock rows by product and variant terms", async () => {
@@ -1519,30 +1711,29 @@ describe("StockAdjustmentWorkspaceContent", () => {
 
     expect(onSearchStateChange).toHaveBeenLastCalledWith({
       availability: "unavailable",
+      category: undefined,
       page: 1,
-      scope: "Books",
-      sku: "sku-unavailable-books",
+      sku: "sku-unavailable-hair",
     });
     expect(screen.getByRole("button", { name: /reserved 4/i })).toHaveAttribute(
       "aria-pressed",
       "true",
     );
     expect(within(table).getByText("Ai Engineering")).toBeInTheDocument();
-    expect(within(table).queryByText("Closure Wig")).not.toBeInTheDocument();
+    expect(within(table).getByText("Closure Wig")).toBeInTheDocument();
     expect(
       within(table).queryByText("Body Wave Bundle"),
     ).not.toBeInTheDocument();
     expect(within(table).queryByText("Lip Gloss")).not.toBeInTheDocument();
-    expect(screen.getByText("Showing 1 of 1 SKU.")).toBeInTheDocument();
+    expect(screen.getByText("Showing 2 of 4 SKUs.")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /reserved 4/i }));
 
     expect(onSearchStateChange).toHaveBeenLastCalledWith({
       availability: undefined,
+      category: undefined,
       page: 1,
-      query: undefined,
-      scope: undefined,
-      sku: undefined,
+      sku: "sku-unavailable-hair",
     });
     expect(screen.getByRole("button", { name: /reserved 4/i })).toHaveAttribute(
       "aria-pressed",
@@ -1567,9 +1758,10 @@ describe("StockAdjustmentWorkspaceContent", () => {
 
     expect(onSearchStateChange).toHaveBeenLastCalledWith({
       availability: undefined,
+      category: undefined,
       page: 1,
       query: "CW",
-      sku: undefined,
+      sku: "sku-1",
     });
 
     await user.click(
@@ -1579,9 +1771,10 @@ describe("StockAdjustmentWorkspaceContent", () => {
 
     expect(onSearchStateChange).toHaveBeenLastCalledWith({
       availability: "unavailable",
+      category: undefined,
       page: 1,
       query: "CW",
-      sku: undefined,
+      sku: "sku-1",
     });
   });
 
@@ -1728,7 +1921,6 @@ describe("StockAdjustmentWorkspaceContent", () => {
       searchState: {
         mode: "cycle_count",
         page: 2,
-        scope: "Inventory",
         sku: "sku-11",
       },
     });
@@ -1770,7 +1962,6 @@ describe("StockAdjustmentWorkspaceContent", () => {
       searchState: {
         mode: "cycle_count",
         page: 3,
-        scope: "Inventory",
         sku: "sku-21",
       },
     });
@@ -1821,24 +2012,22 @@ describe("StockAdjustmentWorkspaceContent", () => {
       onSearchStateChange,
       searchState: {
         mode: "cycle_count",
-        scope: "Inventory",
+        sku: "sku-inventory-1",
       },
     });
 
-    await user.click(screen.getByRole("button", { name: /hair 1 sku/i }));
+    await user.click(screen.getByText("Closure Wig"));
 
     expect(onSearchStateChange).toHaveBeenCalledWith({
-      page: 1,
-      scope: "Hair",
       sku: "sku-1",
     });
 
     await user.click(screen.getByRole("tab", { name: /manual adjustment/i }));
 
     expect(onSearchStateChange).toHaveBeenCalledWith({
+      category: undefined,
       mode: "manual",
       page: 1,
-      scope: "Hair",
       sku: "sku-1",
     });
   });

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
@@ -15,7 +15,6 @@ import {
 } from "@zxing/browser";
 import {
   Camera,
-  CheckCircle2,
   ExternalLink,
   Package,
   PackagePlus,
@@ -123,11 +122,11 @@ export type StockAdjustmentAvailabilityFilter =
 
 export type StockAdjustmentSearchState = {
   availability?: StockAdjustmentAvailabilityFilter;
+  category?: string;
   mode?: StockAdjustmentType;
   o?: string;
   page?: number;
   query?: string;
-  scope?: string;
   sku?: string;
 };
 
@@ -203,16 +202,17 @@ type StockAdjustmentRow = {
   submittedLineItem: SubmitStockAdjustmentArgs["lineItems"][number] | null;
 };
 
-type CountScopeOption = {
-  changedCount: number;
-  itemCount: number;
-  key: string;
-  label: string;
-};
 type CycleCountSubmissionOutcome = "applied" | "review_required" | null;
 type StockAdjustmentFilterState = {
   availability: StockAdjustmentAvailabilityFilter;
+  category: string;
   query: string;
+};
+
+type StockAdjustmentCategoryFilterOption = {
+  itemCount: number;
+  key: string;
+  label: string;
 };
 
 const MANUAL_REASON_LABELS: Record<
@@ -225,6 +225,7 @@ const MANUAL_REASON_LABELS: Record<
   vendor_return: "Vendor return",
 };
 
+const ALL_CATEGORY_FILTER_KEY = "__all_categories";
 const UNCATEGORIZED_SCOPE_KEY = "__uncategorized";
 const INVENTORY_NUMBER_FORMATTER = new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 1,
@@ -240,12 +241,16 @@ const STOCK_ADJUSTMENT_AVAILABILITY_FILTER_LABELS: Record<
   unavailable: "Reserved",
 };
 
-function getCountScopeKey(item: InventorySnapshotItem) {
+function getCountScopeLabel(key: string) {
+  return key === UNCATEGORIZED_SCOPE_KEY ? "Uncategorized" : key;
+}
+
+function getStockAdjustmentCategoryKey(item: InventorySnapshotItem) {
   return item.productCategory?.trim() || UNCATEGORIZED_SCOPE_KEY;
 }
 
-function getCountScopeLabel(key: string) {
-  return key === UNCATEGORIZED_SCOPE_KEY ? "Uncategorized" : key;
+function getStockAdjustmentCategoryLabel(key: string) {
+  return getCountScopeLabel(key);
 }
 
 function buildManualDrafts(inventoryItems: InventorySnapshotItem[]) {
@@ -287,6 +292,13 @@ function pluralize(count: number, singular: string, plural = `${singular}s`) {
 
 function formatInventoryNumber(value: number) {
   return INVENTORY_NUMBER_FORMATTER.format(value).toLowerCase();
+}
+
+function formatCategoryList(labels: string[]) {
+  if (labels.length <= 1) return labels[0] ?? "";
+  if (labels.length === 2) return labels.join(" and ");
+
+  return `${labels.slice(0, -1).join(", ")} and ${labels[labels.length - 1]}`;
 }
 
 function getInventoryItemDisplayName(item: InventorySnapshotItem) {
@@ -390,19 +402,6 @@ function formatInventoryItemPriceLabel(item: InventorySnapshotItem) {
     : "Price pending";
 }
 
-function parseCountScopeKeys(value?: string | null) {
-  return (
-    value
-      ?.split(",")
-      .map((scope) => scope.trim())
-      .filter(Boolean) ?? []
-  );
-}
-
-function serializeCountScopeKeys(keys: string[]) {
-  return keys.length > 0 ? keys.join(",") : undefined;
-}
-
 function rowMatchesStockAdjustmentSearch(
   row: StockAdjustmentRow,
   query: string,
@@ -423,6 +422,13 @@ function rowMatchesStockAdjustmentSearch(
         : String(item.length),
     ],
     query,
+  );
+}
+
+function rowMatchesCategoryFilter(row: StockAdjustmentRow, category: string) {
+  return (
+    category === ALL_CATEGORY_FILTER_KEY ||
+    getStockAdjustmentCategoryKey(row.inventoryItem) === category
   );
 }
 
@@ -1466,7 +1472,6 @@ function StockAdjustmentBarcodeScannerDialog({
     onOpenChange,
     open,
     stopScanner,
-    videoElement,
   ]);
 
   useEffect(() => {
@@ -1686,11 +1691,9 @@ export function StockAdjustmentWorkspaceContent({
         inventoryItems[0]?._id ??
         null,
     );
-  const [selectedCountScopeKeys, setSelectedCountScopeKeys] = useState<
-    string[]
-  >(() => parseCountScopeKeys(searchState?.scope));
   const [filters, setFilters] = useState<StockAdjustmentFilterState>({
     availability: searchState?.availability ?? "all",
+    category: searchState?.category?.trim() || ALL_CATEGORY_FILTER_KEY,
     query: searchState?.query ?? "",
   });
   const [cycleCountSubmissionOutcome, setCycleCountSubmissionOutcome] =
@@ -1720,12 +1723,6 @@ export function StockAdjustmentWorkspaceContent({
   }, [adjustmentType, searchState?.mode]);
 
   useEffect(() => {
-    if (searchState?.scope === undefined) return;
-
-    setSelectedCountScopeKeys(parseCountScopeKeys(searchState.scope));
-  }, [searchState?.scope]);
-
-  useEffect(() => {
     if (searchState?.sku === undefined) return;
 
     setActiveInventoryItemId(
@@ -1738,17 +1735,44 @@ export function StockAdjustmentWorkspaceContent({
   useEffect(() => {
     setFilters((current) => ({
       availability: searchState?.availability ?? current.availability,
+      category:
+        searchState?.category === undefined
+          ? current.category
+          : searchState.category.trim() || ALL_CATEGORY_FILTER_KEY,
       query:
         searchState?.query === undefined ? current.query : searchState.query,
     }));
-  }, [searchState?.availability, searchState?.query]);
+  }, [searchState?.availability, searchState?.category, searchState?.query]);
 
   const handleSelectInventoryItem = useCallback(
     (itemId: Id<"productSku"> | null) => {
       setActiveInventoryItemId(itemId);
+
+      const selectedItem = inventoryItems.find((item) => item._id === itemId);
+      const selectedCategory = selectedItem
+        ? getStockAdjustmentCategoryKey(selectedItem)
+        : ALL_CATEGORY_FILTER_KEY;
+      const shouldMoveCategoryFilter =
+        selectedItem &&
+        filters.category !== ALL_CATEGORY_FILTER_KEY &&
+        selectedCategory !== filters.category;
+
+      if (shouldMoveCategoryFilter) {
+        setFilters((current) => ({
+          ...current,
+          category: selectedCategory,
+        }));
+        onSearchStateChange?.({
+          category: selectedCategory,
+          page: 1,
+          sku: itemId ?? undefined,
+        });
+        return;
+      }
+
       onSearchStateChange?.({ sku: itemId ?? undefined });
     },
-    [onSearchStateChange],
+    [filters.category, inventoryItems, onSearchStateChange],
   );
 
   useEffect(() => {
@@ -1896,47 +1920,26 @@ export function StockAdjustmentWorkspaceContent({
   );
 
   const changedRows = rows.filter((row) => row.submittedLineItem);
-  const countScopeOptions: CountScopeOption[] = useMemo(() => {
-    const scopes = new Map<string, CountScopeOption>();
+  const categoryFilterOptions: StockAdjustmentCategoryFilterOption[] =
+    useMemo(() => {
+      const categories = new Map<string, StockAdjustmentCategoryFilterOption>();
 
-    for (const row of rows) {
-      const key = getCountScopeKey(row.inventoryItem);
-      const existing = scopes.get(key) ?? {
-        changedCount: 0,
-        itemCount: 0,
-        key,
-        label: getCountScopeLabel(key),
-      };
+      for (const row of rows) {
+        const key = getStockAdjustmentCategoryKey(row.inventoryItem);
+        const existing = categories.get(key) ?? {
+          itemCount: 0,
+          key,
+          label: getStockAdjustmentCategoryLabel(key),
+        };
 
-      existing.itemCount += 1;
-      if (row.submittedLineItem) {
-        existing.changedCount += 1;
+        existing.itemCount += 1;
+        categories.set(key, existing);
       }
 
-      scopes.set(key, existing);
-    }
-
-    return Array.from(scopes.values()).sort((a, b) =>
-      a.label.localeCompare(b.label),
-    );
-  }, [rows]);
-  const selectedCountScopes = countScopeOptions.filter((scope) =>
-    selectedCountScopeKeys.includes(scope.key),
-  );
-  const selectedCountScope = selectedCountScopes[0] ?? null;
-  const selectedCountScopeKeySet = useMemo(
-    () => new Set(selectedCountScopeKeys),
-    [selectedCountScopeKeys],
-  );
-  const scopedRows = useMemo(
-    () =>
-      selectedCountScopeKeys.length > 0
-        ? rows.filter((row) =>
-            selectedCountScopeKeySet.has(getCountScopeKey(row.inventoryItem)),
-          )
-        : rows,
-    [rows, selectedCountScopeKeySet, selectedCountScopeKeys],
-  );
+      return Array.from(categories.values()).sort((a, b) =>
+        a.label.localeCompare(b.label),
+      );
+    }, [rows]);
   const normalizedFilterQuery = normalizeSkuSearchQuery(filters.query);
   const quickAddInitialLookupCode = normalizeQuickAddInitialLookupCode(
     filters.query,
@@ -1965,38 +1968,60 @@ export function StockAdjustmentWorkspaceContent({
         })),
     [inventoryItems],
   );
-  const filteredRows = useMemo(
+  const queryAvailabilityFilteredRows = useMemo(
     () =>
-      scopedRows.filter(
+      rows.filter(
         (row) =>
           rowMatchesStockAdjustmentSearch(row, normalizedFilterQuery) &&
           rowMatchesAvailabilityFilter(row, filters.availability),
       ),
-    [filters.availability, normalizedFilterQuery, scopedRows],
+    [filters.availability, normalizedFilterQuery, rows],
   );
-  const unavailableCountScopeKeys = useMemo(() => {
-    const keys = new Set<string>();
+  const filteredRows = useMemo(
+    () =>
+      queryAvailabilityFilteredRows.filter((row) =>
+        rowMatchesCategoryFilter(row, filters.category),
+      ),
+    [filters.category, queryAvailabilityFilteredRows],
+  );
+  const categoryMismatchRows = useMemo(() => {
+    if (!normalizedFilterQuery) return [];
+    if (filters.category === ALL_CATEGORY_FILTER_KEY) return [];
+    if (filteredRows.length > 0) return [];
 
-    for (const row of rows) {
-      const item = row.inventoryItem;
-
-      if (item.inventoryCount > item.quantityAvailable) {
-        keys.add(getCountScopeKey(item));
-      }
-    }
-
-    return Array.from(keys).sort();
-  }, [rows]);
+    return queryAvailabilityFilteredRows.filter(
+      (row) => !rowMatchesCategoryFilter(row, filters.category),
+    );
+  }, [
+    filteredRows.length,
+    filters.category,
+    normalizedFilterQuery,
+    queryAvailabilityFilteredRows,
+  ]);
+  const isShowingCategoryMismatchRows = categoryMismatchRows.length > 0;
+  const tableRows = isShowingCategoryMismatchRows
+    ? categoryMismatchRows
+    : filteredRows;
+  const categoryMismatchCategoryKeys = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          categoryMismatchRows.map((row) =>
+            getStockAdjustmentCategoryKey(row.inventoryItem),
+          ),
+        ),
+      ).sort((a, b) =>
+        getStockAdjustmentCategoryLabel(a).localeCompare(
+          getStockAdjustmentCategoryLabel(b),
+        ),
+      ),
+    [categoryMismatchRows],
+  );
+  const categoryMismatchCategoryLabels = categoryMismatchCategoryKeys.map(
+    getStockAdjustmentCategoryLabel,
+  );
   const isUnavailableScopeSelectionActive =
-    filters.availability === "unavailable" &&
-    unavailableCountScopeKeys.length > 0 &&
-    (adjustmentType === "cycle_count"
-      ? selectedCountScopeKeys.length === 1 &&
-        selectedCountScopeKeys[0] === unavailableCountScopeKeys[0]
-      : selectedCountScopeKeys.length === unavailableCountScopeKeys.length &&
-        unavailableCountScopeKeys.every((key) =>
-          selectedCountScopeKeySet.has(key),
-        ));
+    filters.availability === "unavailable";
   const summary = summarizeStockAdjustmentLineItems(
     changedRows.map((row) => ({
       quantityDelta: row.quantityDelta,
@@ -2108,12 +2133,9 @@ export function StockAdjustmentWorkspaceContent({
   const totalDraftScopeCount = cycleCountDraftSummary?.scopeCount ?? 0;
   const draftScopeNames = cycleCountDraftSummary?.scopeKeys ?? [];
   const scopeDraftChangedLineCount = cycleCountDraft?.changedLineCount ?? 0;
-  const currentScopeLabel =
-    cycleCountDraft?.scopeKey ??
-    selectedCountScope?.label ??
-    (selectedCountScopeKeys[0]
-      ? getCountScopeLabel(selectedCountScopeKeys[0])
-      : null);
+  const currentScopeLabel = cycleCountDraft?.scopeKey
+    ? getCountScopeLabel(cycleCountDraft.scopeKey)
+    : null;
   const cycleCountStatus = cycleCountSubmissionOutcome
     ? cycleCountSubmissionOutcome === "review_required"
       ? {
@@ -2136,7 +2158,8 @@ export function StockAdjustmentWorkspaceContent({
                 "SKU",
               )} across ${totalDraftScopeCount || 1} ${pluralize(
                 totalDraftScopeCount || 1,
-                "scope",
+                "category",
+                "categories",
               )}.`
             : "No saved counts yet.",
         label: isCycleCountDraftSaving
@@ -2163,51 +2186,17 @@ export function StockAdjustmentWorkspaceContent({
     Boolean(onDiscardCycleCountDraft);
 
   useEffect(() => {
-    if (adjustmentType !== "cycle_count") return;
-    if (selectedCountScopeKeys.length === 0) return;
-
-    const validScopeKeys = selectedCountScopeKeys.filter((selectedKey) =>
-      countScopeOptions.some((scope) => scope.key === selectedKey),
-    );
-    if (validScopeKeys.length === selectedCountScopeKeys.length) return;
-
-    setSelectedCountScopeKeys(validScopeKeys);
-    onSearchStateChange?.({
-      page: 1,
-      scope: serializeCountScopeKeys(validScopeKeys),
-      sku: undefined,
-    });
-  }, [
-    adjustmentType,
-    countScopeOptions,
-    onSearchStateChange,
-    selectedCountScopeKeys,
-  ]);
-
-  useEffect(() => {
-    if (adjustmentType !== "cycle_count" || !selectedCountScope) return;
-
     if (
       activeInventoryItemId &&
-      scopedRows.some((row) => row.inventoryItem._id === activeInventoryItemId)
-    ) {
-      return;
-    }
-
-    setActiveInventoryItemId(scopedRows[0]?.inventoryItem._id ?? null);
-  }, [activeInventoryItemId, adjustmentType, scopedRows, selectedCountScope]);
-  useEffect(() => {
-    if (
-      activeInventoryItemId &&
-      filteredRows.some(
+      tableRows.some(
         (row) => row.inventoryItem._id === activeInventoryItemId,
       )
     ) {
       return;
     }
 
-    setActiveInventoryItemId(filteredRows[0]?.inventoryItem._id ?? null);
-  }, [activeInventoryItemId, filteredRows]);
+    setActiveInventoryItemId(tableRows[0]?.inventoryItem._id ?? null);
+  }, [activeInventoryItemId, tableRows]);
   const columns = useMemo<ColumnDef<StockAdjustmentRow>[]>(
     () => [
       {
@@ -2419,8 +2408,31 @@ export function StockAdjustmentWorkspaceContent({
         ),
       },
     ],
-    [adjustmentType, handleSelectInventoryItem, saveCycleCountDraftValue],
+    [
+      adjustmentType,
+      cycleCountDraftLineMap,
+      handleSelectInventoryItem,
+      saveCycleCountDraftValue,
+    ],
   );
+
+  const getFirstFilteredItem = (nextFilters: StockAdjustmentFilterState) => {
+    const nextNormalizedQuery = normalizeSkuSearchQuery(nextFilters.query);
+    const nextRows = rows.filter(
+      (row) =>
+        rowMatchesStockAdjustmentSearch(row, nextNormalizedQuery) &&
+        rowMatchesAvailabilityFilter(row, nextFilters.availability),
+    );
+    const firstExactItem = nextRows.find((row) =>
+      rowMatchesCategoryFilter(row, nextFilters.category),
+    )?.inventoryItem;
+
+    if (firstExactItem) return firstExactItem;
+    if (!nextNormalizedQuery) return undefined;
+    if (nextFilters.category === ALL_CATEGORY_FILTER_KEY) return undefined;
+
+    return nextRows[0]?.inventoryItem;
+  };
 
   const handleModeChange = (nextType: StockAdjustmentType) => {
     setAdjustmentType(nextType);
@@ -2429,23 +2441,19 @@ export function StockAdjustmentWorkspaceContent({
       setCycleCountSubmissionOutcome(null);
     }
 
-    const currentScopeKeys =
-      selectedCountScopeKeys.length > 0 ? selectedCountScopeKeys : [];
-    const nextScope = serializeCountScopeKeys(currentScopeKeys);
     const nextActiveItem =
-      currentScopeKeys.length > 0
-        ? rows.find((row) =>
-            currentScopeKeys.includes(getCountScopeKey(row.inventoryItem)),
-          )?.inventoryItem
-        : rows[0]?.inventoryItem;
+      getFirstFilteredItem(filters) ?? rows[0]?.inventoryItem;
 
     if (nextActiveItem) {
       setActiveInventoryItemId(nextActiveItem._id);
     }
     onSearchStateChange?.({
+      category:
+        filters.category === ALL_CATEGORY_FILTER_KEY
+          ? undefined
+          : filters.category,
       mode: nextType,
       page: 1,
-      scope: nextScope,
       sku: nextActiveItem?._id,
     });
   };
@@ -2455,29 +2463,40 @@ export function StockAdjustmentWorkspaceContent({
       ...filters,
       ...patch,
     };
+    const nextActiveItem = getFirstFilteredItem(nextFilters);
 
     setFilters(nextFilters);
+    setActiveInventoryItemId(nextActiveItem?._id ?? null);
     onSearchStateChange?.({
       availability:
         nextFilters.availability === "all"
           ? undefined
           : nextFilters.availability,
+      category:
+        nextFilters.category === ALL_CATEGORY_FILTER_KEY
+          ? undefined
+          : nextFilters.category,
       page: 1,
       query: trimOptional(nextFilters.query),
-      sku: undefined,
+      sku: nextActiveItem?._id,
     });
   };
 
   const handleClearFilters = () => {
+    const nextActiveItem = rows[0]?.inventoryItem;
+
     setFilters({
       availability: "all",
+      category: ALL_CATEGORY_FILTER_KEY,
       query: "",
     });
+    setActiveInventoryItemId(nextActiveItem?._id ?? null);
     onSearchStateChange?.({
       availability: undefined,
+      category: undefined,
       page: 1,
       query: undefined,
-      sku: undefined,
+      sku: nextActiveItem?._id,
     });
   };
 
@@ -2523,18 +2542,18 @@ export function StockAdjustmentWorkspaceContent({
     if (createdProduct.skuId) {
       const createdSkuId = createdProduct.skuId as Id<"productSku">;
 
-      setSelectedCountScopeKeys([]);
       setFilters((current) => ({
         ...current,
         availability: "all",
+        category: ALL_CATEGORY_FILTER_KEY,
         query: name,
       }));
       setActiveInventoryItemId(createdSkuId);
       onSearchStateChange?.({
         availability: undefined,
+        category: undefined,
         page: 1,
         query: name,
-        scope: undefined,
         sku: createdSkuId,
       });
     }
@@ -2560,18 +2579,18 @@ export function StockAdjustmentWorkspaceContent({
 
     const attachedSkuId = productSkuId as Id<"productSku">;
 
-    setSelectedCountScopeKeys([]);
     setFilters((current) => ({
       ...current,
       availability: "all",
+      category: ALL_CATEGORY_FILTER_KEY,
       query: lookupCode,
     }));
     setActiveInventoryItemId(attachedSkuId);
     onSearchStateChange?.({
       availability: undefined,
+      category: undefined,
       page: 1,
       query: lookupCode,
-      scope: undefined,
       sku: attachedSkuId,
     });
     toast.success("Barcode attached to SKU");
@@ -2581,51 +2600,66 @@ export function StockAdjustmentWorkspaceContent({
     if (inventoryState.unavailableUnits === 0) return;
 
     if (isUnavailableScopeSelectionActive) {
-      setSelectedCountScopeKeys([]);
+      const nextFilters = {
+        ...filters,
+        availability: "all" as StockAdjustmentAvailabilityFilter,
+      };
+      const nextActiveItem = getFirstFilteredItem(nextFilters);
+
       setFilters((current) => ({
         ...current,
         availability: "all",
       }));
+      setActiveInventoryItemId(nextActiveItem?._id ?? null);
       onSearchStateChange?.({
         availability: undefined,
+        category:
+          nextFilters.category === ALL_CATEGORY_FILTER_KEY
+            ? undefined
+            : nextFilters.category,
         page: 1,
-        scope: undefined,
-        sku: undefined,
+        sku: nextActiveItem?._id,
       });
       return;
     }
 
-    if (adjustmentType === "cycle_count") {
-      const nextScopeKey = unavailableCountScopeKeys[0];
-      const firstScopedItem = rows.find(
-        (row) => getCountScopeKey(row.inventoryItem) === nextScopeKey,
-      )?.inventoryItem;
+    const nextFilters = {
+      ...filters,
+      availability: "unavailable" as StockAdjustmentAvailabilityFilter,
+    };
+    const nextActiveItem = getFirstFilteredItem(nextFilters);
 
-      setSelectedCountScopeKeys(nextScopeKey ? [nextScopeKey] : []);
-      setFilters((current) => ({
-        ...current,
-        availability: "unavailable",
-      }));
-      onSearchStateChange?.({
-        availability: "unavailable",
-        page: 1,
-        scope: nextScopeKey,
-        sku: firstScopedItem?._id,
-      });
-      return;
-    }
-
-    setSelectedCountScopeKeys(unavailableCountScopeKeys);
     setFilters((current) => ({
       ...current,
       availability: "unavailable",
     }));
+    setActiveInventoryItemId(nextActiveItem?._id ?? null);
     onSearchStateChange?.({
       availability: "unavailable",
+      category:
+        nextFilters.category === ALL_CATEGORY_FILTER_KEY
+          ? undefined
+          : nextFilters.category,
       page: 1,
-      scope: serializeCountScopeKeys(unavailableCountScopeKeys),
-      sku: undefined,
+      sku: nextActiveItem?._id,
     });
+  };
+
+  const activeCategoryFilterLabel = getStockAdjustmentCategoryLabel(
+    filters.category,
+  );
+  const categoryMismatchActionCategory =
+    categoryMismatchCategoryKeys.length === 1
+      ? categoryMismatchCategoryKeys[0]
+      : ALL_CATEGORY_FILTER_KEY;
+  const categoryMismatchActionLabel =
+    categoryMismatchCategoryKeys.length === 1
+      ? `Switch to ${getStockAdjustmentCategoryLabel(
+          categoryMismatchCategoryKeys[0],
+        )}`
+      : "Show all categories";
+  const handleCategoryMismatchAction = () => {
+    handleFilterChange({ category: categoryMismatchActionCategory });
   };
 
   const awaitPendingCycleCountSaves = async () => {
@@ -2737,7 +2771,7 @@ export function StockAdjustmentWorkspaceContent({
           <>
             {inventoryState.description}{" "}
             {adjustmentType === "cycle_count"
-              ? "Choose a scope, then record physical counts for that group."
+              ? "Select a SKU, then record physical counts for its category."
               : "Record known deltas when physical stock needs correction."}
           </>
         }
@@ -2802,103 +2836,6 @@ export function StockAdjustmentWorkspaceContent({
             </Tabs>
           </div>
 
-          <section
-            aria-labelledby="count-scope-heading"
-            className="space-y-layout-lg"
-          >
-            <h2 className="sr-only" id="count-scope-heading">
-              Stock scopes
-            </h2>
-            <div className="flex justify-end">
-              <Button
-                className="h-8 px-2 text-xs"
-                disabled={selectedCountScopeKeys.length === 0}
-                onClick={() => {
-                  setSelectedCountScopeKeys([]);
-                  onSearchStateChange?.({
-                    page: 1,
-                    scope: undefined,
-                    sku: rows[0]?.inventoryItem._id,
-                  });
-                }}
-                type="button"
-                variant="outline"
-              >
-                Show all scopes
-              </Button>
-            </div>
-            <div className="grid gap-layout-md sm:grid-cols-2 xl:grid-cols-3">
-              {countScopeOptions.map((scope) => {
-                const isSelected = selectedCountScopeKeySet.has(scope.key);
-
-                return (
-                  <button
-                    aria-pressed={isSelected}
-                    className={`rounded-md border px-layout-md py-layout-sm text-left transition-colors ${
-                      isSelected
-                        ? "border-action-workflow-border bg-action-workflow-soft text-foreground"
-                        : "border-border bg-background hover:bg-muted"
-                    }`}
-                    key={scope.key}
-                    onClick={() => {
-                      const nextScopeKeys =
-                        adjustmentType === "cycle_count"
-                          ? isSelected
-                            ? []
-                            : [scope.key]
-                          : isSelected
-                            ? selectedCountScopeKeys.filter(
-                                (selectedKey) => selectedKey !== scope.key,
-                              )
-                            : [...selectedCountScopeKeys, scope.key];
-                      const firstScopedItem =
-                        nextScopeKeys.length > 0
-                          ? rows.find((row) =>
-                              nextScopeKeys.includes(
-                                getCountScopeKey(row.inventoryItem),
-                              ),
-                            )?.inventoryItem
-                          : rows[0]?.inventoryItem;
-
-                      setSelectedCountScopeKeys(nextScopeKeys);
-                      setCycleCountSubmissionOutcome(null);
-                      setActiveInventoryItemId(firstScopedItem?._id ?? null);
-                      onSearchStateChange?.({
-                        page: 1,
-                        scope: serializeCountScopeKeys(nextScopeKeys),
-                        sku: firstScopedItem?._id,
-                      });
-                    }}
-                    type="button"
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <p className="truncate text-sm font-medium">
-                          {scope.label}
-                        </p>
-                        <p className="mt-1 text-xs text-muted-foreground">
-                          {scope.itemCount}{" "}
-                          {scope.itemCount === 1 ? "SKU" : "SKUs"}
-                        </p>
-                      </div>
-                      {isSelected ? (
-                        <CheckCircle2 className="h-4 w-4 shrink-0 text-action-commit" />
-                      ) : null}
-                    </div>
-                    <div className="mt-layout-sm flex items-center gap-2 text-xs text-muted-foreground">
-                      <span className="font-medium text-foreground">
-                        {scope.changedCount}
-                      </span>
-                      <span>
-                        {scope.changedCount === 1 ? "variance" : "variances"}
-                      </span>
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
-          </section>
-
           <SkuSearchFilterBar
             action={
               <Button
@@ -2917,7 +2854,9 @@ export function StockAdjustmentWorkspaceContent({
             filterOptions={STOCK_ADJUSTMENT_AVAILABILITY_FILTER_OPTIONS}
             filterValue={filters.availability}
             hasActiveFilters={Boolean(
-              filters.query || filters.availability !== "all",
+              filters.query ||
+                filters.availability !== "all" ||
+                filters.category !== ALL_CATEGORY_FILTER_KEY,
             )}
             onClearFilters={handleClearFilters}
             onFilterChange={(availability) =>
@@ -2940,20 +2879,103 @@ export function StockAdjustmentWorkspaceContent({
             searchId="stock-adjustment-sku-search"
             searchLabel="Search products, SKUs, or barcodes"
             searchPlaceholder="Search product, SKU, or barcode"
+            secondaryFilters={
+              <div
+                aria-label="Filter by category"
+                className="flex flex-col gap-2 sm:flex-row sm:items-center"
+                role="group"
+              >
+                <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                  Categories
+                </span>
+                <div className="flex min-w-0 flex-wrap gap-1.5">
+                  {[
+                    {
+                      itemCount: rows.length,
+                      key: ALL_CATEGORY_FILTER_KEY,
+                      label: "All categories",
+                    },
+                    ...categoryFilterOptions,
+                  ].map((category) => {
+                    const isSelected = filters.category === category.key;
+
+                    return (
+                      <button
+                        aria-label={`${category.label}, ${category.itemCount} ${pluralize(
+                          category.itemCount,
+                          "SKU",
+                        )}`}
+                        aria-pressed={isSelected}
+                        className={`rounded-md border px-2.5 py-1 text-xs font-medium transition-colors ${
+                          isSelected
+                            ? "border-action-workflow-border bg-action-workflow-soft text-foreground"
+                            : "border-border bg-background text-muted-foreground hover:bg-muted hover:text-foreground"
+                        }`}
+                        key={category.key}
+                        onClick={() =>
+                          handleFilterChange({
+                            category: isSelected
+                              ? ALL_CATEGORY_FILTER_KEY
+                              : category.key,
+                          })
+                        }
+                        type="button"
+                      >
+                        {category.label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            }
             summary={
-              <>
-                Showing {formatInventoryNumber(filteredRows.length)} of{" "}
-                {formatInventoryNumber(scopedRows.length)}{" "}
-                {pluralize(scopedRows.length, "SKU")}.
-              </>
+              isShowingCategoryMismatchRows ? (
+                <>
+                  No {activeCategoryFilterLabel} matches. Showing{" "}
+                  {formatInventoryNumber(tableRows.length)}{" "}
+                  {pluralize(tableRows.length, "match", "matches")} in{" "}
+                  {formatCategoryList(categoryMismatchCategoryLabels)}.
+                </>
+              ) : (
+                <>
+                  Showing {formatInventoryNumber(filteredRows.length)} of{" "}
+                  {formatInventoryNumber(rows.length)}{" "}
+                  {pluralize(rows.length, "SKU")}.
+                </>
+              )
             }
           />
 
           <div className="flex min-h-0 flex-col">
+            {isShowingCategoryMismatchRows ? (
+              <section
+                aria-label="Search matches in other categories"
+                className="mb-layout-md flex flex-col gap-layout-sm rounded-md border border-action-workflow-border bg-action-workflow-soft px-layout-md py-layout-sm sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-foreground">
+                    Matches are in{" "}
+                    {formatCategoryList(categoryMismatchCategoryLabels)}.
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {activeCategoryFilterLabel} has no matching SKUs for this
+                    search.
+                  </p>
+                </div>
+                <Button
+                  className="shrink-0"
+                  onClick={handleCategoryMismatchAction}
+                  type="button"
+                  variant="outline"
+                >
+                  {categoryMismatchActionLabel}
+                </Button>
+              </section>
+            ) : null}
             <GenericDataTable
               autoResetPageIndex={false}
               columns={columns}
-              data={filteredRows}
+              data={tableRows}
               getRowClassName={(row) =>
                 row.original.inventoryItem._id === activeInventoryItemId
                   ? "bg-muted/60 hover:bg-muted/70"
@@ -2972,7 +2994,7 @@ export function StockAdjustmentWorkspaceContent({
               }
               paginationRangeItemLabel="SKU"
               paginationRangeItemPluralLabel="SKUs"
-              tableId={`stock-adjustments-${adjustmentType}-${selectedCountScopeKeys.join("_") || "all"}-${filters.availability}-${normalizedFilterQuery || "all"}`}
+              tableId={`stock-adjustments-${adjustmentType}-${filters.category}-${filters.availability}-${isShowingCategoryMismatchRows ? "category-mismatch" : "exact"}-${normalizedFilterQuery || "all"}`}
             />
           </div>
         </PageWorkspaceMain>
@@ -3022,7 +3044,7 @@ export function StockAdjustmentWorkspaceContent({
                       ) : null}
                       {draftScopeNames.length > 0 ? (
                         <p className="text-xs leading-5 text-muted-foreground">
-                          Scopes: {draftScopeNames.join(", ")}.
+                          Categories: {draftScopeNames.join(", ")}.
                         </p>
                       ) : null}
                     </div>
@@ -3156,7 +3178,7 @@ export function StockAdjustmentWorkspaceContent({
                     </div>
                     <div className="rounded-md border border-border px-3 py-3">
                       <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                        Selected scope
+                        Active category
                       </p>
                       <dl className="mt-2 space-y-2">
                         <div className="flex items-baseline justify-between gap-3">

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
@@ -126,6 +126,20 @@ export function RegisterDrawerGate({
             </p>
           </div>
           <div className="flex flex-wrap gap-2 pt-2">
+            {isTerminalRepair && drawerGate.onRepairTerminalSetup ? (
+              <LoadingButton
+                disabled={Boolean(drawerGate.isRepairingTerminalSetup)}
+                isLoading={Boolean(drawerGate.isRepairingTerminalSetup)}
+                type="button"
+                variant="default"
+                onClick={() => void drawerGate.onRepairTerminalSetup?.()}
+              >
+                <RefreshCwIcon className="mr-2 h-4 w-4" />
+                {drawerGate.isRepairingTerminalSetup
+                  ? "Repairing setup"
+                  : "Repair setup"}
+              </LoadingButton>
+            ) : null}
             {!isTerminalRepair && drawerGate.onRetrySync ? (
               <Button
                 type="button"

--- a/packages/athena-webapp/src/components/stock-ops/SkuSearchFilterBar.tsx
+++ b/packages/athena-webapp/src/components/stock-ops/SkuSearchFilterBar.tsx
@@ -37,6 +37,7 @@ type SkuSearchFilterBarProps<TValue extends string> = {
   searchId: string;
   searchLabel: string;
   searchPlaceholder: string;
+  secondaryFilters?: ReactNode;
   summary: ReactNode;
 };
 
@@ -59,6 +60,7 @@ export function SkuSearchFilterBar<TValue extends string>({
   searchId,
   searchLabel,
   searchPlaceholder,
+  secondaryFilters,
   summary,
 }: SkuSearchFilterBarProps<TValue>) {
   return (
@@ -119,6 +121,11 @@ export function SkuSearchFilterBar<TValue extends string>({
           ) : null}
         </div>
       </div>
+      {secondaryFilters ? (
+        <div className="mt-layout-md border-t border-border pt-layout-sm">
+          {secondaryFilters}
+        </div>
+      ) : null}
       <p className="mt-layout-sm text-xs text-muted-foreground">{summary}</p>
     </section>
   );

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -249,6 +249,7 @@ export interface RegisterDrawerGateState {
   errorMessage: string | null;
   isCloseoutSubmitting?: boolean;
   isCorrectingOpeningFloat?: boolean;
+  isRepairingTerminalSetup?: boolean;
   isReopeningCloseout?: boolean;
   isSubmitting?: boolean;
   onCloseoutCountedCashChange?: (value: string) => void;
@@ -263,6 +264,7 @@ export interface RegisterDrawerGateState {
   onSubmitCloseout?: () => Promise<void>;
   onReopenRegister?: () => Promise<void>;
   onRetrySync?: () => void;
+  onRepairTerminalSetup?: () => Promise<void>;
   onSubmit?: () => Promise<void>;
   onSignOut: () => Promise<void>;
 }

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -27,13 +27,17 @@ const mockSubmitRegisterSessionCloseout = vi.fn();
 const mockAuthenticateStaffCredentialForApproval = vi.fn();
 const mockReopenRegisterSessionCloseout = vi.fn();
 const mockCorrectRegisterSessionOpeningFloat = vi.fn();
+const mockRegisterTerminal = vi.fn();
 const mockNavigateBack = vi.fn();
 const mockUsePosLocalSyncRuntimeStatus = vi.fn();
 const mockUseConvexRegisterCatalogAvailability = vi.fn();
+const mockReadStoredTerminalFingerprint = vi.fn();
 const mockAppendLocalEvent = vi.fn();
 const mockAttachStaffProofTokenToPendingEvents = vi.fn();
 const mockListLocalEvents = vi.fn();
 const mockReadProvisionedTerminalSeed = vi.fn();
+const mockWriteProvisionedTerminalSeed = vi.fn();
+const mockWriteProvisionedTerminalSeedAndClearTerminalIntegrity = vi.fn();
 const mockGetStaffAuthorityReadiness = vi.fn();
 const mockMarkLocalEventsSynced = vi.fn();
 const mockWriteLocalCloudMapping = vi.fn();
@@ -237,6 +241,10 @@ vi.mock("@/hooks/useGetTerminal", () => ({
   useGetTerminal: () => mockTerminal,
 }));
 
+vi.mock("@/lib/pos/infrastructure/terminal/fingerprint", () => ({
+  readStoredTerminalFingerprint: () => mockReadStoredTerminalFingerprint(),
+}));
+
 vi.mock("@/hooks/use-navigate-back", () => ({
   useNavigateBack: () => mockNavigateBack,
 }));
@@ -292,6 +300,7 @@ vi.mock("@/lib/pos/infrastructure/local/usePosLocalSyncRuntime", () => ({
 }));
 
 vi.mock("@/lib/pos/infrastructure/local/posLocalStore", () => ({
+  POS_LOCAL_STORE_SCHEMA_VERSION: 1,
   canUploadPosLocalEventType: (type: string) =>
     type === "register.opened" ||
     type === "transaction.completed" ||
@@ -311,6 +320,9 @@ vi.mock("@/lib/pos/infrastructure/local/posLocalStore", () => ({
     readProvisionedTerminalSeed: mockReadProvisionedTerminalSeed,
     readTerminalIntegrityState: mockReadTerminalIntegrityState,
     markEventsSynced: mockMarkLocalEventsSynced,
+    writeProvisionedTerminalSeed: mockWriteProvisionedTerminalSeed,
+    writeProvisionedTerminalSeedAndClearTerminalIntegrity:
+      mockWriteProvisionedTerminalSeedAndClearTerminalIntegrity,
     writeDrawerAuthorityState: mockWriteDrawerAuthorityState,
     writeLocalCloudMapping: mockWriteLocalCloudMapping,
   })),
@@ -504,6 +516,8 @@ describe("useRegisterViewModel", () => {
       () => mockRegisterCatalogAvailabilityRows,
     );
     localStorage.clear();
+    mockReadStoredTerminalFingerprint.mockReset();
+    mockReadStoredTerminalFingerprint.mockReturnValue(null);
 
     mockUseQuery.mockImplementation(() => mockCashier);
     mockUsePosLocalSyncRuntimeStatus.mockReset();
@@ -533,6 +547,16 @@ describe("useRegisterViewModel", () => {
         terminalId: "local-terminal-1",
       },
     });
+    mockWriteProvisionedTerminalSeed.mockReset();
+    mockWriteProvisionedTerminalSeed.mockResolvedValue({
+      ok: true,
+      value: null,
+    });
+    mockWriteProvisionedTerminalSeedAndClearTerminalIntegrity.mockReset();
+    mockWriteProvisionedTerminalSeedAndClearTerminalIntegrity.mockResolvedValue({
+      ok: true,
+      value: null,
+    });
     mockGetStaffAuthorityReadiness.mockReset();
     mockGetStaffAuthorityReadiness.mockResolvedValue({
       ok: true,
@@ -552,6 +576,18 @@ describe("useRegisterViewModel", () => {
     mockWriteDrawerAuthorityState.mockResolvedValue({ ok: true, value: {} });
     (globalThis as typeof globalThis & { indexedDB?: IDBFactory }).indexedDB =
       {} as IDBFactory;
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value: {
+        getRandomValues: (bytes: Uint8Array) => {
+          bytes.fill(7);
+          return bytes;
+        },
+        subtle: {
+          digest: vi.fn(async () => new Uint8Array([1, 2, 3, 4]).buffer),
+        },
+      },
+    });
     mockUseMutation.mockReset();
     mockUseMutation.mockImplementation(
       () => (args: Record<string, unknown>) => {
@@ -563,6 +599,9 @@ describe("useRegisterViewModel", () => {
         }
         if ("correctedOpeningFloat" in args) {
           return mockCorrectRegisterSessionOpeningFloat(args);
+        }
+        if ("syncSecretHash" in args) {
+          return mockRegisterTerminal(args);
         }
         return mockReopenRegisterSessionCloseout(args);
       },
@@ -593,6 +632,23 @@ describe("useRegisterViewModel", () => {
         action: "corrected",
       }),
     );
+    mockRegisterTerminal.mockReset();
+    mockRegisterTerminal.mockImplementation(async (args) => ({
+      kind: "ok" as const,
+      data: {
+        _id: "terminal-1" as Id<"posTerminal">,
+        _creationTime: 1,
+        browserInfo: args.browserInfo,
+        displayName: args.displayName,
+        fingerprintHash: args.fingerprintHash,
+        registeredAt: 1,
+        registeredByUserId: "user-1" as Id<"athenaUser">,
+        registerNumber: args.registerNumber,
+        status: "active" as const,
+        storeId: args.storeId,
+        syncSecretHash: args.syncSecretHash,
+      },
+    }));
     mockStartSession.mockReset();
     mockStartSession.mockResolvedValue(
       ok({
@@ -6405,6 +6461,88 @@ describe("useRegisterViewModel", () => {
     await waitFor(() =>
       expect(result.current.drawerGate?.mode).toBe("terminalRepair"),
     );
+  });
+
+  it("auto repairs terminal setup when the local seed matches the browser fingerprint", async () => {
+    mockReadStoredTerminalFingerprint.mockReturnValue({
+      fingerprintHash: "local-terminal-1",
+      browserInfo: { userAgent: "test-browser" },
+    });
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: [
+        {
+          localEventId: "local-event-open",
+          schemaVersion: 1,
+          sequence: 1,
+          type: "register.opened",
+          terminalId: "local-terminal-1",
+          storeId: "store-1",
+          registerNumber: "1",
+          localRegisterSessionId: "local-register-1",
+          staffProfileId: "staff-1",
+          payload: {
+            localRegisterSessionId: "local-register-1",
+            openingFloat: 5000,
+          },
+          createdAt: 100,
+          sync: { status: "synced" },
+        },
+      ],
+    });
+    mockReadTerminalIntegrityState.mockResolvedValue({
+      ok: true,
+      value: {
+        observedAt: 110,
+        reason: "authorization_failed",
+        status: "requires_reprovision",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      },
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
+
+    await waitFor(() =>
+      expect(result.current.drawerGate?.mode).toBe("terminalRepair"),
+    );
+    expect(result.current.drawerGate?.errorMessage).toBeNull();
+
+    await waitFor(() =>
+      expect(mockRegisterTerminal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          browserInfo: { userAgent: "test-browser" },
+          displayName: "Front Counter",
+          fingerprintHash: "local-terminal-1",
+          registerNumber: "1",
+          storeId: "store-1",
+          syncSecretHash: expect.any(String),
+        }),
+      ),
+    );
+    expect(
+      mockWriteProvisionedTerminalSeedAndClearTerminalIntegrity,
+    ).toHaveBeenCalledWith({
+      seed: expect.objectContaining({
+        cloudTerminalId: "terminal-1",
+        displayName: "Front Counter",
+        registerNumber: "1",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      }),
+      terminalIntegrity: {
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      },
+    });
+    expect(toast.success).toHaveBeenCalledWith("Terminal setup repaired");
   });
 
   it("routes lifecycle drawer authority blocks to the open-drawer gate", async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -18,6 +18,7 @@ import { useAuth } from "@/hooks/useAuth";
 import useGetActiveStore from "@/hooks/useGetActiveStore";
 import { useGetTerminal } from "@/hooks/useGetTerminal";
 import { useNavigateBack } from "@/hooks/use-navigate-back";
+import { registerAndProvisionPosTerminal } from "@/lib/pos/application/registerAndProvisionPosTerminal";
 import { bootstrapRegister } from "@/lib/pos/application/useCases/bootstrapRegister";
 import { holdSession as runHoldSession } from "@/lib/pos/application/useCases/holdSession";
 import {
@@ -48,6 +49,7 @@ import { readProjectedLocalRegisterModel } from "@/lib/pos/infrastructure/local/
 import { isSyncablePosLocalEvent } from "@/lib/pos/infrastructure/local/syncContract";
 import { usePosLocalSyncRuntimeStatus } from "@/lib/pos/infrastructure/local/usePosLocalSyncRuntime";
 import { useLocalPosEntryContext } from "@/lib/pos/infrastructure/local/localPosEntryContext";
+import { readStoredTerminalFingerprint } from "@/lib/pos/infrastructure/terminal/fingerprint";
 import {
   useConvexRegisterCatalog,
   useConvexRegisterCatalogAvailability,
@@ -1209,6 +1211,8 @@ export function useRegisterViewModel(): RegisterViewModel {
     null,
   );
   const [isOpeningDrawer, setIsOpeningDrawer] = useState(false);
+  const [isRepairingTerminalSetup, setIsRepairingTerminalSetup] =
+    useState(false);
   const [isCorrectingOpeningFloat, setIsCorrectingOpeningFloat] =
     useState(false);
   const [isSubmittingCloseout, setIsSubmittingCloseout] = useState(false);
@@ -1239,6 +1243,7 @@ export function useRegisterViewModel(): RegisterViewModel {
   const pendingSessionStartKeyRef = useRef<string | null>(null);
   const seededRegisterSessionIdsRef = useRef<Set<string>>(new Set());
   const persistedDrawerAuthorityBlockRef = useRef<string | null>(null);
+  const autoTerminalRepairAttemptRef = useRef<string | null>(null);
   const [optimisticCartQuantities, setOptimisticCartQuantities] = useState<
     Record<string, number>
   >({});
@@ -1606,6 +1611,9 @@ export function useRegisterViewModel(): RegisterViewModel {
   );
   const correctRegisterSessionOpeningFloat = useMutation(
     api.cashControls.closeouts.correctRegisterSessionOpeningFloat,
+  );
+  const registerTerminalMutation = useMutation(
+    api.inventory.posTerminal.registerTerminal,
   );
   const {
     resumeSession,
@@ -2342,6 +2350,110 @@ export function useRegisterViewModel(): RegisterViewModel {
               activeSessionHasBlockedRegisterBinding
             ? "recovery"
             : "initialSetup";
+  const handleRepairTerminalSetup = useCallback(async () => {
+    if (!activeStoreId || !terminal?._id || typeof indexedDB === "undefined") {
+      setDrawerErrorMessage(
+        "Terminal setup repair is not available on this browser.",
+      );
+      return;
+    }
+
+    const fingerprint = readStoredTerminalFingerprint();
+    if (!fingerprint) {
+      setDrawerErrorMessage(
+        "Terminal setup repair needs this browser fingerprint. Open POS Settings to repair setup.",
+      );
+      return;
+    }
+
+    setIsRepairingTerminalSetup(true);
+    try {
+      const seedResult = await localStore.readProvisionedTerminalSeed();
+      const seed = seedResult.ok ? seedResult.value : null;
+
+      if (
+        !seed ||
+        seed.storeId !== activeStoreId ||
+        seed.cloudTerminalId !== terminal._id ||
+        seed.terminalId !== fingerprint.fingerprintHash
+      ) {
+        setDrawerErrorMessage(
+          "Terminal setup repair needs the current local setup record. Open POS Settings to repair setup.",
+        );
+        return;
+      }
+
+      const repairRegisterNumber =
+        seed.registerNumber ?? terminal.registerNumber ?? registerNumber;
+      if (!repairRegisterNumber) {
+        setDrawerErrorMessage(
+          "Register number required. Open POS Settings to repair setup.",
+        );
+        return;
+      }
+
+      const result = await registerAndProvisionPosTerminal({
+        activeStoreId,
+        browserInfo: fingerprint.browserInfo,
+        displayName: terminal.displayName || seed.displayName,
+        fingerprintHash: fingerprint.fingerprintHash,
+        registerNumber: repairRegisterNumber,
+        registerTerminalMutation,
+        storeFactory: () => localStore,
+      });
+
+      if (result.kind === "user_error") {
+        setDrawerErrorMessage(toOperatorMessage(result.error.message));
+        return;
+      }
+
+      setDrawerErrorMessage(null);
+      setLocalRegisterReadModelVersion((current) => current + 1);
+      setLocalSyncEventAppendToken((current) => current + 1);
+      await refreshLocalRegisterReadModel();
+      toast.success("Terminal setup repaired");
+    } catch (error) {
+      logger.warn("[POS] Terminal setup auto repair failed", {
+        error,
+        storeId: activeStoreId,
+        terminalId: terminal._id,
+      });
+      setDrawerErrorMessage("Unable to repair terminal setup. Try again.");
+    } finally {
+      setIsRepairingTerminalSetup(false);
+    }
+  }, [
+    activeStoreId,
+    localStore,
+    refreshLocalRegisterReadModel,
+    registerNumber,
+    registerTerminalMutation,
+    terminal?._id,
+    terminal?.displayName,
+    terminal?.registerNumber,
+  ]);
+  useEffect(() => {
+    if (drawerGateMode !== "terminalRepair") {
+      autoTerminalRepairAttemptRef.current = null;
+      return;
+    }
+    if (!activeStoreId || !terminal?._id || isRepairingTerminalSetup) {
+      return;
+    }
+
+    const repairKey = `${activeStoreId}:${terminal._id}`;
+    if (autoTerminalRepairAttemptRef.current === repairKey) {
+      return;
+    }
+    autoTerminalRepairAttemptRef.current = repairKey;
+    void handleRepairTerminalSetup();
+  }, [
+    activeStoreId,
+    drawerGateMode,
+    handleRepairTerminalSetup,
+    isRepairingTerminalSetup,
+    terminal?._id,
+  ]);
   const setPaymentState = useCallback((nextPayments: Payment[]) => {
     paymentsRef.current = nextPayments;
     setPayments(nextPayments);
@@ -5309,6 +5421,7 @@ export function useRegisterViewModel(): RegisterViewModel {
                   ? "Sale assigned to a different drawer. Open that drawer before continuing."
                   : null),
               isSubmitting: isOpeningDrawer,
+              isRepairingTerminalSetup,
               onOpeningFloatChange: (value: string) => {
                 setDrawerOpeningFloat(value);
                 setDrawerErrorMessage(null);
@@ -5321,6 +5434,10 @@ export function useRegisterViewModel(): RegisterViewModel {
               onRetrySync:
                 drawerGateMode === "drawerAuthorityRepair"
                   ? handleRetryLocalSync
+                  : undefined,
+              onRepairTerminalSetup:
+                drawerGateMode === "terminalRepair"
+                  ? handleRepairTerminalSetup
                   : undefined,
               onSignOut: handleCashierSignOut,
             }

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/stock-adjustments.tsx
@@ -8,11 +8,11 @@ const stockAdjustmentSearchSchema = z.object({
   availability: z
     .enum(["all", "all_available", "changed", "unavailable"])
     .optional(),
+  category: z.string().optional(),
   mode: z.enum(["cycle_count", "manual"]).optional(),
   o: z.string().optional(),
   page: z.coerce.number().int().positive().optional(),
   query: z.string().optional(),
-  scope: z.string().optional(),
   sku: z.string().optional(),
 });
 
@@ -37,10 +37,10 @@ function StockAdjustmentsRoute() {
 
         for (const key of [
           "availability",
+          "category",
           "mode",
           "page",
           "query",
-          "scope",
           "sku",
         ] as const) {
           if (next[key] === undefined || next[key] === "") {


### PR DESCRIPTION
## Summary
- Treat stock adjustment categories as filter-only state, infer count scope from the selected SKU, and show matching SKUs from other categories instead of leaving operators at an empty table.
- Add the POS terminal repair path for locally trusted terminal setup, with a repair action in the drawer gate and view-model coverage.
- Add the stock-adjustment/POS terminal repair solution note and refresh graphify artifacts.

## Validation
- `bun run --filter '@athena/webapp' test -- src/components/operations/StockAdjustmentWorkspace.test.tsx`
- `bun run --filter '@athena/webapp' test -- src/components/operations/OperationsQueueView.test.tsx`
- `bun run --filter '@athena/webapp' test -- src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
- `bun run --filter '@athena/webapp' lint:frontend:changed`
- `bun run --filter '@athena/webapp' typecheck`
- `bun run pr:athena`
