### PR TITLE
fix: allow closeout variance without notes

### DIFF
--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
@@ -1593,10 +1593,12 @@ describe("RegisterSessionViewContent", () => {
     );
   });
 
-  it("requires closeout notes when counted cash has a variance", async () => {
+  it("allows closeout variance without closeout notes", async () => {
     const user = userEvent.setup();
     const onAuthenticateStaff = vi.fn();
-    const onSubmitCloseout = vi.fn();
+    const onSubmitCloseout = vi
+      .fn()
+      .mockResolvedValue(ok({ action: "closed" }));
 
     render(
       <RegisterSessionViewContent
@@ -1614,13 +1616,29 @@ describe("RegisterSessionViewContent", () => {
 
     await user.clear(screen.getByLabelText("Closeout counted cash"));
     await user.type(screen.getByLabelText("Closeout counted cash"), "180");
+    expect(screen.getByLabelText("Closeout notes")).not.toBeRequired();
+    expect(
+      screen.queryByText("Notes are required when the count has variance."),
+    ).not.toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Submit closeout" }));
-
-    expect(await screen.findByRole("alert")).toHaveTextContent(
-      "Add closeout notes before submitting a count with variance",
+    await user.click(
+      screen.getByRole("button", { name: "Confirm staff for Submit closeout" }),
     );
-    expect(onAuthenticateStaff).not.toHaveBeenCalled();
-    expect(onSubmitCloseout).not.toHaveBeenCalled();
+
+    expect(onAuthenticateStaff).toHaveBeenCalledWith({
+      allowedRoles: ["cashier", "manager"],
+      pinHash: "hashed-pin",
+      username: "ato",
+    });
+    await waitFor(() =>
+      expect(onSubmitCloseout).toHaveBeenCalledWith({
+        actorStaffProfileId: "staff-1",
+        approvalProofId: undefined,
+        countedCash: 18000,
+        notes: undefined,
+        registerSessionId: "session-1",
+      }),
+    );
   });
 
   it("allows closeout without notes when counted cash matches expected cash", async () => {

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -1319,16 +1319,6 @@ export function RegisterSessionViewContent({
     }
 
     const trimmedCloseoutNotes = trimOptional(closeoutNotes);
-    const expectedCloseoutCash =
-      registerSession.netExpectedCash ?? registerSession.expectedCash;
-
-    if (parsedCountedCash !== expectedCloseoutCash && !trimmedCloseoutNotes) {
-      setCloseoutErrorMessage(
-        "Add closeout notes before submitting a count with variance",
-      );
-      return;
-    }
-
     setCloseoutErrorMessage("");
 
     if (requiresReopenedCloseoutSubmitApproval) {
@@ -1734,7 +1724,6 @@ export function RegisterSessionViewContent({
     registerSession && parsedCountedCash !== undefined
       ? parsedCountedCash - expectedCash
       : (registerSession?.variance ?? null);
-  const closeoutNotesRequired = draftVariance !== null && draftVariance !== 0;
   const hasPendingCloseoutApproval =
     registerSession?.pendingApprovalRequest?.status === "pending";
   const formattedApprovalReason = formatReviewReason(
@@ -3147,20 +3136,13 @@ export function RegisterSessionViewContent({
                         </span>
                         <Textarea
                           aria-label="Closeout notes"
-                          aria-required={closeoutNotesRequired}
                           className="min-h-[96px] border-input bg-background"
                           onChange={(event) =>
                             setCloseoutNotes(event.target.value)
                           }
                           placeholder="Add drawer notes if anything needs follow-up."
-                          required={closeoutNotesRequired}
                           value={closeoutNotes}
                         />
-                        {closeoutNotesRequired ? (
-                          <p className="text-xs text-muted-foreground">
-                            Notes are required when the count has variance.
-                          </p>
-                        ) : null}
                       </label>
 
                       <LoadingButton

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -2281,10 +2281,10 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("GH₵50")).toBeInTheDocument();
     expect(screen.getByText("GH₵-5")).toBeInTheDocument();
     expect(screen.getByLabelText(/counted cash/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/closeout notes/i)).toBeRequired();
+    expect(screen.getByLabelText(/closeout notes/i)).not.toBeRequired();
     expect(
-      screen.getByText("Notes are required when the count has variance."),
-    ).toBeInTheDocument();
+      screen.queryByText("Notes are required when the count has variance."),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /submit closeout/i }),
     ).toBeInTheDocument();

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
@@ -270,9 +270,6 @@ export function RegisterDrawerGate({
     const isSubmittedCloseout = Boolean(closeoutSubmittedReason);
     const isManagerReviewCloseout =
       closeoutSubmittedReason === "manager_review";
-    const closeoutNotesRequired =
-      drawerGate.closeoutDraftVariance !== undefined &&
-      drawerGate.closeoutDraftVariance !== 0;
 
     return (
       <div className="mx-auto max-w-2xl rounded-lg border border-stone-200 bg-white p-8 shadow-sm">
@@ -440,21 +437,14 @@ export function RegisterDrawerGate({
                   Closeout notes
                 </span>
                 <Textarea
-                  aria-required={closeoutNotesRequired}
                   disabled={drawerGate.isCloseoutSubmitting}
                   onChange={(event) =>
                     drawerGate.onCloseoutNotesChange?.(event.target.value)
                   }
                   placeholder="Add drawer notes if anything needs follow-up."
-                  required={closeoutNotesRequired}
                   rows={3}
                   value={drawerGate.closeoutNotes ?? ""}
                 />
-                {closeoutNotesRequired ? (
-                  <p className="text-xs text-stone-500">
-                    Notes are required when the count has variance.
-                  </p>
-                ) : null}
               </label>
 
               {drawerGate.errorMessage ? (

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -2869,7 +2869,7 @@ describe("useRegisterViewModel", () => {
     );
   });
 
-  it("requires closeout notes for POS closeout variance", async () => {
+  it("allows POS closeout variance without closeout notes", async () => {
     mockRegisterState = {
       phase: "readyToStart",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -2906,9 +2906,19 @@ describe("useRegisterViewModel", () => {
     });
 
     expect(mockSubmitRegisterSessionCloseout).not.toHaveBeenCalled();
-    expect(result.current.drawerGate?.errorMessage).toBe(
-      "Closeout notes required. Add notes before submitting a count with variance.",
+    await waitFor(() =>
+      expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "register.closeout_started",
+          localRegisterSessionId: "drawer-1",
+          payload: expect.objectContaining({
+            countedCash: 4_800,
+            notes: null,
+          }),
+        }),
+      ),
     );
+    expect(result.current.drawerGate?.errorMessage).toBeNull();
   });
 
   it("records closeout locally without waiting for a server approval response", async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -3489,13 +3489,6 @@ export function useRegisterViewModel(): RegisterViewModel {
       expectedCloseoutCash !== undefined &&
       parsedCountedCash !== expectedCloseoutCash;
 
-    if (hasCloseoutVariance && !trimmedCloseoutNotes) {
-      setDrawerErrorMessage(
-        "Closeout notes required. Add notes before submitting a count with variance.",
-      );
-      return;
-    }
-
     setDrawerErrorMessage(null);
     setIsSubmittingCloseout(true);
     await waitForCheckoutMutationQueues();


### PR DESCRIPTION
## Summary
- make closeout notes optional for cash-count variances in Cash Controls
- apply the same optional-notes behavior to the POS register closeout gate
- update register and view-model tests for variance submission without notes

## Validation
- bun run --filter '@athena/webapp' test -- src/components/cash-controls/RegisterSessionView.test.tsx src/components/pos/register/POSRegisterView.test.tsx src/lib/pos/presentation/register/useRegisterViewModel.test.ts\n- bun run --filter '@athena/webapp' lint:frontend:changed\n- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json\n- bun run --filter '@athena/webapp' build\n- bun run graphify:rebuild\n- bun run pr:athena