### PR TITLE
Add POS recovery-code login

### DIFF
--- a/docs/plans/2026-06-03-001-feat-pos-recovery-code-login-plan.html
+++ b/docs/plans/2026-06-03-001-feat-pos-recovery-code-login-plan.html
@@ -1,0 +1,301 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>feat: Add POS recovery-code login for field operators</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f8fa;
+      --panel: #ffffff;
+      --text: #172033;
+      --muted: #5e6878;
+      --line: #d9dee8;
+      --accent: #0f766e;
+      --warn: #9a5b00;
+      --danger: #b42318;
+      --code: #eef2f7;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    header, main {
+      width: min(1120px, calc(100% - 40px));
+      margin: 0 auto;
+    }
+    header { padding: 38px 0 16px; }
+    .eyebrow {
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+    }
+    h1 {
+      margin: 8px 0 10px;
+      font-size: clamp(28px, 4vw, 42px);
+      line-height: 1.12;
+      letter-spacing: 0;
+    }
+    .meta {
+      color: var(--muted);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px 18px;
+    }
+    nav {
+      margin: 22px 0 0;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+    nav a {
+      color: var(--text);
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 6px 10px;
+      text-decoration: none;
+      background: var(--panel);
+    }
+    main { padding: 12px 0 48px; }
+    section {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 22px;
+      margin: 16px 0;
+    }
+    h2 {
+      margin: 0 0 12px;
+      font-size: 22px;
+      letter-spacing: 0;
+    }
+    h3 {
+      margin: 18px 0 8px;
+      font-size: 16px;
+      letter-spacing: 0;
+    }
+    p { margin: 0 0 12px; }
+    ul, ol { margin: 8px 0 0; padding-left: 22px; }
+    li { margin: 5px 0; }
+    code {
+      background: var(--code);
+      border-radius: 4px;
+      padding: 1px 4px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: .92em;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 10px;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 9px 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: #f1f4f8; }
+    .callout {
+      border-left: 4px solid var(--accent);
+      background: #eef8f6;
+      padding: 12px 14px;
+      border-radius: 6px;
+    }
+    .warn {
+      border-left-color: var(--warn);
+      background: #fff7ed;
+    }
+    .danger {
+      border-left-color: var(--danger);
+      background: #fff1f0;
+    }
+    .unit {
+      border-top: 1px solid var(--line);
+      padding-top: 16px;
+      margin-top: 16px;
+    }
+    .unit:first-of-type {
+      border-top: 0;
+      padding-top: 0;
+    }
+    pre {
+      white-space: pre-wrap;
+      background: #111827;
+      color: #f8fafc;
+      border-radius: 8px;
+      padding: 14px;
+      overflow: auto;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="eyebrow">Deep Plan</div>
+    <h1>feat: Add POS recovery-code login for field operators</h1>
+    <div class="meta">
+      <span>Date: 2026-06-03</span>
+      <span>Status: draft</span>
+      <span>Scope: Wigclub POS account recovery</span>
+    </div>
+    <nav aria-label="Plan sections">
+      <a href="#summary">Summary</a>
+      <a href="#requirements">Requirements</a>
+      <a href="#decisions">Decisions</a>
+      <a href="#alternatives">Alternatives</a>
+      <a href="#units">Units</a>
+      <a href="#signoff">Sign-off</a>
+    </nav>
+  </header>
+  <main>
+    <section id="summary">
+      <h2>Summary</h2>
+      <p>Add a tightly scoped recovery-code login path for the shared <code>pos@wigclub.store</code> POS app account. Field operators can sign in on a fresh browser when the normal OTP flow is blocked by lack of inbox access.</p>
+      <div class="callout">
+        The recommended path is a static-until-rotated POS recovery code stored server-side as a hash, validated through a dedicated Convex Auth credentials provider, and managed by full admins.
+      </div>
+    </section>
+
+    <section>
+      <h2>Problem Frame</h2>
+      <p>The POS field account occasionally needs to sign in again. The current login path sends an OTP to the email address on the app account, but operators using the POS do not have inbox access.</p>
+      <ul>
+        <li><code>pos@wigclub.store</code> loads the POS web app.</li>
+        <li>Staff PIN and terminal-scoped credentials identify the cashier/operator.</li>
+        <li>Terminal trust, drawer lifecycle, and command checks still decide whether a sale can happen.</li>
+      </ul>
+    </section>
+
+    <section id="requirements">
+      <h2>Requirements</h2>
+      <ul>
+        <li>Fresh browsers can sign in as <code>pos@wigclub.store</code> without email OTP access.</li>
+        <li>Recovery is restricted to the configured POS account and rejects admin or non-<code>pos_only</code> accounts.</li>
+        <li>Successful recovery creates a normal authenticated app session and reuses Athena auth sync.</li>
+        <li>Staff PIN remains the cashier/operator identity layer.</li>
+        <li>Recovery code storage is server-side hash only.</li>
+        <li>Failed attempts are rate-limited, locked, and audited.</li>
+        <li>Full admins can create, rotate, lock, unlock, or revoke the code.</li>
+        <li>Codes are generated server-side with enough entropy for shared-credential use.</li>
+      </ul>
+    </section>
+
+    <section id="decisions">
+      <h2>Key Technical Decisions</h2>
+      <table>
+        <thead>
+          <tr><th>Decision</th><th>Rationale</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Dedicated Convex Auth credentials provider</td><td>Keeps recovery inside the supported auth system and reuses existing auth sync.</td></tr>
+          <tr><td>Configured email, store, and <code>pos_only</code> scope</td><td>Limits blast radius to the POS app account.</td></tr>
+          <tr><td>Hashed, DB-managed recovery code</td><td>Supports rotation and audit without committing a static secret.</td></tr>
+          <tr><td>Stable until rotated</td><td>Gives field staff a low-friction path that does not depend on a live admin or inbox.</td></tr>
+          <tr><td>Full-admin management</td><td>The code is a shared credential and should be controlled by trusted admins.</td></tr>
+          <tr><td>Staff PIN remains separate</td><td>App-account recovery loads the app; staff proof still identifies the operator.</td></tr>
+          <tr><td>Strong server-generated codes</td><td>The v1 code should be readable but not human-chosen or guessable.</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="alternatives">
+      <h2>Alternatives</h2>
+      <table>
+        <thead>
+          <tr><th>Alternative</th><th>Benefits</th><th>Problems</th><th>Recommendation</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Static-until-rotated recovery code</td><td>Fresh-browser capable and low friction</td><td>Shared secret needs protection and lockout</td><td>Recommended for v1</td></tr>
+          <tr><td>Longer auth sessions only</td><td>Minimal UI work</td><td>Does not help fresh browsers</td><td>Not sufficient</td></tr>
+          <tr><td>Terminal-bound app-session recovery</td><td>Strong device scope</td><td>Not fresh-browser capable before terminal context exists</td><td>Separate continuity feature</td></tr>
+          <tr><td>Full-admin one-time code</td><td>Stronger than static</td><td>Still requires a live admin</td><td>Later option</td></tr>
+          <tr><td>Shared inbox or OTP forwarding</td><td>No code change</td><td>Brittle and expands email access</td><td>Avoid</td></tr>
+          <tr><td>Staff PIN signs in app account</td><td>Familiar to cashiers</td><td>Blurs staff identity with app login</td><td>Avoid</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>High-Level Flow</h2>
+      <pre>Operator -&gt; Login UI: Enter pos@wigclub.store recovery code
+Login UI -&gt; POS recovery provider: signIn(provider, email, code, store)
+Provider -&gt; Provider: Validate account scope, code hash, lockout
+Provider -&gt; Convex Auth: Return configured auth user id
+Convex Auth -&gt; Login UI: Auth session established
+Login UI -&gt; Athena auth sync: Trigger existing pending auth sync
+Athena auth sync -&gt; POS runtime: Store Athena user id and POS app account id
+POS runtime -&gt; POS runtime: Staff PIN and drawer gates still apply</pre>
+    </section>
+
+    <section id="units">
+      <h2>Implementation Units</h2>
+      <div class="unit">
+        <h3>U1. Add POS recovery credential storage</h3>
+        <p>Add a server-side <code>posRecoveryCredential</code> table scoped to organization, store, and POS app account. Store only hashes, status, counters, lockout metadata, and rotation audit fields.</p>
+      </div>
+      <div class="unit">
+        <h3>U2. Add a dedicated Convex Auth recovery provider</h3>
+        <p>Register a <code>ConvexCredentials</code> provider that validates the configured account, <code>pos_only</code> membership, recovery code hash, and lockout before returning the real auth user id.</p>
+      </div>
+      <div class="unit">
+        <h3>U3. Add a recovery-code login UI</h3>
+        <p>Keep OTP as the default. Add a secondary POS recovery-code form that uses the same pending-auth-sync handoff as OTP success.</p>
+      </div>
+      <div class="unit">
+        <h3>U4. Add full-admin recovery-code management</h3>
+        <p>Let full admins create, rotate, unlock, and revoke the code. Show plaintext once on create or rotate only.</p>
+      </div>
+      <div class="unit">
+        <h3>U5. Preserve POS authority boundaries and auditability</h3>
+        <p>Confirm recovery login never substitutes for staff proof. POS actions should still attribute cashier/operator activity through staff profiles.</p>
+      </div>
+      <div class="unit">
+        <h3>U6. Validate, rollout, and document operations</h3>
+        <p>Run targeted provider, UI, settings, staff-authority, Convex, typecheck, build, browser, and graphify validation before shipping.</p>
+      </div>
+    </section>
+
+    <section>
+      <h2>Security Notes</h2>
+      <ul>
+        <li>Keep validation server-side; UI hiding is not security.</li>
+        <li>Do not log submitted code, code hash, salt, or pepper.</li>
+        <li>Use generic failure copy for invalid, locked, missing, or disallowed states.</li>
+        <li>Rotate after staff turnover or suspected exposure.</li>
+      </ul>
+      <table>
+        <thead>
+          <tr><th>Threat</th><th>Mitigation</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Brute-force guessing</td><td>High-entropy generated code, server-side hash comparison, bounded attempts, generic failures.</td></tr>
+          <tr><td>Denial-of-service by repeated wrong attempts</td><td>Credential lockout telemetry, full-admin unlock, clear admin status, and rollout guidance for support.</td></tr>
+          <tr><td>Using the code for an admin account</td><td>Provider hard-checks configured email, store, and active <code>pos_only</code> membership.</td></tr>
+          <tr><td>Secret leakage</td><td>Audit events and metadata exclude code, hash, salt, and pepper.</td></tr>
+          <tr><td>Staff accountability loss</td><td>Recovery login audit stays separate from POS action audit.</td></tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="signoff">
+      <h2>Final Sign-Off Needed</h2>
+      <ol>
+        <li>The v1 recovery account is exactly <code>pos@wigclub.store</code> for Wigclub.</li>
+        <li>The recovery code remains valid until a full admin rotates or revokes it.</li>
+        <li>Full admins are the only users who can manage the recovery code.</li>
+        <li>Failed attempts lock the recovery code globally after a small number of failures, with full-admin unlock.</li>
+        <li>Staff PIN remains mandatory for cashier/operator identity.</li>
+      </ol>
+      <div class="callout warn">
+        No implementation should start until these policy choices are confirmed.
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/plans/2026-06-03-001-feat-pos-recovery-code-login-plan.md
+++ b/docs/plans/2026-06-03-001-feat-pos-recovery-code-login-plan.md
@@ -1,0 +1,406 @@
+---
+title: "feat: Add POS recovery-code login for field operators"
+type: feat
+status: draft
+date: 2026-06-03
+depth: deep
+---
+
+# feat: Add POS recovery-code login for field operators
+
+## Summary
+
+Add a tightly scoped recovery-code login path for the shared `pos@wigclub.store` POS app account. The goal is to let field operators sign in on a fresh browser when the normal OTP flow is blocked by lack of inbox access, without broadening access to admin accounts, weakening staff PIN checks, or storing raw credentials.
+
+The recommended path is a static-until-rotated POS recovery code stored server-side as a hash, validated through a dedicated Convex Auth credentials provider, and managed by full admins. "Static" here means stable for field use until explicitly rotated, not hard-coded in source, not stored in client storage, and not exposed after creation.
+
+## Problem Frame
+
+The POS field account occasionally needs to sign in again. The current login path sends an OTP to the email address on the app account, but the operators using the POS do not have access to that inbox. That creates operational friction at exactly the point where the field team needs a low-friction recovery path.
+
+Athena already separates app account identity from operational staff authority:
+
+- `pos@wigclub.store` is the app account that lets the POS web app load in the field.
+- Staff PIN and terminal-scoped staff credentials identify the cashier/operator for POS actions.
+- Terminal trust, drawer lifecycle, and POS command checks still decide whether a sale can happen.
+
+This plan should only solve app-account recovery for the specific POS account. It should not become a general bypass for arbitrary users, admins, or full-admin operations.
+
+## Requirements
+
+- R1. A fresh browser must be able to sign in as the `pos@wigclub.store` POS app account using a recovery code without email OTP access.
+- R2. The recovery-code path must be restricted to the configured POS recovery account and must reject other account emails, admin accounts, and non-`pos_only` memberships.
+- R3. A successful recovery-code login must create a normal authenticated app session and reuse the existing Athena auth-sync handoff.
+- R4. Staff PINs must remain the cashier/operator identity layer after app-account login; recovery-code login must not authorize POS commands by itself.
+- R5. Recovery codes must be stored server-side as hashes only, never committed in source, never stored in browser storage, and never written to operational logs.
+- R6. Failed recovery attempts must be rate-limited, eventually locked, and logged in support-safe audit events.
+- R7. Full admins must be able to create, rotate, lock, unlock, or revoke the POS recovery code, with plaintext shown only once when generated.
+- R8. Operator-facing login errors must be generic and operational, without revealing whether the account, code, or lock state was the exact failure reason.
+- R9. The flow must preserve existing OTP login behavior for all normal users.
+- R10. Tests must cover the auth provider, recovery-code management, login UI, auth-sync handoff, lockout behavior, and POS staff-authority separation.
+- R11. Recovery codes must be generated with enough entropy for shared-credential use; do not ask admins to invent memorable codes.
+
+## Scope Boundaries
+
+- This is scoped to the `pos@wigclub.store` POS app account for Wigclub.
+- This does not replace normal OTP login for admins, operators with inbox access, or any non-POS account.
+- This does not create a new staff identity model.
+- This does not bypass staff PIN, manager approval, terminal integrity, drawer authority, or local-first POS command invariants.
+- This does not add persistent shared passwords, plaintext recovery codes, OTP inbox polling, or reusable bearer tokens to the client.
+- This does not implement a broad "trusted device" login flow for every registered terminal.
+
+### Deferred to Follow-Up Work
+
+- A generic multi-store recovery-code product for every POS-only app account.
+- Per-terminal recovery codes or terminal-issued device credentials.
+- Hardware security keys or passkeys for store devices.
+- Fleet-level alerting for repeated failed recovery-code attempts.
+- SMS or messaging-based delivery of one-time login codes.
+
+## Context and Research
+
+### Existing Auth Flow
+
+- `packages/athena-webapp/convex/auth.ts` wires Convex Auth providers. Today it uses the Email OTP provider.
+- `packages/athena-webapp/shared/auth.ts` defines `ATHENA_EMAIL_OTP_PROVIDER_ID`.
+- `packages/athena-webapp/src/components/auth/Login/LoginForm.tsx` starts OTP sign-in.
+- `packages/athena-webapp/src/components/auth/Login/InputOTP.tsx` marks `PENDING_ATHENA_AUTH_SYNC_KEY`, dispatches `ATHENA_PENDING_AUTH_SYNC_EVENT`, and navigates back into the app after OTP success.
+- `packages/athena-webapp/src/routes/login/_layout.tsx` runs `api.inventory.auth.syncAuthenticatedAthenaUser`, stores `LOGGED_IN_USER_ID_KEY` and `POS_APP_ACCOUNT_ID_KEY`, and navigates after app-account sync.
+- `packages/athena-webapp/src/lib/constants.ts` defines auth-sync and POS app-account local storage keys.
+
+### Existing Staff and POS Authority Patterns
+
+- `packages/athena-webapp/convex/operations/staffCredentials.ts` already has failure limits, lockout windows, and terminal-aware staff credential checks.
+- Staff credentials are operational actor proof. They are not the same thing as Athena app login.
+- `packages/athena-webapp/convex/pos/public/terminalAppSessions.ts` already demonstrates server-side POS app-account validation, route scoping, safe operational events, and secret-leakage tests for terminal-bound app-session recovery.
+- `packages/athena-webapp/convex/operationalEvents.ts` is the right audit surface for support-safe recovery events.
+
+### Convex Auth Provider Direction
+
+Local package types show `@convex-dev/auth/providers/ConvexCredentials` supports custom credentials providers whose `authorize(credentials, ctx)` handler returns an auth `users` id, optionally with a session id. That makes a dedicated provider the right implementation direction because the recovery path can still create a real Convex Auth session and then reuse the existing Athena auth-sync route.
+
+Implementation must verify the exact Convex Auth helper APIs for finding or linking the auth `users` row for `pos@wigclub.store`; the important boundary is that the provider returns a real auth user id and does not manually fake app state in local storage.
+
+## Key Technical Decisions
+
+| Decision | Rationale |
+|---|---|
+| Use a dedicated Convex Auth credentials provider | It keeps recovery login inside the supported auth system and lets the existing login sync path run normally after sign-in. |
+| Restrict by configured email, store, and `pos_only` membership | The recovery code is operationally convenient but powerful, so the blast radius must be the POS app account only. |
+| Store a hashed, DB-managed recovery code | This supports rotation and audit without committing a static secret or exposing raw code after creation. |
+| Keep the recovery code stable until rotated | Field staff need a low-friction path that works during real operations. Short-lived codes would reintroduce the same availability problem as email OTP. |
+| Require full-admin management for rotation and revocation | The code is a credential for a shared app account, so only full admins should create or rotate it. |
+| Use generic failure copy and server-side lockout | The login page should not leak whether the code, account, membership, or lockout was the exact reason for failure. |
+| Reuse existing Athena auth sync | Avoid a parallel app-login model; recovery-code success should look like OTP success after Convex Auth signs in. |
+| Keep staff PIN separate | The POS app account loads the app. Staff proof still answers who performed the POS action. |
+| Generate strong recovery codes server-side | A shared static code is only acceptable if it is high entropy, not a human-chosen PIN or short phrase. |
+
+## Alternatives Considered
+
+| Alternative | Benefits | Problems | Recommendation |
+|---|---|---|---|
+| Static-until-rotated recovery code | Fresh-browser capable, low friction, easy to explain, can be scoped and audited | Shared secret must be protected, rotated, and rate-limited | Recommended for v1 with tight guardrails |
+| Longer Convex Auth sessions only | Minimal UI work | Does not help fresh browsers or cleared cookies; still depends on prior login | Not sufficient |
+| Terminal-bound app-session recovery only | Strong device scope and already partly planned elsewhere | Does not work on a fresh browser before terminal context exists | Keep as separate continuity feature |
+| Full-admin one-time code issued on demand | Stronger than a static code | Operators still need a remote admin at sign-in time | Useful later, not the lowest-friction path |
+| Shared inbox or OTP forwarding | No code change | Operationally brittle and expands email access | Avoid |
+| Staff PIN signs in the app account | Familiar to cashiers | Blurs staff identity with app login and turns staff PINs into app credentials | Avoid |
+| Passkeys or hardware keys | Strong phishing resistance | Higher setup and field-support burden | Consider after v1 |
+
+## High-Level Technical Design
+
+```mermaid
+sequenceDiagram
+  participant Operator
+  participant Login as Login UI
+  participant Provider as POS recovery provider
+  participant Auth as Convex Auth
+  participant Sync as Athena auth sync
+  participant POS as POS runtime
+
+  Operator->>Login: Enters pos@wigclub.store recovery code
+  Login->>Provider: signIn(pos-recovery-code, email, code, store)
+  Provider->>Provider: Validate account scope, code hash, lockout
+  Provider->>Auth: Return configured auth user id
+  Auth-->>Login: Auth session established
+  Login->>Sync: Trigger existing pending auth sync
+  Sync-->>Login: Athena user id and POS app account id
+  Login->>POS: Navigate to requested POS route
+  POS->>POS: Staff PIN and drawer gates still apply
+```
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1["U1 recovery credential schema"]
+  U2["U2 credentials provider"]
+  U3["U3 login UI"]
+  U4["U4 admin management"]
+  U5["U5 POS authority and audit checks"]
+  U6["U6 tests and rollout"]
+  U1 --> U2
+  U2 --> U3
+  U1 --> U4
+  U3 --> U5
+  U4 --> U5
+  U5 --> U6
+```
+
+### U1. Add POS recovery credential storage
+
+**Goal:** Store the recovery credential as a server-side, rotatable, auditable record.
+
+**Requirements:** R2, R5, R6, R7, R8.
+
+**Dependencies:** None.
+
+**Files:**
+
+- Modify: `packages/athena-webapp/convex/schema.ts`
+- Add: `packages/athena-webapp/convex/pos/public/posRecoveryCodes.ts` or `packages/athena-webapp/convex/auth/posRecoveryCodes.ts`
+- Modify: `packages/athena-webapp/convex/operationalEvents.ts` if event typing needs extension
+- Test: `packages/athena-webapp/convex/pos/public/posRecoveryCodes.test.ts`
+
+**Approach:**
+
+- Add a `posRecoveryCredential` table scoped to `organizationId`, `storeId`, and the POS Athena app account id.
+- Store only `codeHash`, code salt or version metadata, status, failure count, `lockedUntil`, `lastUsedAt`, `rotatedAt`, and `rotatedByUserId`.
+- Use the existing server-side hashing style closest to terminal sync-secret and staff verifier patterns. If implementation finds no suitable shared helper, add a small server helper that hashes with per-code salt and an environment-backed pepper.
+- Generate recovery codes server-side with high entropy, such as a grouped random code that is readable over the phone but not guessable. Do not accept admin-supplied low-entropy codes in v1.
+- Keep credential lockout behavior close to `staffCredentials.ts`: bounded failures, lock window, reset on success, and full-admin unlock. Treat global lockout as an explicit availability tradeoff and expose status in the admin surface.
+- Write safe operational events for rotate, revoke, lock, failed attempt, and successful use. Do not include the raw code, code hash, or submitted email/code pair in event metadata.
+
+**Test scenarios:**
+
+- Creating or rotating a code returns plaintext only once and stores a hash.
+- Old code fails after rotation.
+- Failed attempts increment counters and eventually lock the credential.
+- Successful login resets failure counters and updates `lastUsedAt`.
+- Audit events contain safe metadata and do not include the raw code or hash.
+
+### U2. Add a dedicated Convex Auth recovery provider
+
+**Goal:** Let the recovery code establish a real Convex Auth session for the configured POS account.
+
+**Requirements:** R1, R2, R3, R5, R6, R8, R9.
+
+**Dependencies:** U1.
+
+**Files:**
+
+- Modify: `packages/athena-webapp/convex/auth.ts`
+- Modify: `packages/athena-webapp/shared/auth.ts`
+- Add: `packages/athena-webapp/convex/auth/PosRecoveryCode.ts`
+- Test: `packages/athena-webapp/convex/auth/PosRecoveryCode.test.ts`
+
+**Approach:**
+
+- Add `ATHENA_POS_RECOVERY_CODE_PROVIDER_ID`, for example `"athena-pos-recovery-code"`.
+- Register a `ConvexCredentials` provider next to the existing Email OTP provider.
+- Provider input should include the email and recovery code. If the login route has store context, include org/store slug or id as a hint only. The provider must enforce the configured Wigclub POS account and store server-side; never trust client-provided scope as authority.
+- Validate all of these before returning an auth user id:
+  - Submitted email matches the configured POS recovery account, currently `pos@wigclub.store`.
+  - The auth `users` row exists and links to the Athena user used by `syncAuthenticatedAthenaUser`.
+  - The Athena user has an active organization membership for Wigclub.
+  - The organization membership role is `pos_only`, not admin or full admin.
+  - The recovery credential is active, not locked, and the submitted code matches the stored hash.
+- Return a generic failure for every rejection path.
+- On success, return the real Convex Auth user id so the client can reuse the existing `PENDING_ATHENA_AUTH_SYNC_KEY` and `syncAuthenticatedAthenaUser` flow.
+
+**Implementation risk to resolve early:** Convex Auth credential providers return auth `users` ids, while Athena uses `athenaUser` records after sync. The implementing agent should first prove the `pos@wigclub.store` auth user exists and is linked by email to the correct Athena user. If it does not, add an explicit admin-only setup or migration step rather than creating a hidden ad hoc account during login.
+
+**Test scenarios:**
+
+- Correct code for the configured POS account signs in and triggers auth sync.
+- Correct code for a non-POS account fails.
+- Correct code for a POS email without `pos_only` membership fails.
+- Wrong code fails with generic copy and increments failure count.
+- Locked credential fails with generic copy and does not leak lock details.
+- OTP provider behavior remains unchanged.
+
+### U3. Add a recovery-code login UI
+
+**Goal:** Give field staff a simple login path that works on a fresh browser while preserving OTP as the default flow.
+
+**Requirements:** R1, R3, R8, R9.
+
+**Dependencies:** U2.
+
+**Files:**
+
+- Modify: `packages/athena-webapp/src/components/auth/Login/LoginForm.tsx`
+- Add: `packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.tsx`
+- Modify: `packages/athena-webapp/src/components/auth/Login/InputOTP.tsx` if the auth-sync handoff should become a shared helper
+- Modify: `packages/athena-webapp/src/routes/login/_layout.tsx` only if redirect handling needs POS route preservation
+- Test: `packages/athena-webapp/src/components/auth/Login/LoginForm.test.tsx`
+- Test: `packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.test.tsx`
+- Test: `packages/athena-webapp/src/routes/login/_layout.test.tsx`
+
+**Approach:**
+
+- Keep OTP as the primary login flow.
+- Add a secondary "Use POS recovery code" action. Product copy should stay calm and operational, following `docs/product-copy-tone.md`.
+- The recovery form should be intentionally narrow: default the email to `pos@wigclub.store` or display it as the POS account being recovered, then ask for the recovery code.
+- Call `signIn(ATHENA_POS_RECOVERY_CODE_PROVIDER_ID, { email, code, ...context })`.
+- On success, run the same pending-auth-sync handoff as OTP success:
+  - Set `PENDING_ATHENA_AUTH_SYNC_KEY`.
+  - Dispatch `ATHENA_PENDING_AUTH_SYNC_EVENT`.
+  - Navigate back into the app or preserved POS redirect target.
+- On failure, show a generic message such as "That recovery code could not sign in the POS account." Avoid copy that distinguishes invalid, locked, missing, or wrong account states.
+
+**Test scenarios:**
+
+- OTP remains the default visible flow.
+- Recovery option opens the recovery form without requiring email inbox access.
+- Successful recovery sign-in sets pending auth sync and navigates through the same path as OTP.
+- Failed recovery sign-in shows generic safe copy.
+- Code is not persisted in local storage or query params.
+- Fresh-browser flow can navigate to the POS route after sync.
+
+### U4. Add full-admin recovery-code management
+
+**Goal:** Let trusted administrators rotate and revoke the static recovery code without a deploy.
+
+**Requirements:** R5, R6, R7.
+
+**Dependencies:** U1.
+
+**Files:**
+
+- Modify: `packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx` or the existing admin/settings surface that owns POS account setup
+- Add: `packages/athena-webapp/src/components/pos/settings/PosRecoveryCodeSettings.tsx`
+- Add or modify Convex mutations in the U1 backend module
+- Test: `packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx`
+- Test: `packages/athena-webapp/convex/pos/public/posRecoveryCodes.test.ts`
+
+**Approach:**
+
+- Gate all management mutations with full-admin organization membership.
+- Show current status only: active, locked, revoked, last used, last rotated, and who rotated it.
+- Generate or rotate the code server-side and show plaintext exactly once in the mutation response. Do not add any "show current code" endpoint.
+- Provide revoke and unlock actions. Unlock should clear lockout state but not reveal the code.
+- Record operational events for every management action with the admin actor id.
+
+**Test scenarios:**
+
+- Full admin can rotate, revoke, and unlock.
+- Non-full-admin users cannot manage recovery codes.
+- Plaintext appears only in the rotate/create response.
+- Status view never exposes code hash or plaintext.
+
+### U5. Preserve POS authority boundaries and auditability
+
+**Goal:** Ensure app-account recovery does not accidentally authorize POS actions or obscure actor identity.
+
+**Requirements:** R4, R6, R8, R10.
+
+**Dependencies:** U2, U3, U4.
+
+**Files:**
+
+- Verify: `packages/athena-webapp/convex/operations/staffCredentials.ts`
+- Verify: `packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx`
+- Verify: `packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx`
+- Verify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Test: `packages/athena-webapp/convex/operations/staffCredentials.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- Test: `packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx`
+
+**Approach:**
+
+- Confirm no POS command path treats the recovered app account as staff proof.
+- Confirm staff PIN prompts still appear after recovery where they appeared before.
+- Confirm operational events for sale-affecting actions still use staff profile actor fields when staff proof is required.
+- Add explicit regression coverage if any POS code path currently assumes a signed-in app account is enough to act.
+- Keep recovery login audit separate from cashier action audit: the former answers "the POS app account was recovered"; the latter answers "this staff member performed this action."
+
+**Test scenarios:**
+
+- After recovery-code login, opening or selling still requires the existing drawer/staff gates.
+- POS actions continue to attribute actor staff profile, not only `pos@wigclub.store`.
+- Recovery audit events never stand in for transaction actor audit.
+
+### U6. Validate, rollout, and document operations
+
+**Goal:** Ship the feature with enough test coverage and operational guidance for field use.
+
+**Requirements:** R1-R10.
+
+**Dependencies:** U1, U2, U3, U4, U5.
+
+**Files:**
+
+- Modify or add tests listed in U1-U5.
+- Modify: `docs/solutions/` if implementation reveals a reusable auth or POS recovery pattern.
+- Rebuild: `graphify-out/graph.json` after code changes.
+
+**Validation commands:**
+
+- `bun run --filter '@athena/webapp' audit:convex`
+- `bun run --filter '@athena/webapp' lint:convex:changed`
+- `bun run --filter '@athena/webapp' lint:frontend:changed`
+- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
+- `bun run --filter '@athena/webapp' build`
+- `bun run graphify:rebuild`
+- Targeted tests for new Convex auth/provider and recovery-code modules.
+- Targeted tests for `LoginForm`, `PosRecoveryCodeForm`, `login/_layout`, POS settings, staff credentials, and POS register authority boundaries.
+
+**Browser validation:**
+
+- In a fresh browser profile, navigate to the Wigclub POS URL while signed out.
+- Choose POS recovery code, sign in as `pos@wigclub.store`, and verify the existing auth-sync flow lands in the POS route.
+- Verify staff PIN or drawer gates still appear before sale-affecting actions.
+- Submit wrong codes until lockout and verify safe generic copy.
+- Rotate the code as a full admin, then verify old code fails and new code succeeds.
+
+## Security Notes
+
+- Treat the recovery code as a shared credential with operational convenience, not as a low-risk token.
+- Keep all validation server-side. Client-side hiding of the recovery form is only UX, not security.
+- Avoid route or response behavior that leaks whether a submitted account exists.
+- Do not include submitted code, code hash, salt, or pepper in logs, telemetry, local storage, query strings, or operational event metadata.
+- Consider forcing code rotation after staff turnover or suspected exposure.
+- Consider adding a short post-v1 metric: failed recovery attempts per day and lockout count.
+
+### Threats and Mitigations
+
+| Threat | Mitigation |
+|---|---|
+| Brute-force guessing | High-entropy generated code, server-side hash comparison, bounded attempts, generic failures. |
+| Denial-of-service by repeated wrong attempts | Credential lockout telemetry, full-admin unlock, clear admin status, and rollout guidance for support. |
+| Using the code for an admin account | Provider hard-checks configured email, store, and active `pos_only` membership before returning an auth user id. |
+| Secret leakage through logs or browser storage | Never store raw code client-side; audit events and metadata exclude code, hash, salt, and pepper. |
+| Staff accountability loss | Recovery login audit is separate from POS action audit; staff PIN remains the cashier/operator proof. |
+
+## Rollout Plan
+
+1. Implement backend storage and provider behind the configured `pos@wigclub.store` account.
+2. Add full-admin setup/rotation UI and create the initial recovery code outside source control.
+3. Add login UI and reuse existing auth-sync handoff.
+4. Run targeted tests, Convex/frontend checks, typecheck, build, and graphify rebuild.
+5. Browser-test a fresh profile using the local dev server.
+6. Deploy after admin has a plan for securely sharing the initial code with field leads.
+7. Rotate the code once after field staff confirm the flow and support copy are clear.
+
+## Acceptance Criteria
+
+- A fresh browser can sign in to Wigclub POS with the recovery code and no email OTP.
+- The same recovery code cannot sign in another Athena account.
+- A non-`pos_only` account cannot use the recovery-code provider.
+- OTP login still works for normal users.
+- Recovery code plaintext is visible only once when created or rotated.
+- Wrong recovery attempts are rate-limited and locked.
+- Login failure copy is generic and safe.
+- Staff PIN and drawer authority still gate POS actions after recovery login.
+- Audit events show recovery success/failure and admin rotation without exposing secrets.
+
+## Final Sign-Off Needed
+
+Before implementation, confirm these policy choices:
+
+1. The v1 recovery account is exactly `pos@wigclub.store` for Wigclub.
+2. The recovery code should remain valid until a full admin rotates or revokes it.
+3. Full admins are the only users who can create, rotate, unlock, or revoke the code.
+4. Failed attempts should lock the recovery code globally for the account after a small number of failures, similar to staff credential lockout, with full-admin unlock as the recovery path.
+5. Staff PIN remains mandatory for cashier/operator identity and is not part of the app-account login flow.

--- a/docs/solutions/architecture/athena-pos-recovery-code-login-2026-06-03.md
+++ b/docs/solutions/architecture/athena-pos-recovery-code-login-2026-06-03.md
@@ -1,0 +1,105 @@
+---
+title: Athena POS Recovery-Code Login Keeps App Account And Staff Authority Separate
+date: 2026-06-03
+category: architecture
+module: athena-webapp
+problem_type: pos_recovery_code_login
+component: pos
+symptoms:
+  - "Field operators need fresh-browser POS app login without inbox access"
+  - "A shared POS app credential can be mistaken for staff proof"
+  - "Recovery-code rotation can leak plaintext if status views expose too much"
+root_cause: pos_app_account_recovery_needed_a_server_hashed_credential_boundary_separate_from_staff_actor_authority
+resolution_type: scoped_credentials_provider_and_staff_authority_boundary
+severity: high
+tags:
+  - pos
+  - auth
+  - recovery-code
+  - staff-authority
+  - audit
+---
+
+# Athena POS Recovery-Code Login Keeps App Account And Staff Authority Separate
+
+## Problem
+
+The shared `pos@wigclub.store` app account sometimes needs to sign in from a
+fresh browser, but field operators do not have inbox access for the normal OTP
+flow. A static operational recovery code solves that availability problem only
+if it stays tightly scoped: it must sign in the POS app account, not identify a
+cashier, unlock a drawer, or authorize a sale-affecting command.
+
+## Solution
+
+Keep POS recovery-code login inside Convex Auth and keep the credential state on
+the server:
+
+- Store a per-store POS recovery credential as hash plus salt/version metadata,
+  status, failure counters, lockout timestamps, last-used, rotation, and actor
+  fields. Never store or return plaintext outside the create/rotate response.
+- Use a dedicated Convex Auth credentials provider for the recovery path. The
+  provider validates the configured POS account, store scope, `pos_only`
+  organization membership, credential status, lockout, and hash match before it
+  returns the real Convex Auth `users` id.
+- Let the browser reuse the existing Athena pending-auth-sync handoff after
+  provider success. Do not write the recovery code to local storage, session
+  storage, query params, logs, or runtime diagnostics.
+- Put create/rotate/unlock/revoke behind full-admin POS Settings controls.
+  Plaintext appears only immediately after create or rotate.
+- Emit operational events for create, rotate, revoke, unlock, failed attempts,
+  lockout, and successful use. Event metadata may include status, reason,
+  failed-attempt count, and POS account id, but not raw code, hash, salt, or
+  pepper material.
+
+## Staff Authority Boundary
+
+Recovery-code login answers which app account loaded Athena. It does not answer
+who performed POS work.
+
+After recovery-code login, existing POS gates still apply:
+
+- staff PIN and staff proof for cashier/operator identity;
+- manager proof when a command requires manager approval;
+- terminal integrity for the provisioned register;
+- drawer lifecycle authority before sale-affecting commands;
+- POS command invariants and audit attribution for sale, cash, and correction
+  workflows.
+
+POS action audit events should continue to use staff actor fields when staff
+proof is required. Recovery-login audit events are separate app-account events.
+
+## Regression Targets
+
+- `convex/pos/public/posRecoveryCodes.test.ts` proves hash-only storage,
+  rotation invalidation, generic failed attempts, lockout, successful use, and
+  secret-safe audit metadata.
+- `src/components/auth/Login/PosRecoveryCodeForm.test.tsx` proves the recovery
+  form uses the dedicated provider, starts the same pending-auth-sync handoff as
+  OTP, shows generic failure copy, and does not persist the submitted code.
+- `src/components/pos/settings/POSSettingsView.test.tsx` proves full-admin
+  management can rotate the code and hides the panel from non-full-admin
+  accounts.
+- `convex/operations/staffCredentials.test.ts`,
+  `src/components/pos/CashierAuthDialog.test.tsx`,
+  `src/components/pos/register/POSRegisterView.test.tsx`, and
+  `src/lib/pos/presentation/register/useRegisterViewModel.test.ts` prove staff
+  proof, drawer gates, and register view-model boundaries remain separate from
+  app login.
+
+## Prevention
+
+- Do not accept admin-supplied memorable codes for this shared credential.
+  Generate high-entropy codes server-side.
+- Do not broaden the credentials provider to arbitrary accounts, admin
+  accounts, or non-`pos_only` memberships without a new security review.
+- Do not expose raw backend failure reasons in the login form. Keep failure copy
+  generic so account existence, membership, lockout, and code validity are not
+  distinguishable.
+- Do not use app-account identity as `actorStaffProfileId` or as a substitute
+  for staff proof.
+
+## Related
+
+- [Athena POS Hub App-Session Continuity Is Route Scoped](./athena-pos-hub-app-session-continuity-2026-06-02.md)
+- [Athena POS Stale Terminal Sale Blocks](../logic-errors/athena-pos-stale-terminal-sale-block-2026-05-29.md)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1803 files · ~0 words
+- 1813 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6008 nodes · 6435 edges · 1731 communities detected
+- 6050 nodes · 6491 edges · 1741 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1741,6 +1741,16 @@
 - [[_COMMUNITY_Community 1728|Community 1728]]
 - [[_COMMUNITY_Community 1729|Community 1729]]
 - [[_COMMUNITY_Community 1730|Community 1730]]
+- [[_COMMUNITY_Community 1731|Community 1731]]
+- [[_COMMUNITY_Community 1732|Community 1732]]
+- [[_COMMUNITY_Community 1733|Community 1733]]
+- [[_COMMUNITY_Community 1734|Community 1734]]
+- [[_COMMUNITY_Community 1735|Community 1735]]
+- [[_COMMUNITY_Community 1736|Community 1736]]
+- [[_COMMUNITY_Community 1737|Community 1737]]
+- [[_COMMUNITY_Community 1738|Community 1738]]
+- [[_COMMUNITY_Community 1739|Community 1739]]
+- [[_COMMUNITY_Community 1740|Community 1740]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1981,632 +1991,632 @@ Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
 ### Community 53 - "Community 53"
+Cohesion: 0.27
+Nodes (14): bytesToHex(), findAthenaUserByEmail(), findAuthUserByEmail(), generateRecoveryCode(), getCredentialForStore(), getFailureAuditBucket(), hashPosRecoveryCode(), normalizeEmail() (+6 more)
+
+### Community 54 - "Community 54"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
 Cohesion: 0.29
 Nodes (15): asRecord(), buildPosLocalSyncUploadEvents(), customerInfoFromPayload(), getCompletedSaleItems(), getCompletedServiceLines(), hasLaterCompletedSale(), nullableStringToOptional(), numberOrZero() (+7 more)
 
-### Community 55 - "Community 55"
+### Community 56 - "Community 56"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 56 - "Community 56"
+### Community 57 - "Community 57"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.15
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
 Cohesion: 0.14
 Nodes (4): DailyCloseHistoryView(), getDailyCloseHistoryApi(), getHistoryRecordSnapshot(), normalizeHistorySnapshot()
 
-### Community 60 - "Community 60"
+### Community 61 - "Community 61"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 61 - "Community 61"
+### Community 62 - "Community 62"
 Cohesion: 0.26
 Nodes (13): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget() (+5 more)
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.33
 Nodes (14): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+6 more)
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.17
 Nodes (6): buildServerPricedCheckoutProducts(), calculateItemsSubtotal(), deriveDeliveryOptionFromAddress(), isDeliveryFeeWaived(), normalizeDeliveryOption(), resolveServerDeliveryFee()
 
-### Community 64 - "Community 64"
+### Community 65 - "Community 65"
 Cohesion: 0.24
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.26
 Nodes (11): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), getReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), mapSyncStatus(), normalizeStaffAuthorityStatus(), snapshotAges() (+3 more)
 
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.22
 Nodes (10): extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isBarcodeShapedInput(), normalizeIdentifier(), parseCatalogSearchInput(), searchByText(), searchRegisterCatalog() (+2 more)
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
+Cohesion: 0.14
+Nodes (2): getBlockedPosTerminalShellCopy(), PosTerminalBlockedShell()
+
+### Community 69 - "Community 69"
 Cohesion: 0.22
 Nodes (10): createApp(), createHandlers(), createRedisClient(), createRedisCluster(), deleteKeysIndividually(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline(), scanNodeForPattern() (+2 more)
 
-### Community 68 - "Community 68"
+### Community 70 - "Community 70"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 69 - "Community 69"
+### Community 71 - "Community 71"
 Cohesion: 0.31
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getOperationalWorkItemStatus() (+5 more)
 
-### Community 70 - "Community 70"
+### Community 72 - "Community 72"
 Cohesion: 0.15
 Nodes (2): formatTimelineRange(), formatTimelineTime()
 
-### Community 71 - "Community 71"
+### Community 73 - "Community 73"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 72 - "Community 72"
+### Community 74 - "Community 74"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 73 - "Community 73"
+### Community 75 - "Community 75"
 Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
-### Community 74 - "Community 74"
+### Community 76 - "Community 76"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 75 - "Community 75"
+### Community 77 - "Community 77"
 Cohesion: 0.23
 Nodes (7): buildTerminalHealthSummary(), deriveTerminalHealth(), deriveTerminalHealthAttentionReasons(), getTerminalHealthSummary(), resolveAttentionReasonActionTargets(), resolveCloudRegisterSessionTargets(), stripRuntimeStatusIdentity()
 
-### Community 76 - "Community 76"
+### Community 78 - "Community 78"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 77 - "Community 77"
+### Community 79 - "Community 79"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
 
-### Community 78 - "Community 78"
+### Community 80 - "Community 80"
 Cohesion: 0.17
 Nodes (2): handleKeyDown(), isDebugShortcut()
 
-### Community 79 - "Community 79"
+### Community 81 - "Community 81"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 80 - "Community 80"
+### Community 82 - "Community 82"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 81 - "Community 81"
-Cohesion: 0.17
-Nodes (2): getBlockedPosTerminalShellCopy(), PosTerminalBlockedShell()
-
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
 
-### Community 85 - "Community 85"
+### Community 86 - "Community 86"
 Cohesion: 0.31
 Nodes (12): collectFilesUnder(), collectProofSnapshot(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof(), hashValidationWiring(), normalizeRepoPath(), readPrAthenaScript(), recordPrePushValidationProof() (+4 more)
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.24
 Nodes (7): classifyTerminalHealth(), formatAge(), formatStatusLabel(), getPrimaryTerminalAttentionReason(), getReviewEvidenceCount(), getSnapshotAgeSummary(), getTerminalAttentionReasons()
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.2
 Nodes (3): handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.21
 Nodes (5): formatDeposit(), formatMoney(), handleCancelEdit(), handleSaveEdit(), summarizeService()
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.24
 Nodes (7): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), useConvexRegisterServiceCatalog(), usePrewarmRegisterCatalogOfflineSnapshots()
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.29
 Nodes (10): bestFuzzyTokenScore(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreFuzzySearchEntry(), scoreFuzzyTokenMatch(), scoreQueryTokenForEntry() (+2 more)
 
-### Community 92 - "Community 92"
+### Community 93 - "Community 93"
 Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
-### Community 93 - "Community 93"
-Cohesion: 0.36
-Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
-
 ### Community 94 - "Community 94"
-Cohesion: 0.36
-Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
-
-### Community 95 - "Community 95"
-Cohesion: 0.33
-Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
-
-### Community 96 - "Community 96"
-Cohesion: 0.24
-Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
-
-### Community 97 - "Community 97"
 Cohesion: 0.29
 Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
+### Community 95 - "Community 95"
+Cohesion: 0.36
+Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
+
+### Community 96 - "Community 96"
+Cohesion: 0.36
+Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
+
+### Community 97 - "Community 97"
+Cohesion: 0.33
+Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
+
 ### Community 98 - "Community 98"
+Cohesion: 0.24
+Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
+
+### Community 99 - "Community 99"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.24
 Nodes (5): blocked(), evaluateLocalPosReadiness(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
-
-### Community 101 - "Community 101"
-Cohesion: 0.18
-Nodes (0):
 
 ### Community 102 - "Community 102"
 Cohesion: 0.18
 Nodes (0):
 
 ### Community 103 - "Community 103"
+Cohesion: 0.18
+Nodes (0):
+
+### Community 104 - "Community 104"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.24
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.22
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.31
 Nodes (7): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), parseVariantDisplayMoney(), saveProduct(), updateVariantSku()
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.22
 Nodes (2): formatServiceLabel(), formatServiceLineMeta()
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.29
 Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.42
 Nodes (7): getRegisterCatalogPrice(), listRegisterCatalog(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.39
 Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
+Cohesion: 0.22
+Nodes (0):
+
+### Community 123 - "Community 123"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 122 - "Community 122"
+### Community 124 - "Community 124"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 123 - "Community 123"
+### Community 125 - "Community 125"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 124 - "Community 124"
+### Community 126 - "Community 126"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 125 - "Community 125"
+### Community 127 - "Community 127"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 126 - "Community 126"
+### Community 128 - "Community 128"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 127 - "Community 127"
+### Community 129 - "Community 129"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 128 - "Community 128"
+### Community 130 - "Community 130"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 129 - "Community 129"
+### Community 131 - "Community 131"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 130 - "Community 130"
+### Community 132 - "Community 132"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 131 - "Community 131"
+### Community 133 - "Community 133"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 132 - "Community 132"
+### Community 134 - "Community 134"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 133 - "Community 133"
+### Community 135 - "Community 135"
 Cohesion: 0.43
 Nodes (6): assertActiveTerminal(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 134 - "Community 134"
+### Community 136 - "Community 136"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 135 - "Community 135"
+### Community 137 - "Community 137"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 136 - "Community 136"
-Cohesion: 0.25
-Nodes (0):
-
-### Community 137 - "Community 137"
-Cohesion: 0.25
-Nodes (0):
-
 ### Community 138 - "Community 138"
-Cohesion: 0.39
-Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 139 - "Community 139"
 Cohesion: 0.25
-Nodes (1): DataTableRowActions()
+Nodes (0):
 
 ### Community 140 - "Community 140"
-Cohesion: 0.32
-Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
+Cohesion: 0.39
+Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
 ### Community 141 - "Community 141"
 Cohesion: 0.25
-Nodes (0):
+Nodes (1): DataTableRowActions()
 
 ### Community 142 - "Community 142"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.32
+Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
 ### Community 143 - "Community 143"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 144 - "Community 144"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 145 - "Community 145"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.39
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 146 - "Community 146"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 147 - "Community 147"
-Cohesion: 0.46
-Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
-
-### Community 148 - "Community 148"
-Cohesion: 0.43
-Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
-
-### Community 149 - "Community 149"
 Cohesion: 0.25
 Nodes (0):
 
+### Community 148 - "Community 148"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 149 - "Community 149"
+Cohesion: 0.46
+Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
+
 ### Community 150 - "Community 150"
+Cohesion: 0.43
+Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
+
+### Community 151 - "Community 151"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 152 - "Community 152"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 151 - "Community 151"
+### Community 153 - "Community 153"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 152 - "Community 152"
+### Community 154 - "Community 154"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 153 - "Community 153"
+### Community 155 - "Community 155"
 Cohesion: 0.33
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 154 - "Community 154"
+### Community 156 - "Community 156"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 155 - "Community 155"
+### Community 157 - "Community 157"
 Cohesion: 0.33
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 156 - "Community 156"
+### Community 158 - "Community 158"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 157 - "Community 157"
+### Community 159 - "Community 159"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 158 - "Community 158"
+### Community 160 - "Community 160"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 159 - "Community 159"
+### Community 161 - "Community 161"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 160 - "Community 160"
+### Community 162 - "Community 162"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 161 - "Community 161"
+### Community 163 - "Community 163"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 162 - "Community 162"
+### Community 164 - "Community 164"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 163 - "Community 163"
+### Community 165 - "Community 165"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 164 - "Community 164"
+### Community 166 - "Community 166"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 165 - "Community 165"
+### Community 167 - "Community 167"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 166 - "Community 166"
+### Community 168 - "Community 168"
 Cohesion: 0.33
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 167 - "Community 167"
+### Community 169 - "Community 169"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 168 - "Community 168"
+### Community 170 - "Community 170"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
 
-### Community 169 - "Community 169"
+### Community 171 - "Community 171"
 Cohesion: 0.33
 Nodes (2): handlePinChange(), normalizeOtpCode()
 
-### Community 170 - "Community 170"
+### Community 172 - "Community 172"
 Cohesion: 0.33
 Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
-### Community 171 - "Community 171"
+### Community 173 - "Community 173"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 172 - "Community 172"
+### Community 174 - "Community 174"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 173 - "Community 173"
+### Community 175 - "Community 175"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 174 - "Community 174"
+### Community 176 - "Community 176"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 175 - "Community 175"
+### Community 177 - "Community 177"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 176 - "Community 176"
-Cohesion: 0.33
-Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
-
-### Community 177 - "Community 177"
-Cohesion: 0.29
-Nodes (0):
-
 ### Community 178 - "Community 178"
 Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
+Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
 
 ### Community 179 - "Community 179"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 180 - "Community 180"
-Cohesion: 0.52
-Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 181 - "Community 181"
-Cohesion: 0.43
-Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 182 - "Community 182"
 Cohesion: 0.52
-Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
+Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
 ### Community 183 - "Community 183"
-Cohesion: 0.33
-Nodes (2): overwriteFreshGraphifyArtifacts(), write()
+Cohesion: 0.43
+Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
 ### Community 184 - "Community 184"
-Cohesion: 0.38
-Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
+Cohesion: 0.52
+Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
 ### Community 185 - "Community 185"
 Cohesion: 0.33
-Nodes (1): ValkeyClient
+Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
 ### Community 186 - "Community 186"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.38
+Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
 ### Community 187 - "Community 187"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ValkeyClient
 
 ### Community 188 - "Community 188"
-Cohesion: 0.47
-Nodes (4): buildOperationalEvent(), matchesExistingEvent(), metadataDedupeKeysMatch(), recordOperationalEventWithCtx()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 189 - "Community 189"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 190 - "Community 190"
+Cohesion: 0.47
+Nodes (4): buildOperationalEvent(), matchesExistingEvent(), metadataDedupeKeysMatch(), recordOperationalEventWithCtx()
+
+### Community 191 - "Community 191"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 192 - "Community 192"
 Cohesion: 0.4
 Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
-### Community 191 - "Community 191"
+### Community 193 - "Community 193"
 Cohesion: 0.4
 Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
 
-### Community 192 - "Community 192"
+### Community 194 - "Community 194"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 193 - "Community 193"
+### Community 195 - "Community 195"
 Cohesion: 0.53
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 194 - "Community 194"
+### Community 196 - "Community 196"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 195 - "Community 195"
+### Community 197 - "Community 197"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 196 - "Community 196"
+### Community 198 - "Community 198"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 197 - "Community 197"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 198 - "Community 198"
-Cohesion: 0.53
-Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
-
 ### Community 199 - "Community 199"
 Cohesion: 0.33
-Nodes (1): DataTableToolbar()
+Nodes (0):
 
 ### Community 200 - "Community 200"
 Cohesion: 0.53
-Nodes (2): SelectedProductsProvider(), useSelectedProducts()
+Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
 ### Community 201 - "Community 201"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): DataTableToolbar()
 
 ### Community 202 - "Community 202"
-Cohesion: 0.47
-Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
+Cohesion: 0.53
+Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
 ### Community 203 - "Community 203"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 204 - "Community 204"
+Cohesion: 0.47
+Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
+
+### Community 205 - "Community 205"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 206 - "Community 206"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 205 - "Community 205"
+### Community 207 - "Community 207"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 206 - "Community 206"
+### Community 208 - "Community 208"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 207 - "Community 207"
-Cohesion: 0.33
-Nodes (1): ResizeObserverStub
-
-### Community 208 - "Community 208"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 209 - "Community 209"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 210 - "Community 210"
 Cohesion: 0.33
@@ -2614,31 +2624,31 @@ Nodes (0):
 
 ### Community 211 - "Community 211"
 Cohesion: 0.33
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 212 - "Community 212"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 213 - "Community 213"
+Cohesion: 0.33
+Nodes (1): ResizeObserverStub
+
+### Community 214 - "Community 214"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 215 - "Community 215"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 214 - "Community 214"
+### Community 216 - "Community 216"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 215 - "Community 215"
+### Community 217 - "Community 217"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 216 - "Community 216"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 217 - "Community 217"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 218 - "Community 218"
 Cohesion: 0.33
@@ -2653,16 +2663,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 221 - "Community 221"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 222 - "Community 222"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 223 - "Community 223"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 224 - "Community 224"
 Cohesion: 0.33
@@ -2673,132 +2683,132 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 226 - "Community 226"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 227 - "Community 227"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 228 - "Community 228"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 227 - "Community 227"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 228 - "Community 228"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
 ### Community 229 - "Community 229"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 230 - "Community 230"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 231 - "Community 231"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 230 - "Community 230"
+### Community 232 - "Community 232"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
-
-### Community 231 - "Community 231"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 232 - "Community 232"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
 
 ### Community 233 - "Community 233"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 234 - "Community 234"
-Cohesion: 0.53
-Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
 
 ### Community 235 - "Community 235"
-Cohesion: 0.47
-Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 236 - "Community 236"
 Cohesion: 0.53
-Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
+Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
 ### Community 237 - "Community 237"
+Cohesion: 0.47
+Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
+
+### Community 238 - "Community 238"
+Cohesion: 0.53
+Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
+
+### Community 239 - "Community 239"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 238 - "Community 238"
+### Community 240 - "Community 240"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 239 - "Community 239"
+### Community 241 - "Community 241"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 240 - "Community 240"
+### Community 242 - "Community 242"
 Cohesion: 0.5
 Nodes (2): createAuthorizedRegisterDepositCtx(), createQueryCtx()
 
-### Community 241 - "Community 241"
+### Community 243 - "Community 243"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
-### Community 242 - "Community 242"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 243 - "Community 243"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 244 - "Community 244"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 245 - "Community 245"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 246 - "Community 246"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
-### Community 245 - "Community 245"
+### Community 247 - "Community 247"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
-### Community 246 - "Community 246"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 247 - "Community 247"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 248 - "Community 248"
-Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 249 - "Community 249"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 250 - "Community 250"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
 ### Community 251 - "Community 251"
-Cohesion: 0.7
-Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 252 - "Community 252"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 253 - "Community 253"
-Cohesion: 0.6
-Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 254 - "Community 254"
-Cohesion: 0.5
-Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+Cohesion: 0.7
+Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
 ### Community 255 - "Community 255"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 256 - "Community 256"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
 ### Community 257 - "Community 257"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
 ### Community 258 - "Community 258"
 Cohesion: 0.4
@@ -2809,8 +2819,8 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 260 - "Community 260"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 261 - "Community 261"
 Cohesion: 0.4
@@ -2821,16 +2831,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 263 - "Community 263"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 264 - "Community 264"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 265 - "Community 265"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 266 - "Community 266"
 Cohesion: 0.4
@@ -2841,12 +2851,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 268 - "Community 268"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 269 - "Community 269"
 Cohesion: 0.4
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 270 - "Community 270"
 Cohesion: 0.4
@@ -2854,187 +2864,187 @@ Nodes (0):
 
 ### Community 271 - "Community 271"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 272 - "Community 272"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 273 - "Community 273"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 274 - "Community 274"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 275 - "Community 275"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 274 - "Community 274"
+### Community 276 - "Community 276"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 275 - "Community 275"
+### Community 277 - "Community 277"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 276 - "Community 276"
+### Community 278 - "Community 278"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 277 - "Community 277"
-Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
-
-### Community 278 - "Community 278"
-Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 279 - "Community 279"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 280 - "Community 280"
 Cohesion: 0.6
-Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 281 - "Community 281"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 282 - "Community 282"
 Cohesion: 0.6
-Nodes (3): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier()
+Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
 ### Community 283 - "Community 283"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 284 - "Community 284"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier()
 
 ### Community 285 - "Community 285"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 286 - "Community 286"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 287 - "Community 287"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 288 - "Community 288"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.5
+Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 289 - "Community 289"
-Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 290 - "Community 290"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 291 - "Community 291"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 292 - "Community 292"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 293 - "Community 293"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 294 - "Community 294"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 295 - "Community 295"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 296 - "Community 296"
-Cohesion: 0.6
-Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 297 - "Community 297"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 298 - "Community 298"
-Cohesion: 0.7
-Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
+Cohesion: 0.6
+Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
 ### Community 299 - "Community 299"
-Cohesion: 0.5
+Cohesion: 0.4
 Nodes (0):
 
 ### Community 300 - "Community 300"
+Cohesion: 0.7
+Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
+
+### Community 301 - "Community 301"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 302 - "Community 302"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 301 - "Community 301"
+### Community 303 - "Community 303"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 302 - "Community 302"
+### Community 304 - "Community 304"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
 
-### Community 303 - "Community 303"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 304 - "Community 304"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 305 - "Community 305"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 306 - "Community 306"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 307 - "Community 307"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 308 - "Community 308"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 309 - "Community 309"
-Cohesion: 0.67
-Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 310 - "Community 310"
-Cohesion: 0.83
-Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 311 - "Community 311"
 Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
 ### Community 312 - "Community 312"
-Cohesion: 0.67
-Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
+Cohesion: 0.83
+Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
 ### Community 313 - "Community 313"
 Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
 ### Community 314 - "Community 314"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
 ### Community 315 - "Community 315"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 316 - "Community 316"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 317 - "Community 317"
 Cohesion: 0.5
@@ -3042,7 +3052,7 @@ Nodes (0):
 
 ### Community 318 - "Community 318"
 Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 319 - "Community 319"
 Cohesion: 0.5
@@ -3050,27 +3060,27 @@ Nodes (0):
 
 ### Community 320 - "Community 320"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 321 - "Community 321"
-Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 322 - "Community 322"
-Cohesion: 0.67
-Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
+Cohesion: 0.83
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 323 - "Community 323"
 Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 324 - "Community 324"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
 ### Community 325 - "Community 325"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 326 - "Community 326"
 Cohesion: 0.5
@@ -3081,28 +3091,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 328 - "Community 328"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 329 - "Community 329"
-Cohesion: 0.83
-Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 330 - "Community 330"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 329 - "Community 329"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 330 - "Community 330"
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
+
 ### Community 331 - "Community 331"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
 ### Community 332 - "Community 332"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 333 - "Community 333"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 334 - "Community 334"
 Cohesion: 0.5
@@ -3113,20 +3123,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 336 - "Community 336"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 337 - "Community 337"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 338 - "Community 338"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 339 - "Community 339"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 340 - "Community 340"
 Cohesion: 0.5
@@ -3141,48 +3151,48 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 343 - "Community 343"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 344 - "Community 344"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 345 - "Community 345"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 346 - "Community 346"
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
+
+### Community 347 - "Community 347"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 348 - "Community 348"
 Cohesion: 0.67
 Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
-### Community 346 - "Community 346"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 347 - "Community 347"
-Cohesion: 0.67
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
-
-### Community 348 - "Community 348"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 349 - "Community 349"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 350 - "Community 350"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
 ### Community 351 - "Community 351"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 352 - "Community 352"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 353 - "Community 353"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 354 - "Community 354"
 Cohesion: 0.5
@@ -3194,111 +3204,111 @@ Nodes (0):
 
 ### Community 356 - "Community 356"
 Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 357 - "Community 357"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 358 - "Community 358"
-Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 359 - "Community 359"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 360 - "Community 360"
-Cohesion: 1.0
-Nodes (3): canAccessFullAdminSurface(), canAccessStoreDaySurface(), getSurfaceAccess()
-
-### Community 361 - "Community 361"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 361 - "Community 361"
+Cohesion: 0.67
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 362 - "Community 362"
 Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
 
 ### Community 363 - "Community 363"
+Cohesion: 1.0
+Nodes (3): canAccessFullAdminSurface(), canAccessStoreDaySurface(), getSurfaceAccess()
+
+### Community 364 - "Community 364"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 364 - "Community 364"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
-
 ### Community 365 - "Community 365"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 366 - "Community 366"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 367 - "Community 367"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 368 - "Community 368"
 Cohesion: 0.67
-Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 369 - "Community 369"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 370 - "Community 370"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 371 - "Community 371"
+Cohesion: 0.67
+Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+
+### Community 372 - "Community 372"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 373 - "Community 373"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 371 - "Community 371"
+### Community 374 - "Community 374"
 Cohesion: 0.83
 Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 372 - "Community 372"
+### Community 375 - "Community 375"
 Cohesion: 0.83
 Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
-### Community 373 - "Community 373"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 374 - "Community 374"
-Cohesion: 0.83
-Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
-
-### Community 375 - "Community 375"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 376 - "Community 376"
-Cohesion: 0.67
-Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 377 - "Community 377"
 Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
+Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
 ### Community 378 - "Community 378"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 379 - "Community 379"
+Cohesion: 0.67
+Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
+
+### Community 380 - "Community 380"
+Cohesion: 0.83
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
+
+### Community 381 - "Community 381"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 379 - "Community 379"
+### Community 382 - "Community 382"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 380 - "Community 380"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 381 - "Community 381"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 382 - "Community 382"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 383 - "Community 383"
 Cohesion: 0.5
@@ -3321,68 +3331,68 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 388 - "Community 388"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
-
-### Community 389 - "Community 389"
-Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
-
-### Community 390 - "Community 390"
-Cohesion: 0.83
-Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
-
-### Community 391 - "Community 391"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 389 - "Community 389"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 390 - "Community 390"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 391 - "Community 391"
+Cohesion: 0.67
+Nodes (2): useOptionalStoreContext(), useStoreContext()
+
 ### Community 392 - "Community 392"
-Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
 ### Community 393 - "Community 393"
 Cohesion: 0.83
-Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
+Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
 ### Community 394 - "Community 394"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 395 - "Community 395"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
+Cohesion: 0.83
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 396 - "Community 396"
-Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Cohesion: 0.83
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
 ### Community 397 - "Community 397"
-Cohesion: 0.83
-Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 398 - "Community 398"
 Cohesion: 0.67
-Nodes (2): collectHarnessTestTargets(), runHarnessTest()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 399 - "Community 399"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
 ### Community 400 - "Community 400"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
 ### Community 401 - "Community 401"
 Cohesion: 0.67
-Nodes (0):
+Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
 ### Community 402 - "Community 402"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 403 - "Community 403"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 404 - "Community 404"
 Cohesion: 0.67
@@ -3393,8 +3403,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 406 - "Community 406"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 407 - "Community 407"
 Cohesion: 0.67
@@ -3421,8 +3431,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 413 - "Community 413"
-Cohesion: 1.0
-Nodes (2): buildCtx(), createDb()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 414 - "Community 414"
 Cohesion: 0.67
@@ -3433,8 +3443,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 416 - "Community 416"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildCtx(), createDb()
 
 ### Community 417 - "Community 417"
 Cohesion: 0.67
@@ -3445,8 +3455,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 419 - "Community 419"
-Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 420 - "Community 420"
 Cohesion: 0.67
@@ -3454,11 +3464,11 @@ Nodes (0):
 
 ### Community 421 - "Community 421"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 422 - "Community 422"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 423 - "Community 423"
 Cohesion: 0.67
@@ -3466,15 +3476,15 @@ Nodes (0):
 
 ### Community 424 - "Community 424"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 425 - "Community 425"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 426 - "Community 426"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 427 - "Community 427"
 Cohesion: 0.67
@@ -3486,7 +3496,7 @@ Nodes (0):
 
 ### Community 429 - "Community 429"
 Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 430 - "Community 430"
 Cohesion: 0.67
@@ -3497,60 +3507,60 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 432 - "Community 432"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 433 - "Community 433"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 434 - "Community 434"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 435 - "Community 435"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 436 - "Community 436"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 437 - "Community 437"
 Cohesion: 1.0
 Nodes (2): listBagItems(), loadBagWithItems()
 
-### Community 435 - "Community 435"
+### Community 438 - "Community 438"
 Cohesion: 1.0
 Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
-### Community 436 - "Community 436"
+### Community 439 - "Community 439"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
-### Community 437 - "Community 437"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 438 - "Community 438"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 439 - "Community 439"
-Cohesion: 1.0
-Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
-
 ### Community 440 - "Community 440"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 441 - "Community 441"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 442 - "Community 442"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
 ### Community 443 - "Community 443"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 444 - "Community 444"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 445 - "Community 445"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 446 - "Community 446"
 Cohesion: 0.67
@@ -3561,12 +3571,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 448 - "Community 448"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 449 - "Community 449"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 450 - "Community 450"
 Cohesion: 0.67
@@ -3577,16 +3587,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 452 - "Community 452"
-Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Cohesion: 1.0
+Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
 ### Community 453 - "Community 453"
 Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 454 - "Community 454"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 455 - "Community 455"
 Cohesion: 0.67
@@ -3598,11 +3608,11 @@ Nodes (0):
 
 ### Community 457 - "Community 457"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 458 - "Community 458"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 459 - "Community 459"
 Cohesion: 0.67
@@ -3658,95 +3668,95 @@ Nodes (0):
 
 ### Community 472 - "Community 472"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 473 - "Community 473"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (0):
 
 ### Community 474 - "Community 474"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (0):
 
 ### Community 475 - "Community 475"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (0):
 
 ### Community 476 - "Community 476"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (0):
 
 ### Community 477 - "Community 477"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 478 - "Community 478"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): ErrorPage()
 
 ### Community 479 - "Community 479"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
+Cohesion: 0.67
+Nodes (1): AppSkeleton()
 
 ### Community 480 - "Community 480"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (1): DashboardSkeleton()
 
 ### Community 481 - "Community 481"
 Cohesion: 0.67
-Nodes (1): Badge()
+Nodes (1): TableSkeleton()
 
 ### Community 482 - "Community 482"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): TransactionsSkeleton()
 
 ### Community 483 - "Community 483"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): NotFound()
 
 ### Community 484 - "Community 484"
-Cohesion: 0.67
-Nodes (1): onChange()
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
 ### Community 485 - "Community 485"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): AppContextMenu()
 
 ### Community 486 - "Community 486"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): Badge()
 
 ### Community 487 - "Community 487"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (0):
 
 ### Community 488 - "Community 488"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): LoadingButton()
 
 ### Community 489 - "Community 489"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): onChange()
 
 ### Community 490 - "Community 490"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): AlertModal()
 
 ### Community 491 - "Community 491"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): OverlayModal()
 
 ### Community 492 - "Community 492"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Skeleton()
 
 ### Community 493 - "Community 493"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 494 - "Community 494"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 495 - "Community 495"
 Cohesion: 0.67
@@ -3762,7 +3772,7 @@ Nodes (0):
 
 ### Community 498 - "Community 498"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 499 - "Community 499"
 Cohesion: 0.67
@@ -3777,20 +3787,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 502 - "Community 502"
-Cohesion: 1.0
-Nodes (2): getApprovalGuidance(), presentCommandToast()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 503 - "Community 503"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (1): useAuth()
 
 ### Community 504 - "Community 504"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 505 - "Community 505"
-Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 506 - "Community 506"
 Cohesion: 0.67
@@ -3798,27 +3808,27 @@ Nodes (0):
 
 ### Community 507 - "Community 507"
 Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+Nodes (2): getApprovalGuidance(), presentCommandToast()
 
 ### Community 508 - "Community 508"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 509 - "Community 509"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 510 - "Community 510"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 511 - "Community 511"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 512 - "Community 512"
 Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 513 - "Community 513"
 Cohesion: 0.67
@@ -3829,68 +3839,68 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 515 - "Community 515"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 516 - "Community 516"
-Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 517 - "Community 517"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 518 - "Community 518"
 Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Nodes (0):
 
 ### Community 519 - "Community 519"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (0):
 
 ### Community 520 - "Community 520"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 521 - "Community 521"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 522 - "Community 522"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (1): hashPassword()
 
 ### Community 523 - "Community 523"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): createVersionChecker()
 
 ### Community 524 - "Community 524"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (1): manualChunks()
 
 ### Community 525 - "Community 525"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 526 - "Community 526"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 527 - "Community 527"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 528 - "Community 528"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 529 - "Community 529"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 530 - "Community 530"
 Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 531 - "Community 531"
 Cohesion: 0.67
@@ -3905,12 +3915,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 534 - "Community 534"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 535 - "Community 535"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 535 - "Community 535"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 536 - "Community 536"
 Cohesion: 0.67
@@ -3925,8 +3935,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 539 - "Community 539"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 540 - "Community 540"
 Cohesion: 0.67
@@ -3977,64 +3987,64 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 552 - "Community 552"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 553 - "Community 553"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 554 - "Community 554"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 555 - "Community 555"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 556 - "Community 556"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 557 - "Community 557"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
 
 ### Community 558 - "Community 558"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 559 - "Community 559"
 Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
-### Community 559 - "Community 559"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 560 - "Community 560"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 561 - "Community 561"
 Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 562 - "Community 562"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 563 - "Community 563"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 564 - "Community 564"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 565 - "Community 565"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 566 - "Community 566"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 567 - "Community 567"
 Cohesion: 1.0
@@ -8692,2346 +8702,2396 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1731 - "Community 1731"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1732 - "Community 1732"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1733 - "Community 1733"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1734 - "Community 1734"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1735 - "Community 1735"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1736 - "Community 1736"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1737 - "Community 1737"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1738 - "Community 1738"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1739 - "Community 1739"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1740 - "Community 1740"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 562`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 567`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 563`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 568`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 564`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 569`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 565`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 570`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 566`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 571`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 567`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 572`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 573`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 574`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 575`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 576`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 577`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 578`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 579`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 580`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 581`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 582`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 583`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 584`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 585`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 586`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 587`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 588`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 589`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 590`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 591`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 592`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 593`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 594`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 595`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 596`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 597`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 598`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 599`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 600`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 601`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 602`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 603`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 604`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 605`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 606`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 607`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 608`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 609`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 610`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 611`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 612`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 613`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 614`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 615`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
+- **Thin community `Community 616`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
+- **Thin community `Community 617`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 618`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 619`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 620`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 621`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 622`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
+- **Thin community `Community 623`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 624`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 625`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 626`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 627`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 628`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 629`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 630`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 631`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 632`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 633`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 634`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 635`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 636`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 637`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 638`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 639`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 640`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 641`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 642`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 643`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 644`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 645`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 646`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 647`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 648`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 649`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 650`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 651`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 652`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 653`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 654`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 655`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 656`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 657`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 658`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 659`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 660`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 661`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 662`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 663`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 664`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 665`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 666`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 667`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 668`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 669`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 670`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 671`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 672`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 673`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 674`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 675`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 676`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `Login()`, `index.tsx`
+- **Thin community `Community 677`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 678`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 679`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 680`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 681`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 682`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 683`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 684`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 685`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 686`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 687`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 688`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 689`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 690`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 691`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 692`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 693`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 694`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 695`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 696`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 697`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 698`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 699`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 700`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 701`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 702`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 703`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 704`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 705`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 706`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
+- **Thin community `Community 707`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 708`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 709`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 710`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 711`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 712`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 713`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 714`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 715`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 716`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 717`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
+- **Thin community `Community 718`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 719`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 720`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 721`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 722`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 723`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 724`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 725`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 726`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 727`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 728`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 729`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 730`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 731`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 732`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 733`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 734`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 735`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 736`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 737`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 738`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 739`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 740`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 741`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 742`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 743`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 744`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 745`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 746`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 747`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 748`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 749`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 750`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 751`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 752`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
+- **Thin community `Community 753`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 754`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 755`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 756`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 757`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 758`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 759`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 760`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 761`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 762`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 763`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 764`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 765`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 766`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 767`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 768`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 769`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 770`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 771`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 772`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 773`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 774`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 775`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 776`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 777`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 778`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 779`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 780`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 781`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 782`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 783`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 784`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 785`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 786`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 787`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 788`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 789`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 790`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 791`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 792`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 793`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 794`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 795`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 796`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 797`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 798`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 799`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 800`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 801`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 802`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 803`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 804`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 805`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 806`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 807`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 808`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 809`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 810`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 811`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 812`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 813`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 814`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 815`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 816`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 817`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 818`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 819`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 820`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 821`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 822`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 823`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 824`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 825`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 826`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 827`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 828`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 829`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 830`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 831`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 832`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 833`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 834`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 835`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 836`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 837`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 838`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 839`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 840`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 841`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 842`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 843`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 844`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 845`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 846`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 847`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 848`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 849`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 850`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 851`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 852`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 853`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 854`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 855`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 856`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 857`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 858`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 859`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 860`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 861`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 862`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 863`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 864`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 865`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 866`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 867`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 868`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 869`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 870`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 871`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 872`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 873`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 874`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 875`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 876`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 877`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 878`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 879`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 880`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 881`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 882`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 883`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 884`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 885`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 886`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 887`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 888`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 889`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 890`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 891`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 892`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 893`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 894`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 895`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 896`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 897`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 898`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 899`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 900`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 901`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 902`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 903`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 904`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 905`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 906`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 907`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 908`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 909`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 910`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 911`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 912`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 913`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 914`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 915`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 916`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 917`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 918`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 919`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 920`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 921`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 922`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 923`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 924`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 925`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 926`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 927`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 928`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 929`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 930`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 931`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 932`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 933`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 934`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 935`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 936`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 937`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 938`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 939`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 940`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 941`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 942`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 943`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 944`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 945`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 946`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 947`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 948`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 949`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 950`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 951`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 952`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 953`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 954`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 955`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 956`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 957`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 958`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 959`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 960`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 961`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 962`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 963`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 964`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 965`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 966`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 967`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 968`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 969`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 970`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 971`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 972`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 973`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 974`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 975`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 976`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 977`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 978`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 979`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 980`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 981`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 982`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 983`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 984`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (1 nodes): `api.d.ts`
+- **Thin community `Community 985`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (1 nodes): `api.js`
+- **Thin community `Community 986`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 987`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (1 nodes): `server.d.ts`
+- **Thin community `Community 988`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `server.js`
+- **Thin community `Community 989`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `app.ts`
+- **Thin community `Community 990`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `auth.config.js`
+- **Thin community `Community 991`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `auth.ts`
+- **Thin community `Community 992`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 993`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 994`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 995`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `countries.ts`
+- **Thin community `Community 996`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `email.ts`
+- **Thin community `Community 997`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `ghana.ts`
+- **Thin community `Community 998`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `payment.ts`
+- **Thin community `Community 999`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `crons.ts`
+- **Thin community `Community 1000`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1001`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `internal.ts`
+- **Thin community `Community 1002`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1003`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1004`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1005`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1006`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1007`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1008`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1009`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1010`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1011`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1012`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1013`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `env.ts`
+- **Thin community `Community 1014`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1015`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `auth.ts`
+- **Thin community `Community 1016`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1017`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `colors.ts`
+- **Thin community `Community 1018`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `index.ts`
+- **Thin community `Community 1019`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `organizations.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `products.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `storefrontHidden.test.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `stores.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `bag.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `guest.ts`
+- **Thin community `Community 1020`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1021`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `me.ts`
+- **Thin community `Community 1022`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `offers.ts`
+- **Thin community `Community 1023`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1024`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1025`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1026`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1027`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1028`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1029`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1030`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1031`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1032`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `user.ts`
+- **Thin community `Community 1033`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1034`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `index.ts`
+- **Thin community `Community 1035`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1036`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `http.ts`
+- **Thin community `Community 1037`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1038`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1039`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1040`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `categories.ts`
+- **Thin community `Community 1041`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `colors.ts`
+- **Thin community `Community 1042`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1043`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 1044`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1045`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1046`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1047`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1048`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `pos.ts`
+- **Thin community `Community 1049`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1050`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1051`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1052`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1053`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1054`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1055`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1056`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1057`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1058`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1059`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1060`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1061`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1062`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1063`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1064`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1065`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `types.ts`
+- **Thin community `Community 1066`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1067`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1068`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1069`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1070`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1071`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1072`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `dto.ts`
+- **Thin community `Community 1073`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1074`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1075`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `types.ts`
+- **Thin community `Community 1076`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `types.ts`
+- **Thin community `Community 1077`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1078`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `customers.ts`
+- **Thin community `Community 1079`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `register.ts`
+- **Thin community `Community 1080`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `sync.ts`
+- **Thin community `Community 1081`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `schema.ts`
+- **Thin community `Community 1082`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1083`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `index.ts`
+- **Thin community `Community 1084`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1085`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1086`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1087`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1088`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1089`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `category.ts`
+- **Thin community `Community 1090`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `color.ts`
+- **Thin community `Community 1091`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1092`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1093`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `index.ts`
+- **Thin community `Community 1094`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1095`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1096`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `organization.ts`
+- **Thin community `Community 1097`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1098`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `product.ts`
+- **Thin community `Community 1099`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1100`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1101`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `store.ts`
+- **Thin community `Community 1102`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1103`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `index.ts`
+- **Thin community `Community 1104`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1105`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1106`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1107`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1108`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1109`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1110`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1111`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `index.ts`
+- **Thin community `Community 1112`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1113`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1114`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1115`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1116`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1117`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1118`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1119`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1120`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1121`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1122`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1123`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `customer.ts`
+- **Thin community `Community 1124`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1125`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1126`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1127`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1128`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `index.ts`
+- **Thin community `Community 1129`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1130`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1131`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1132`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1133`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1134`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1135`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1136`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1137`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1138`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1139`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1140`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1141`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1142`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1143`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1144`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1145`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `index.ts`
+- **Thin community `Community 1146`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1147`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1148`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1149`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1150`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1151`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1152`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `index.ts`
+- **Thin community `Community 1153`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1154`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1155`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1156`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1157`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1158`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1159`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `bag.ts`
+- **Thin community `Community 1160`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1161`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1162`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1163`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `guest.ts`
+- **Thin community `Community 1164`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `index.ts`
+- **Thin community `Community 1165`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `offer.ts`
+- **Thin community `Community 1166`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1167`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1168`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `review.ts`
+- **Thin community `Community 1169`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1170`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1171`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1172`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1173`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1174`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1175`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1176`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1177`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1178`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `bag.ts`
+- **Thin community `Community 1179`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1180`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `customer.ts`
+- **Thin community `Community 1181`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `guest.ts`
+- **Thin community `Community 1182`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1183`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1184`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1185`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1186`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `payment.ts`
+- **Thin community `Community 1187`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1188`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1189`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1190`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `users.ts`
+- **Thin community `Community 1191`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `payment.ts`
+- **Thin community `Community 1192`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1193`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1194`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1195`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1196`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1197`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `index.ts`
+- **Thin community `Community 1198`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1199`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1200`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `auth.ts`
+- **Thin community `Community 1201`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1202`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1203`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1204`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1205`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1206`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1207`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1208`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1209`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1210`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1211`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1212`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1213`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1214`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1215`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `constants.ts`
+- **Thin community `Community 1216`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1217`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1218`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1219`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `types.ts`
+- **Thin community `Community 1220`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1221`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1222`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1223`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1224`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1225`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1226`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1227`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1228`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1229`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1230`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1231`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1232`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1233`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1234`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1235`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1236`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1237`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1238`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1239`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1240`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `constants.ts`
+- **Thin community `Community 1241`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1242`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1243`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1244`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `data.ts`
+- **Thin community `Community 1245`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1246`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1247`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1248`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1249`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1250`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1251`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1252`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1253`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1254`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `constants.ts`
+- **Thin community `Community 1255`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1256`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1257`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1258`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `data.ts`
+- **Thin community `Community 1259`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1260`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1261`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1262`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1263`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1264`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1265`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1266`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1267`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1268`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1269`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `constants.ts`
+- **Thin community `Community 1270`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1271`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1272`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1273`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1274`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1275`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1276`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1277`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1278`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1279`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1280`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1281`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1282`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1283`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1284`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1285`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1286`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1287`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1288`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1289`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1290`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1291`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1292`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1293`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1294`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1295`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1296`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1297`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1298`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1299`** (1 nodes): `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1300`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1301`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1302`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `constants.ts`
+- **Thin community `Community 1303`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1304`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1305`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1306`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `data.ts`
+- **Thin community `Community 1307`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1308`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1309`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `constants.ts`
+- **Thin community `Community 1310`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1311`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1312`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1313`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1314`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `data.ts`
+- **Thin community `Community 1315`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1316`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `constants.ts`
+- **Thin community `Community 1317`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1318`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1319`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1320`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1321`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `data.ts`
+- **Thin community `Community 1322`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1323`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1324`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1325`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1326`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1327`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1328`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1329`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1330`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1331`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1332`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1333`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1334`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1335`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1336`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1337`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1338`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1339`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1340`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1341`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1342`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1343`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1344`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1345`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1346`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1347`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `POSSettingsView.test.tsx`
+- **Thin community `Community 1348`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1349`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `POSTerminalHealthView.test.tsx`
+- **Thin community `Community 1350`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1351`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1352`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1353`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `types.ts`
+- **Thin community `Community 1354`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1355`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1356`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1357`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1358`** (1 nodes): `POSSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1359`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1360`** (1 nodes): `POSTerminalHealthView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1361`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1362`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1363`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1364`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1365`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1366`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1367`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1368`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1369`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `data.ts`
+- **Thin community `Community 1370`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1371`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1372`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1373`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1374`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1375`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1376`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1377`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1378`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1379`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1380`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1381`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1382`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `constants.ts`
+- **Thin community `Community 1383`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1384`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1385`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1386`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `data.ts`
+- **Thin community `Community 1387`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `types.ts`
+- **Thin community `Community 1388`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1389`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1390`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1391`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1392`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1393`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `index.tsx`
+- **Thin community `Community 1394`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1395`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1396`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1397`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1398`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1399`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1400`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1401`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1402`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `index.tsx`
+- **Thin community `Community 1403`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1404`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1405`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1406`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `button.tsx`
+- **Thin community `Community 1407`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1408`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `card.tsx`
+- **Thin community `Community 1409`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1410`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1411`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `command.tsx`
+- **Thin community `Community 1412`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1413`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1414`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1415`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `form.tsx`
+- **Thin community `Community 1416`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1417`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1418`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `input.tsx`
+- **Thin community `Community 1419`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1420`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1421`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1422`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1423`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1424`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1425`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `select.tsx`
+- **Thin community `Community 1426`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1427`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1428`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1429`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `table.tsx`
+- **Thin community `Community 1430`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1431`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1432`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1433`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1434`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1435`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1436`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1437`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1438`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `constants.ts`
+- **Thin community `Community 1439`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1440`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1441`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1442`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `data.ts`
+- **Thin community `Community 1443`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1444`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1445`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1446`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1447`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1448`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1449`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1450`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1451`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1452`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1453`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1454`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `index.ts`
+- **Thin community `Community 1455`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1456`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1457`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1458`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1459`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1460`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1461`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1462`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1463`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1464`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1465`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `aws.ts`
+- **Thin community `Community 1466`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `constants.ts`
+- **Thin community `Community 1467`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `countries.ts`
+- **Thin community `Community 1468`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1469`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1470`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1471`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1472`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1473`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1474`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `dto.ts`
+- **Thin community `Community 1475`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `ports.ts`
+- **Thin community `Community 1476`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1477`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1478`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1479`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `index.ts`
+- **Thin community `Community 1480`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1481`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `types.ts`
+- **Thin community `Community 1482`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1483`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1484`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1485`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1486`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1487`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1488`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1489`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1490`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1491`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1492`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `category.ts`
+- **Thin community `Community 1493`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `product.ts`
+- **Thin community `Community 1494`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `store.ts`
+- **Thin community `Community 1495`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1496`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `user.ts`
+- **Thin community `Community 1497`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1498`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1499`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1500`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1501`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1502`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1503`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1504`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `index.tsx`
+- **Thin community `Community 1505`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `index.tsx`
+- **Thin community `Community 1506`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `index.tsx`
+- **Thin community `Community 1507`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1508`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1509`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1510`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1511`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1512`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `index.tsx`
+- **Thin community `Community 1513`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1514`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1515`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1516`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `home.tsx`
+- **Thin community `Community 1517`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1518`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1519`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1520`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `index.tsx`
+- **Thin community `Community 1521`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1522`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1523`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1524`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1525`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1526`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `index.tsx`
+- **Thin community `Community 1527`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1528`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1529`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1530`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1531`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1532`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1533`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `index.tsx`
+- **Thin community `Community 1534`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1535`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1536`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1537`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1538`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1539`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1540`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1541`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1542`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1543`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1544`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1545`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `index.tsx`
+- **Thin community `Community 1546`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `new.tsx`
+- **Thin community `Community 1547`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `index.tsx`
+- **Thin community `Community 1548`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `new.tsx`
+- **Thin community `Community 1549`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1550`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1551`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `index.tsx`
+- **Thin community `Community 1552`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `new.tsx`
+- **Thin community `Community 1553`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1554`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1555`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1556`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1557`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1558`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `index.tsx`
+- **Thin community `Community 1559`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1560`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1561`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1562`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `index.tsx`
+- **Thin community `Community 1563`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1564`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1565`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1566`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1567`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1568`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1569`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1570`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1571`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1572`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1573`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1574`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1575`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1576`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1577`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1578`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1579`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1580`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1581`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1582`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1583`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1584`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1585`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1586`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1587`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `setup.ts`
+- **Thin community `Community 1588`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1589`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `types.ts`
+- **Thin community `Community 1590`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1591`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1592`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1593`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1594`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1595`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `types.ts`
+- **Thin community `Community 1596`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1597`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1598`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1599`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1600`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1601`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1602`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1603`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1604`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1605`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `schema.ts`
+- **Thin community `Community 1606`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1607`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1608`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1609`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1610`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1611`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1612`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1613`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1614`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1615`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `types.ts`
+- **Thin community `Community 1616`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1617`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1618`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1619`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1620`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1621`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1622`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1623`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `constants.ts`
+- **Thin community `Community 1624`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1625`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `About.tsx`
+- **Thin community `Community 1626`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1627`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1628`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1629`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1630`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1631`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1632`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1633`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1634`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1635`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1636`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `types.ts`
+- **Thin community `Community 1637`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1638`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1639`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1640`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1641`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1642`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1643`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1644`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1645`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1646`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1647`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1648`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `button.tsx`
+- **Thin community `Community 1649`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `card.tsx`
+- **Thin community `Community 1650`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1651`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `command.tsx`
+- **Thin community `Community 1652`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1653`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1654`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1655`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `form.tsx`
+- **Thin community `Community 1656`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1657`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1658`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1659`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1660`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `input.tsx`
+- **Thin community `Community 1661`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `label.tsx`
+- **Thin community `Community 1662`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1663`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1664`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1665`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `index.ts`
+- **Thin community `Community 1666`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `types.ts`
+- **Thin community `Community 1667`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1668`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1669`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1670`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1671`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `select.tsx`
+- **Thin community `Community 1672`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1673`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1674`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `table.tsx`
+- **Thin community `Community 1675`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1676`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1677`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1678`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1679`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1680`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `config.ts`
+- **Thin community `Community 1681`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1682`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1683`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1684`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1685`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `constants.ts`
+- **Thin community `Community 1686`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `countries.ts`
+- **Thin community `Community 1687`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1688`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1689`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1690`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1691`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `index.ts`
+- **Thin community `Community 1692`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `store.ts`
+- **Thin community `Community 1693`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `bag.ts`
+- **Thin community `Community 1694`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1695`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `category.ts`
+- **Thin community `Community 1696`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `organization.ts`
+- **Thin community `Community 1697`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `product.ts`
+- **Thin community `Community 1698`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `store.ts`
+- **Thin community `Community 1699`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1700`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `user.ts`
+- **Thin community `Community 1701`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `states.ts`
+- **Thin community `Community 1702`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1703`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1704`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1705`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1706`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1707`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1708`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1709`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `index.tsx`
+- **Thin community `Community 1710`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1711`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `index.tsx`
+- **Thin community `Community 1712`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1713`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1714`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1715`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1716`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1717`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `index.tsx`
+- **Thin community `Community 1718`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1719`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1720`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1721`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1722`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1723`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `index.js`
+- **Thin community `Community 1724`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1725`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1726`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1727`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1728`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1729`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1730`** (1 nodes): `tailwind.config.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1731`** (1 nodes): `storefront-boot.e2e.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1732`** (1 nodes): `vitest.config.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1733`** (1 nodes): `vitest.setup.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1734`** (1 nodes): `index.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1735`** (1 nodes): `harness-app-registry.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1736`** (1 nodes): `athena-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1737`** (1 nodes): `storefront-runtime-api.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1738`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1739`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1740`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1803
-- Graph nodes: 6008
-- Graph edges: 6435
-- Communities: 1731
+- Code files discovered: 1813
+- Graph nodes: 6050
+- Graph edges: 6491
+- Communities: 1741
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (82 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -20,7 +20,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - `storefrontJourneyEvents.ts` (45 edges, Community 5) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 5) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 39) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `checkoutSession.ts` (14 edges, Community 60) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `checkoutSession.ts` (14 edges, Community 61) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 - `storeConfig.ts` (14 edges, Community 39) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -17,11 +17,11 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 - [validation-map.json](../../../packages/valkey-proxy-server/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `app.js` (14 edges, Community 67) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 126) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
-- `createRedisClient()` (4 edges, Community 67) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `createRedisCluster()` (3 edges, Community 67) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `deleteKeysIndividually()` (3 edges, Community 67) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.js` (14 edges, Community 69) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.test.js` (6 edges, Community 128) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `createRedisClient()` (4 edges, Community 69) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisCluster()` (3 edges, Community 69) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `deleteKeysIndividually()` (3 edges, Community 69) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/_generated/api.d.ts
+++ b/packages/athena-webapp/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as app from "../app.js";
 import type * as auth from "../auth.js";
+import type * as auth_PosRecoveryCode from "../auth/PosRecoveryCode.js";
 import type * as authConfig from "../authConfig.js";
 import type * as cache_index from "../cache/index.js";
 import type * as cashControls_closeouts from "../cashControls/closeouts.js";
@@ -192,6 +193,7 @@ import type * as pos_infrastructure_repositories_terminalRepository from "../pos
 import type * as pos_infrastructure_repositories_transactionRepository from "../pos/infrastructure/repositories/transactionRepository.js";
 import type * as pos_public_catalog from "../pos/public/catalog.js";
 import type * as pos_public_customers from "../pos/public/customers.js";
+import type * as pos_public_posRecoveryCodes from "../pos/public/posRecoveryCodes.js";
 import type * as pos_public_register from "../pos/public/register.js";
 import type * as pos_public_sync from "../pos/public/sync.js";
 import type * as pos_public_terminalAppSessions from "../pos/public/terminalAppSessions.js";
@@ -249,6 +251,7 @@ import type * as schemas_pos_posLocalSyncConflict from "../schemas/pos/posLocalS
 import type * as schemas_pos_posLocalSyncCursor from "../schemas/pos/posLocalSyncCursor.js";
 import type * as schemas_pos_posLocalSyncEvent from "../schemas/pos/posLocalSyncEvent.js";
 import type * as schemas_pos_posLocalSyncMapping from "../schemas/pos/posLocalSyncMapping.js";
+import type * as schemas_pos_posRecoveryCredential from "../schemas/pos/posRecoveryCredential.js";
 import type * as schemas_pos_posSession from "../schemas/pos/posSession.js";
 import type * as schemas_pos_posSessionItem from "../schemas/pos/posSessionItem.js";
 import type * as schemas_pos_posTerminal from "../schemas/pos/posTerminal.js";
@@ -351,6 +354,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   app: typeof app;
   auth: typeof auth;
+  "auth/PosRecoveryCode": typeof auth_PosRecoveryCode;
   authConfig: typeof authConfig;
   "cache/index": typeof cache_index;
   "cashControls/closeouts": typeof cashControls_closeouts;
@@ -533,6 +537,7 @@ declare const fullApi: ApiFromModules<{
   "pos/infrastructure/repositories/transactionRepository": typeof pos_infrastructure_repositories_transactionRepository;
   "pos/public/catalog": typeof pos_public_catalog;
   "pos/public/customers": typeof pos_public_customers;
+  "pos/public/posRecoveryCodes": typeof pos_public_posRecoveryCodes;
   "pos/public/register": typeof pos_public_register;
   "pos/public/sync": typeof pos_public_sync;
   "pos/public/terminalAppSessions": typeof pos_public_terminalAppSessions;
@@ -590,6 +595,7 @@ declare const fullApi: ApiFromModules<{
   "schemas/pos/posLocalSyncCursor": typeof schemas_pos_posLocalSyncCursor;
   "schemas/pos/posLocalSyncEvent": typeof schemas_pos_posLocalSyncEvent;
   "schemas/pos/posLocalSyncMapping": typeof schemas_pos_posLocalSyncMapping;
+  "schemas/pos/posRecoveryCredential": typeof schemas_pos_posRecoveryCredential;
   "schemas/pos/posSession": typeof schemas_pos_posSession;
   "schemas/pos/posSessionItem": typeof schemas_pos_posSessionItem;
   "schemas/pos/posTerminal": typeof schemas_pos_posTerminal;

--- a/packages/athena-webapp/convex/auth.test.ts
+++ b/packages/athena-webapp/convex/auth.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ATHENA_POS_RECOVERY_CODE_PROVIDER_ID } from "../shared/auth";
+
+const authMocks = vi.hoisted(() => ({
+  EmailOTP: { id: "athena-email-otp" },
+  PosRecoveryCode: { id: "athena-pos-recovery-code" },
+  convexAuth: vi.fn(() => ({
+    auth: vi.fn(),
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    store: vi.fn(),
+  })),
+}));
+
+vi.mock("@convex-dev/auth/server", () => ({
+  convexAuth: authMocks.convexAuth,
+}));
+
+vi.mock("./otp/EmailOTP", () => ({
+  EmailOTP: authMocks.EmailOTP,
+}));
+
+vi.mock("./auth/PosRecoveryCode", () => ({
+  PosRecoveryCode: authMocks.PosRecoveryCode,
+}));
+
+describe("Convex Auth provider composition", () => {
+  it("registers email OTP and POS recovery-code providers", async () => {
+    await import("./auth");
+
+    expect(authMocks.convexAuth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providers: [
+          expect.objectContaining({ id: "athena-email-otp" }),
+          expect.objectContaining({ id: ATHENA_POS_RECOVERY_CODE_PROVIDER_ID }),
+        ],
+      }),
+    );
+  });
+});

--- a/packages/athena-webapp/convex/auth.ts
+++ b/packages/athena-webapp/convex/auth.ts
@@ -1,9 +1,10 @@
 import { convexAuth } from "@convex-dev/auth/server";
 import { EmailOTP } from "./otp/EmailOTP";
 import { athenaAuthJwtConfig, athenaAuthSessionConfig } from "./authConfig";
+import { PosRecoveryCode } from "./auth/PosRecoveryCode";
 
 export const { auth, signIn, signOut, store } = convexAuth({
-  providers: [EmailOTP],
+  providers: [EmailOTP, PosRecoveryCode],
   session: athenaAuthSessionConfig,
   jwt: athenaAuthJwtConfig,
 });

--- a/packages/athena-webapp/convex/auth/PosRecoveryCode.test.ts
+++ b/packages/athena-webapp/convex/auth/PosRecoveryCode.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { Id } from "../_generated/dataModel";
+import { ATHENA_POS_RECOVERY_CODE_PROVIDER_ID } from "../../shared/auth";
+
+const providerMocks = vi.hoisted(() => ({
+  ConvexCredentials: vi.fn((config) => config),
+}));
+
+vi.mock("@convex-dev/auth/providers/ConvexCredentials", () => ({
+  ConvexCredentials: providerMocks.ConvexCredentials,
+}));
+
+import { PosRecoveryCode } from "./PosRecoveryCode";
+
+const AUTH_USER_ID = "auth-user-pos" as Id<"users">;
+
+describe("PosRecoveryCode auth provider", () => {
+  it("registers the Athena POS recovery-code provider id", () => {
+    expect(PosRecoveryCode.id).toBe(ATHENA_POS_RECOVERY_CODE_PROVIDER_ID);
+  });
+
+  it("returns null when required credentials or store scope are missing", async () => {
+    const ctx = { runMutation: vi.fn() };
+
+    await expect(
+      PosRecoveryCode.authorize(
+        { code: "abc-123", email: "pos@wigclub.store" },
+        ctx as never,
+      ),
+    ).resolves.toBeNull();
+    await expect(
+      PosRecoveryCode.authorize(
+        {
+          email: "pos@wigclub.store",
+          orgUrlSlug: "wigclub",
+          storeUrlSlug: "wigclub",
+        },
+        ctx as never,
+      ),
+    ).resolves.toBeNull();
+    expect(ctx.runMutation).not.toHaveBeenCalled();
+  });
+
+  it("maps successful internal verification to Convex Auth user identity", async () => {
+    const ctx = {
+      runMutation: vi.fn(async () => ({ authUserId: AUTH_USER_ID })),
+    };
+
+    await expect(
+      PosRecoveryCode.authorize(
+        {
+          code: "abc-123",
+          email: "pos@wigclub.store",
+          orgUrlSlug: "wigclub",
+          storeUrlSlug: "wigclub",
+        },
+        ctx as never,
+      ),
+    ).resolves.toEqual({ userId: AUTH_USER_ID });
+    expect(ctx.runMutation).toHaveBeenCalledWith(expect.anything(), {
+      code: "abc-123",
+      email: "pos@wigclub.store",
+      orgUrlSlug: "wigclub",
+      storeId: undefined,
+      storeUrlSlug: "wigclub",
+    });
+  });
+
+  it("returns null when internal verification rejects", async () => {
+    const ctx = {
+      runMutation: vi.fn(async () => {
+        throw new Error("POS recovery sign-in failed.");
+      }),
+    };
+
+    await expect(
+      PosRecoveryCode.authorize(
+        {
+          code: "abc-123",
+          email: "pos@wigclub.store",
+          storeId: "store-1",
+        },
+        ctx as never,
+      ),
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/athena-webapp/convex/auth/PosRecoveryCode.ts
+++ b/packages/athena-webapp/convex/auth/PosRecoveryCode.ts
@@ -1,0 +1,48 @@
+import { ConvexCredentials } from "@convex-dev/auth/providers/ConvexCredentials";
+
+import { internal } from "../_generated/api";
+import type { Id } from "../_generated/dataModel";
+import { ATHENA_POS_RECOVERY_CODE_PROVIDER_ID } from "../../shared/auth";
+
+const verifyRecoveryCodeForAuthProviderRef = (internal as any).pos.public
+  .posRecoveryCodes.verifyRecoveryCodeForAuthProvider;
+
+type PosRecoveryAuthorizeResult = { userId: Id<"users"> } | null;
+
+export const PosRecoveryCode: ReturnType<typeof ConvexCredentials> =
+  ConvexCredentials({
+  id: ATHENA_POS_RECOVERY_CODE_PROVIDER_ID,
+  authorize: async (credentials, ctx): Promise<PosRecoveryAuthorizeResult> => {
+    const email = typeof credentials.email === "string" ? credentials.email : "";
+    const code = typeof credentials.code === "string" ? credentials.code : "";
+    const orgUrlSlug =
+      typeof credentials.orgUrlSlug === "string" ? credentials.orgUrlSlug : undefined;
+    const storeId =
+      typeof credentials.storeId === "string" ? credentials.storeId : undefined;
+    const storeUrlSlug =
+      typeof credentials.storeUrlSlug === "string"
+        ? credentials.storeUrlSlug
+        : undefined;
+
+    if (!email || !code || (!storeId && (!orgUrlSlug || !storeUrlSlug))) {
+      return null;
+    }
+
+    try {
+      const result = (await ctx.runMutation(
+        verifyRecoveryCodeForAuthProviderRef,
+        {
+          code,
+          email,
+          orgUrlSlug,
+          storeId: storeId as never,
+          storeUrlSlug,
+        },
+      )) as { authUserId: Id<"users"> };
+
+      return { userId: result.authUserId };
+    } catch {
+      return null;
+    }
+  },
+});

--- a/packages/athena-webapp/convex/pos/public/posRecoveryCodes.test.ts
+++ b/packages/athena-webapp/convex/pos/public/posRecoveryCodes.test.ts
@@ -1,0 +1,560 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Id } from "../../_generated/dataModel";
+
+const authServerMocks = vi.hoisted(() => ({
+  getAuthUserId: vi.fn(),
+}));
+
+vi.mock("@convex-dev/auth/server", () => ({
+  getAuthUserId: authServerMocks.getAuthUserId,
+}));
+
+import {
+  createOrRotateRecoveryCodeForTest,
+  getRecoveryCodeStatus,
+  hashPosRecoveryCode,
+  revokeRecoveryCode,
+  rotateRecoveryCode,
+  unlockRecoveryCode,
+  verifyRecoveryCodeForAuthProvider,
+} from "./posRecoveryCodes";
+
+function getHandler(definition: unknown) {
+  return (definition as { _handler: Function })._handler;
+}
+
+const STORE_ID = "store-1" as Id<"store">;
+const ORG_ID = "org-1" as Id<"organization">;
+const POS_ACCOUNT_ID = "athena-pos-account-1" as Id<"athenaUser">;
+const AUTH_USER_ID = "auth-user-pos" as Id<"users">;
+const FULL_ADMIN_ID = "athena-full-admin-1" as Id<"athenaUser">;
+const FULL_ADMIN_AUTH_USER_ID = "auth-user-full-admin" as Id<"users">;
+
+describe("POS recovery codes", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    authServerMocks.getAuthUserId.mockResolvedValue(null);
+    let byte = 0;
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value: {
+        getRandomValues: (bytes: Uint8Array) => {
+          for (let index = 0; index < bytes.length; index += 1) {
+            byte = (byte + 1) % 255;
+            bytes[index] = byte;
+          }
+          return bytes;
+        },
+        subtle: {
+          digest: vi.fn(async (_algorithm: string, data: ArrayBuffer) => {
+            const source = Array.from(new Uint8Array(data));
+            const output = new Uint8Array(32);
+            source.forEach((value, index) => {
+              output[index % output.length] ^= value;
+            });
+            return output.buffer;
+          }),
+        },
+      },
+    });
+  });
+
+  it("creates a hash-only credential and verifies the generated code", async () => {
+    const ctx = buildCtx();
+    const create = getHandler(createOrRotateRecoveryCodeForTest);
+    const verify = getHandler(verifyRecoveryCodeForAuthProvider);
+
+    const created = await create(ctx, { storeId: STORE_ID });
+
+    expect(created.code).toMatch(/^[0-9a-f-]+$/);
+    expect(ctx.tables.posRecoveryCredential).toHaveLength(1);
+    const credential = ctx.tables.posRecoveryCredential[0];
+    expect(credential.codeHash).not.toBe(created.code);
+    expect(JSON.stringify(credential)).not.toContain(created.code);
+
+    const result = await verify(ctx, {
+      code: created.code,
+      email: "pos@wigclub.store",
+      storeId: STORE_ID,
+    });
+
+    expect(result).toEqual({ authUserId: AUTH_USER_ID });
+    expect(ctx.tables.posRecoveryCredential[0].failedAttemptCount).toBe(0);
+    expect(ctx.tables.posRecoveryCredential[0].lastUsedAt).toEqual(
+      expect.any(Number),
+    );
+    expect(JSON.stringify(ctx.tables.operationalEvent)).not.toContain(
+      created.code,
+    );
+    expect(JSON.stringify(ctx.tables.operationalEvent)).not.toContain(
+      credential.codeHash,
+    );
+  });
+
+  it("verifies recovery codes through org and store slugs", async () => {
+    const ctx = buildCtx();
+    const create = getHandler(createOrRotateRecoveryCodeForTest);
+    const verify = getHandler(verifyRecoveryCodeForAuthProvider);
+
+    const created = await create(ctx, { storeId: STORE_ID });
+
+    await expect(
+      verify(ctx, {
+        code: created.code,
+        email: "pos@wigclub.store",
+        orgUrlSlug: "wigclub",
+        storeUrlSlug: "wigclub",
+      }),
+    ).resolves.toEqual({ authUserId: AUTH_USER_ID });
+  });
+
+  it("rejects mismatched org and store slugs before credential failure accounting", async () => {
+    const ctx = buildCtx();
+    const create = getHandler(createOrRotateRecoveryCodeForTest);
+    const verify = getHandler(verifyRecoveryCodeForAuthProvider);
+    const created = await create(ctx, { storeId: STORE_ID });
+
+    await expect(
+      verify(ctx, {
+        code: created.code,
+        email: "pos@wigclub.store",
+        orgUrlSlug: "wigclub",
+        storeUrlSlug: "unknown",
+      }),
+    ).rejects.toThrow("POS recovery sign-in failed.");
+
+    expect(ctx.tables.posRecoveryCredential[0].failedAttemptCount).toBe(0);
+    expect(ctx.tables.operationalEvent).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: "pos_recovery_code_login_failed",
+        }),
+      ]),
+    );
+  });
+
+  it("invalidates old codes when rotated", async () => {
+    const ctx = buildCtx();
+    const create = getHandler(createOrRotateRecoveryCodeForTest);
+    const verify = getHandler(verifyRecoveryCodeForAuthProvider);
+
+    const first = await create(ctx, { storeId: STORE_ID });
+    const second = await create(ctx, { storeId: STORE_ID });
+
+    await expect(
+      verify(ctx, {
+        code: first.code,
+        email: "pos@wigclub.store",
+        storeId: STORE_ID,
+      }),
+    ).rejects.toThrow("POS recovery sign-in failed.");
+
+    await expect(
+      verify(ctx, {
+        code: second.code,
+        email: "pos@wigclub.store",
+        storeId: STORE_ID,
+      }),
+    ).resolves.toEqual({ authUserId: AUTH_USER_ID });
+  });
+
+  it("records repeated wrong attempts without letting public guessing lock the credential", async () => {
+    const ctx = buildCtx();
+    const create = getHandler(createOrRotateRecoveryCodeForTest);
+    const verify = getHandler(verifyRecoveryCodeForAuthProvider);
+
+    const created = await create(ctx, { storeId: STORE_ID });
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      await expect(
+        verify(ctx, {
+          code: `wrong-${attempt}`,
+          email: "pos@wigclub.store",
+          storeId: STORE_ID,
+        }),
+      ).rejects.toThrow("POS recovery sign-in failed.");
+    }
+
+    expect(ctx.tables.posRecoveryCredential[0]).toEqual(
+      expect.objectContaining({
+        failedAttemptCount: 1,
+        failureAuditBucket: expect.any(Number),
+        lastFailedAt: expect.any(Number),
+        status: "active",
+      }),
+    );
+    expect(ctx.tables.posRecoveryCredential[0]).not.toHaveProperty("lockedAt");
+    expect(ctx.tables.posRecoveryCredential[0]).not.toHaveProperty("lockedUntil");
+    const failedAttemptEvents = ctx.tables.operationalEvent.filter(
+      (event) => event.eventType === "pos_recovery_code_login_failed",
+    );
+    expect(failedAttemptEvents).toHaveLength(1);
+    expect(failedAttemptEvents[0]).toEqual(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          failedAttemptCount: 1,
+          failureAuditBucket: expect.any(Number),
+          reason: "invalid_code",
+        }),
+      }),
+    );
+
+    await expect(
+      verify(ctx, {
+        code: created.code,
+        email: "pos@wigclub.store",
+        storeId: STORE_ID,
+      }),
+    ).resolves.toEqual({ authUserId: AUTH_USER_ID });
+  });
+
+  it("rejects non-POS account emails without inspecting submitted code details", async () => {
+    const ctx = buildCtx();
+    const create = getHandler(createOrRotateRecoveryCodeForTest);
+    const verify = getHandler(verifyRecoveryCodeForAuthProvider);
+
+    const created = await create(ctx, { storeId: STORE_ID });
+
+    await expect(
+      verify(ctx, {
+        code: created.code,
+        email: "admin@wigclub.store",
+        storeId: STORE_ID,
+      }),
+    ).rejects.toThrow("POS recovery sign-in failed.");
+  });
+
+  it("limits recovery-code status to full admins", async () => {
+    const ctx = buildCtx();
+    const create = getHandler(createOrRotateRecoveryCodeForTest);
+    const getStatus = getHandler(getRecoveryCodeStatus);
+
+    await create(ctx, { storeId: STORE_ID });
+
+    authServerMocks.getAuthUserId.mockResolvedValue(FULL_ADMIN_AUTH_USER_ID);
+    await expect(getStatus(ctx, { storeId: STORE_ID })).resolves.toEqual(
+      expect.objectContaining({ status: "active", storeId: STORE_ID }),
+    );
+
+    authServerMocks.getAuthUserId.mockResolvedValue(AUTH_USER_ID);
+    await expect(getStatus(ctx, { storeId: STORE_ID })).rejects.toThrow(
+      "Only full admins can manage POS recovery codes.",
+    );
+  });
+
+  it("lets full admins rotate through the public mutation with actor attribution", async () => {
+    const ctx = buildCtx();
+    const create = getHandler(createOrRotateRecoveryCodeForTest);
+    const rotate = getHandler(rotateRecoveryCode);
+    await create(ctx, { storeId: STORE_ID });
+
+    authServerMocks.getAuthUserId.mockResolvedValue(FULL_ADMIN_AUTH_USER_ID);
+    const result = await rotate(ctx, { storeId: STORE_ID });
+
+    expect(result.code).toMatch(/^[0-9a-f-]+$/);
+    expect(result.credential).toEqual(
+      expect.objectContaining({
+        rotatedByUserId: FULL_ADMIN_ID,
+        status: "active",
+        storeId: STORE_ID,
+      }),
+    );
+    expect(JSON.stringify(ctx.tables.posRecoveryCredential[0])).not.toContain(
+      result.code,
+    );
+    expect(ctx.tables.posRecoveryCredential[0]).toEqual(
+      expect.objectContaining({
+        rotatedByUserId: FULL_ADMIN_ID,
+        status: "active",
+      }),
+    );
+    expect(ctx.tables.operationalEvent).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          actorUserId: FULL_ADMIN_ID,
+          eventType: "pos_recovery_code_rotated",
+          metadata: expect.objectContaining({ reason: "rotated" }),
+        }),
+      ]),
+    );
+  });
+
+  it.each([
+    {
+      label: "missing membership",
+      mutate: (ctx: ReturnType<typeof buildCtx>) => {
+        ctx.tables.organizationMember = ctx.tables.organizationMember.filter(
+          (member) => member.userId !== POS_ACCOUNT_ID,
+        );
+      },
+    },
+    {
+      label: "membership in another organization",
+      mutate: (ctx: ReturnType<typeof buildCtx>) => {
+        const membership = ctx.tables.organizationMember.find(
+          (member) => member.userId === POS_ACCOUNT_ID,
+        );
+        membership.organizationId = "org-other";
+      },
+    },
+    {
+      label: "non-POS-only membership",
+      mutate: (ctx: ReturnType<typeof buildCtx>) => {
+        const membership = ctx.tables.organizationMember.find(
+          (member) => member.userId === POS_ACCOUNT_ID,
+        );
+        membership.role = "full_admin";
+      },
+    },
+  ])("rejects recovery verification for $label", async ({ mutate }) => {
+    const ctx = buildCtx();
+    const create = getHandler(createOrRotateRecoveryCodeForTest);
+    const verify = getHandler(verifyRecoveryCodeForAuthProvider);
+    const created = await create(ctx, { storeId: STORE_ID });
+    mutate(ctx);
+    const credential = ctx.tables.posRecoveryCredential[0];
+
+    await expect(
+      verify(ctx, {
+        code: created.code,
+        email: "pos@wigclub.store",
+        storeId: STORE_ID,
+      }),
+    ).rejects.toThrow("POS recovery sign-in failed.");
+
+    expect(credential.failedAttemptCount).toBe(0);
+    expect(ctx.tables.operationalEvent).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: "pos_recovery_code_login_failed",
+        }),
+      ]),
+    );
+  });
+
+  it("rejects locked credentials until full-admin unlock clears lock fields", async () => {
+    const ctx = buildCtx();
+    const create = getHandler(createOrRotateRecoveryCodeForTest);
+    const verify = getHandler(verifyRecoveryCodeForAuthProvider);
+    const unlock = getHandler(unlockRecoveryCode);
+    const created = await create(ctx, { storeId: STORE_ID });
+    Object.assign(ctx.tables.posRecoveryCredential[0], {
+      failedAttemptCount: 5,
+      lockedAt: 100,
+      lockedUntil: Date.now() + 60_000,
+      status: "locked",
+    });
+
+    await expect(
+      verify(ctx, {
+        code: created.code,
+        email: "pos@wigclub.store",
+        storeId: STORE_ID,
+      }),
+    ).rejects.toThrow("POS recovery sign-in failed.");
+    await expect(
+      verify(ctx, {
+        code: created.code,
+        email: "pos@wigclub.store",
+        storeId: STORE_ID,
+      }),
+    ).rejects.toThrow("POS recovery sign-in failed.");
+    expect(
+      ctx.tables.operationalEvent.filter(
+        (event) =>
+          event.eventType === "pos_recovery_code_login_failed" &&
+          event.reason === "locked",
+      ),
+    ).toHaveLength(1);
+
+    authServerMocks.getAuthUserId.mockResolvedValue(FULL_ADMIN_AUTH_USER_ID);
+    await expect(unlock(ctx, { storeId: STORE_ID })).resolves.toEqual(
+      expect.objectContaining({ status: "active" }),
+    );
+    expect(ctx.tables.posRecoveryCredential[0]).toEqual(
+      expect.objectContaining({
+        failedAttemptCount: 0,
+        failureAuditBucket: undefined,
+        lockedAt: undefined,
+        lockedUntil: undefined,
+        status: "active",
+      }),
+    );
+    expect(ctx.tables.operationalEvent).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: "pos_recovery_code_unlocked",
+          metadata: expect.objectContaining({ reason: "unlocked" }),
+        }),
+      ]),
+    );
+  });
+
+  it("revokes credentials and keeps revoked credentials unusable", async () => {
+    const ctx = buildCtx();
+    const create = getHandler(createOrRotateRecoveryCodeForTest);
+    const revoke = getHandler(revokeRecoveryCode);
+    const unlock = getHandler(unlockRecoveryCode);
+    const verify = getHandler(verifyRecoveryCodeForAuthProvider);
+    const created = await create(ctx, { storeId: STORE_ID });
+
+    authServerMocks.getAuthUserId.mockResolvedValue(FULL_ADMIN_AUTH_USER_ID);
+    await expect(revoke(ctx, { storeId: STORE_ID })).resolves.toEqual(
+      expect.objectContaining({ status: "revoked" }),
+    );
+    await expect(unlock(ctx, { storeId: STORE_ID })).resolves.toEqual(
+      expect.objectContaining({ status: "revoked" }),
+    );
+
+    await expect(
+      verify(ctx, {
+        code: created.code,
+        email: "pos@wigclub.store",
+        storeId: STORE_ID,
+      }),
+    ).rejects.toThrow("POS recovery sign-in failed.");
+    await expect(
+      verify(ctx, {
+        code: created.code,
+        email: "pos@wigclub.store",
+        storeId: STORE_ID,
+      }),
+    ).rejects.toThrow("POS recovery sign-in failed.");
+    expect(
+      ctx.tables.operationalEvent.filter(
+        (event) =>
+          event.eventType === "pos_recovery_code_login_failed" &&
+          event.reason === "revoked",
+      ),
+    ).toHaveLength(1);
+    expect(ctx.tables.operationalEvent).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: "pos_recovery_code_revoked",
+          metadata: expect.objectContaining({ reason: "revoked" }),
+        }),
+      ]),
+    );
+  });
+
+  it("rejects non-full-admin recovery-code management", async () => {
+    const ctx = buildCtx();
+    const rotate = getHandler(rotateRecoveryCode);
+    const revoke = getHandler(revokeRecoveryCode);
+    const unlock = getHandler(unlockRecoveryCode);
+    authServerMocks.getAuthUserId.mockResolvedValue(AUTH_USER_ID);
+
+    await expect(rotate(ctx, { storeId: STORE_ID })).rejects.toThrow(
+      "Only full admins can manage POS recovery codes.",
+    );
+    await expect(revoke(ctx, { storeId: STORE_ID })).rejects.toThrow(
+      "Only full admins can manage POS recovery codes.",
+    );
+    await expect(unlock(ctx, { storeId: STORE_ID })).rejects.toThrow(
+      "Only full admins can manage POS recovery codes.",
+    );
+  });
+});
+
+function buildCtx() {
+  let nextId = 1;
+  const tables: Record<string, any[]> = {
+    athenaUser: [
+      { _id: POS_ACCOUNT_ID, email: "pos@wigclub.store" },
+      { _id: FULL_ADMIN_ID, email: "admin@wigclub.store" },
+    ],
+    organization: [{ _id: ORG_ID, slug: "wigclub" }],
+    organizationMember: [
+      {
+        _id: "member-1",
+        organizationId: ORG_ID,
+        role: "pos_only",
+        userId: POS_ACCOUNT_ID,
+      },
+      {
+        _id: "member-2",
+        organizationId: ORG_ID,
+        role: "full_admin",
+        userId: FULL_ADMIN_ID,
+      },
+    ],
+    operationalEvent: [],
+    posRecoveryCredential: [],
+    store: [{ _id: STORE_ID, organizationId: ORG_ID, slug: "wigclub" }],
+    users: [
+      { _id: AUTH_USER_ID, email: "pos@wigclub.store" },
+      { _id: FULL_ADMIN_AUTH_USER_ID, email: "admin@wigclub.store" },
+    ],
+  };
+
+  const ctx = {
+    tables,
+    db: {
+      get: vi.fn(async (tableOrId: string, maybeId?: string) => {
+        if (maybeId !== undefined) {
+          return tables[tableOrId]?.find((row) => row._id === maybeId) ?? null;
+        }
+        return (
+          Object.values(tables)
+            .flat()
+            .find((row) => row._id === tableOrId) ?? null
+        );
+      }),
+      insert: vi.fn(async (table: string, value: Record<string, unknown>) => {
+        const id = `${table}-${nextId++}`;
+        tables[table].push({ _id: id, _creationTime: Date.now(), ...value });
+        return id;
+      }),
+      patch: vi.fn(async (...args: [string, string, Record<string, unknown>] | [string, Record<string, unknown>]) => {
+        const id = args.length === 3 ? args[1] : args[0];
+        const patch = args.length === 3 ? args[2] : args[1];
+        const row = Object.values(tables)
+          .flat()
+          .find((candidate) => candidate._id === id);
+        if (!row) {
+          throw new Error(`Missing row ${id}`);
+        }
+        Object.assign(row, patch);
+      }),
+      query: vi.fn((table: string) => createQuery(tables[table] ?? [])),
+    },
+  };
+
+  return ctx;
+}
+
+function createQuery(rows: any[]) {
+  let currentRows = rows;
+  const query = {
+    collect: vi.fn(async () => currentRows),
+    filter: vi.fn((predicate: Function) => {
+      currentRows = currentRows.filter((row) => predicate(createFilter(row)));
+      return query;
+    }),
+    first: vi.fn(async () => currentRows[0] ?? null),
+    take: vi.fn(async (limit: number) => currentRows.slice(0, limit)),
+    withIndex: vi.fn((_name: string, predicate?: Function) => {
+      if (predicate) {
+        const indexBuilder = {
+          eq: (field: string, value: unknown) => {
+            currentRows = currentRows.filter((row) => row[field] === value);
+            return indexBuilder;
+          },
+        };
+        predicate(indexBuilder);
+      }
+      return query;
+    }),
+  };
+  return query;
+}
+
+function createFilter(row: Record<string, unknown>) {
+  return {
+    and: (...values: boolean[]) => values.every(Boolean),
+    eq: (left: unknown, right: unknown) => left === right,
+    field: (name: string) => row[name],
+    or: (...values: boolean[]) => values.some(Boolean),
+  };
+}

--- a/packages/athena-webapp/convex/pos/public/posRecoveryCodes.ts
+++ b/packages/athena-webapp/convex/pos/public/posRecoveryCodes.ts
@@ -1,0 +1,550 @@
+import { v } from "convex/values";
+
+import type { Doc, Id } from "../../_generated/dataModel";
+import {
+  internalMutation,
+  mutation,
+  query,
+  type MutationCtx,
+  type QueryCtx,
+} from "../../_generated/server";
+import { recordOperationalEventWithCtx } from "../../operations/operationalEvents";
+import {
+  requireAuthenticatedAthenaUserWithCtx,
+  requireOrganizationMemberRoleWithCtx,
+} from "../../lib/athenaUserAuth";
+
+const POS_RECOVERY_ACCOUNT_EMAIL = "pos@wigclub.store";
+const POS_RECOVERY_CODE_VERSION = 1;
+const POS_RECOVERY_CODE_BYTES = 18;
+const POS_RECOVERY_FAILURE_AUDIT_BUCKET_MS = 15 * 60 * 1000;
+const GENERIC_RECOVERY_FAILURE = "POS recovery sign-in failed.";
+
+type PosRecoveryCredential = Doc<"posRecoveryCredential">;
+type PosRecoveryCtx = Pick<QueryCtx, "db"> | Pick<MutationCtx, "db">;
+type PosRecoveryAccessCtx =
+  | Pick<QueryCtx, "auth" | "db">
+  | Pick<MutationCtx, "auth" | "db">;
+
+function normalizeEmail(email: string) {
+  return email.trim().toLowerCase();
+}
+
+function bytesToHex(bytes: ArrayBuffer | Uint8Array) {
+  const data = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  return Array.from(data)
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function randomHex(byteCount: number) {
+  const bytes = new Uint8Array(byteCount);
+  crypto.getRandomValues(bytes);
+  return bytesToHex(bytes);
+}
+
+function generateRecoveryCode() {
+  return randomHex(POS_RECOVERY_CODE_BYTES).match(/.{1,6}/g)?.join("-") ?? "";
+}
+
+function getFailureAuditBucket(now: number) {
+  return Math.floor(now / POS_RECOVERY_FAILURE_AUDIT_BUCKET_MS);
+}
+
+export async function hashPosRecoveryCode(args: {
+  code: string;
+  salt: string;
+}) {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(`${args.salt}:${args.code.trim()}`),
+  );
+
+  return bytesToHex(digest);
+}
+
+async function findAthenaUserByEmail(
+  ctx: PosRecoveryCtx,
+  email: string,
+) {
+  const normalizedEmail = normalizeEmail(email);
+  // Case-insensitive lookup mirrors the existing Athena auth-sync helper until
+  // athenaUser gains a normalized-email index.
+  // eslint-disable-next-line @convex-dev/no-collect-in-query
+  const users = await ctx.db.query("athenaUser").collect();
+  const matches = users.filter(
+    (user) => normalizeEmail(user.email) === normalizedEmail,
+  );
+
+  if (matches.length > 1) {
+    throw new Error("Multiple Athena users match the POS recovery account.");
+  }
+
+  return matches[0] ?? null;
+}
+
+async function findAuthUserByEmail(ctx: PosRecoveryCtx, email: string) {
+  const normalizedEmail = normalizeEmail(email);
+  // Convex Auth's user table does not expose a stable generated email index in
+  // this repo, so match the existing auth-sync fallback.
+  // eslint-disable-next-line @convex-dev/no-collect-in-query
+  const users = await ctx.db.query("users").collect();
+  const matches = users.filter((user) => {
+    const candidate = "email" in user ? user.email : undefined;
+    return typeof candidate === "string" && normalizeEmail(candidate) === normalizedEmail;
+  });
+
+  if (matches.length > 1) {
+    throw new Error("Multiple auth users match the POS recovery account.");
+  }
+
+  return matches[0] ?? null;
+}
+
+async function getCredentialForStore(
+  ctx: PosRecoveryCtx,
+  args: {
+    posAccountId: Id<"athenaUser">;
+    storeId: Id<"store">;
+  },
+) {
+  return ctx.db
+    .query("posRecoveryCredential")
+    .withIndex("by_storeId_posAccountId", (q) =>
+      q.eq("storeId", args.storeId).eq("posAccountId", args.posAccountId),
+    )
+    .first();
+}
+
+async function resolveRecoveryStore(
+  ctx: PosRecoveryCtx,
+  args: {
+    orgUrlSlug?: string;
+    storeId?: Id<"store">;
+    storeUrlSlug?: string;
+  },
+) {
+  if (args.storeId) {
+    return ctx.db.get("store", args.storeId);
+  }
+
+  const orgSlug = args.orgUrlSlug?.trim();
+  const storeSlug = args.storeUrlSlug?.trim();
+  if (!orgSlug || !storeSlug) {
+    return null;
+  }
+
+  const organization = await ctx.db
+    .query("organization")
+    .filter((q) => q.eq(q.field("slug"), orgSlug))
+    .first();
+  if (!organization) {
+    return null;
+  }
+
+  return ctx.db
+    .query("store")
+    .filter((q) =>
+      q.and(
+        q.eq(q.field("organizationId"), organization._id),
+        q.eq(q.field("slug"), storeSlug),
+      ),
+    )
+    .first();
+}
+
+async function recordRecoveryCodeEvent(
+  ctx: MutationCtx,
+  args: {
+    actorUserId?: Id<"athenaUser">;
+    credential: Pick<
+      PosRecoveryCredential,
+      "_id" | "organizationId" | "posAccountId" | "storeId" | "status"
+    >;
+    eventType: string;
+    metadataDedupeKeys?: string[];
+    reason: string;
+    metadata?: Record<string, unknown>;
+  },
+) {
+  await recordOperationalEventWithCtx(ctx, {
+    storeId: args.credential.storeId,
+    organizationId: args.credential.organizationId,
+    actorUserId: args.actorUserId,
+    eventType: args.eventType,
+    subjectType: "posRecoveryCredential",
+    subjectId: args.credential._id,
+    reason: args.reason,
+    message: "POS recovery-code credential updated.",
+    metadata: {
+      eventDedupeNonce: randomHex(8),
+      eventRecordedAt: Date.now(),
+      posAccountId: args.credential.posAccountId,
+      reason: args.reason,
+      status: args.credential.status,
+      ...args.metadata,
+    },
+    metadataDedupeKeys: args.metadataDedupeKeys ?? ["eventDedupeNonce"],
+  });
+}
+
+async function requireFullAdminRecoveryAccess(
+  ctx: PosRecoveryAccessCtx,
+  storeId: Id<"store">,
+) {
+  const store = await ctx.db.get("store", storeId);
+  if (!store) {
+    throw new Error("Store not found.");
+  }
+
+  const actor = await requireAuthenticatedAthenaUserWithCtx(ctx);
+  await requireOrganizationMemberRoleWithCtx(ctx, {
+    allowedRoles: ["full_admin"],
+    failureMessage: "Only full admins can manage POS recovery codes.",
+    organizationId: store.organizationId,
+    userId: actor._id,
+  });
+
+  return { actor, store };
+}
+
+async function requirePosRecoveryAccount(ctx: PosRecoveryCtx) {
+  const account = await findAthenaUserByEmail(ctx, POS_RECOVERY_ACCOUNT_EMAIL);
+  if (!account) {
+    throw new Error("POS recovery account is not configured.");
+  }
+  return account;
+}
+
+function publicCredentialStatus(credential: PosRecoveryCredential | null) {
+  if (!credential) {
+    return null;
+  }
+
+  return {
+    _id: credential._id,
+    createdAt: credential.createdAt,
+    failedAttemptCount: credential.failedAttemptCount,
+    lastFailedAt: credential.lastFailedAt,
+    lastUsedAt: credential.lastUsedAt,
+    lockedAt: credential.lockedAt,
+    lockedUntil: credential.lockedUntil,
+    posAccountId: credential.posAccountId,
+    revokedAt: credential.revokedAt,
+    rotatedAt: credential.rotatedAt,
+    rotatedByUserId: credential.rotatedByUserId,
+    status: credential.status,
+    storeId: credential.storeId,
+  };
+}
+
+async function rotateCredentialWithCtx(
+  ctx: MutationCtx,
+  args: {
+    actorUserId?: Id<"athenaUser">;
+    reason: "created" | "rotated";
+    storeId: Id<"store">;
+  },
+) {
+  const store = await ctx.db.get("store", args.storeId);
+  if (!store) {
+    throw new Error("Store not found.");
+  }
+  const account = await requirePosRecoveryAccount(ctx);
+  const now = Date.now();
+  const code = generateRecoveryCode();
+  const codeSalt = randomHex(16);
+  const codeHash = await hashPosRecoveryCode({ code, salt: codeSalt });
+  const existing = await getCredentialForStore(ctx, {
+    posAccountId: account._id,
+    storeId: args.storeId,
+  });
+
+  if (existing) {
+    await ctx.db.patch("posRecoveryCredential", existing._id, {
+      codeHash,
+      codeSalt,
+      codeVersion: POS_RECOVERY_CODE_VERSION,
+      failedAttemptCount: 0,
+      failureAuditBucket: undefined,
+      lastFailedAt: undefined,
+      lockedAt: undefined,
+      lockedUntil: undefined,
+      revokedAt: undefined,
+      revokedByUserId: undefined,
+      rotatedAt: now,
+      rotatedByUserId: args.actorUserId,
+      status: "active",
+    });
+    const credential = (await ctx.db.get("posRecoveryCredential", existing._id))!;
+    await recordRecoveryCodeEvent(ctx, {
+      actorUserId: args.actorUserId,
+      credential,
+      eventType: "pos_recovery_code_rotated",
+      reason: "rotated",
+    });
+    return { code, credential };
+  }
+
+  const credentialId = await ctx.db.insert("posRecoveryCredential", {
+    codeHash,
+    codeSalt,
+    codeVersion: POS_RECOVERY_CODE_VERSION,
+    createdAt: now,
+    createdByUserId: args.actorUserId,
+    failedAttemptCount: 0,
+    organizationId: store.organizationId,
+    posAccountId: account._id,
+    rotatedAt: now,
+    rotatedByUserId: args.actorUserId,
+    status: "active",
+    storeId: args.storeId,
+  });
+  const credential = (await ctx.db.get("posRecoveryCredential", credentialId))!;
+  await recordRecoveryCodeEvent(ctx, {
+    actorUserId: args.actorUserId,
+    credential,
+    eventType: "pos_recovery_code_created",
+    reason: args.reason,
+  });
+
+  return { code, credential };
+}
+
+async function verifyCredentialWithCtx(
+  ctx: MutationCtx,
+  args: {
+    code: string;
+    email: string;
+    orgUrlSlug?: string;
+    storeId?: Id<"store">;
+    storeUrlSlug?: string;
+  },
+) {
+  const submittedEmail = normalizeEmail(args.email);
+  const store = await resolveRecoveryStore(ctx, args);
+  const account = await findAthenaUserByEmail(ctx, POS_RECOVERY_ACCOUNT_EMAIL);
+
+  if (!store || !account || submittedEmail !== POS_RECOVERY_ACCOUNT_EMAIL) {
+    throw new Error(GENERIC_RECOVERY_FAILURE);
+  }
+
+  const membership = await ctx.db
+    .query("organizationMember")
+    .filter((q) =>
+      q.and(
+        q.eq(q.field("organizationId"), store.organizationId),
+        q.eq(q.field("userId"), account._id),
+      ),
+    )
+    .first();
+
+  if (!membership || membership.role !== "pos_only") {
+    throw new Error(GENERIC_RECOVERY_FAILURE);
+  }
+
+  const credential = await getCredentialForStore(ctx, {
+    posAccountId: account._id,
+    storeId: store._id,
+  });
+  if (!credential) {
+    throw new Error(GENERIC_RECOVERY_FAILURE);
+  }
+
+  const now = Date.now();
+  if (
+    credential.status === "revoked" ||
+    (credential.lockedUntil && credential.lockedUntil > now)
+  ) {
+    const failureAuditBucket = getFailureAuditBucket(now);
+    await recordRecoveryCodeEvent(ctx, {
+      credential,
+      eventType: "pos_recovery_code_login_failed",
+      reason: credential.status === "revoked" ? "revoked" : "locked",
+      metadata: { failureAuditBucket },
+      metadataDedupeKeys: ["reason", "failureAuditBucket"],
+    });
+    throw new Error(GENERIC_RECOVERY_FAILURE);
+  }
+
+  const submittedHash = await hashPosRecoveryCode({
+    code: args.code,
+    salt: credential.codeSalt,
+  });
+  if (submittedHash !== credential.codeHash) {
+    const failureAuditBucket = getFailureAuditBucket(now);
+    const shouldRecordCredentialFailure =
+      credential.failureAuditBucket !== failureAuditBucket;
+    const patch = shouldRecordCredentialFailure
+      ? {
+          failedAttemptCount: credential.failedAttemptCount + 1,
+          failureAuditBucket,
+          lastFailedAt: now,
+        }
+      : null;
+    if (patch) {
+      await ctx.db.patch("posRecoveryCredential", credential._id, patch);
+    }
+    const nextCredential = patch ? { ...credential, ...patch } : credential;
+    await recordRecoveryCodeEvent(ctx, {
+      credential: nextCredential,
+      eventType: "pos_recovery_code_login_failed",
+      reason: "invalid_code",
+      metadata: {
+        failedAttemptCount: nextCredential.failedAttemptCount,
+        failureAuditBucket,
+      },
+      metadataDedupeKeys: ["reason", "failureAuditBucket"],
+    });
+    throw new Error(GENERIC_RECOVERY_FAILURE);
+  }
+
+  const authUser = await findAuthUserByEmail(ctx, POS_RECOVERY_ACCOUNT_EMAIL);
+  if (!authUser) {
+    throw new Error(GENERIC_RECOVERY_FAILURE);
+  }
+
+  await ctx.db.patch("posRecoveryCredential", credential._id, {
+    failedAttemptCount: 0,
+    failureAuditBucket: undefined,
+    lastFailedAt: undefined,
+    lastUsedAt: now,
+    lockedAt: undefined,
+    lockedUntil: undefined,
+    status: "active",
+  });
+  await recordRecoveryCodeEvent(ctx, {
+    credential: { ...credential, status: "active" },
+    eventType: "pos_recovery_code_login_succeeded",
+    reason: "verified",
+  });
+
+  return { authUserId: authUser._id };
+}
+
+export const getRecoveryCodeStatus = query({
+  args: {
+    storeId: v.id("store"),
+  },
+  handler: async (ctx, args) => {
+    await requireFullAdminRecoveryAccess(ctx, args.storeId);
+    const account = await findAthenaUserByEmail(ctx, POS_RECOVERY_ACCOUNT_EMAIL);
+    if (!account) {
+      return null;
+    }
+    return publicCredentialStatus(
+      await getCredentialForStore(ctx, {
+        posAccountId: account._id,
+        storeId: args.storeId,
+      }),
+    );
+  },
+});
+
+export const rotateRecoveryCode = mutation({
+  args: {
+    storeId: v.id("store"),
+  },
+  handler: async (ctx, args) => {
+    const { actor } = await requireFullAdminRecoveryAccess(ctx, args.storeId);
+    const { code, credential } = await rotateCredentialWithCtx(ctx, {
+      actorUserId: actor._id,
+      reason: "rotated",
+      storeId: args.storeId,
+    });
+
+    return { code, credential: publicCredentialStatus(credential) };
+  },
+});
+
+export const revokeRecoveryCode = mutation({
+  args: {
+    storeId: v.id("store"),
+  },
+  handler: async (ctx, args) => {
+    const { actor } = await requireFullAdminRecoveryAccess(ctx, args.storeId);
+    const account = await requirePosRecoveryAccount(ctx);
+    const credential = await getCredentialForStore(ctx, {
+      posAccountId: account._id,
+      storeId: args.storeId,
+    });
+    if (!credential) {
+      return null;
+    }
+    const now = Date.now();
+    await ctx.db.patch("posRecoveryCredential", credential._id, {
+      revokedAt: now,
+      revokedByUserId: actor._id,
+      status: "revoked",
+    });
+    const nextCredential = { ...credential, revokedAt: now, status: "revoked" as const };
+    await recordRecoveryCodeEvent(ctx, {
+      actorUserId: actor._id,
+      credential: nextCredential,
+      eventType: "pos_recovery_code_revoked",
+      reason: "revoked",
+    });
+
+    return publicCredentialStatus(nextCredential);
+  },
+});
+
+export const unlockRecoveryCode = mutation({
+  args: {
+    storeId: v.id("store"),
+  },
+  handler: async (ctx, args) => {
+    const { actor } = await requireFullAdminRecoveryAccess(ctx, args.storeId);
+    const account = await requirePosRecoveryAccount(ctx);
+    const credential = await getCredentialForStore(ctx, {
+      posAccountId: account._id,
+      storeId: args.storeId,
+    });
+    if (!credential || credential.status === "revoked") {
+      return publicCredentialStatus(credential);
+    }
+    await ctx.db.patch("posRecoveryCredential", credential._id, {
+      failedAttemptCount: 0,
+      failureAuditBucket: undefined,
+      lastFailedAt: undefined,
+      lockedAt: undefined,
+      lockedUntil: undefined,
+      status: "active",
+    });
+    const nextCredential = { ...credential, status: "active" as const };
+    await recordRecoveryCodeEvent(ctx, {
+      actorUserId: actor._id,
+      credential: nextCredential,
+      eventType: "pos_recovery_code_unlocked",
+      reason: "unlocked",
+    });
+
+    return publicCredentialStatus(nextCredential);
+  },
+});
+
+export const verifyRecoveryCodeForAuthProvider = internalMutation({
+  args: {
+    code: v.string(),
+    email: v.string(),
+    orgUrlSlug: v.optional(v.string()),
+    storeId: v.optional(v.id("store")),
+    storeUrlSlug: v.optional(v.string()),
+  },
+  handler: verifyCredentialWithCtx,
+});
+
+export const createOrRotateRecoveryCodeForTest = internalMutation({
+  args: {
+    actorUserId: v.optional(v.id("athenaUser")),
+    storeId: v.id("store"),
+  },
+  handler: async (ctx, args) => {
+    const { code, credential } = await rotateCredentialWithCtx(ctx, {
+      actorUserId: args.actorUserId,
+      reason: "created",
+      storeId: args.storeId,
+    });
+    return { code, credential: publicCredentialStatus(credential) };
+  },
+});

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -63,6 +63,7 @@ import {
   posLocalSyncEventSchema,
   posLocalSyncMappingSchema,
   posLocalStaffProofSchema,
+  posRecoveryCredentialSchema,
   posTerminalRuntimeStatusSchema,
 } from "./schemas/pos";
 import { posSessionSchema } from "./schemas/pos/posSession";
@@ -323,6 +324,10 @@ const schema = defineSchema({
     .index("by_storeId", ["storeId"])
     .index("by_storeId_and_fingerprintHash", ["storeId", "fingerprintHash"])
     .index("by_storeId_registerNumber", ["storeId", "registerNumber"]),
+  posRecoveryCredential: defineTable(posRecoveryCredentialSchema)
+    .index("by_storeId", ["storeId"])
+    .index("by_storeId_posAccountId", ["storeId", "posAccountId"])
+    .index("by_organizationId_status", ["organizationId", "status"]),
   posTerminalRuntimeStatus: defineTable(posTerminalRuntimeStatusSchema)
     .index("by_store_terminal", ["storeId", "terminalId"])
     .index("by_store_reportedAt", ["storeId", "reportedAt"])

--- a/packages/athena-webapp/convex/schemas/pos/index.ts
+++ b/packages/athena-webapp/convex/schemas/pos/index.ts
@@ -6,6 +6,7 @@ export * from "./posTransactionAdjustmentLine";
 export * from "./posSessionItem";
 export * from "./customer";
 export * from "./posTerminal";
+export * from "./posRecoveryCredential";
 export * from "./posTerminalRuntimeStatus";
 export * from "./expenseSession";
 export * from "./expenseSessionItem";

--- a/packages/athena-webapp/convex/schemas/pos/posRecoveryCredential.ts
+++ b/packages/athena-webapp/convex/schemas/pos/posRecoveryCredential.ts
@@ -1,0 +1,23 @@
+import { v } from "convex/values";
+
+export const posRecoveryCredentialSchema = v.object({
+  codeHash: v.string(),
+  codeSalt: v.string(),
+  codeVersion: v.number(),
+  createdAt: v.number(),
+  createdByUserId: v.optional(v.id("athenaUser")),
+  failedAttemptCount: v.number(),
+  failureAuditBucket: v.optional(v.number()),
+  lastFailedAt: v.optional(v.number()),
+  lastUsedAt: v.optional(v.number()),
+  lockedAt: v.optional(v.number()),
+  lockedUntil: v.optional(v.number()),
+  organizationId: v.id("organization"),
+  posAccountId: v.id("athenaUser"),
+  revokedAt: v.optional(v.number()),
+  revokedByUserId: v.optional(v.id("athenaUser")),
+  rotatedAt: v.number(),
+  rotatedByUserId: v.optional(v.id("athenaUser")),
+  status: v.union(v.literal("active"), v.literal("locked"), v.literal("revoked")),
+  storeId: v.id("store"),
+});

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -7,7 +7,7 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Core app surfaces
 
 - [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 86 file(s); key children: __root.tsx, _authed, _authed.test.tsx, _authed.tsx, index.test.tsx.
-- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 587 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
+- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 591 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
 - [`src/components/traces`](../../src/components/traces) — Shared workflow trace screens, ordered timelines, and trace detail primitives. Currently 3 file(s); key children: WorkflowTraceRouteLink.tsx, WorkflowTraceView.test.tsx, WorkflowTraceView.tsx.
 - [`src/components/operations`](../../src/components/operations) — Manager-queue and stock-adjustment workflows that share approval rails with other operational surfaces. Currently 24 file(s); key children: CommandApprovalDialog.test.tsx, CommandApprovalDialog.tsx, DailyCloseHistoryView.test.tsx, DailyCloseHistoryView.tsx, DailyCloseView.test.tsx.
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.
@@ -22,7 +22,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/stockOps`](../../convex/stockOps) — Stock-adjustment, procurement, replenishment, receiving, and vendor flows layered over inventory state. Currently 14 file(s); key children: access.test.ts, access.ts, adjustments.test.ts, adjustments.ts, cycleCountDrafts.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 6 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCases.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 11 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 469 file(s); key children: README.md, _generated, app.ts, auth.config.js, auth.ts.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 475 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 6 file(s); key children: README.md, SUMMARY.md, pos.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -16,6 +16,8 @@ This index enumerates the current automated test files and ties them back to the
 
 ## Section `convex`
 
+- [`convex/auth.test.ts`](../../convex/auth.test.ts)
+- [`convex/auth/PosRecoveryCode.test.ts`](../../convex/auth/PosRecoveryCode.test.ts)
 - [`convex/authConfig.test.ts`](../../convex/authConfig.test.ts)
 - [`convex/cashControls/closeouts.test.ts`](../../convex/cashControls/closeouts.test.ts)
 - [`convex/cashControls/deposits.test.ts`](../../convex/cashControls/deposits.test.ts)
@@ -103,6 +105,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`convex/pos/infrastructure/repositories/sessionRepository.test.ts`](../../convex/pos/infrastructure/repositories/sessionRepository.test.ts)
 - [`convex/pos/infrastructure/repositories/terminalRepository.test.ts`](../../convex/pos/infrastructure/repositories/terminalRepository.test.ts)
 - [`convex/pos/public/catalog.test.ts`](../../convex/pos/public/catalog.test.ts)
+- [`convex/pos/public/posRecoveryCodes.test.ts`](../../convex/pos/public/posRecoveryCodes.test.ts)
 - [`convex/pos/public/sync.test.ts`](../../convex/pos/public/sync.test.ts)
 - [`convex/pos/public/terminalAppSessions.test.ts`](../../convex/pos/public/terminalAppSessions.test.ts)
 - [`convex/pos/public/terminals.test.ts`](../../convex/pos/public/terminals.test.ts)
@@ -157,6 +160,8 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/components/auth/DefaultCatchBoundary.test.tsx`](../../src/components/auth/DefaultCatchBoundary.test.tsx)
 - [`src/components/auth/Login/InputOTP.test.tsx`](../../src/components/auth/Login/InputOTP.test.tsx)
 - [`src/components/auth/Login/LoginForm.test.tsx`](../../src/components/auth/Login/LoginForm.test.tsx)
+- [`src/components/auth/Login/PosRecoveryCodeForm.test.tsx`](../../src/components/auth/Login/PosRecoveryCodeForm.test.tsx)
+- [`src/components/auth/Login/index.test.tsx`](../../src/components/auth/Login/index.test.tsx)
 - [`src/components/bulk-operations/BulkOperationsPreview.test.tsx`](../../src/components/bulk-operations/BulkOperationsPreview.test.tsx)
 - [`src/components/cash-controls/CashControlsDashboard.auth.test.tsx`](../../src/components/cash-controls/CashControlsDashboard.auth.test.tsx)
 - [`src/components/cash-controls/CashControlsDashboard.test.tsx`](../../src/components/cash-controls/CashControlsDashboard.test.tsx)

--- a/packages/athena-webapp/shared/auth.ts
+++ b/packages/athena-webapp/shared/auth.ts
@@ -1,3 +1,5 @@
 // Keep the provider id stable so existing Convex auth-account records continue
 // to work while Athena uses the shared MailerSend delivery path for OTPs.
 export const ATHENA_EMAIL_OTP_PROVIDER_ID = "resend-otp";
+export const ATHENA_POS_RECOVERY_CODE_PROVIDER_ID =
+  "athena-pos-recovery-code";

--- a/packages/athena-webapp/src/components/auth/Login/InputOTP.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/InputOTP.tsx
@@ -18,9 +18,8 @@ import { ATHENA_EMAIL_OTP_PROVIDER_ID } from "../../../../shared/auth";
 import { LoadingButton } from "~/src/components/ui/loading-button";
 import {
   ATHENA_AUTH_SYNC_FAILED_EVENT,
-  ATHENA_PENDING_AUTH_SYNC_EVENT,
-  PENDING_ATHENA_AUTH_SYNC_KEY,
 } from "~/src/lib/constants";
+import { startAthenaAuthSyncHandoff } from "./authSyncHandoff";
 import { useForm } from "react-hook-form";
 import { useEffect, useRef, useState } from "react";
 import { z } from "zod";
@@ -149,10 +148,9 @@ export function InputOTPForm({
         return;
       }
 
-      sessionStorage.setItem(PENDING_ATHENA_AUTH_SYNC_KEY, "1");
+      startAthenaAuthSyncHandoff();
       setIsAuthHandoffPending(true);
       setIsSigningIn(false);
-      window.dispatchEvent(new Event(ATHENA_PENDING_AUTH_SYNC_EVENT));
       navigate({ to: "/" });
       return;
     } catch (e) {

--- a/packages/athena-webapp/src/components/auth/Login/LoginForm.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/LoginForm.tsx
@@ -9,8 +9,10 @@ import { z } from "zod";
 import { ArrowRight } from "lucide-react";
 
 export function LoginForm({
+  onUsePosRecoveryCode,
   setStep,
 }: {
+  onUsePosRecoveryCode?: () => void;
   setStep: (step: { email: string }) => void;
 }) {
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -93,6 +95,15 @@ export function LoginForm({
           Continue
           <ArrowRight className="h-4 w-4 transition-transform duration-standard ease-emphasized group-hover:translate-x-1 group-focus-visible:translate-x-1" />
         </LoadingButton>
+        {onUsePosRecoveryCode ? (
+          <button
+            type="button"
+            className="relative z-10 text-sm text-muted-foreground underline-offset-4 transition-colors duration-standard ease-standard hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            onClick={onUsePosRecoveryCode}
+          >
+            Use POS recovery code
+          </button>
+        ) : null}
       </form>
     </div>
   );

--- a/packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.test.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.test.tsx
@@ -1,0 +1,166 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ATHENA_POS_RECOVERY_CODE_PROVIDER_ID } from "../../../../shared/auth";
+import {
+  ATHENA_AUTH_SYNC_FAILED_EVENT,
+  PENDING_ATHENA_AUTH_SYNC_KEY,
+} from "~/src/lib/constants";
+import { PosRecoveryCodeForm } from "./PosRecoveryCodeForm";
+
+const mocked = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  signIn: vi.fn(),
+}));
+
+vi.mock("@convex-dev/auth/react", () => ({
+  useAuthActions: () => ({ signIn: mocked.signIn }),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mocked.navigate,
+}));
+
+describe("PosRecoveryCodeForm", () => {
+  beforeEach(() => {
+    mocked.navigate.mockReset();
+    mocked.signIn.mockReset();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  it("signs in the POS account and starts the shared Athena auth-sync handoff", async () => {
+    const user = userEvent.setup();
+    mocked.signIn.mockResolvedValue({ signingIn: true });
+
+    render(
+      <PosRecoveryCodeForm
+        orgUrlSlug="wigclub"
+        redirectTo="/wigclub/store/wigclub/pos/register"
+        storeUrlSlug="wigclub"
+        onBack={vi.fn()}
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/recovery code/i), "abc-123");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() =>
+      expect(mocked.signIn).toHaveBeenCalledWith(
+        ATHENA_POS_RECOVERY_CODE_PROVIDER_ID,
+        {
+          code: "abc-123",
+          email: "pos@wigclub.store",
+          orgUrlSlug: "wigclub",
+          storeUrlSlug: "wigclub",
+        },
+      ),
+    );
+    expect(window.sessionStorage.setItem).toHaveBeenCalledWith(
+      PENDING_ATHENA_AUTH_SYNC_KEY,
+      "1",
+    );
+    expect(mocked.navigate).toHaveBeenCalledWith({
+      to: "/wigclub/store/wigclub/pos/register",
+    });
+    expect(window.localStorage.setItem).not.toHaveBeenCalledWith(
+      expect.any(String),
+      "abc-123",
+    );
+    expect(window.sessionStorage.setItem).not.toHaveBeenCalledWith(
+      expect.any(String),
+      "abc-123",
+    );
+  });
+
+  it("uses generic failure copy for rejected recovery sign-in", async () => {
+    const user = userEvent.setup();
+    mocked.signIn.mockResolvedValue({ signingIn: false });
+
+    render(
+      <PosRecoveryCodeForm
+        orgUrlSlug="wigclub"
+        storeUrlSlug="wigclub"
+        onBack={vi.fn()}
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/recovery code/i), "wrong-code");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    expect(
+      await screen.findByText(
+        "Sign-in details not recognized. Enter the recovery code again.",
+      ),
+    ).toBeInTheDocument();
+    expect(mocked.navigate).not.toHaveBeenCalled();
+  });
+
+  it("reenables the form when auth sync fails after provider success", async () => {
+    const user = userEvent.setup();
+    mocked.signIn.mockResolvedValue({ signingIn: true });
+
+    render(
+      <PosRecoveryCodeForm storeId="store-1" onBack={vi.fn()} />,
+    );
+
+    await user.type(screen.getByLabelText(/recovery code/i), "abc-123");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled(),
+    );
+
+    act(() => {
+      window.dispatchEvent(new Event(ATHENA_AUTH_SYNC_FAILED_EVENT));
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /continue/i })).toBeEnabled(),
+    );
+  });
+
+  it("falls back to home when the redirect target is external", async () => {
+    const user = userEvent.setup();
+    mocked.signIn.mockResolvedValue({ signingIn: true });
+
+    render(
+      <PosRecoveryCodeForm
+        orgUrlSlug="wigclub"
+        redirectTo="//attacker.example/pos"
+        storeUrlSlug="wigclub"
+        onBack={vi.fn()}
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/recovery code/i), "abc-123");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() => expect(mocked.navigate).toHaveBeenCalledWith({ to: "/" }));
+  });
+
+  it("navigates query-bearing recovery redirects with separate search params", async () => {
+    const user = userEvent.setup();
+    mocked.signIn.mockResolvedValue({ signingIn: true });
+
+    render(
+      <PosRecoveryCodeForm
+        orgUrlSlug="wigclub"
+        redirectTo="/wigclub/store/wigclub/pos/register?drawer=front"
+        storeUrlSlug="wigclub"
+        onBack={vi.fn()}
+      />,
+    );
+
+    await user.type(screen.getByLabelText(/recovery code/i), "abc-123");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() =>
+      expect(mocked.navigate).toHaveBeenCalledWith({
+        to: "/wigclub/store/wigclub/pos/register",
+        search: { drawer: "front" },
+      }),
+    );
+  });
+});

--- a/packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.tsx
@@ -1,0 +1,191 @@
+import { useAuthActions } from "@convex-dev/auth/react";
+import { useNavigate } from "@tanstack/react-router";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { ATHENA_POS_RECOVERY_CODE_PROVIDER_ID } from "../../../../shared/auth";
+import { Input } from "../../ui/input";
+import { LoadingButton } from "../../ui/loading-button";
+import { ATHENA_AUTH_SYNC_FAILED_EVENT } from "~/src/lib/constants";
+import { startAthenaAuthSyncHandoff } from "./authSyncHandoff";
+
+const POS_RECOVERY_ACCOUNT_EMAIL = "pos@wigclub.store";
+const RECOVERY_FAILURE_COPY =
+  "Sign-in details not recognized. Enter the recovery code again.";
+
+function navigationTargetForRedirect(redirectTo: string) {
+  const [pathname, queryString] = redirectTo.split("?", 2);
+  if (!queryString) {
+    return { to: pathname };
+  }
+
+  return {
+    to: pathname,
+    search: Object.fromEntries(new URLSearchParams(queryString)),
+  };
+}
+
+export function PosRecoveryCodeForm({
+  onBack,
+  orgUrlSlug,
+  redirectTo,
+  storeId,
+  storeUrlSlug,
+}: {
+  onBack: () => void;
+  orgUrlSlug?: string | null;
+  redirectTo?: string | null;
+  storeId?: string | null;
+  storeUrlSlug?: string | null;
+}) {
+  const [code, setCode] = useState("");
+  const [isSigningIn, setIsSigningIn] = useState(false);
+  const [isAuthHandoffPending, setIsAuthHandoffPending] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const signInInFlightRef = useRef(false);
+  const { signIn } = useAuthActions();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const handleAuthSyncFailed = () => {
+      signInInFlightRef.current = false;
+      setIsSigningIn(false);
+      setIsAuthHandoffPending(false);
+    };
+
+    window.addEventListener(ATHENA_AUTH_SYNC_FAILED_EVENT, handleAuthSyncFailed);
+    return () =>
+      window.removeEventListener(
+        ATHENA_AUTH_SYNC_FAILED_EVENT,
+        handleAuthSyncFailed,
+      );
+  }, []);
+
+  const canSubmit =
+    Boolean(storeId || (orgUrlSlug && storeUrlSlug)) &&
+    code.trim().length > 0 &&
+    !isSigningIn &&
+    !isAuthHandoffPending;
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (
+      !canSubmit ||
+      signInInFlightRef.current ||
+      (!storeId && (!orgUrlSlug || !storeUrlSlug))
+    ) {
+      return;
+    }
+
+    try {
+      signInInFlightRef.current = true;
+      setIsSigningIn(true);
+      setErrorMessage(null);
+
+      const payload: Record<string, string> = {
+        code: code.trim(),
+        email: POS_RECOVERY_ACCOUNT_EMAIL,
+      };
+      if (storeId) {
+        payload.storeId = storeId;
+      }
+      if (orgUrlSlug && storeUrlSlug) {
+        payload.orgUrlSlug = orgUrlSlug;
+        payload.storeUrlSlug = storeUrlSlug;
+      }
+
+      const result = await signIn(ATHENA_POS_RECOVERY_CODE_PROVIDER_ID, payload);
+
+      if (!result.signingIn) {
+        setErrorMessage(RECOVERY_FAILURE_COPY);
+        signInInFlightRef.current = false;
+        setIsSigningIn(false);
+        setIsAuthHandoffPending(false);
+        return;
+      }
+
+      const targetPath = startAthenaAuthSyncHandoff(redirectTo);
+      setIsAuthHandoffPending(true);
+      setIsSigningIn(false);
+      navigate(navigationTargetForRedirect(targetPath) as never);
+    } catch {
+      setErrorMessage(RECOVERY_FAILURE_COPY);
+      signInInFlightRef.current = false;
+      setIsSigningIn(false);
+      setIsAuthHandoffPending(false);
+    }
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-layout-lg">
+      <div className="space-y-layout-md">
+        <h2 className="bg-background font-display text-2xl font-light uppercase tracking-[0.18em] text-foreground">
+          POS recovery
+        </h2>
+        <p className="w-fit bg-background text-sm leading-6 text-muted-foreground">
+          Sign in the POS account with the recovery code.
+        </p>
+        <button
+          type="button"
+          className="group inline-flex items-center gap-layout-xs text-sm text-muted-foreground underline-offset-4 transition-colors duration-standard ease-standard hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          onClick={onBack}
+        >
+          <ArrowLeft className="h-3.5 w-3.5 transition-transform duration-standard ease-emphasized group-hover:-translate-x-1 group-focus-visible:-translate-x-1" />
+          Use email code
+        </button>
+      </div>
+
+      <form
+        className="relative flex w-full flex-col items-start gap-layout-md overflow-hidden rounded-lg border border-none bg-background p-layout-xs before:pointer-events-none before:absolute before:inset-0"
+        onSubmit={handleSubmit}
+      >
+        <div className="relative z-10 flex w-full flex-col gap-layout-sm">
+          <label className="text-sm font-medium text-foreground" htmlFor="pos-recovery-account">
+            POS account
+          </label>
+          <Input
+            id="pos-recovery-account"
+            value={POS_RECOVERY_ACCOUNT_EMAIL}
+            readOnly
+            className="h-control-standard border-border/80 bg-background shadow-[inset_0_1px_0_hsl(var(--background)/0.85)]"
+          />
+        </div>
+
+        <div className="relative z-10 flex w-full flex-col gap-layout-sm">
+          <label className="text-sm font-medium text-foreground" htmlFor="pos-recovery-code">
+            Recovery code
+          </label>
+          <Input
+            id="pos-recovery-code"
+            autoComplete="off"
+            inputMode="text"
+            value={code}
+            onChange={(event) => setCode(event.target.value)}
+            className="h-control-standard border-border/80 bg-background shadow-[inset_0_1px_0_hsl(var(--background)/0.85)]"
+          />
+        </div>
+
+        <div className="relative z-10 min-h-5 px-layout-xs">
+          {errorMessage ? (
+            <span className="text-sm text-destructive">{errorMessage}</span>
+          ) : null}
+          {!storeId && (!orgUrlSlug || !storeUrlSlug) ? (
+            <span className="text-sm text-muted-foreground">
+              Open recovery from the store login route.
+            </span>
+          ) : null}
+        </div>
+
+        <LoadingButton
+          isLoading={isSigningIn}
+          disabled={!canSubmit}
+          type="submit"
+          className="group relative z-10 h-control-standard w-fit shadow-[0_16px_34px_-22px_hsl(var(--signal)/0.72)]"
+        >
+          Continue
+          <ArrowRight className="h-4 w-4 transition-transform duration-standard ease-emphasized group-hover:translate-x-1 group-focus-visible:translate-x-1" />
+        </LoadingButton>
+      </form>
+    </div>
+  );
+}

--- a/packages/athena-webapp/src/components/auth/Login/authSyncHandoff.ts
+++ b/packages/athena-webapp/src/components/auth/Login/authSyncHandoff.ts
@@ -1,0 +1,19 @@
+import {
+  ATHENA_PENDING_AUTH_SYNC_EVENT,
+  PENDING_ATHENA_AUTH_SYNC_KEY,
+} from "~/src/lib/constants";
+
+function normalizeAuthSyncRedirect(redirectTo?: string | null) {
+  if (!redirectTo?.startsWith("/") || redirectTo.startsWith("//")) {
+    return "/";
+  }
+
+  return redirectTo;
+}
+
+export function startAthenaAuthSyncHandoff(redirectTo?: string | null) {
+  sessionStorage.setItem(PENDING_ATHENA_AUTH_SYNC_KEY, "1");
+  window.dispatchEvent(new Event(ATHENA_PENDING_AUTH_SYNC_EVENT));
+
+  return normalizeAuthSyncRedirect(redirectTo);
+}

--- a/packages/athena-webapp/src/components/auth/Login/index.test.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/index.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ATHENA_POS_RECOVERY_CODE_PROVIDER_ID } from "../../../../shared/auth";
+import { Login } from "./index";
+
+const mocked = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  signIn: vi.fn(),
+  useSearch: vi.fn(),
+}));
+
+vi.mock("@convex-dev/auth/react", () => ({
+  useAuthActions: () => ({ signIn: mocked.signIn }),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mocked.navigate,
+  useSearch: mocked.useSearch,
+}));
+
+describe("Login", () => {
+  beforeEach(() => {
+    mocked.navigate.mockReset();
+    mocked.signIn.mockReset();
+    mocked.useSearch.mockReset();
+    window.sessionStorage.clear();
+  });
+
+  it("passes POS route scope from redirectTo into recovery-code sign-in", async () => {
+    const user = userEvent.setup();
+    mocked.signIn.mockResolvedValue({ signingIn: true });
+    mocked.useSearch.mockReturnValue({
+      redirectTo: "/wigclub/store/wigclub/pos/register",
+    });
+
+    render(<Login />);
+
+    await user.click(
+      screen.getByRole("button", { name: /use pos recovery code/i }),
+    );
+    await user.type(screen.getByLabelText(/recovery code/i), "abc-123");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() =>
+      expect(mocked.signIn).toHaveBeenCalledWith(
+        ATHENA_POS_RECOVERY_CODE_PROVIDER_ID,
+        {
+          code: "abc-123",
+          email: "pos@wigclub.store",
+          orgUrlSlug: "wigclub",
+          storeUrlSlug: "wigclub",
+        },
+      ),
+    );
+    expect(mocked.navigate).toHaveBeenCalledWith({
+      to: "/wigclub/store/wigclub/pos/register",
+    });
+  });
+
+  it("disables recovery-code submission when redirectTo is not a POS route", async () => {
+    const user = userEvent.setup();
+    mocked.useSearch.mockReturnValue({ redirectTo: "/login" });
+
+    render(<Login />);
+
+    await user.click(
+      screen.getByRole("button", { name: /use pos recovery code/i }),
+    );
+    await user.type(screen.getByLabelText(/recovery code/i), "abc-123");
+
+    expect(
+      screen.getByText("Open recovery from the store login route."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /continue/i })).toBeDisabled();
+    expect(mocked.signIn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/athena-webapp/src/components/auth/Login/index.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/index.tsx
@@ -1,12 +1,52 @@
 import { useState } from "react";
 import { LoginForm } from "./LoginForm";
 import { InputOTPForm } from "./InputOTP";
+import { PosRecoveryCodeForm } from "./PosRecoveryCodeForm";
+import { useSearch } from "@tanstack/react-router";
+
+const POS_ROUTE_PATTERN =
+  /^\/(?<orgUrlSlug>[^/]+)\/store\/(?<storeUrlSlug>[^/]+)\/pos(?:\/.*)?$/;
+
+function getPosRouteScope(redirectTo?: string) {
+  const match = redirectTo?.match(POS_ROUTE_PATTERN);
+  const groups = match?.groups;
+  if (!groups?.orgUrlSlug || !groups.storeUrlSlug) {
+    return null;
+  }
+
+  return {
+    orgUrlSlug: groups.orgUrlSlug,
+    storeUrlSlug: groups.storeUrlSlug,
+  };
+}
 
 export function Login() {
-  const [step, setStep] = useState<"signIn" | { email: string }>("signIn");
+  const [step, setStep] = useState<"signIn" | "posRecovery" | { email: string }>(
+    "signIn",
+  );
+  const search = useSearch({ strict: false }) as
+    | { redirectTo?: string; storeId?: string }
+    | undefined;
+  const posRouteScope = getPosRouteScope(search?.redirectTo);
 
   if (step === "signIn") {
-    return <LoginForm setStep={setStep} />;
+    return (
+      <LoginForm
+        setStep={setStep}
+        onUsePosRecoveryCode={() => setStep("posRecovery")}
+      />
+    );
+  }
+  if (step === "posRecovery") {
+    return (
+      <PosRecoveryCodeForm
+        orgUrlSlug={posRouteScope?.orgUrlSlug ?? null}
+        redirectTo={search?.redirectTo ?? null}
+        storeId={search?.storeId ?? null}
+        storeUrlSlug={posRouteScope?.storeUrlSlug ?? null}
+        onBack={() => setStep("signIn")}
+      />
+    );
   }
   return (
     <InputOTPForm email={step.email} onBack={() => setStep("signIn")} />

--- a/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
@@ -11,7 +11,11 @@ import userEvent from "@testing-library/user-event";
 const mocks = vi.hoisted(() => ({
   generateBrowserFingerprint: vi.fn(),
   registerTerminalMutation: vi.fn(),
+  rotateRecoveryCode: vi.fn(),
+  revokeRecoveryCode: vi.fn(),
+  unlockRecoveryCode: vi.fn(),
   useMutation: vi.fn(),
+  usePermissions: vi.fn(),
   useQuery: vi.fn(),
 }));
 
@@ -22,6 +26,10 @@ vi.mock("convex/react", () => ({
 
 vi.mock("@/hooks/useGetActiveStore", () => ({
   default: () => ({ activeStore: { _id: "store-1" } }),
+}));
+
+vi.mock("@/hooks/usePermissions", () => ({
+  usePermissions: mocks.usePermissions,
 }));
 
 vi.mock("@tanstack/react-router", () => ({
@@ -50,7 +58,19 @@ vi.mock("@tanstack/react-router", () => ({
 }));
 
 vi.mock("~/convex/_generated/api", () => ({
-  api: { inventory: { posTerminal: {} } },
+  api: {
+    inventory: { posTerminal: {} },
+    pos: {
+      public: {
+        posRecoveryCodes: {
+          getRecoveryCodeStatus: "getRecoveryCodeStatus",
+          rotateRecoveryCode: "rotateRecoveryCode",
+          revokeRecoveryCode: "revokeRecoveryCode",
+          unlockRecoveryCode: "unlockRecoveryCode",
+        },
+      },
+    },
+  },
 }));
 
 vi.mock("@/components/ui/input", () => ({
@@ -112,8 +132,33 @@ describe("registerAndProvisionPosTerminal", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     window.localStorage.clear();
-    mocks.useMutation.mockReturnValue(mocks.registerTerminalMutation);
-    mocks.useQuery.mockReturnValue(null);
+    mocks.rotateRecoveryCode.mockResolvedValue({
+      code: "abc123-def456",
+      credential: { status: "active" },
+    });
+    mocks.revokeRecoveryCode.mockResolvedValue({ status: "revoked" });
+    mocks.unlockRecoveryCode.mockResolvedValue({ status: "active" });
+    mocks.useMutation.mockImplementation((ref) => {
+      if (ref === "rotateRecoveryCode") return mocks.rotateRecoveryCode;
+      if (ref === "revokeRecoveryCode") return mocks.revokeRecoveryCode;
+      if (ref === "unlockRecoveryCode") return mocks.unlockRecoveryCode;
+      return mocks.registerTerminalMutation;
+    });
+    mocks.usePermissions.mockReturnValue({
+      hasFullAdminAccess: true,
+      isLoading: false,
+    });
+    mocks.useQuery.mockImplementation((ref) =>
+      ref === "getRecoveryCodeStatus"
+        ? {
+            failedAttemptCount: 0,
+            lastUsedAt: undefined,
+            lockedUntil: undefined,
+            rotatedAt: 1,
+            status: "active",
+          }
+        : null,
+    );
     mocks.generateBrowserFingerprint.mockResolvedValue({
       browserInfo: { userAgent: "test" },
       fingerprintHash: "fingerprint-1",
@@ -261,6 +306,95 @@ describe("registerAndProvisionPosTerminal", () => {
         syncSecretHash: "01020304",
         terminalId: "fingerprint-1",
       }),
+    );
+  });
+
+  it("lets full admins rotate the POS recovery code and shows plaintext once", async () => {
+    const user = userEvent.setup();
+
+    render(<POSSettingsView />);
+
+    await user.click(
+      await screen.findByRole("button", { name: /rotate recovery code/i }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.rotateRecoveryCode).toHaveBeenCalledWith({
+        storeId: "store-1",
+      }),
+    );
+    expect(screen.getByText("abc123-def456")).toBeInTheDocument();
+  });
+
+  it("lets full admins unlock a locked POS recovery code", async () => {
+    const user = userEvent.setup();
+    mocks.useQuery.mockImplementation((ref) =>
+      ref === "getRecoveryCodeStatus"
+        ? {
+            failedAttemptCount: 5,
+            lastUsedAt: undefined,
+            lockedUntil: Date.now() + 60_000,
+            rotatedAt: 1,
+            status: "locked",
+          }
+        : null,
+    );
+
+    render(<POSSettingsView />);
+
+    await user.click(await screen.findByRole("button", { name: /unlock/i }));
+
+    await waitFor(() =>
+      expect(mocks.unlockRecoveryCode).toHaveBeenCalledWith({
+        storeId: "store-1",
+      }),
+    );
+  });
+
+  it("lets full admins revoke an active POS recovery code", async () => {
+    const user = userEvent.setup();
+
+    render(<POSSettingsView />);
+
+    await user.click(await screen.findByRole("button", { name: /revoke/i }));
+
+    await waitFor(() =>
+      expect(mocks.revokeRecoveryCode).toHaveBeenCalledWith({
+        storeId: "store-1",
+      }),
+    );
+  });
+
+  it("disables revoke for revoked POS recovery codes", async () => {
+    mocks.useQuery.mockImplementation((ref) =>
+      ref === "getRecoveryCodeStatus"
+        ? {
+            failedAttemptCount: 0,
+            lastUsedAt: undefined,
+            lockedUntil: undefined,
+            rotatedAt: 1,
+            status: "revoked",
+          }
+        : null,
+    );
+
+    render(<POSSettingsView />);
+
+    expect(await screen.findByRole("button", { name: /revoke/i })).toBeDisabled();
+  });
+
+  it("hides recovery-code management from non-full-admin accounts", async () => {
+    mocks.usePermissions.mockReturnValue({
+      hasFullAdminAccess: false,
+      isLoading: false,
+    });
+
+    render(<POSSettingsView />);
+
+    expect(screen.queryByText("POS recovery code")).not.toBeInTheDocument();
+    expect(mocks.useQuery).toHaveBeenCalledWith(
+      "getRecoveryCodeStatus",
+      "skip",
     );
   });
 

--- a/packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx
+++ b/packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx
@@ -20,6 +20,7 @@ import {
   registerAndProvisionPosTerminal,
   type ProvisionedTerminalRecord,
 } from "@/lib/pos/application/registerAndProvisionPosTerminal";
+import { usePermissions } from "@/hooks/usePermissions";
 
 type HealthLinkProps = {
   children: ReactNode;
@@ -170,6 +171,199 @@ function FingerprintRegistrationCard({
               {primaryActionLabel}
             </LoadingButton>
           )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function formatRecoveryTimestamp(value?: number | null) {
+  if (!value) {
+    return "Not recorded";
+  }
+
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function POSRecoveryCodeAdminPanel({
+  storeId,
+}: {
+  storeId?: string | null;
+}) {
+  const { hasFullAdminAccess, isLoading } = usePermissions();
+  const status = useQuery(
+    api.pos.public.posRecoveryCodes.getRecoveryCodeStatus,
+    !isLoading && hasFullAdminAccess && storeId
+      ? { storeId: storeId as never }
+      : "skip",
+  ) as
+    | {
+        failedAttemptCount: number;
+        lastUsedAt?: number;
+        lockedUntil?: number;
+        rotatedAt: number;
+        status: "active" | "locked" | "revoked";
+      }
+    | null
+    | undefined;
+  const rotateRecoveryCode = useMutation(
+    api.pos.public.posRecoveryCodes.rotateRecoveryCode,
+  );
+  const unlockRecoveryCode = useMutation(
+    api.pos.public.posRecoveryCodes.unlockRecoveryCode,
+  );
+  const revokeRecoveryCode = useMutation(
+    api.pos.public.posRecoveryCodes.revokeRecoveryCode,
+  );
+  const [isRotating, setIsRotating] = useState(false);
+  const [isUnlocking, setIsUnlocking] = useState(false);
+  const [isRevoking, setIsRevoking] = useState(false);
+  const [revealedCode, setRevealedCode] = useState<string | null>(null);
+
+  const handleRotate = async () => {
+    if (!storeId) {
+      toast.error("Select a store before managing POS recovery codes");
+      return;
+    }
+    setIsRotating(true);
+    setRevealedCode(null);
+    try {
+      const result = await rotateRecoveryCode({ storeId: storeId as never });
+      setRevealedCode(result.code);
+      toast.success("POS recovery code rotated");
+    } catch (error) {
+      console.error(error);
+      toast.error("Unable to rotate POS recovery code");
+    } finally {
+      setIsRotating(false);
+    }
+  };
+
+  const handleUnlock = async () => {
+    if (!storeId) {
+      return;
+    }
+    setIsUnlocking(true);
+    try {
+      await unlockRecoveryCode({ storeId: storeId as never });
+      toast.success("POS recovery code unlocked");
+    } catch (error) {
+      console.error(error);
+      toast.error("Unable to unlock POS recovery code");
+    } finally {
+      setIsUnlocking(false);
+    }
+  };
+
+  const handleRevoke = async () => {
+    if (!storeId) {
+      return;
+    }
+    setIsRevoking(true);
+    setRevealedCode(null);
+    try {
+      await revokeRecoveryCode({ storeId: storeId as never });
+      toast.success("POS recovery code revoked");
+    } catch (error) {
+      console.error(error);
+      toast.error("Unable to revoke POS recovery code");
+    } finally {
+      setIsRevoking(false);
+    }
+  };
+
+  if (isLoading || !hasFullAdminAccess) {
+    return null;
+  }
+
+  const statusLabel = status?.status ?? "not configured";
+
+  return (
+    <section className="grid gap-layout-xl border-b border-border py-layout-2xl lg:grid-cols-[17rem_minmax(0,1fr)]">
+      <div className="space-y-layout-sm">
+        <h2 className="text-2xl font-medium text-foreground">
+          POS recovery code
+        </h2>
+        <p className="text-sm leading-6 text-muted-foreground">
+          Manage the recovery code for the shared POS app account. Athena shows
+          a new code only when it is created or rotated.
+        </p>
+      </div>
+
+      <div className="space-y-layout-lg">
+        <div className="flex flex-wrap gap-layout-xs">
+          <span className="inline-flex rounded-full border border-border bg-background px-layout-sm py-layout-2xs text-sm text-muted-foreground">
+            {statusLabel}
+          </span>
+          <span className="inline-flex rounded-full border border-border bg-background px-layout-sm py-layout-2xs text-sm text-muted-foreground">
+            Rotated {formatRecoveryTimestamp(status?.rotatedAt)}
+          </span>
+          <span className="inline-flex rounded-full border border-border bg-background px-layout-sm py-layout-2xs text-sm text-muted-foreground">
+            Used {formatRecoveryTimestamp(status?.lastUsedAt)}
+          </span>
+        </div>
+
+        {revealedCode ? (
+          <div
+            className="rounded-md border border-signal/30 bg-signal/10 px-layout-md py-layout-sm"
+            role="status"
+          >
+            <p className="text-sm font-medium text-foreground">
+              New recovery code
+            </p>
+            <p className="mt-layout-xs font-mono text-lg tracking-wide text-foreground">
+              {revealedCode}
+            </p>
+            <p className="mt-layout-xs text-sm text-muted-foreground">
+              Store this with the field operations runbook. It will not be shown
+              again.
+            </p>
+          </div>
+        ) : null}
+
+        <div className="grid gap-layout-sm text-sm text-muted-foreground sm:grid-cols-3">
+          <div>
+            <p className="font-medium text-foreground">Failed attempts</p>
+            <p>{status?.failedAttemptCount ?? 0}</p>
+          </div>
+          <div>
+            <p className="font-medium text-foreground">Lockout</p>
+            <p>{formatRecoveryTimestamp(status?.lockedUntil)}</p>
+          </div>
+          <div>
+            <p className="font-medium text-foreground">Plaintext</p>
+            <p>Shown only after rotate</p>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-layout-sm border-t border-border pt-layout-md">
+          <LoadingButton
+            isLoading={isRotating}
+            disabled={!storeId || isRotating}
+            onClick={handleRotate}
+            variant="default"
+          >
+            {status ? "Rotate recovery code" : "Create recovery code"}
+          </LoadingButton>
+          <LoadingButton
+            isLoading={isUnlocking}
+            disabled={!storeId || status?.status !== "locked" || isUnlocking}
+            onClick={handleUnlock}
+            variant="outline"
+          >
+            Unlock
+          </LoadingButton>
+          <LoadingButton
+            isLoading={isRevoking}
+            disabled={!storeId || !status || status.status === "revoked" || isRevoking}
+            onClick={handleRevoke}
+            variant="outline"
+          >
+            Revoke
+          </LoadingButton>
         </div>
       </div>
     </section>
@@ -458,6 +652,8 @@ export function POSSettingsView({
               }
             />
           </section>
+
+          <POSRecoveryCodeAdminPanel storeId={activeStore?._id ?? null} />
 
           <section className="grid gap-layout-xl border-b border-border py-layout-2xl lg:grid-cols-[17rem_minmax(0,1fr)]">
             <div className="space-y-layout-sm">

--- a/packages/athena-webapp/src/routes/_authed.test.tsx
+++ b/packages/athena-webapp/src/routes/_authed.test.tsx
@@ -575,7 +575,6 @@ describe("Authed layout", () => {
     ["/wigclub/store/wigclub/cash-controls", "Cash Controls"],
     ["/wigclub/admin", "Admin"],
     ["/wigclub/store/wigclub/settings", "Store Settings"],
-    ["/wigclub/store/wigclub/pos/settings", "POS Settings"],
   ])(
     "redirects %s when the app session is gone even if a POS terminal seed exists",
     async (pathname) => {
@@ -598,6 +597,96 @@ describe("Authed layout", () => {
       );
     },
   );
+
+  it("redirects signed-out POS routes to login with the original POS path", async () => {
+    mocked.useAuth.mockReturnValue({
+      user: null,
+      isLoading: false,
+    });
+    mocked.useLocalPosEntryContext.mockReturnValue(readyLocalPosEntryContext());
+    mocked.usePosTerminalAppSessionRecovery.mockReturnValue(
+      recoveryState("not_recoverable"),
+    );
+    mocked.useRouterState.mockImplementation(({ select }) =>
+      select({
+        location: { pathname: "/wigclub/store/wigclub/pos/register" },
+      }),
+    );
+
+    const { container } = render(<Layout />);
+
+    expect(container).toBeEmptyDOMElement();
+    await waitFor(() =>
+      expect(mocked.navigate).toHaveBeenCalledWith({
+        to: "/login",
+        search: { redirectTo: "/wigclub/store/wigclub/pos/register" },
+      }),
+    );
+  });
+
+  it("keeps query parameters for signed-out POS redirects on matched router paths", async () => {
+    mocked.useAuth.mockReturnValue({
+      user: null,
+      isLoading: false,
+    });
+    mocked.useLocalPosEntryContext.mockReturnValue(readyLocalPosEntryContext());
+    mocked.usePosTerminalAppSessionRecovery.mockReturnValue(
+      recoveryState("not_recoverable"),
+    );
+    mocked.useRouterState.mockImplementation(({ select }) =>
+      select({
+        location: { pathname: "/wigclub/store/wigclub/pos/register" },
+      }),
+    );
+    window.history.replaceState(
+      {},
+      "",
+      "/wigclub/store/wigclub/pos/register?drawer=front",
+    );
+
+    const { container } = render(<Layout />);
+
+    expect(container).toBeEmptyDOMElement();
+    await waitFor(() =>
+      expect(mocked.navigate).toHaveBeenCalledWith({
+        to: "/login",
+        search: {
+          redirectTo: "/wigclub/store/wigclub/pos/register?drawer=front",
+        },
+      }),
+    );
+  });
+
+  it("uses the browser pathname for signed-out POS redirects while the router path is unknown", async () => {
+    mocked.useAuth.mockReturnValue({
+      user: null,
+      isLoading: false,
+    });
+    mocked.useLocalPosEntryContext.mockReturnValue(readyLocalPosEntryContext());
+    mocked.usePosTerminalAppSessionRecovery.mockReturnValue(
+      recoveryState("not_recoverable"),
+    );
+    mocked.useRouterState.mockImplementation(({ select }) =>
+      select({ location: { pathname: "/" } }),
+    );
+    window.history.replaceState(
+      {},
+      "",
+      "/wigclub/store/wigclub/pos/register?drawer=front",
+    );
+
+    const { container } = render(<Layout />);
+
+    expect(container).toBeEmptyDOMElement();
+    await waitFor(() =>
+      expect(mocked.navigate).toHaveBeenCalledWith({
+        to: "/login",
+        search: {
+          redirectTo: "/wigclub/store/wigclub/pos/register?drawer=front",
+        },
+      }),
+    );
+  });
 
   it("renders a safe blocked POS shell when terminal continuity is not recoverable", () => {
     mocked.useAuth.mockReturnValue({

--- a/packages/athena-webapp/src/routes/_authed.tsx
+++ b/packages/athena-webapp/src/routes/_authed.tsx
@@ -98,6 +98,22 @@ function getBrowserPathname() {
   return typeof window === "undefined" ? "" : window.location.pathname;
 }
 
+function getBrowserPathWithSearch() {
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  return `${window.location.pathname}${window.location.search}`;
+}
+
+function getRedirectPathWithSearch(pathname: string, browserPathWithSearch: string) {
+  if (typeof window === "undefined" || window.location.pathname !== pathname) {
+    return pathname;
+  }
+
+  return browserPathWithSearch;
+}
+
 function isUnknownRouterPath(pathname?: string) {
   return !pathname || pathname === "/";
 }
@@ -386,6 +402,7 @@ export default function Layout() {
   });
   const { isLoading, user } = useAuth();
   const browserPathname = getBrowserPathname();
+  const browserPathWithSearch = getBrowserPathWithSearch();
   const routerPosHubParams = getPosHubRouteParams(pathname);
   const browserPosHubParams = getPosHubRouteParams(browserPathname);
   const routeParams =
@@ -482,9 +499,24 @@ export default function Layout() {
     }
 
     if (!isLoading && user === null) {
-      navigate({ to: "/login" });
+      const redirectTo = isUnknownRouterPath(pathname)
+        ? browserPathWithSearch
+        : getRedirectPathWithSearch(pathname, browserPathWithSearch);
+      const loginTarget = routeWantsPos
+        ? {
+            to: "/login" as const,
+            search: {
+              redirectTo,
+            } as never,
+          }
+        : { to: "/login" as const };
+      navigate(loginTarget);
     }
   }, [
+    browserPathname,
+    browserPathWithSearch,
+    pathname,
+    routeWantsPos,
     shouldRenderPosTerminalShell,
     shouldRenderPendingPosTerminalShell,
     isBlockedPosAppSession,

--- a/scripts/preview-worktree.test.ts
+++ b/scripts/preview-worktree.test.ts
@@ -57,7 +57,9 @@ describe("preview-worktree", () => {
     const first = await startPreview(previewOptions(stateDir, worktreeRoot));
     const second = await startPreview(previewOptions(stateDir, worktreeRoot));
 
-    expect(first.url).toBe("http://127.0.0.1:5701/");
+    expect(first.port).toBeGreaterThanOrEqual(5701);
+    expect(first.port).toBeLessThanOrEqual(5710);
+    expect(first.url).toBe(`http://127.0.0.1:${first.port}/`);
     expect(second).toMatchObject({
       port: first.port,
       reused: true,
@@ -76,11 +78,14 @@ describe("preview-worktree", () => {
     const first = await startPreview(previewOptions(stateDir, worktreeOne));
     const second = await startPreview(previewOptions(stateDir, worktreeTwo));
 
-    expect(first.port).toBe(5701);
-    expect(second.port).toBe(5702);
+    expect(first.port).toBeGreaterThanOrEqual(5701);
+    expect(first.port).toBeLessThanOrEqual(5710);
+    expect(second.port).toBeGreaterThanOrEqual(5701);
+    expect(second.port).toBeLessThanOrEqual(5710);
+    expect(second.port).not.toBe(first.port);
     expect(await listPreviews({ stateDir })).toEqual([
-      expect.objectContaining({ port: 5701, worktreeRoot: real(worktreeOne) }),
-      expect.objectContaining({ port: 5702, worktreeRoot: real(worktreeTwo) }),
+      expect.objectContaining({ port: first.port, worktreeRoot: real(worktreeOne) }),
+      expect.objectContaining({ port: second.port, worktreeRoot: real(worktreeTwo) }),
     ]);
 
     await stopPreview(previewOptions(stateDir, worktreeOne));
@@ -115,7 +120,9 @@ describe("preview-worktree", () => {
 
     const preview = await startPreview(previewOptions(stateDir, worktreeRoot));
 
-    expect(preview.port).toBe(5701);
+    expect(preview.port).toBeGreaterThanOrEqual(5701);
+    expect(preview.port).toBeLessThanOrEqual(5710);
+    expect(preview.port).not.toBe(5704);
     expect(preview.reused).toBe(false);
 
     await stopPreview(previewOptions(stateDir, worktreeRoot));
@@ -187,8 +194,9 @@ describe("preview-worktree", () => {
     await runPreviewCli(["list", "athena"], env, worktreeRoot, (line) => output.push(line));
     await runPreviewCli(["stop", "athena"], env, worktreeRoot, (line) => output.push(line));
 
-    expect(output[0]).toBe("http://127.0.0.1:5701/");
+    expect(output[0]).toMatch(/^http:\/\/127\.0\.0\.1:57\d{2}\/$/);
     expect(output[1]).toContain(`${real(worktreeRoot)} pid=`);
+    expect(output[1]).toContain(output[0]);
     expect(output[2]).toBe("Stopped preview.");
   });
 


### PR DESCRIPTION
## Summary
- add a scoped Convex Auth credentials provider for POS recovery-code login
- add full-admin recovery-code lifecycle management in POS settings
- preserve POS redirects through fresh-browser recovery login and share the auth sync handoff with OTP
- store only hashed recovery-code material and audit create/rotate/revoke/unlock/success/failure boundaries

## Linear
- V26-654
- V26-655
- V26-656
- V26-657
- V26-658
- V26-659

## Validation
- `bun run pr:athena` passed locally
- pre-push validation passed on push, including graphify, harness review, coverage, changed lints, build, mapped POS/auth tests, and runtime behavior scenarios
- focused reviewer loop reached unanimous approval across security, correctness, testing, and standards reviewers

## Deploy
- No prod deploy requested or performed
