### PR TITLE
Deliver POS operations access controls

### DIFF
--- a/docs/solutions/logic-errors/athena-terminal-manager-elevation-command-boundary-2026-05-10.md
+++ b/docs/solutions/logic-errors/athena-terminal-manager-elevation-command-boundary-2026-05-10.md
@@ -38,7 +38,7 @@ Keep terminal elevation in its own table and capability path.
 - Scope elevation by store, organization, terminal, signed-in Athena account, manager staff profile, credential, creation time, expiry, and end state.
 - Authenticate elevation through active staff credentials with an active `manager` role for the current store.
 - Query active elevation server-side; refresh should preserve only unexpired, unended records.
-- Combine active elevation with account role in capability helpers. Elevation may unlock approved store-day surfaces, but it must not change the underlying account role or make `hasFullAdminAccess` true.
+- Combine active elevation with account role in capability helpers. POS-only accounts may open approved store-day surfaces directly; elevation may also unlock those surfaces for the current account, but it must not change the underlying account role or make `hasFullAdminAccess` true.
 - Keep procurement, analytics, configuration, organization members, storefront admin, services admin, bulk operations, promo codes, and reviews admin tied to `full_admin`.
 - Keep protected mutations on the existing command approval rail. Elevation state is not an `approvalProofId`, does not satisfy action/subject binding, and is never trusted from the browser as command authority.
 - Record operational events for elevation lifecycle transitions so operator-facing access changes are auditable.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1813 files · ~0 words
+- 1814 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6050 nodes · 6491 edges · 1741 communities detected
+- 6057 nodes · 6492 edges · 1742 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1751,6 +1751,7 @@
 - [[_COMMUNITY_Community 1738|Community 1738]]
 - [[_COMMUNITY_Community 1739|Community 1739]]
 - [[_COMMUNITY_Community 1740|Community 1740]]
+- [[_COMMUNITY_Community 1741|Community 1741]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1780,7 +1781,7 @@
 
 ### Community 0 - "Community 0"
 Cohesion: 0.04
-Nodes (50): buildDailyCloseTransactionSearch(), canReopenDailyClose(), cn(), formatDailyCloseMoney(), formatMetadataDisplayValue(), formatMetadataValue(), formatTimestampMetadata(), getBucketConfigs() (+42 more)
+Nodes (51): buildDailyCloseTransactionSearch(), canReopenDailyClose(), cn(), formatDailyCloseMoney(), formatMetadataDisplayValue(), formatMetadataValue(), formatTimestampMetadata(), getBucketConfigs() (+43 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.06
@@ -1919,36 +1920,36 @@ Cohesion: 0.16
 Nodes (20): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle(), formatSignedQuantity() (+12 more)
 
 ### Community 35 - "Community 35"
-Cohesion: 0.14
-Nodes (15): CashPositionSummary(), cn(), formatCashExposureSupporting(), formatCurrency(), formatStaffByline(), formatStatusLabel(), formatTimestamp(), getSessionActionLabel() (+7 more)
-
-### Community 36 - "Community 36"
 Cohesion: 0.15
 Nodes (16): buildGitProcessEnv(), collectCommandsForChangedFiles(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets() (+8 more)
 
-### Community 37 - "Community 37"
+### Community 36 - "Community 36"
 Cohesion: 0.1
 Nodes (2): buildCashControlsDashboardSnapshot(), sumDepositsBySession()
 
-### Community 38 - "Community 38"
+### Community 37 - "Community 37"
 Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
-### Community 39 - "Community 39"
+### Community 38 - "Community 38"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 40 - "Community 40"
+### Community 39 - "Community 39"
 Cohesion: 0.17
 Nodes (17): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionOpeningFloatCorrectionPatch() (+9 more)
 
-### Community 41 - "Community 41"
+### Community 40 - "Community 40"
 Cohesion: 0.18
 Nodes (19): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildSkuActivityEvent(), buildTimeline(), getImpactQuantities() (+11 more)
 
-### Community 42 - "Community 42"
+### Community 41 - "Community 41"
 Cohesion: 0.18
 Nodes (16): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding(), runBindSessionToRegisterSessionCommand() (+8 more)
+
+### Community 42 - "Community 42"
+Cohesion: 0.21
+Nodes (18): bytesToHex(), findAthenaUserByEmail(), findAuthUserByEmail(), formatRecoveryCode(), generateRecoveryCode(), getCredentialForStore(), getFailureAuditBucket(), hashPosRecoveryCode() (+10 more)
 
 ### Community 43 - "Community 43"
 Cohesion: 0.1
@@ -1991,12 +1992,12 @@ Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
 ### Community 53 - "Community 53"
-Cohesion: 0.27
-Nodes (14): bytesToHex(), findAthenaUserByEmail(), findAuthUserByEmail(), generateRecoveryCode(), getCredentialForStore(), getFailureAuditBucket(), hashPosRecoveryCode(), normalizeEmail() (+6 more)
-
-### Community 54 - "Community 54"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
+
+### Community 54 - "Community 54"
+Cohesion: 0.13
+Nodes (4): DailyCloseHistoryView(), getDailyCloseHistoryApi(), getHistoryRecordSnapshot(), normalizeHistorySnapshot()
 
 ### Community 55 - "Community 55"
 Cohesion: 0.29
@@ -2019,24 +2020,24 @@ Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
 ### Community 60 - "Community 60"
-Cohesion: 0.14
-Nodes (4): DailyCloseHistoryView(), getDailyCloseHistoryApi(), getHistoryRecordSnapshot(), normalizeHistorySnapshot()
-
-### Community 61 - "Community 61"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 62 - "Community 62"
+### Community 61 - "Community 61"
 Cohesion: 0.26
 Nodes (13): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget() (+5 more)
 
-### Community 63 - "Community 63"
+### Community 62 - "Community 62"
 Cohesion: 0.33
 Nodes (14): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+6 more)
 
-### Community 64 - "Community 64"
+### Community 63 - "Community 63"
 Cohesion: 0.17
 Nodes (6): buildServerPricedCheckoutProducts(), calculateItemsSubtotal(), deriveDeliveryOptionFromAddress(), isDeliveryFeeWaived(), normalizeDeliveryOption(), resolveServerDeliveryFee()
+
+### Community 64 - "Community 64"
+Cohesion: 0.15
+Nodes (4): formatCurrency(), formatFinancialLabel(), formatTimelineRange(), formatTimelineTime()
 
 ### Community 65 - "Community 65"
 Cohesion: 0.24
@@ -2067,36 +2068,36 @@ Cohesion: 0.31
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getOperationalWorkItemStatus() (+5 more)
 
 ### Community 72 - "Community 72"
-Cohesion: 0.15
-Nodes (2): formatTimelineRange(), formatTimelineTime()
-
-### Community 73 - "Community 73"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 74 - "Community 74"
+### Community 73 - "Community 73"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 75 - "Community 75"
+### Community 74 - "Community 74"
 Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
-### Community 76 - "Community 76"
+### Community 75 - "Community 75"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 77 - "Community 77"
+### Community 76 - "Community 76"
 Cohesion: 0.23
 Nodes (7): buildTerminalHealthSummary(), deriveTerminalHealth(), deriveTerminalHealthAttentionReasons(), getTerminalHealthSummary(), resolveAttentionReasonActionTargets(), resolveCloudRegisterSessionTargets(), stripRuntimeStatusIdentity()
 
-### Community 78 - "Community 78"
+### Community 77 - "Community 77"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 79 - "Community 79"
+### Community 78 - "Community 78"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
+
+### Community 79 - "Community 79"
+Cohesion: 0.15
+Nodes (0):
 
 ### Community 80 - "Community 80"
 Cohesion: 0.17
@@ -2175,60 +2176,60 @@ Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
 ### Community 99 - "Community 99"
+Cohesion: 0.2
+Nodes (2): formatServiceLabel(), formatServiceLineMeta()
+
+### Community 100 - "Community 100"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.24
 Nodes (5): blocked(), evaluateLocalPosReadiness(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
-
-### Community 102 - "Community 102"
-Cohesion: 0.18
-Nodes (0):
 
 ### Community 103 - "Community 103"
 Cohesion: 0.18
 Nodes (0):
 
 ### Community 104 - "Community 104"
+Cohesion: 0.18
+Nodes (0):
+
+### Community 105 - "Community 105"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.24
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.22
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.31
 Nodes (7): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), parseVariantDisplayMoney(), saveProduct(), updateVariantSku()
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
-
-### Community 112 - "Community 112"
-Cohesion: 0.22
-Nodes (2): formatServiceLabel(), formatServiceLineMeta()
 
 ### Community 113 - "Community 113"
 Cohesion: 0.29
@@ -2248,15 +2249,15 @@ Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalize
 
 ### Community 117 - "Community 117"
 Cohesion: 0.39
-Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 118 - "Community 118"
-Cohesion: 0.42
-Nodes (7): getRegisterCatalogPrice(), listRegisterCatalog(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
+Cohesion: 0.39
+Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
 ### Community 119 - "Community 119"
-Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Cohesion: 0.42
+Nodes (7): getRegisterCatalogPrice(), listRegisterCatalog(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
 
 ### Community 120 - "Community 120"
 Cohesion: 0.5
@@ -2543,16 +2544,16 @@ Cohesion: 0.47
 Nodes (4): buildOperationalEvent(), matchesExistingEvent(), metadataDedupeKeysMatch(), recordOperationalEventWithCtx()
 
 ### Community 191 - "Community 191"
+Cohesion: 0.4
+Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
+
+### Community 192 - "Community 192"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 192 - "Community 192"
-Cohesion: 0.4
-Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
-
 ### Community 193 - "Community 193"
 Cohesion: 0.4
-Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
+Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
 ### Community 194 - "Community 194"
 Cohesion: 0.33
@@ -2619,8 +2620,8 @@ Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
 ### Community 210 - "Community 210"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
 ### Community 211 - "Community 211"
 Cohesion: 0.33
@@ -2632,23 +2633,23 @@ Nodes (0):
 
 ### Community 213 - "Community 213"
 Cohesion: 0.33
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 214 - "Community 214"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 215 - "Community 215"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 216 - "Community 216"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 216 - "Community 216"
+### Community 217 - "Community 217"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
-
-### Community 217 - "Community 217"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 218 - "Community 218"
 Cohesion: 0.33
@@ -2723,68 +2724,68 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 236 - "Community 236"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+
+### Community 237 - "Community 237"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 0.5
 Nodes (2): createAuthorizedRegisterDepositCtx(), createQueryCtx()
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 244 - "Community 244"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 245 - "Community 245"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 246 - "Community 246"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 247 - "Community 247"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
-### Community 247 - "Community 247"
+### Community 248 - "Community 248"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
-
-### Community 248 - "Community 248"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 249 - "Community 249"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 250 - "Community 250"
-Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
-
-### Community 251 - "Community 251"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 251 - "Community 251"
+Cohesion: 0.7
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
 ### Community 252 - "Community 252"
 Cohesion: 0.4
@@ -2795,24 +2796,24 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 254 - "Community 254"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 255 - "Community 255"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 255 - "Community 255"
+### Community 256 - "Community 256"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
-
-### Community 258 - "Community 258"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 259 - "Community 259"
 Cohesion: 0.4
@@ -2831,12 +2832,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 263 - "Community 263"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 264 - "Community 264"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 264 - "Community 264"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 265 - "Community 265"
 Cohesion: 0.4
@@ -2851,12 +2852,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 268 - "Community 268"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
-
-### Community 269 - "Community 269"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 269 - "Community 269"
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 270 - "Community 270"
 Cohesion: 0.4
@@ -2864,11 +2865,11 @@ Nodes (0):
 
 ### Community 271 - "Community 271"
 Cohesion: 0.4
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 272 - "Community 272"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 273 - "Community 273"
 Cohesion: 0.4
@@ -2879,180 +2880,180 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 275 - "Community 275"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 276 - "Community 276"
 Cohesion: 0.7
-Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
 ### Community 277 - "Community 277"
+Cohesion: 0.8
+Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
+
+### Community 278 - "Community 278"
+Cohesion: 0.7
+Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+
+### Community 279 - "Community 279"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 278 - "Community 278"
+### Community 280 - "Community 280"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 279 - "Community 279"
-Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
-
-### Community 280 - "Community 280"
-Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 281 - "Community 281"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 282 - "Community 282"
 Cohesion: 0.6
-Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 283 - "Community 283"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 284 - "Community 284"
 Cohesion: 0.6
-Nodes (3): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier()
+Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
 ### Community 285 - "Community 285"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 286 - "Community 286"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier()
 
 ### Community 287 - "Community 287"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 288 - "Community 288"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 289 - "Community 289"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 290 - "Community 290"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.5
+Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 291 - "Community 291"
-Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 292 - "Community 292"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 293 - "Community 293"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 294 - "Community 294"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 295 - "Community 295"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 296 - "Community 296"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 297 - "Community 297"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 298 - "Community 298"
-Cohesion: 0.6
-Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 299 - "Community 299"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 300 - "Community 300"
-Cohesion: 0.7
-Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
+Cohesion: 0.6
+Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
 ### Community 301 - "Community 301"
-Cohesion: 0.5
+Cohesion: 0.4
 Nodes (0):
 
 ### Community 302 - "Community 302"
+Cohesion: 0.7
+Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
+
+### Community 303 - "Community 303"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 304 - "Community 304"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 303 - "Community 303"
+### Community 305 - "Community 305"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 304 - "Community 304"
+### Community 306 - "Community 306"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
 
-### Community 305 - "Community 305"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 306 - "Community 306"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 307 - "Community 307"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 308 - "Community 308"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 309 - "Community 309"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 310 - "Community 310"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 311 - "Community 311"
-Cohesion: 0.67
-Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 312 - "Community 312"
-Cohesion: 0.83
-Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 313 - "Community 313"
 Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
 ### Community 314 - "Community 314"
-Cohesion: 0.67
-Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
+Cohesion: 0.83
+Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
 ### Community 315 - "Community 315"
 Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
 ### Community 316 - "Community 316"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
 ### Community 317 - "Community 317"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 318 - "Community 318"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 319 - "Community 319"
 Cohesion: 0.5
@@ -3060,7 +3061,7 @@ Nodes (0):
 
 ### Community 320 - "Community 320"
 Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 321 - "Community 321"
 Cohesion: 0.5
@@ -3068,27 +3069,27 @@ Nodes (0):
 
 ### Community 322 - "Community 322"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 323 - "Community 323"
-Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 324 - "Community 324"
-Cohesion: 0.67
-Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
+Cohesion: 0.83
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 325 - "Community 325"
 Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 326 - "Community 326"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
 ### Community 327 - "Community 327"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 328 - "Community 328"
 Cohesion: 0.5
@@ -3099,28 +3100,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 330 - "Community 330"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 331 - "Community 331"
-Cohesion: 0.83
-Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
-
-### Community 332 - "Community 332"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 331 - "Community 331"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 332 - "Community 332"
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
+
 ### Community 333 - "Community 333"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
 ### Community 334 - "Community 334"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 335 - "Community 335"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 336 - "Community 336"
 Cohesion: 0.5
@@ -3131,24 +3132,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 338 - "Community 338"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 339 - "Community 339"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 340 - "Community 340"
 Cohesion: 0.67
 Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
-### Community 339 - "Community 339"
+### Community 341 - "Community 341"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
-### Community 340 - "Community 340"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 341 - "Community 341"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 342 - "Community 342"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 343 - "Community 343"
 Cohesion: 0.5
@@ -3163,60 +3164,60 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 346 - "Community 346"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 347 - "Community 347"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 348 - "Community 348"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 349 - "Community 349"
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
+
+### Community 350 - "Community 350"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 351 - "Community 351"
 Cohesion: 0.67
 Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
-### Community 349 - "Community 349"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 350 - "Community 350"
-Cohesion: 0.67
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
-
-### Community 351 - "Community 351"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 352 - "Community 352"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 353 - "Community 353"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 354 - "Community 354"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 355 - "Community 355"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 356 - "Community 356"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 357 - "Community 357"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 358 - "Community 358"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 359 - "Community 359"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 360 - "Community 360"
 Cohesion: 0.5
@@ -3224,95 +3225,95 @@ Nodes (0):
 
 ### Community 361 - "Community 361"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 362 - "Community 362"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 363 - "Community 363"
+Cohesion: 0.67
+Nodes (2): useGetArchivedProducts(), useGetProducts()
+
+### Community 364 - "Community 364"
 Cohesion: 0.67
 Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
 
-### Community 363 - "Community 363"
-Cohesion: 1.0
-Nodes (3): canAccessFullAdminSurface(), canAccessStoreDaySurface(), getSurfaceAccess()
-
-### Community 364 - "Community 364"
+### Community 365 - "Community 365"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 365 - "Community 365"
+### Community 366 - "Community 366"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 366 - "Community 366"
+### Community 367 - "Community 367"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 367 - "Community 367"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 368 - "Community 368"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 369 - "Community 369"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 370 - "Community 370"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 371 - "Community 371"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 372 - "Community 372"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 372 - "Community 372"
+### Community 373 - "Community 373"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 373 - "Community 373"
+### Community 374 - "Community 374"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 374 - "Community 374"
+### Community 375 - "Community 375"
 Cohesion: 0.83
 Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 375 - "Community 375"
+### Community 376 - "Community 376"
 Cohesion: 0.83
 Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
-### Community 376 - "Community 376"
+### Community 377 - "Community 377"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 377 - "Community 377"
+### Community 378 - "Community 378"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 378 - "Community 378"
+### Community 379 - "Community 379"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 379 - "Community 379"
+### Community 380 - "Community 380"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 380 - "Community 380"
+### Community 381 - "Community 381"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 381 - "Community 381"
+### Community 382 - "Community 382"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 382 - "Community 382"
+### Community 383 - "Community 383"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 383 - "Community 383"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 384 - "Community 384"
 Cohesion: 0.5
@@ -3343,59 +3344,59 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 391 - "Community 391"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 392 - "Community 392"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 393 - "Community 393"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 394 - "Community 394"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 394 - "Community 394"
+### Community 395 - "Community 395"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 395 - "Community 395"
-Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 396 - "Community 396"
 Cohesion: 0.83
-Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 397 - "Community 397"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
 ### Community 398 - "Community 398"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 399 - "Community 399"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 400 - "Community 400"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 401 - "Community 401"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 401 - "Community 401"
+### Community 402 - "Community 402"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 402 - "Community 402"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 403 - "Community 403"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 404 - "Community 404"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 405 - "Community 405"
@@ -3403,12 +3404,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 406 - "Community 406"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 407 - "Community 407"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 407 - "Community 407"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 408 - "Community 408"
 Cohesion: 0.67
@@ -3443,12 +3444,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 416 - "Community 416"
-Cohesion: 1.0
-Nodes (2): buildCtx(), createDb()
-
-### Community 417 - "Community 417"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 417 - "Community 417"
+Cohesion: 1.0
+Nodes (2): buildCtx(), createDb()
 
 ### Community 418 - "Community 418"
 Cohesion: 0.67
@@ -3467,20 +3468,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 422 - "Community 422"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 423 - "Community 423"
 Cohesion: 1.0
 Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
-### Community 423 - "Community 423"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 424 - "Community 424"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 425 - "Community 425"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 426 - "Community 426"
 Cohesion: 0.67
@@ -3495,24 +3496,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 429 - "Community 429"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 430 - "Community 430"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 430 - "Community 430"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 431 - "Community 431"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 432 - "Community 432"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 433 - "Community 433"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 433 - "Community 433"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 434 - "Community 434"
 Cohesion: 0.67
@@ -3527,36 +3528,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 437 - "Community 437"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 438 - "Community 438"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 439 - "Community 439"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 440 - "Community 440"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 441 - "Community 441"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 442 - "Community 442"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 443 - "Community 443"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 443 - "Community 443"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 444 - "Community 444"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 445 - "Community 445"
 Cohesion: 0.67
@@ -3571,12 +3572,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 448 - "Community 448"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 449 - "Community 449"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 449 - "Community 449"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 450 - "Community 450"
 Cohesion: 0.67
@@ -3587,12 +3588,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 452 - "Community 452"
-Cohesion: 1.0
-Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 453 - "Community 453"
 Cohesion: 1.0
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
 ### Community 454 - "Community 454"
 Cohesion: 0.67
@@ -3688,79 +3689,79 @@ Nodes (0):
 
 ### Community 477 - "Community 477"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 478 - "Community 478"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 479 - "Community 479"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 480 - "Community 480"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 481 - "Community 481"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 482 - "Community 482"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 483 - "Community 483"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 484 - "Community 484"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 485 - "Community 485"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 485 - "Community 485"
+### Community 486 - "Community 486"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 486 - "Community 486"
+### Community 487 - "Community 487"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 487 - "Community 487"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 488 - "Community 488"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 489 - "Community 489"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 490 - "Community 490"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 491 - "Community 491"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 492 - "Community 492"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 493 - "Community 493"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 494 - "Community 494"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 495 - "Community 495"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 496 - "Community 496"
 Cohesion: 0.67
@@ -3792,11 +3793,11 @@ Nodes (0):
 
 ### Community 503 - "Community 503"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 504 - "Community 504"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 505 - "Community 505"
 Cohesion: 0.67
@@ -3807,32 +3808,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 507 - "Community 507"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 508 - "Community 508"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 508 - "Community 508"
+### Community 509 - "Community 509"
 Cohesion: 0.67
 Nodes (1): isInMaintenanceMode()
 
-### Community 509 - "Community 509"
+### Community 510 - "Community 510"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 510 - "Community 510"
+### Community 511 - "Community 511"
 Cohesion: 1.0
 Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
-### Community 511 - "Community 511"
+### Community 512 - "Community 512"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 512 - "Community 512"
-Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 513 - "Community 513"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 514 - "Community 514"
 Cohesion: 0.67
@@ -3844,67 +3845,67 @@ Nodes (0):
 
 ### Community 516 - "Community 516"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 517 - "Community 517"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 518 - "Community 518"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 519 - "Community 519"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 520 - "Community 520"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 521 - "Community 521"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 522 - "Community 522"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 523 - "Community 523"
 Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Nodes (1): hashPassword()
 
 ### Community 524 - "Community 524"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): createVersionChecker()
 
 ### Community 525 - "Community 525"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 526 - "Community 526"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 527 - "Community 527"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 528 - "Community 528"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 528 - "Community 528"
+### Community 529 - "Community 529"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 529 - "Community 529"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 530 - "Community 530"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 531 - "Community 531"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 532 - "Community 532"
 Cohesion: 0.67
@@ -3919,12 +3920,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 535 - "Community 535"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 536 - "Community 536"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 536 - "Community 536"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 537 - "Community 537"
 Cohesion: 0.67
@@ -3935,12 +3936,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 539 - "Community 539"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 540 - "Community 540"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 540 - "Community 540"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 541 - "Community 541"
 Cohesion: 0.67
@@ -4007,16 +4008,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 557 - "Community 557"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 558 - "Community 558"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 559 - "Community 559"
+### Community 558 - "Community 558"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 559 - "Community 559"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 560 - "Community 560"
 Cohesion: 1.0
@@ -4035,20 +4036,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 564 - "Community 564"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 565 - "Community 565"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 566 - "Community 566"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 567 - "Community 567"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 568 - "Community 568"
 Cohesion: 1.0
@@ -8742,2356 +8743,2360 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1741 - "Community 1741"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 567`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 568`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 568`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 569`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 570`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 571`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 572`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 573`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 574`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 575`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 576`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 577`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 578`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 579`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 580`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 581`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 582`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 583`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 584`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 585`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 586`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 587`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 588`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 589`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 590`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 591`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 592`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 593`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 594`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 595`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 596`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 597`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 598`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 599`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 600`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 601`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 602`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 603`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 604`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 605`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 606`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 607`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 608`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 609`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 610`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 611`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 612`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 613`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 614`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 615`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 616`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
+- **Thin community `Community 617`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
+- **Thin community `Community 618`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 619`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 620`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 621`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 622`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 623`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
+- **Thin community `Community 624`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 625`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 626`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 627`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 628`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 629`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 630`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 631`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 632`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 633`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 634`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 635`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 636`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 637`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 638`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 639`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 640`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 641`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 642`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 643`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 644`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 645`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 646`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 647`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 648`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 649`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 650`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 651`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 652`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 653`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 654`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 655`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 656`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 657`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 658`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 659`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 660`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 661`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 662`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 663`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 664`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 665`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 666`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 667`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 668`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 669`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 670`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 671`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 672`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 673`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 674`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 675`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 676`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 677`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 678`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 679`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 680`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 681`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 682`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 683`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 684`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 685`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 686`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 687`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 688`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 689`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 690`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 691`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 692`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 693`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 694`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 695`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 696`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 697`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 698`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 699`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 700`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 701`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 702`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 703`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 704`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 705`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 706`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
+- **Thin community `Community 707`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 708`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 709`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 710`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 711`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 712`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 713`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 714`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 715`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 716`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 717`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `ExpenseCompletionPanel()`, `ExpenseCompletionPanel.tsx`
+- **Thin community `Community 718`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 719`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 720`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 721`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 722`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 723`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 724`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 725`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 726`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 727`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 728`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 729`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 730`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 731`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 732`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 733`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 734`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 735`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 736`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 737`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 738`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 739`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 740`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 741`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 742`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 743`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 744`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 745`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 746`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 747`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 748`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 749`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 750`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 751`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 752`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
+- **Thin community `Community 753`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 754`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 755`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 756`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 757`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 758`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 759`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 760`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 761`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 762`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 763`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 764`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 765`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 766`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 767`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 768`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 769`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 770`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 771`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 772`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 773`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 774`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 775`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 776`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 777`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 778`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 779`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 780`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 781`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 782`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 783`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 784`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 785`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 786`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 787`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 788`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 789`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 790`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 791`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 792`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 793`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 794`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 795`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 796`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 797`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 798`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 799`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 800`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 801`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 802`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 803`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 804`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 805`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 806`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 807`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 808`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 809`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 810`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 811`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 812`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 813`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 814`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 815`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 816`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 817`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 818`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 819`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 820`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 821`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 822`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 823`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 824`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 825`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 826`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 827`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 828`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 829`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 830`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 831`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 832`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 833`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 834`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 835`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 836`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 837`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 838`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 839`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 840`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 841`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 842`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 843`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 844`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 845`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 846`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 847`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 848`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 849`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 850`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 851`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 852`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 853`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 854`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 855`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 856`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 857`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 858`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 859`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 860`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 861`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 862`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 863`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 864`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 865`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 866`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 867`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 868`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 869`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 870`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 871`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 872`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 873`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 874`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 875`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 876`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 877`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 878`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 879`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 880`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 881`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 882`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 883`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 884`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 885`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 886`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 887`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 888`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 889`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 890`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 891`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 892`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 893`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 894`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 895`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 896`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 897`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 898`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 899`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 900`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 901`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 902`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 903`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 904`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 905`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 906`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 907`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 908`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 909`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 910`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 911`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 912`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 913`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 914`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 915`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 916`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 917`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 918`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 919`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 920`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 921`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 922`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 923`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 924`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 925`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 926`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 927`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 928`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 929`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 930`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 931`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 932`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 933`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 934`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 935`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 936`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 937`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 938`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 939`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 940`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 941`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 942`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 943`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 944`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 945`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 946`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 947`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 948`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 949`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 950`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 951`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 952`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 953`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 954`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 955`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 956`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 957`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 958`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 959`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 960`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 961`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 962`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 963`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 964`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 965`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 966`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 967`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 968`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 969`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 970`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 971`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 972`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 973`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 974`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 975`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 976`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 977`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 978`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 979`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 980`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 981`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 982`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 983`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 984`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (1 nodes): `api.d.ts`
+- **Thin community `Community 985`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (1 nodes): `api.js`
+- **Thin community `Community 986`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 987`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `server.d.ts`
+- **Thin community `Community 988`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `server.js`
+- **Thin community `Community 989`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `app.ts`
+- **Thin community `Community 990`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 991`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 992`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `auth.config.js`
+- **Thin community `Community 993`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 994`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `auth.ts`
+- **Thin community `Community 995`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 996`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 997`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 998`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `countries.ts`
+- **Thin community `Community 999`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `email.ts`
+- **Thin community `Community 1000`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1001`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `payment.ts`
+- **Thin community `Community 1002`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `crons.ts`
+- **Thin community `Community 1003`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1004`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `internal.ts`
+- **Thin community `Community 1005`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1006`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1007`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1008`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1009`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1010`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1011`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1012`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1013`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1014`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1015`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1016`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `env.ts`
+- **Thin community `Community 1017`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1018`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `auth.ts`
+- **Thin community `Community 1019`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1020`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `colors.ts`
+- **Thin community `Community 1021`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `index.ts`
+- **Thin community `Community 1022`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1023`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `products.ts`
+- **Thin community `Community 1024`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1025`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `stores.ts`
+- **Thin community `Community 1026`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `bag.ts`
+- **Thin community `Community 1027`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `guest.ts`
+- **Thin community `Community 1028`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `index.ts`
+- **Thin community `Community 1029`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `me.ts`
+- **Thin community `Community 1030`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `offers.ts`
+- **Thin community `Community 1031`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1032`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1033`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1034`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1035`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1036`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1037`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1038`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1039`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1040`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `user.ts`
+- **Thin community `Community 1041`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1042`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `index.ts`
+- **Thin community `Community 1043`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1044`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `http.ts`
+- **Thin community `Community 1045`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1046`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1047`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1048`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `categories.ts`
+- **Thin community `Community 1049`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `colors.ts`
+- **Thin community `Community 1050`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1051`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 1052`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1053`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1054`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1055`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1056`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `pos.ts`
+- **Thin community `Community 1057`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1058`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1059`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1060`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1061`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1062`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1063`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1064`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1065`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1066`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1067`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1068`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1069`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1070`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1071`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1072`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1073`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `types.ts`
+- **Thin community `Community 1074`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1075`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1076`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1077`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1078`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1079`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1080`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `dto.ts`
+- **Thin community `Community 1081`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1082`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1083`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `types.ts`
+- **Thin community `Community 1084`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `types.ts`
+- **Thin community `Community 1085`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1086`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `customers.ts`
+- **Thin community `Community 1087`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `register.ts`
+- **Thin community `Community 1088`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `sync.ts`
+- **Thin community `Community 1089`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `schema.ts`
+- **Thin community `Community 1090`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1091`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `index.ts`
+- **Thin community `Community 1092`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1093`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1094`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1095`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1096`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1097`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `category.ts`
+- **Thin community `Community 1098`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `color.ts`
+- **Thin community `Community 1099`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1100`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1101`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `index.ts`
+- **Thin community `Community 1102`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1103`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1104`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `organization.ts`
+- **Thin community `Community 1105`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1106`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `product.ts`
+- **Thin community `Community 1107`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1108`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1109`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `store.ts`
+- **Thin community `Community 1110`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1111`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `index.ts`
+- **Thin community `Community 1112`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1113`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1114`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1115`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1116`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1117`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1118`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1119`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `index.ts`
+- **Thin community `Community 1120`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1121`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1122`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1123`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1124`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1125`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1126`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1127`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1128`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1129`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1130`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1131`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `customer.ts`
+- **Thin community `Community 1132`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1133`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1134`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1135`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1136`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `index.ts`
+- **Thin community `Community 1137`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1138`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1139`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1140`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1141`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1142`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1143`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1144`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1145`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1146`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1147`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1148`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1149`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1150`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1151`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1152`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1153`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1154`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `index.ts`
+- **Thin community `Community 1155`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1156`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1157`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1158`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1159`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1160`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1161`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `index.ts`
+- **Thin community `Community 1162`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1163`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1164`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1165`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1166`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1167`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1168`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `bag.ts`
+- **Thin community `Community 1169`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1170`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1171`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1172`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `guest.ts`
+- **Thin community `Community 1173`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `index.ts`
+- **Thin community `Community 1174`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `offer.ts`
+- **Thin community `Community 1175`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1176`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1177`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `review.ts`
+- **Thin community `Community 1178`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1179`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1180`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1181`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1182`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1183`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1184`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1185`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1186`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1187`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `bag.ts`
+- **Thin community `Community 1188`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1189`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `customer.ts`
+- **Thin community `Community 1190`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `guest.ts`
+- **Thin community `Community 1191`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1192`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1193`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1194`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1195`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `payment.ts`
+- **Thin community `Community 1196`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1197`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1198`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1199`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `users.ts`
+- **Thin community `Community 1200`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `payment.ts`
+- **Thin community `Community 1201`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1202`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1203`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1204`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1205`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1206`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `index.ts`
+- **Thin community `Community 1207`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1208`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1209`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `auth.ts`
+- **Thin community `Community 1210`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1211`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1212`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1213`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1214`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1215`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1216`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1217`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1218`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1219`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1220`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1221`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1222`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1223`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1224`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `constants.ts`
+- **Thin community `Community 1225`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1226`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1227`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1228`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `types.ts`
+- **Thin community `Community 1229`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1230`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1231`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1232`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1233`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1234`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1235`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1236`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1237`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1238`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1239`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1240`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1241`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1242`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1243`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1244`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1245`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1246`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1247`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1248`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1249`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `constants.ts`
+- **Thin community `Community 1250`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1251`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1252`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1253`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `data.ts`
+- **Thin community `Community 1254`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1255`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1256`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1257`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1258`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1259`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1260`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1261`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1262`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1263`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `constants.ts`
+- **Thin community `Community 1264`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1265`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1266`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1267`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `data.ts`
+- **Thin community `Community 1268`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1269`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1270`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1271`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1272`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1273`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1274`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1275`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1276`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1277`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1278`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1279`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1280`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `constants.ts`
+- **Thin community `Community 1281`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1282`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1283`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1284`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1285`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1286`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1287`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1288`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1289`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1290`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1291`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1292`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1293`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1294`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1295`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1296`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1297`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1298`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1299`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `ExpenseCompletion.tsx`
+- **Thin community `Community 1300`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1301`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1302`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1303`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1304`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1305`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1306`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1307`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1308`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1309`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1310`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1311`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1312`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1313`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `constants.ts`
+- **Thin community `Community 1314`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1315`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1316`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1317`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `data.ts`
+- **Thin community `Community 1318`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1319`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1320`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `constants.ts`
+- **Thin community `Community 1321`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1322`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1323`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1324`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1325`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `data.ts`
+- **Thin community `Community 1326`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1327`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `constants.ts`
+- **Thin community `Community 1328`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1329`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1330`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1331`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1332`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `data.ts`
+- **Thin community `Community 1333`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1334`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1335`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1336`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1337`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1338`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1339`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1340`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1341`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1342`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1343`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1344`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1345`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1346`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1347`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1348`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1349`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1350`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1351`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1352`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1353`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1354`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1355`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1356`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1357`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1358`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `POSSettingsView.test.tsx`
+- **Thin community `Community 1359`** (1 nodes): `POSSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1360`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `POSTerminalHealthView.test.tsx`
+- **Thin community `Community 1361`** (1 nodes): `POSTerminalHealthView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1362`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1363`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1364`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `types.ts`
+- **Thin community `Community 1365`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1366`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1367`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1368`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1369`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1370`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1371`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1372`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1373`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1374`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1375`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1376`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1377`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1378`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1379`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1380`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `data.ts`
+- **Thin community `Community 1381`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1382`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1383`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1384`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1385`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1386`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1387`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1388`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1389`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1390`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1391`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1392`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1393`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `constants.ts`
+- **Thin community `Community 1394`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1395`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1396`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1397`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `data.ts`
+- **Thin community `Community 1398`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `types.ts`
+- **Thin community `Community 1399`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1400`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1401`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1402`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1403`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1404`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `index.tsx`
+- **Thin community `Community 1405`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1406`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1407`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1408`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1409`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1410`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1411`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1412`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1413`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `index.tsx`
+- **Thin community `Community 1414`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1415`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1416`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1417`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `button.tsx`
+- **Thin community `Community 1418`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1419`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `card.tsx`
+- **Thin community `Community 1420`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1421`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1422`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `command.tsx`
+- **Thin community `Community 1423`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1424`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1425`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1426`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `form.tsx`
+- **Thin community `Community 1427`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1428`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1429`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `input.tsx`
+- **Thin community `Community 1430`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1431`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1432`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1433`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1434`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1435`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1436`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `select.tsx`
+- **Thin community `Community 1437`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1438`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1439`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1440`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `table.tsx`
+- **Thin community `Community 1441`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1442`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1443`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1444`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1445`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1446`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1447`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1448`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1449`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `constants.ts`
+- **Thin community `Community 1450`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1451`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1452`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1453`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `data.ts`
+- **Thin community `Community 1454`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1455`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1456`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1457`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1458`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1459`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1460`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1461`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1462`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1463`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1464`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1465`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `index.ts`
+- **Thin community `Community 1466`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1467`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1468`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1469`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1470`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1471`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1472`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1473`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1474`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1475`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1476`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `aws.ts`
+- **Thin community `Community 1477`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `constants.ts`
+- **Thin community `Community 1478`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `countries.ts`
+- **Thin community `Community 1479`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1480`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1481`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1482`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1483`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1484`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1485`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `dto.ts`
+- **Thin community `Community 1486`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `ports.ts`
+- **Thin community `Community 1487`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `constants.ts`
+- **Thin community `Community 1488`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1489`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1490`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `index.ts`
+- **Thin community `Community 1491`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1492`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `types.ts`
+- **Thin community `Community 1493`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1494`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1495`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1496`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1497`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1498`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1499`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1500`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1501`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1502`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1503`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `category.ts`
+- **Thin community `Community 1504`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `product.ts`
+- **Thin community `Community 1505`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `store.ts`
+- **Thin community `Community 1506`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1507`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `user.ts`
+- **Thin community `Community 1508`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1509`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1510`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1511`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1512`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1513`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1514`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `__root.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `index.tsx`
+- **Thin community `Community 1515`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1516`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1517`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1518`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1519`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1520`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1521`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1522`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `index.tsx`
+- **Thin community `Community 1523`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1524`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1525`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1526`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `home.tsx`
+- **Thin community `Community 1527`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1528`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1529`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1530`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `index.tsx`
+- **Thin community `Community 1531`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1532`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `index.tsx`
+- **Thin community `Community 1533`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1534`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1535`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1536`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `index.tsx`
+- **Thin community `Community 1537`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1538`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1539`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1540`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1541`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1542`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1543`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `index.tsx`
+- **Thin community `Community 1544`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1545`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1546`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1547`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1548`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1549`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1550`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1551`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1552`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1553`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `index.tsx`
+- **Thin community `Community 1554`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1555`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `index.tsx`
+- **Thin community `Community 1556`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `new.tsx`
+- **Thin community `Community 1557`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `index.tsx`
+- **Thin community `Community 1558`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `new.tsx`
+- **Thin community `Community 1559`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1560`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1561`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `index.tsx`
+- **Thin community `Community 1562`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `new.tsx`
+- **Thin community `Community 1563`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `index.tsx`
+- **Thin community `Community 1564`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1565`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1566`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1567`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1568`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `index.tsx`
+- **Thin community `Community 1569`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1570`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1571`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1572`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `index.tsx`
+- **Thin community `Community 1573`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1574`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1575`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1576`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1577`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1578`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1579`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1580`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1581`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1582`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1583`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1584`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1585`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1586`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1587`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1588`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1589`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1590`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1591`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1592`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1593`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1594`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1595`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1596`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1597`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `setup.ts`
+- **Thin community `Community 1598`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1599`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `types.ts`
+- **Thin community `Community 1600`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1601`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1602`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1603`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1604`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1605`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `types.ts`
+- **Thin community `Community 1606`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1607`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1608`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1609`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1610`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1611`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1612`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1613`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1614`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1615`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `schema.ts`
+- **Thin community `Community 1616`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1617`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1618`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1619`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1620`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1621`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1622`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1623`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1624`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1625`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `types.ts`
+- **Thin community `Community 1626`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1627`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1628`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1629`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1630`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1631`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1632`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1633`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `constants.ts`
+- **Thin community `Community 1634`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1635`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `About.tsx`
+- **Thin community `Community 1636`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1637`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1638`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1639`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1640`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1641`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1642`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1643`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1644`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1645`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1646`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `types.ts`
+- **Thin community `Community 1647`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1648`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1649`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1650`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1651`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1652`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1653`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1654`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1655`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1656`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1657`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1658`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `button.tsx`
+- **Thin community `Community 1659`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `card.tsx`
+- **Thin community `Community 1660`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1661`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `command.tsx`
+- **Thin community `Community 1662`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1663`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1664`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1665`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `form.tsx`
+- **Thin community `Community 1666`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1667`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1668`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1669`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1670`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `input.tsx`
+- **Thin community `Community 1671`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `label.tsx`
+- **Thin community `Community 1672`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1673`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1674`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1675`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `index.ts`
+- **Thin community `Community 1676`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `types.ts`
+- **Thin community `Community 1677`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1678`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1679`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1680`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1681`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `select.tsx`
+- **Thin community `Community 1682`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1683`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1684`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `table.tsx`
+- **Thin community `Community 1685`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1686`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1687`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1688`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1689`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1690`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `config.ts`
+- **Thin community `Community 1691`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1692`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1693`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1694`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1695`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `constants.ts`
+- **Thin community `Community 1696`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `countries.ts`
+- **Thin community `Community 1697`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1698`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1699`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1700`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1701`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `index.ts`
+- **Thin community `Community 1702`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `store.ts`
+- **Thin community `Community 1703`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `bag.ts`
+- **Thin community `Community 1704`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1705`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `category.ts`
+- **Thin community `Community 1706`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `organization.ts`
+- **Thin community `Community 1707`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `product.ts`
+- **Thin community `Community 1708`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `store.ts`
+- **Thin community `Community 1709`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1710`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `user.ts`
+- **Thin community `Community 1711`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `states.ts`
+- **Thin community `Community 1712`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1713`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1714`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1715`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1716`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1717`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1718`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1719`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `index.tsx`
+- **Thin community `Community 1720`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1721`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `index.tsx`
+- **Thin community `Community 1722`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1723`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1724`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1725`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1726`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1727`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `index.tsx`
+- **Thin community `Community 1728`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1729`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1730`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1731`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1732`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1733`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `index.js`
+- **Thin community `Community 1734`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1735`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1736`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1737`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1738`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1739`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1740`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1741`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,13 +7,13 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1813
-- Graph nodes: 6050
-- Graph edges: 6491
-- Communities: 1741
+- Code files discovered: 1814
+- Graph nodes: 6057
+- Graph edges: 6492
+- Communities: 1742
 
 ## Graph Hotspots
-- `DailyCloseView.tsx` (82 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `DailyCloseView.tsx` (84 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `useRegisterViewModel.ts` (55 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `harness-inferential-review.ts` (46 edges, Community 3) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -17,7 +17,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - [validation-map.json](../../../packages/athena-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `DailyCloseView.tsx` (82 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
+- `DailyCloseView.tsx` (84 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `useRegisterViewModel.ts` (55 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `RegisterSessionView.tsx` (45 edges, Community 4) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -19,9 +19,9 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 5) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 5) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 39) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `checkoutSession.ts` (14 edges, Community 61) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
-- `storeConfig.ts` (14 edges, Community 39) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `getStoreConfigV2()` (17 edges, Community 38) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `checkoutSession.ts` (14 edges, Community 60) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `storeConfig.ts` (14 edges, Community 38) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/operations/operationalWorkItems.test.ts
+++ b/packages/athena-webapp/convex/operations/operationalWorkItems.test.ts
@@ -92,8 +92,8 @@ describe("getQueueSnapshot", () => {
     expect(
       athenaUserAuth.requireOrganizationMemberRoleWithCtx,
     ).toHaveBeenCalledWith(ctx, {
-      allowedRoles: ["full_admin"],
-      failureMessage: "Only full admins can view approval queue.",
+      allowedRoles: ["full_admin", "pos_only"],
+      failureMessage: "Only POS operators can view approval queue.",
       organizationId: "org-1",
       userId: "user-1",
     });

--- a/packages/athena-webapp/convex/operations/operationalWorkItems.ts
+++ b/packages/athena-webapp/convex/operations/operationalWorkItems.ts
@@ -230,8 +230,8 @@ export const getQueueSnapshot = query({
 
     const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
     await requireOrganizationMemberRoleWithCtx(ctx, {
-      allowedRoles: ["full_admin"],
-      failureMessage: "Only full admins can view approval queue.",
+      allowedRoles: ["full_admin", "pos_only"],
+      failureMessage: "Only POS operators can view approval queue.",
       organizationId: store.organizationId,
       userId: athenaUser._id,
     });

--- a/packages/athena-webapp/convex/pos/application/commands/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/terminals.ts
@@ -266,6 +266,7 @@ export type TerminalRuntimeStatusInput = {
   snapshots: {
     catalogAgeMs?: number;
     availabilityAgeMs?: number;
+    serviceCatalogAgeMs?: number;
     registerReadModelAgeMs?: number;
   };
 };
@@ -404,6 +405,9 @@ export async function submitTerminalRuntimeStatus(
       catalogAgeMs: nonNegativeInteger(args.status.snapshots.catalogAgeMs),
       availabilityAgeMs: nonNegativeInteger(
         args.status.snapshots.availabilityAgeMs,
+      ),
+      serviceCatalogAgeMs: nonNegativeInteger(
+        args.status.snapshots.serviceCatalogAgeMs,
       ),
       registerReadModelAgeMs: nonNegativeInteger(
         args.status.snapshots.registerReadModelAgeMs,

--- a/packages/athena-webapp/convex/pos/public/posRecoveryCodes.test.ts
+++ b/packages/athena-webapp/convex/pos/public/posRecoveryCodes.test.ts
@@ -30,6 +30,7 @@ const POS_ACCOUNT_ID = "athena-pos-account-1" as Id<"athenaUser">;
 const AUTH_USER_ID = "auth-user-pos" as Id<"users">;
 const FULL_ADMIN_ID = "athena-full-admin-1" as Id<"athenaUser">;
 const FULL_ADMIN_AUTH_USER_ID = "auth-user-full-admin" as Id<"users">;
+const RECOVERY_CODE_PATTERN = /^[a-z]+\d{2}$/;
 
 describe("POS recovery codes", () => {
   beforeEach(() => {
@@ -60,18 +61,17 @@ describe("POS recovery codes", () => {
     });
   });
 
-  it("creates a hash-only credential and verifies the generated code", async () => {
+  it("creates a persisted credential and verifies the generated code", async () => {
     const ctx = buildCtx();
     const create = getHandler(createOrRotateRecoveryCodeForTest);
     const verify = getHandler(verifyRecoveryCodeForAuthProvider);
 
     const created = await create(ctx, { storeId: STORE_ID });
 
-    expect(created.code).toMatch(/^[0-9a-f-]+$/);
+    expect(created.code).toMatch(RECOVERY_CODE_PATTERN);
     expect(ctx.tables.posRecoveryCredential).toHaveLength(1);
     const credential = ctx.tables.posRecoveryCredential[0];
     expect(credential.codeHash).not.toBe(created.code);
-    expect(JSON.stringify(credential)).not.toContain(created.code);
 
     const result = await verify(ctx, {
       code: created.code,
@@ -83,6 +83,11 @@ describe("POS recovery codes", () => {
     expect(ctx.tables.posRecoveryCredential[0].failedAttemptCount).toBe(0);
     expect(ctx.tables.posRecoveryCredential[0].lastUsedAt).toEqual(
       expect.any(Number),
+    );
+    expect(created.credential).toEqual(
+      expect.objectContaining({
+        plaintextCode: created.code,
+      }),
     );
     expect(JSON.stringify(ctx.tables.operationalEvent)).not.toContain(
       created.code,
@@ -105,6 +110,26 @@ describe("POS recovery codes", () => {
         email: "pos@wigclub.store",
         orgUrlSlug: "wigclub",
         storeUrlSlug: "wigclub",
+      }),
+    ).resolves.toEqual({ authUserId: AUTH_USER_ID });
+  });
+
+  it("accepts recovery codes without exact casing or word separators", async () => {
+    const ctx = buildCtx();
+    const create = getHandler(createOrRotateRecoveryCodeForTest);
+    const verify = getHandler(verifyRecoveryCodeForAuthProvider);
+
+    const created = await create(ctx, { storeId: STORE_ID });
+    const staffTypedCode = created.code
+      .replace(/(.{4})/g, "$1 ")
+      .trim()
+      .toUpperCase();
+
+    await expect(
+      verify(ctx, {
+        code: staffTypedCode,
+        email: "pos@wigclub.store",
+        storeId: STORE_ID,
       }),
     ).resolves.toEqual({ authUserId: AUTH_USER_ID });
   });
@@ -234,7 +259,11 @@ describe("POS recovery codes", () => {
 
     authServerMocks.getAuthUserId.mockResolvedValue(FULL_ADMIN_AUTH_USER_ID);
     await expect(getStatus(ctx, { storeId: STORE_ID })).resolves.toEqual(
-      expect.objectContaining({ status: "active", storeId: STORE_ID }),
+      expect.objectContaining({
+        plaintextCode: expect.any(String),
+        status: "active",
+        storeId: STORE_ID,
+      }),
     );
 
     authServerMocks.getAuthUserId.mockResolvedValue(AUTH_USER_ID);
@@ -252,7 +281,7 @@ describe("POS recovery codes", () => {
     authServerMocks.getAuthUserId.mockResolvedValue(FULL_ADMIN_AUTH_USER_ID);
     const result = await rotate(ctx, { storeId: STORE_ID });
 
-    expect(result.code).toMatch(/^[0-9a-f-]+$/);
+    expect(result.code).toMatch(RECOVERY_CODE_PATTERN);
     expect(result.credential).toEqual(
       expect.objectContaining({
         rotatedByUserId: FULL_ADMIN_ID,
@@ -260,11 +289,9 @@ describe("POS recovery codes", () => {
         storeId: STORE_ID,
       }),
     );
-    expect(JSON.stringify(ctx.tables.posRecoveryCredential[0])).not.toContain(
-      result.code,
-    );
     expect(ctx.tables.posRecoveryCredential[0]).toEqual(
       expect.objectContaining({
+        plaintextCode: result.code,
         rotatedByUserId: FULL_ADMIN_ID,
         status: "active",
       }),
@@ -275,6 +302,53 @@ describe("POS recovery codes", () => {
           actorUserId: FULL_ADMIN_ID,
           eventType: "pos_recovery_code_rotated",
           metadata: expect.objectContaining({ reason: "rotated" }),
+        }),
+      ]),
+    );
+  });
+
+  it.each([
+    {
+      label: "missing POS membership",
+      mutate: (ctx: ReturnType<typeof buildCtx>) => {
+        ctx.tables.organizationMember = ctx.tables.organizationMember.filter(
+          (member) => member.userId !== POS_ACCOUNT_ID,
+        );
+      },
+      reason: "POS recovery account must have POS-only access.",
+    },
+    {
+      label: "admin POS membership",
+      mutate: (ctx: ReturnType<typeof buildCtx>) => {
+        const membership = ctx.tables.organizationMember.find(
+          (member) => member.userId === POS_ACCOUNT_ID,
+        );
+        membership.role = "full_admin";
+      },
+      reason: "POS recovery account must have POS-only access.",
+    },
+    {
+      label: "missing auth user",
+      mutate: (ctx: ReturnType<typeof buildCtx>) => {
+        ctx.tables.users = ctx.tables.users.filter(
+          (user) => user.email !== "pos@wigclub.store",
+        );
+      },
+      reason: "POS recovery account auth user is not configured.",
+    },
+  ])("does not generate recovery codes for $label", async ({ mutate, reason }) => {
+    const ctx = buildCtx();
+    const rotate = getHandler(rotateRecoveryCode);
+    mutate(ctx);
+
+    authServerMocks.getAuthUserId.mockResolvedValue(FULL_ADMIN_AUTH_USER_ID);
+    await expect(rotate(ctx, { storeId: STORE_ID })).rejects.toThrow(reason);
+
+    expect(ctx.tables.posRecoveryCredential).toHaveLength(0);
+    expect(ctx.tables.operationalEvent).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: expect.stringMatching(/^pos_recovery_code_/),
         }),
       ]),
     );

--- a/packages/athena-webapp/convex/pos/public/posRecoveryCodes.ts
+++ b/packages/athena-webapp/convex/pos/public/posRecoveryCodes.ts
@@ -16,8 +16,102 @@ import {
 
 const POS_RECOVERY_ACCOUNT_EMAIL = "pos@wigclub.store";
 const POS_RECOVERY_CODE_VERSION = 1;
-const POS_RECOVERY_CODE_BYTES = 18;
 const POS_RECOVERY_FAILURE_AUDIT_BUCKET_MS = 15 * 60 * 1000;
+const POS_RECOVERY_CODE_ALPHABET = "23456789ABCDEFGHJKMNPQRSTUVWXYZ";
+const POS_RECOVERY_CODE_GROUP_SIZE = 4;
+const POS_RECOVERY_CODE_GROUP_COUNT = 3;
+const POS_RECOVERY_CODE_LENGTH =
+  POS_RECOVERY_CODE_GROUP_SIZE * POS_RECOVERY_CODE_GROUP_COUNT;
+const POS_RECOVERY_CODE_WORDS = [
+  "anchor",
+  "apron",
+  "basket",
+  "beacon",
+  "berry",
+  "blanket",
+  "bottle",
+  "bridge",
+  "brush",
+  "button",
+  "candle",
+  "canvas",
+  "cart",
+  "cedar",
+  "chair",
+  "circle",
+  "clay",
+  "clock",
+  "cloud",
+  "cocoa",
+  "copper",
+  "coral",
+  "cotton",
+  "cup",
+  "daisy",
+  "desk",
+  "drum",
+  "fabric",
+  "feather",
+  "field",
+  "flame",
+  "flower",
+  "frame",
+  "garden",
+  "ginger",
+  "glass",
+  "globe",
+  "grape",
+  "harbor",
+  "hazel",
+  "honey",
+  "ivory",
+  "jacket",
+  "jewel",
+  "kettle",
+  "ladder",
+  "lamp",
+  "leaf",
+  "linen",
+  "maple",
+  "marble",
+  "meadow",
+  "mint",
+  "mirror",
+  "moss",
+  "needle",
+  "notebook",
+  "olive",
+  "orange",
+  "paddle",
+  "paper",
+  "pearl",
+  "pencil",
+  "pepper",
+  "petal",
+  "pillow",
+  "plum",
+  "pocket",
+  "ribbon",
+  "river",
+  "saddle",
+  "saffron",
+  "shell",
+  "silver",
+  "sketch",
+  "slate",
+  "spoon",
+  "stone",
+  "table",
+  "thread",
+  "ticket",
+  "toast",
+  "velvet",
+  "violet",
+  "walnut",
+  "window",
+  "wood",
+  "wool",
+] as const;
 const GENERIC_RECOVERY_FAILURE = "POS recovery sign-in failed.";
 
 type PosRecoveryCredential = Doc<"posRecoveryCredential">;
@@ -43,8 +137,47 @@ function randomHex(byteCount: number) {
   return bytesToHex(bytes);
 }
 
+function randomIndex(max: number) {
+  const maxUniformByte = Math.floor(256 / max) * max;
+  const byte = new Uint8Array(1);
+
+  do {
+    crypto.getRandomValues(byte);
+  } while (byte[0] >= maxUniformByte);
+
+  return byte[0] % max;
+}
+
+function formatRecoveryCode(compactCode: string) {
+  return (
+    compactCode
+      .match(new RegExp(`.{1,${POS_RECOVERY_CODE_GROUP_SIZE}}`, "g"))
+      ?.join("-") ?? compactCode
+  );
+}
+
 function generateRecoveryCode() {
-  return randomHex(POS_RECOVERY_CODE_BYTES).match(/.{1,6}/g)?.join("-") ?? "";
+  const words = Array.from({ length: 2 }, () =>
+    POS_RECOVERY_CODE_WORDS[randomIndex(POS_RECOVERY_CODE_WORDS.length)],
+  );
+  const number = randomIndex(100).toString().padStart(2, "0");
+
+  return `${words.join("")}${number}`;
+}
+
+function normalizeRecoveryCode(code: string) {
+  const compactCode = code.trim().toUpperCase().replace(/[\s-]+/g, "");
+
+  if (
+    compactCode.length === POS_RECOVERY_CODE_LENGTH &&
+    Array.from(compactCode).every((character) =>
+      POS_RECOVERY_CODE_ALPHABET.includes(character),
+    )
+  ) {
+    return formatRecoveryCode(compactCode);
+  }
+
+  return code.trim().toLowerCase().replace(/[-\s]+/g, "");
 }
 
 function getFailureAuditBucket(now: number) {
@@ -57,7 +190,7 @@ export async function hashPosRecoveryCode(args: {
 }) {
   const digest = await crypto.subtle.digest(
     "SHA-256",
-    new TextEncoder().encode(`${args.salt}:${args.code.trim()}`),
+    new TextEncoder().encode(`${args.salt}:${normalizeRecoveryCode(args.code)}`),
   );
 
   return bytesToHex(digest);
@@ -216,6 +349,35 @@ async function requirePosRecoveryAccount(ctx: PosRecoveryCtx) {
   return account;
 }
 
+async function requireUsablePosRecoveryAccount(
+  ctx: PosRecoveryCtx,
+  args: {
+    account: Doc<"athenaUser">;
+    organizationId: Id<"organization">;
+  },
+) {
+  const membership = await ctx.db
+    .query("organizationMember")
+    .filter((q) =>
+      q.and(
+        q.eq(q.field("organizationId"), args.organizationId),
+        q.eq(q.field("userId"), args.account._id),
+      ),
+    )
+    .first();
+
+  if (!membership || membership.role !== "pos_only") {
+    throw new Error("POS recovery account must have POS-only access.");
+  }
+
+  const authUser = await findAuthUserByEmail(ctx, POS_RECOVERY_ACCOUNT_EMAIL);
+  if (!authUser) {
+    throw new Error("POS recovery account auth user is not configured.");
+  }
+
+  return { authUser, membership };
+}
+
 function publicCredentialStatus(credential: PosRecoveryCredential | null) {
   if (!credential) {
     return null;
@@ -229,6 +391,7 @@ function publicCredentialStatus(credential: PosRecoveryCredential | null) {
     lastUsedAt: credential.lastUsedAt,
     lockedAt: credential.lockedAt,
     lockedUntil: credential.lockedUntil,
+    plaintextCode: credential.plaintextCode,
     posAccountId: credential.posAccountId,
     revokedAt: credential.revokedAt,
     rotatedAt: credential.rotatedAt,
@@ -251,6 +414,10 @@ async function rotateCredentialWithCtx(
     throw new Error("Store not found.");
   }
   const account = await requirePosRecoveryAccount(ctx);
+  await requireUsablePosRecoveryAccount(ctx, {
+    account,
+    organizationId: store.organizationId,
+  });
   const now = Date.now();
   const code = generateRecoveryCode();
   const codeSalt = randomHex(16);
@@ -270,6 +437,7 @@ async function rotateCredentialWithCtx(
       lastFailedAt: undefined,
       lockedAt: undefined,
       lockedUntil: undefined,
+      plaintextCode: code,
       revokedAt: undefined,
       revokedByUserId: undefined,
       rotatedAt: now,
@@ -294,6 +462,7 @@ async function rotateCredentialWithCtx(
     createdByUserId: args.actorUserId,
     failedAttemptCount: 0,
     organizationId: store.organizationId,
+    plaintextCode: code,
     posAccountId: account._id,
     rotatedAt: now,
     rotatedByUserId: args.actorUserId,
@@ -473,11 +642,17 @@ export const revokeRecoveryCode = mutation({
     }
     const now = Date.now();
     await ctx.db.patch("posRecoveryCredential", credential._id, {
+      plaintextCode: undefined,
       revokedAt: now,
       revokedByUserId: actor._id,
       status: "revoked",
     });
-    const nextCredential = { ...credential, revokedAt: now, status: "revoked" as const };
+    const nextCredential = {
+      ...credential,
+      plaintextCode: undefined,
+      revokedAt: now,
+      status: "revoked" as const,
+    };
     await recordRecoveryCodeEvent(ctx, {
       actorUserId: actor._id,
       credential: nextCredential,

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -325,6 +325,7 @@ function stripRuntimeStatusInput(
     snapshots: {
       catalogAgeMs: status.snapshots.catalogAgeMs,
       availabilityAgeMs: status.snapshots.availabilityAgeMs,
+      serviceCatalogAgeMs: status.snapshots.serviceCatalogAgeMs,
       registerReadModelAgeMs: status.snapshots.registerReadModelAgeMs,
     },
   };

--- a/packages/athena-webapp/convex/schemas/pos/posRecoveryCredential.ts
+++ b/packages/athena-webapp/convex/schemas/pos/posRecoveryCredential.ts
@@ -13,6 +13,7 @@ export const posRecoveryCredentialSchema = v.object({
   lockedAt: v.optional(v.number()),
   lockedUntil: v.optional(v.number()),
   organizationId: v.id("organization"),
+  plaintextCode: v.optional(v.string()),
   posAccountId: v.id("athenaUser"),
   revokedAt: v.optional(v.number()),
   revokedByUserId: v.optional(v.id("athenaUser")),

--- a/packages/athena-webapp/convex/schemas/pos/posTerminalRuntimeStatus.ts
+++ b/packages/athena-webapp/convex/schemas/pos/posTerminalRuntimeStatus.ts
@@ -90,6 +90,7 @@ export const posTerminalRuntimeStaffAuthorityValidator = v.object({
 export const posTerminalRuntimeSnapshotsValidator = v.object({
   catalogAgeMs: v.optional(v.number()),
   availabilityAgeMs: v.optional(v.number()),
+  serviceCatalogAgeMs: v.optional(v.number()),
   registerReadModelAgeMs: v.optional(v.number()),
 });
 

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -7,7 +7,7 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Core app surfaces
 
 - [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 86 file(s); key children: __root.tsx, _authed, _authed.test.tsx, _authed.tsx, index.test.tsx.
-- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 591 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
+- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 592 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
 - [`src/components/traces`](../../src/components/traces) — Shared workflow trace screens, ordered timelines, and trace detail primitives. Currently 3 file(s); key children: WorkflowTraceRouteLink.tsx, WorkflowTraceView.test.tsx, WorkflowTraceView.tsx.
 - [`src/components/operations`](../../src/components/operations) — Manager-queue and stock-adjustment workflows that share approval rails with other operational surfaces. Currently 24 file(s); key children: CommandApprovalDialog.test.tsx, CommandApprovalDialog.tsx, DailyCloseHistoryView.test.tsx, DailyCloseHistoryView.tsx, DailyCloseView.test.tsx.
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.

--- a/packages/athena-webapp/src/components/app-sidebar.test.tsx
+++ b/packages/athena-webapp/src/components/app-sidebar.test.tsx
@@ -135,7 +135,7 @@ describe("AppSidebar capability gates", () => {
     mocks.useQuery.mockReturnValue([]);
   });
 
-  it("lets manager elevation expose store-day surfaces without admin surfaces", () => {
+  it("lets POS-only accounts open store-day surfaces without admin surfaces", () => {
     mocks.usePermissions.mockReturnValue({
       canAccessAdmin: () => false,
       canAccessFullAdminSurfaces: () => false,

--- a/packages/athena-webapp/src/components/auth/Login/LoginForm.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/LoginForm.tsx
@@ -6,7 +6,7 @@ import { Input } from "../../ui/input";
 import { LoadingButton } from "../../ui/loading-button";
 import { ATHENA_EMAIL_OTP_PROVIDER_ID } from "../../../../shared/auth";
 import { z } from "zod";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, KeyRound } from "lucide-react";
 
 export function LoginForm({
   onUsePosRecoveryCode,
@@ -46,7 +46,7 @@ export function LoginForm({
         </h2>
       </div>
       <form
-        className="relative flex w-full flex-col items-start gap-layout-md overflow-hidden rounded-lg border border-none bg-background p-layout-xs before:pointer-events-none before:absolute before:inset-0"
+        className="relative flex w-full flex-col items-start gap-layout-lg overflow-hidden rounded-lg border border-none bg-background p-layout-xs before:pointer-events-none before:absolute before:inset-0"
         onSubmit={(e) => {
           e.preventDefault();
           e.stopPropagation();
@@ -96,13 +96,25 @@ export function LoginForm({
           <ArrowRight className="h-4 w-4 transition-transform duration-standard ease-emphasized group-hover:translate-x-1 group-focus-visible:translate-x-1" />
         </LoadingButton>
         {onUsePosRecoveryCode ? (
-          <button
-            type="button"
-            className="relative z-10 text-sm text-muted-foreground underline-offset-4 transition-colors duration-standard ease-standard hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-            onClick={onUsePosRecoveryCode}
-          >
-            Use POS recovery code
-          </button>
+          <section className="relative z-10 w-full border-t border-border pt-layout-md">
+            <button
+              type="button"
+              aria-label="POS sign in"
+              className="group flex w-full items-center justify-between gap-layout-sm rounded-md border border-action-workflow-border bg-action-workflow-soft px-layout-md py-layout-sm text-left text-sm font-medium text-action-workflow transition-colors duration-standard ease-standard hover:bg-action-workflow-soft/75 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              onClick={onUsePosRecoveryCode}
+            >
+              <span className="inline-flex min-w-0 items-center gap-layout-sm">
+                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-background text-action-workflow">
+                  <KeyRound aria-hidden="true" className="h-4 w-4" />
+                </span>
+                <span>POS sign in</span>
+              </span>
+              <ArrowRight
+                aria-hidden="true"
+                className="h-4 w-4 shrink-0 transition-transform duration-standard ease-emphasized group-hover:translate-x-1 group-focus-visible:translate-x-1"
+              />
+            </button>
+          </section>
         ) : null}
       </form>
     </div>

--- a/packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/PosRecoveryCodeForm.tsx
@@ -158,6 +158,7 @@ export function PosRecoveryCodeForm({
           <Input
             id="pos-recovery-code"
             autoComplete="off"
+            autoCapitalize="none"
             inputMode="text"
             value={code}
             onChange={(event) => setCode(event.target.value)}

--- a/packages/athena-webapp/src/components/auth/Login/index.test.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/index.test.tsx
@@ -7,6 +7,7 @@ import { Login } from "./index";
 
 const mocked = vi.hoisted(() => ({
   navigate: vi.fn(),
+  readProvisionedTerminalSeed: vi.fn(),
   signIn: vi.fn(),
   useSearch: vi.fn(),
 }));
@@ -20,11 +21,21 @@ vi.mock("@tanstack/react-router", () => ({
   useSearch: mocked.useSearch,
 }));
 
+vi.mock("@/lib/pos/infrastructure/local/posLocalStore", () => ({
+  createIndexedDbPosLocalStorageAdapter: () => ({}),
+  createPosLocalStore: () => ({
+    readProvisionedTerminalSeed: mocked.readProvisionedTerminalSeed,
+  }),
+}));
+
 describe("Login", () => {
   beforeEach(() => {
     mocked.navigate.mockReset();
+    mocked.readProvisionedTerminalSeed.mockReset();
+    mocked.readProvisionedTerminalSeed.mockResolvedValue({ ok: true, value: null });
     mocked.signIn.mockReset();
     mocked.useSearch.mockReset();
+    vi.stubGlobal("indexedDB", {});
     window.sessionStorage.clear();
   });
 
@@ -38,7 +49,7 @@ describe("Login", () => {
     render(<Login />);
 
     await user.click(
-      screen.getByRole("button", { name: /use pos recovery code/i }),
+      screen.getByRole("button", { name: /pos sign in/i }),
     );
     await user.type(screen.getByLabelText(/recovery code/i), "abc-123");
     await user.click(screen.getByRole("button", { name: /continue/i }));
@@ -59,14 +70,106 @@ describe("Login", () => {
     });
   });
 
-  it("disables recovery-code submission when redirectTo is not a POS route", async () => {
+  it("uses the provisioned local terminal seed for generic login recovery", async () => {
+    const user = userEvent.setup();
+    mocked.signIn.mockResolvedValue({ signingIn: true });
+    mocked.useSearch.mockReturnValue({});
+    mocked.readProvisionedTerminalSeed.mockResolvedValue({
+      ok: true,
+      value: {
+        cloudTerminalId: "terminal-1",
+        displayName: "Front register",
+        orgUrlSlug: "wigclub",
+        provisionedAt: 1,
+        schemaVersion: 7,
+        storeId: "store-1",
+        storeUrlSlug: "wigclub",
+        syncSecretHash: "secret-hash",
+        terminalId: "fingerprint-1",
+      },
+    });
+
+    render(<Login />);
+
+    await user.click(
+      screen.getByRole("button", { name: /pos sign in/i }),
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Open recovery from the store login route."),
+      ).not.toBeInTheDocument(),
+    );
+    await user.type(screen.getByLabelText(/recovery code/i), "abc-123");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() =>
+      expect(mocked.signIn).toHaveBeenCalledWith(
+        ATHENA_POS_RECOVERY_CODE_PROVIDER_ID,
+        {
+          code: "abc-123",
+          email: "pos@wigclub.store",
+          orgUrlSlug: "wigclub",
+          storeId: "store-1",
+          storeUrlSlug: "wigclub",
+        },
+      ),
+    );
+    expect(mocked.navigate).toHaveBeenCalledWith({
+      to: "/wigclub/store/wigclub/pos",
+    });
+  });
+
+  it("uses an existing provisioned terminal seed without slugs for store-scoped recovery", async () => {
+    const user = userEvent.setup();
+    mocked.signIn.mockResolvedValue({ signingIn: true });
+    mocked.useSearch.mockReturnValue({});
+    mocked.readProvisionedTerminalSeed.mockResolvedValue({
+      ok: true,
+      value: {
+        cloudTerminalId: "terminal-1",
+        displayName: "Front register",
+        provisionedAt: 1,
+        schemaVersion: 7,
+        storeId: "store-1",
+        syncSecretHash: "secret-hash",
+        terminalId: "fingerprint-1",
+      },
+    });
+
+    render(<Login />);
+
+    await user.click(
+      screen.getByRole("button", { name: /pos sign in/i }),
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Open recovery from the store login route."),
+      ).not.toBeInTheDocument(),
+    );
+    await user.type(screen.getByLabelText(/recovery code/i), "abc-123");
+    await user.click(screen.getByRole("button", { name: /continue/i }));
+
+    await waitFor(() =>
+      expect(mocked.signIn).toHaveBeenCalledWith(
+        ATHENA_POS_RECOVERY_CODE_PROVIDER_ID,
+        {
+          code: "abc-123",
+          email: "pos@wigclub.store",
+          storeId: "store-1",
+        },
+      ),
+    );
+    expect(mocked.navigate).toHaveBeenCalledWith({ to: "/" });
+  });
+
+  it("disables recovery-code submission when neither url nor local browser state identifies a store", async () => {
     const user = userEvent.setup();
     mocked.useSearch.mockReturnValue({ redirectTo: "/login" });
 
     render(<Login />);
 
     await user.click(
-      screen.getByRole("button", { name: /use pos recovery code/i }),
+      screen.getByRole("button", { name: /pos sign in/i }),
     );
     await user.type(screen.getByLabelText(/recovery code/i), "abc-123");
 

--- a/packages/athena-webapp/src/components/auth/Login/index.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/index.tsx
@@ -1,8 +1,13 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { LoginForm } from "./LoginForm";
 import { InputOTPForm } from "./InputOTP";
 import { PosRecoveryCodeForm } from "./PosRecoveryCodeForm";
 import { useSearch } from "@tanstack/react-router";
+import {
+  createIndexedDbPosLocalStorageAdapter,
+  createPosLocalStore,
+  type PosProvisionedTerminalSeed,
+} from "@/lib/pos/infrastructure/local/posLocalStore";
 
 const POS_ROUTE_PATTERN =
   /^\/(?<orgUrlSlug>[^/]+)\/store\/(?<storeUrlSlug>[^/]+)\/pos(?:\/.*)?$/;
@@ -20,14 +25,48 @@ function getPosRouteScope(redirectTo?: string) {
   };
 }
 
+function getPosRedirectFromSeed(seed: PosProvisionedTerminalSeed | null) {
+  if (!seed?.orgUrlSlug || !seed.storeUrlSlug) return null;
+
+  return `/${seed.orgUrlSlug}/store/${seed.storeUrlSlug}/pos`;
+}
+
 export function Login() {
   const [step, setStep] = useState<"signIn" | "posRecovery" | { email: string }>(
     "signIn",
   );
+  const [localTerminalSeed, setLocalTerminalSeed] =
+    useState<PosProvisionedTerminalSeed | null>(null);
   const search = useSearch({ strict: false }) as
     | { redirectTo?: string; storeId?: string }
     | undefined;
   const posRouteScope = getPosRouteScope(search?.redirectTo);
+  const localPosRedirect = useMemo(
+    () => getPosRedirectFromSeed(localTerminalSeed),
+    [localTerminalSeed],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (typeof indexedDB === "undefined") {
+      return;
+    }
+
+    void (async () => {
+      const result = await createPosLocalStore({
+        adapter: createIndexedDbPosLocalStorageAdapter(),
+      }).readProvisionedTerminalSeed();
+
+      if (!cancelled && result.ok) {
+        setLocalTerminalSeed(result.value);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   if (step === "signIn") {
     return (
@@ -40,10 +79,14 @@ export function Login() {
   if (step === "posRecovery") {
     return (
       <PosRecoveryCodeForm
-        orgUrlSlug={posRouteScope?.orgUrlSlug ?? null}
-        redirectTo={search?.redirectTo ?? null}
-        storeId={search?.storeId ?? null}
-        storeUrlSlug={posRouteScope?.storeUrlSlug ?? null}
+        orgUrlSlug={
+          posRouteScope?.orgUrlSlug ?? localTerminalSeed?.orgUrlSlug ?? null
+        }
+        redirectTo={search?.redirectTo ?? localPosRedirect}
+        storeId={search?.storeId ?? localTerminalSeed?.storeId ?? null}
+        storeUrlSlug={
+          posRouteScope?.storeUrlSlug ?? localTerminalSeed?.storeUrlSlug ?? null
+        }
         onBack={() => setStep("signIn")}
       />
     );

--- a/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.test.tsx
@@ -416,6 +416,60 @@ describe("CashControlsDashboardContent", () => {
     expect(screen.getByText("BANK-339")).toBeInTheDocument();
   });
 
+  it("redacts cash amounts for POS-only users without manager access", () => {
+    render(
+      <CashControlsDashboardContent
+        currency="USD"
+        dashboardSnapshot={{
+          ...baseSnapshot,
+          openSessions: [
+            {
+              _id: "session-open",
+              expectedCash: 24800,
+              openedAt: new Date("2026-04-21T09:15:00.000Z").getTime(),
+              openingFloat: 5000,
+              registerNumber: "Register 1",
+              status: "active",
+              totalDeposited: 8000,
+              variance: 0,
+            },
+          ],
+          recentDeposits: [
+            {
+              _id: "deposit-1",
+              amount: 8000,
+              recordedAt: new Date("2026-04-21T13:00:00.000Z").getTime(),
+              reference: "BANK-117",
+              registerNumber: "Register 1",
+              registerSessionId: "session-open",
+            },
+          ],
+          registerSessions: [
+            {
+              _id: "session-open",
+              expectedCash: 24800,
+              openedAt: new Date("2026-04-21T09:15:00.000Z").getTime(),
+              openingFloat: 5000,
+              registerNumber: "Register 1",
+              status: "active",
+              totalDeposited: 8000,
+              variance: 0,
+            },
+          ],
+        }}
+        hasFinancialDetailsAccess={false}
+        isLoading={false}
+        orgUrlSlug="v26"
+        storeUrlSlug="east-legon"
+      />,
+    );
+
+    expect(screen.queryByText("$248")).not.toBeInTheDocument();
+    expect(screen.queryByText("$80")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Manager only")).not.toHaveLength(0);
+    expect(screen.getAllByText("Register 1")).not.toHaveLength(0);
+  });
+
   it("replaces the closed-session preview table with a store history snapshot when all drawers are closed", () => {
     render(
       <CashControlsDashboardContent

--- a/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/CashControlsDashboard.tsx
@@ -1,6 +1,7 @@
 import { Link, useParams } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
 import { ArrowRight, ArrowUpRight } from "lucide-react";
+import type { ReactNode } from "react";
 
 import { useProtectedAdminPageState } from "@/hooks/useProtectedAdminPageState";
 import { capitalizeWords, cn } from "@/lib/utils";
@@ -8,6 +9,7 @@ import { formatStoredCurrencyAmount } from "@/lib/pos/displayAmounts";
 import { api } from "~/convex/_generated/api";
 import View from "../View";
 import { FadeIn } from "../common/FadeIn";
+import { FinancialValue } from "../common/FinancialValue";
 import {
   PageLevelHeader,
   PageWorkspace,
@@ -93,6 +95,7 @@ export type CashControlsDashboardSnapshot = {
 type CashControlsDashboardContentProps = {
   currency: string;
   dashboardSnapshot: CashControlsDashboardSnapshot;
+  hasFinancialDetailsAccess?: boolean;
   isLoading: boolean;
   orgUrlSlug: string;
   storeUrlSlug: string;
@@ -106,6 +109,24 @@ function formatCurrency(currency: string, amount?: number | null) {
   return formatStoredCurrencyAmount(currency, amount, {
     revealMinorUnits: true,
   });
+}
+
+function CashControlsFinancialValue({
+  amount,
+  canView,
+  currency,
+  label,
+}: {
+  amount?: number | null;
+  canView: boolean;
+  currency: string;
+  label: string;
+}) {
+  return (
+    <FinancialValue canView={canView} label={label}>
+      {formatCurrency(currency, amount)}
+    </FinancialValue>
+  );
 }
 
 function formatStatusLabel(status: string) {
@@ -196,9 +217,11 @@ function formatCashExposureSupporting(snapshot: CashControlsDashboardSnapshot) {
 
 function CashPositionSummary({
   currency,
+  hasFinancialDetailsAccess,
   snapshot,
 }: {
   currency: string;
+  hasFinancialDetailsAccess: boolean;
   snapshot: CashControlsDashboardSnapshot;
 }) {
   const {
@@ -212,22 +235,50 @@ function CashPositionSummary({
     {
       label: "Expected in drawers",
       supporting: formatCashExposureSupporting(snapshot),
-      value: formatCurrency(currency, expectedCashTotal),
+      value: (
+        <CashControlsFinancialValue
+          amount={expectedCashTotal}
+          canView={hasFinancialDetailsAccess}
+          currency={currency}
+          label="Expected in drawers"
+        />
+      ),
     },
     {
       label: "Deposits recorded",
       supporting: `${snapshot.recentDeposits.length == 0 ? "No" : snapshot.recentDeposits.length} recent drop${snapshot.recentDeposits.length === 1 ? "" : "s"}`,
-      value: formatCurrency(currency, depositedTotal),
+      value: (
+        <CashControlsFinancialValue
+          amount={depositedTotal}
+          canView={hasFinancialDetailsAccess}
+          currency={currency}
+          label="Deposits recorded"
+        />
+      ),
     },
     {
       label: "Still in drawers",
       supporting: "Live and review drawers minus deposits",
-      value: formatCurrency(currency, onHandTotal),
+      value: (
+        <CashControlsFinancialValue
+          amount={onHandTotal}
+          canView={hasFinancialDetailsAccess}
+          currency={currency}
+          label="Still in drawers"
+        />
+      ),
     },
     {
       label: "Variance to review",
       supporting: `${snapshot.unresolvedVariances.length} unresolved`,
-      value: formatCurrency(currency, unresolvedVarianceTotal),
+      value: (
+        <CashControlsFinancialValue
+          amount={unresolvedVarianceTotal}
+          canView={hasFinancialDetailsAccess}
+          currency={currency}
+          label="Variance to review"
+        />
+      ),
       valueClassName:
         snapshot.unresolvedVariances.length > 0
           ? "text-danger"
@@ -377,7 +428,7 @@ function WorkflowSummaryItem({
 }: {
   label: string;
   tone?: string;
-  value: string;
+  value: ReactNode;
 }) {
   return (
     <div className="rounded-lg border border-border bg-background/70 px-layout-sm py-layout-xs">
@@ -398,12 +449,14 @@ function WorkflowSummaryItem({
 
 function DrawerSessionCard({
   currency,
+  hasFinancialDetailsAccess,
   orgUrlSlug,
   session,
   storeUrlSlug,
   variant = "standard",
 }: {
   currency: string;
+  hasFinancialDetailsAccess: boolean;
   orgUrlSlug: string;
   session: CashControlsDashboardSession;
   storeUrlSlug: string;
@@ -503,7 +556,12 @@ function DrawerSessionCard({
             Expected cash
           </dt>
           <dd className="mt-1 font-numeric tabular-nums text-sm text-foreground">
-            {formatCurrency(currency, session.expectedCash)}
+            <CashControlsFinancialValue
+              amount={session.expectedCash}
+              canView={hasFinancialDetailsAccess}
+              currency={currency}
+              label="Expected cash"
+            />
           </dd>
         </div>
         {showDeposited ? (
@@ -512,7 +570,12 @@ function DrawerSessionCard({
               Deposited
             </dt>
             <dd className="mt-1 font-numeric tabular-nums text-sm text-foreground">
-              {formatCurrency(currency, session.totalDeposited)}
+              <CashControlsFinancialValue
+                amount={session.totalDeposited}
+                canView={hasFinancialDetailsAccess}
+                currency={currency}
+                label="Deposited"
+              />
             </dd>
           </div>
         ) : null}
@@ -522,7 +585,12 @@ function DrawerSessionCard({
               Counted
             </dt>
             <dd className="mt-1 font-numeric tabular-nums text-sm text-foreground">
-              {formatCurrency(currency, session.countedCash ?? 0)}
+              <CashControlsFinancialValue
+                amount={session.countedCash ?? 0}
+                canView={hasFinancialDetailsAccess}
+                currency={currency}
+                label="Counted cash"
+              />
             </dd>
           </div>
         ) : null}
@@ -537,7 +605,12 @@ function DrawerSessionCard({
                 getVarianceTone(variance),
               )}
             >
-              {formatCurrency(currency, variance)}
+              <CashControlsFinancialValue
+                amount={variance}
+                canView={hasFinancialDetailsAccess}
+                currency={currency}
+                label="Variance"
+              />
             </dd>
           </div>
         ) : null}
@@ -575,6 +648,7 @@ function DrawerSessionCard({
 function DrawerSessionLane({
   currency,
   emptyDescription,
+  hasFinancialDetailsAccess,
   orgUrlSlug,
   sessions,
   storeUrlSlug,
@@ -583,6 +657,7 @@ function DrawerSessionLane({
 }: {
   currency: string;
   emptyDescription: string;
+  hasFinancialDetailsAccess: boolean;
   orgUrlSlug: string;
   sessions: CashControlsDashboardSession[];
   storeUrlSlug: string;
@@ -611,6 +686,7 @@ function DrawerSessionLane({
           {sessions.map((session) => (
             <DrawerSessionCard
               currency={currency}
+              hasFinancialDetailsAccess={hasFinancialDetailsAccess}
               key={session._id}
               orgUrlSlug={orgUrlSlug}
               session={session}
@@ -626,11 +702,13 @@ function DrawerSessionLane({
 
 function ClosedSessionsSummary({
   currency,
+  hasFinancialDetailsAccess,
   orgUrlSlug,
   sessions,
   storeUrlSlug,
 }: {
   currency: string;
+  hasFinancialDetailsAccess: boolean;
   orgUrlSlug: string;
   sessions: CashControlsDashboardSession[];
   storeUrlSlug: string;
@@ -742,7 +820,7 @@ function ClosedSessionsSummary({
                     <Link
                       aria-label={`Open ${formatRegisterName(session.registerNumber)} variance ${formatCurrency(
                         currency,
-                        session.variance ?? 0,
+                        hasFinancialDetailsAccess ? (session.variance ?? 0) : null,
                       )}`}
                       className="block h-full w-full px-4 py-4 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
                       params={{
@@ -753,7 +831,12 @@ function ClosedSessionsSummary({
                       search={{ o: getOrigin() }}
                       to="/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId"
                     >
-                      {formatCurrency(currency, session.variance ?? 0)}
+                      <CashControlsFinancialValue
+                        amount={session.variance ?? 0}
+                        canView={hasFinancialDetailsAccess}
+                        currency={currency}
+                        label="Variance"
+                      />
                     </Link>
                   </TableCell>
                 </TableRow>
@@ -787,11 +870,13 @@ function ClosedSessionsSummary({
 
 function ClosedSessionsSnapshot({
   currency,
+  hasFinancialDetailsAccess,
   orgUrlSlug,
   sessions,
   storeUrlSlug,
 }: {
   currency: string;
+  hasFinancialDetailsAccess: boolean;
   orgUrlSlug: string;
   sessions: CashControlsDashboardSession[];
   storeUrlSlug: string;
@@ -867,16 +952,37 @@ function ClosedSessionsSnapshot({
         <WorkflowSummaryItem label="Closed sessions" value={`${closedCount}`} />
         <WorkflowSummaryItem
           label="Expected cash"
-          value={formatCurrency(currency, expectedTotal)}
+          value={
+            <CashControlsFinancialValue
+              amount={expectedTotal}
+              canView={hasFinancialDetailsAccess}
+              currency={currency}
+              label="Expected cash"
+            />
+          }
         />
         <WorkflowSummaryItem
           label="Counted cash"
-          value={formatCurrency(currency, countedTotal)}
+          value={
+            <CashControlsFinancialValue
+              amount={countedTotal}
+              canView={hasFinancialDetailsAccess}
+              currency={currency}
+              label="Counted cash"
+            />
+          }
         />
         <WorkflowSummaryItem
           label="Net variance"
           tone={getVarianceTone(netVariance)}
-          value={formatCurrency(currency, netVariance)}
+          value={
+            <CashControlsFinancialValue
+              amount={netVariance}
+              canView={hasFinancialDetailsAccess}
+              currency={currency}
+              label="Net variance"
+            />
+          }
         />
       </dl>
 
@@ -894,7 +1000,13 @@ function ClosedSessionsSnapshot({
             Short drawers
           </p>
           <p className="font-numeric tabular-nums text-sm text-danger">
-            {shortSessions.length} / {formatCurrency(currency, shortTotal)}
+            {shortSessions.length} /{" "}
+            <CashControlsFinancialValue
+              amount={shortTotal}
+              canView={hasFinancialDetailsAccess}
+              currency={currency}
+              label="Short drawers total"
+            />
           </p>
         </div>
         <div className="space-y-1">
@@ -902,7 +1014,13 @@ function ClosedSessionsSnapshot({
             Over drawers
           </p>
           <p className="font-numeric tabular-nums text-sm text-success">
-            {overSessions.length} / {formatCurrency(currency, overTotal)}
+            {overSessions.length} /{" "}
+            <CashControlsFinancialValue
+              amount={overTotal}
+              canView={hasFinancialDetailsAccess}
+              currency={currency}
+              label="Over drawers total"
+            />
           </p>
         </div>
         <div className="space-y-1">
@@ -921,7 +1039,12 @@ function ClosedSessionsSnapshot({
             Deposited across closed sessions
           </span>
           <span className="font-numeric tabular-nums text-foreground">
-            {formatCurrency(currency, depositedTotal)}
+            <CashControlsFinancialValue
+              amount={depositedTotal}
+              canView={hasFinancialDetailsAccess}
+              currency={currency}
+              label="Deposited across closed sessions"
+            />
           </span>
         </div>
       </div>
@@ -931,11 +1054,13 @@ function ClosedSessionsSnapshot({
 
 function CashroomWorkflow({
   currency,
+  hasFinancialDetailsAccess,
   snapshot,
   orgUrlSlug,
   storeUrlSlug,
 }: {
   currency: string;
+  hasFinancialDetailsAccess: boolean;
   snapshot: CashControlsDashboardSnapshot;
   orgUrlSlug: string;
   storeUrlSlug: string;
@@ -991,6 +1116,7 @@ function CashroomWorkflow({
             <DrawerSessionLane
               currency={currency}
               emptyDescription={primaryLane.emptyDescription}
+              hasFinancialDetailsAccess={hasFinancialDetailsAccess}
               orgUrlSlug={orgUrlSlug}
               sessions={primaryLane.sessions}
               storeUrlSlug={storeUrlSlug}
@@ -1003,6 +1129,7 @@ function CashroomWorkflow({
               <DrawerSessionLane
                 currency={currency}
                 emptyDescription="No live drawers are open right now"
+                hasFinancialDetailsAccess={hasFinancialDetailsAccess}
                 orgUrlSlug={orgUrlSlug}
                 sessions={liveDrawers}
                 storeUrlSlug={storeUrlSlug}
@@ -1012,6 +1139,7 @@ function CashroomWorkflow({
             {primaryLane ? (
               <ClosedSessionsSummary
                 currency={currency}
+                hasFinancialDetailsAccess={hasFinancialDetailsAccess}
                 orgUrlSlug={orgUrlSlug}
                 sessions={closedSessions}
                 storeUrlSlug={storeUrlSlug}
@@ -1019,6 +1147,7 @@ function CashroomWorkflow({
             ) : (
               <ClosedSessionsSnapshot
                 currency={currency}
+                hasFinancialDetailsAccess={hasFinancialDetailsAccess}
                 orgUrlSlug={orgUrlSlug}
                 sessions={closedSessions}
                 storeUrlSlug={storeUrlSlug}
@@ -1034,11 +1163,13 @@ function CashroomWorkflow({
 function DepositsLedger({
   currency,
   deposits,
+  hasFinancialDetailsAccess,
   orgUrlSlug,
   storeUrlSlug,
 }: {
   currency: string;
   deposits: CashControlsDashboardDeposit[];
+  hasFinancialDetailsAccess: boolean;
   orgUrlSlug: string;
   storeUrlSlug: string;
 }) {
@@ -1090,7 +1221,12 @@ function DepositsLedger({
                     {formatRegisterName(deposit.registerNumber)}
                   </TableCell>
                   <TableCell className="font-numeric tabular-nums text-foreground">
-                    {formatCurrency(currency, deposit.amount)}
+                    <CashControlsFinancialValue
+                      amount={deposit.amount}
+                      canView={hasFinancialDetailsAccess}
+                      currency={currency}
+                      label="Deposit amount"
+                    />
                   </TableCell>
                   <TableCell className="text-muted-foreground">
                     {formatTimestamp(deposit.recordedAt)}
@@ -1141,6 +1277,7 @@ function DepositsLedger({
 export function CashControlsDashboardContent({
   currency,
   dashboardSnapshot,
+  hasFinancialDetailsAccess = true,
   isLoading,
   orgUrlSlug,
   storeUrlSlug,
@@ -1174,12 +1311,14 @@ export function CashControlsDashboardContent({
                 </div>
                 <CashPositionSummary
                   currency={currency}
+                  hasFinancialDetailsAccess={hasFinancialDetailsAccess}
                   snapshot={dashboardSnapshot}
                 />
               </section>
 
               <CashroomWorkflow
                 currency={currency}
+                hasFinancialDetailsAccess={hasFinancialDetailsAccess}
                 orgUrlSlug={orgUrlSlug}
                 snapshot={dashboardSnapshot}
                 storeUrlSlug={storeUrlSlug}
@@ -1188,6 +1327,7 @@ export function CashControlsDashboardContent({
               <DepositsLedger
                 currency={currency}
                 deposits={dashboardSnapshot.recentDeposits}
+                hasFinancialDetailsAccess={hasFinancialDetailsAccess}
                 orgUrlSlug={orgUrlSlug}
                 storeUrlSlug={storeUrlSlug}
               />
@@ -1204,6 +1344,7 @@ export function CashControlsDashboard() {
     activeStore,
     canAccessProtectedSurface,
     canQueryProtectedData,
+    hasFinancialDetailsAccess,
     hasFullAdminAccess,
     isAuthenticated,
     isLoadingAccess,
@@ -1261,6 +1402,7 @@ export function CashControlsDashboard() {
           unresolvedVariances: [],
         }
       }
+      hasFinancialDetailsAccess={hasFinancialDetailsAccess}
       isLoading={dashboardSnapshot === undefined}
       orgUrlSlug={params.orgUrlSlug}
       storeUrlSlug={params.storeUrlSlug}

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionsView.tsx
@@ -27,6 +27,7 @@ import type {
 
 type RegisterSessionsViewContentProps = {
   currency: string;
+  hasFinancialDetailsAccess?: boolean;
   isLoading: boolean;
   orgUrlSlug: string;
   registerSessions: CashControlsDashboardSession[];
@@ -41,6 +42,18 @@ function formatCurrency(currency: string, amount?: number | null) {
   return formatStoredCurrencyAmount(currency, amount, {
     revealMinorUnits: true,
   });
+}
+
+function formatFinancialLabel(
+  hasFinancialDetailsAccess: boolean,
+  currency: string,
+  amount?: number | null,
+) {
+  if (!hasFinancialDetailsAccess) {
+    return "Manager only";
+  }
+
+  return formatCurrency(currency, amount);
 }
 
 function formatRegisterName(registerNumber?: string | null) {
@@ -147,6 +160,7 @@ function formatSessionCode(sessionId: string) {
 
 export function RegisterSessionsViewContent({
   currency,
+  hasFinancialDetailsAccess = true,
   isLoading,
   orgUrlSlug,
   registerSessions,
@@ -160,9 +174,21 @@ export function RegisterSessionsViewContent({
         closedAtLabel: session.closedAt
           ? formatTimestamp(session.closedAt)
           : "Not closed",
-        countedCashLabel: formatCurrency(currency, session.countedCash),
-        depositedLabel: formatCurrency(currency, session.totalDeposited),
-        expectedCashLabel: formatCurrency(currency, session.expectedCash),
+        countedCashLabel: formatFinancialLabel(
+          hasFinancialDetailsAccess,
+          currency,
+          session.countedCash,
+        ),
+        depositedLabel: formatFinancialLabel(
+          hasFinancialDetailsAccess,
+          currency,
+          session.totalDeposited,
+        ),
+        expectedCashLabel: formatFinancialLabel(
+          hasFinancialDetailsAccess,
+          currency,
+          session.expectedCash,
+        ),
         expectedCashValue: session.expectedCash,
         openedAtLabel: formatTimestamp(session.openedAt),
         openedAtSort: session.openedAt,
@@ -178,11 +204,15 @@ export function RegisterSessionsViewContent({
           session.closedAt,
         ),
         varianceCaption: getVarianceCaption(session.variance),
-        varianceLabel: formatCurrency(currency, session.variance ?? 0),
+        varianceLabel: formatFinancialLabel(
+          hasFinancialDetailsAccess,
+          currency,
+          session.variance ?? 0,
+        ),
         varianceTone: getVarianceTone(session.variance),
         varianceValue: session.variance ?? 0,
       })),
-    [currency, registerSessions],
+    [currency, hasFinancialDetailsAccess, registerSessions],
   );
 
   return (
@@ -240,6 +270,7 @@ export function RegisterSessionsView() {
     activeStore,
     canAccessProtectedSurface,
     canQueryProtectedData,
+    hasFinancialDetailsAccess,
     hasFullAdminAccess,
     isAuthenticated,
     isLoadingAccess,
@@ -288,6 +319,7 @@ export function RegisterSessionsView() {
   return (
     <RegisterSessionsViewContent
       currency={activeStore.currency || "USD"}
+      hasFinancialDetailsAccess={hasFinancialDetailsAccess}
       isLoading={dashboardSnapshot === undefined}
       orgUrlSlug={params.orgUrlSlug}
       registerSessions={dashboardSnapshot?.registerSessions ?? []}

--- a/packages/athena-webapp/src/components/common/FinancialValue.tsx
+++ b/packages/athena-webapp/src/components/common/FinancialValue.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+type FinancialValueProps = {
+  canView: boolean;
+  children: ReactNode;
+  className?: string;
+  label?: string;
+};
+
+export function FinancialValue({
+  canView,
+  children,
+  className,
+  label = "Financial detail",
+}: FinancialValueProps) {
+  if (canView) {
+    return <>{children}</>;
+  }
+
+  return (
+    <span
+      aria-label={`${label} hidden until manager access is active`}
+      className={cn(
+        "inline-flex min-w-[6.5rem] items-center justify-center rounded-md border border-border bg-muted/60 px-2 py-0.5 text-xs font-medium text-muted-foreground",
+        className,
+      )}
+    >
+      Manager only
+    </span>
+  );
+}

--- a/packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx
+++ b/packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx
@@ -3,7 +3,7 @@ import { CartItem } from "../pos/types";
 import useGetActiveStore from "~/src/hooks/useGetActiveStore";
 import { currencyFormatter } from "~/convex/utils";
 import { toDisplayAmount } from "~/convex/lib/currency";
-import { Check, Printer } from "lucide-react";
+import { Check, Plus, Printer } from "lucide-react";
 
 interface ExpenseCompletionProps {
   cartItems: CartItem[];
@@ -20,6 +20,7 @@ interface ExpenseCompletionProps {
     notes?: string | null;
   } | null;
   reportNumber?: string | null;
+  recordedBy?: string | null;
   onPrintReceipt?: () => void | Promise<void>;
   onTransactionStateChange?: (isCompleted: boolean) => void;
 }
@@ -32,6 +33,7 @@ export function ExpenseCompletion({
   isCompleted,
   completedTransactionData,
   reportNumber,
+  recordedBy,
   onPrintReceipt,
   onTransactionStateChange,
 }: ExpenseCompletionProps) {
@@ -45,84 +47,93 @@ export function ExpenseCompletion({
     );
 
     return (
-      <div className="flex min-h-0 flex-1 flex-col gap-4">
-        <div className="rounded-lg border border-[hsl(var(--success)/0.24)] bg-[hsl(var(--success)/0.08)] p-4">
-          <div className="flex items-start gap-3">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[hsl(var(--success))] text-[hsl(var(--success-foreground))]">
-              <Check className="h-5 w-5" />
+      <section className="relative flex h-full min-h-[36rem] flex-1 flex-col overflow-hidden rounded-[1.75rem] border border-border/80 bg-[linear-gradient(145deg,hsl(var(--surface-raised))_0%,hsl(var(--surface))_52%,hsl(var(--muted)/0.72)_100%)] p-8 shadow-[var(--shadow-surface)] md:p-10">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-x-8 top-0 h-px bg-gradient-to-r from-transparent via-primary/40 to-transparent"
+        />
+
+        <div className="flex flex-1 flex-col">
+          <div className="space-y-10">
+            <div className="inline-flex h-16 w-16 items-center justify-center rounded-[1.4rem] bg-[hsl(var(--success))] text-[hsl(var(--success-foreground))] shadow-[0_20px_40px_-24px_hsl(var(--success)/0.75)] animate-[presence-lift_var(--motion-standard)_var(--ease-emphasized)_both]">
+              <Check className="h-7 w-7" />
             </div>
-            <div className="min-w-0 flex-1">
-              <p className="text-xs font-semibold uppercase tracking-[0.22em] text-[hsl(var(--success))]">
-                Expense recorded
+
+            <div className="max-w-2xl space-y-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.28em] text-muted-foreground">
+                Expense complete
               </p>
-              <h3 className="mt-1 text-xl font-semibold text-foreground">
-                Receipt ready
-              </h3>
-              {reportNumber ? (
-                <p className="mt-1 text-sm text-muted-foreground">
-                  Report #{reportNumber}
+              <h2 className="text-3xl font-semibold tracking-tight text-foreground md:text-[3rem]">
+                Ready for next expense
+              </h2>
+            </div>
+          </div>
+
+          <div className="mt-auto space-y-5">
+            <div className="grid gap-3 md:grid-cols-4 md:gap-4">
+              <div className="rounded-lg border border-border/70 bg-surface-raised p-4 backdrop-blur-sm">
+                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                  Total value
                 </p>
-              ) : null}
+                <p className="mt-3 text-2xl font-semibold text-foreground">
+                  {formatter.format(
+                    toDisplayAmount(completedTransactionData.totalValue),
+                  )}
+                </p>
+              </div>
+              <div className="rounded-lg border border-border/70 bg-surface-raised p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                  Items
+                </p>
+                <p className="mt-3 text-2xl font-semibold text-foreground">
+                  {itemCount}
+                </p>
+              </div>
+              <div className="rounded-lg border border-border/70 bg-surface-raised p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                  Report
+                </p>
+                <p className="mt-3 truncate text-sm font-medium text-foreground">
+                  #{reportNumber ?? "Pending"}
+                </p>
+              </div>
+              <div className="rounded-lg border border-border/70 bg-surface-raised p-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                  Recorded by
+                </p>
+                <p className="mt-3 truncate text-sm font-medium text-foreground">
+                  {recordedBy ?? "Unassigned"}
+                </p>
+              </div>
             </div>
-          </div>
-        </div>
 
-        <div className="grid gap-3">
-          <div className="rounded-lg border border-border bg-surface-raised p-4">
-            <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
-              Total value
-            </p>
-            <p className="mt-2 text-3xl font-bold text-foreground">
-              {formatter.format(
-                toDisplayAmount(completedTransactionData.totalValue),
-              )}
-            </p>
-          </div>
-          <div className="grid grid-cols-2 gap-3">
-            <div className="rounded-lg border border-border bg-surface-raised p-4">
-              <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
-                Items
-              </p>
-              <p className="mt-2 text-lg font-semibold text-foreground">
-                {itemCount}
-              </p>
-            </div>
-            <div className="rounded-lg border border-border bg-surface-raised p-4">
-              <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
-                Printed
-              </p>
-              <p className="mt-2 text-lg font-semibold text-foreground">
-                Ready
-              </p>
+            <div className="grid gap-3 md:grid-cols-2">
+              <Button
+                type="button"
+                onClick={onPrintReceipt}
+                disabled={!onPrintReceipt}
+                className="h-14 rounded-2xl border-[hsl(var(--foreground))] bg-[hsl(var(--foreground))] px-5 text-sm font-semibold text-white shadow-[hsl(var(--foreground))/0.18] hover:border-[hsl(var(--primary))] hover:bg-[hsl(var(--primary))] hover:text-[hsl(var(--primary-foreground))]"
+                variant="outline"
+              >
+                <Printer className="h-4 w-4" />
+                Print receipt
+              </Button>
+              <Button
+                type="button"
+                onClick={() => {
+                  onTransactionStateChange?.(false);
+                  onComplete();
+                }}
+                className="h-14 rounded-2xl border-border bg-background px-5 text-sm font-semibold"
+                variant="outline"
+              >
+                <Plus className="h-4 w-4" />
+                Start new expense
+              </Button>
             </div>
           </div>
         </div>
-
-        <div className="mt-auto grid gap-3">
-          <Button
-            type="button"
-            onClick={onPrintReceipt}
-            disabled={!onPrintReceipt}
-            className="w-full gap-2"
-            variant="outline"
-            size="lg"
-          >
-            <Printer className="h-4 w-4" />
-            Print receipt
-          </Button>
-          <Button
-            onClick={() => {
-              onTransactionStateChange?.(false);
-              onComplete();
-            }}
-            className="w-full bg-signal p-8 text-signal-foreground hover:bg-signal/90 hover:text-signal-foreground"
-            variant="outline"
-            size="lg"
-          >
-            Start new expense
-          </Button>
-        </div>
-      </div>
+      </section>
     );
   }
 
@@ -168,7 +179,6 @@ export function ExpenseCompletion({
               ? "Recording expense..."
               : "Complete expense"}
         </Button>
-
       </div>
     </div>
   );

--- a/packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseHistoryView.test.tsx
@@ -16,6 +16,7 @@ const mockedHooks = vi.hoisted(() => ({
 }));
 
 const mockedRouter = vi.hoisted(() => ({
+  navigate: vi.fn(),
   navigateBack: vi.fn(),
   search: {} as Record<string, unknown>,
 }));
@@ -57,6 +58,7 @@ vi.mock("@tanstack/react-router", () => ({
     orgUrlSlug: "wigclub",
     storeUrlSlug: "osu",
   }),
+  useNavigate: () => mockedRouter.navigate,
   useSearch: () => mockedRouter.search,
 }));
 
@@ -358,6 +360,37 @@ describe("DailyCloseHistoryView", () => {
     expect(screen.getByRole("region", { name: "Historical Daily Close detail" }))
       .toHaveTextContent("Clean close.");
     expect(screen.getByText(/Completed by Kofi Mensah/)).toBeInTheDocument();
+    expect(mockedRouter.navigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        search: expect.any(Function),
+      }),
+    );
+
+    const navigateCall = mockedRouter.navigate.mock.calls.at(-1)?.[0] as {
+      search: (current: Record<string, unknown>) => Record<string, unknown>;
+    };
+
+    expect(navigateCall.search({ o: "/wigclub/store/osu/operations" })).toEqual({
+      day: "2026-05-07",
+      o: "/wigclub/store/osu/operations",
+    });
+  });
+
+  it("selects the active day from the route search", () => {
+    mockedRouter.search = {
+      day: "2026-05-07",
+      o: "/wigclub/store/osu/operations",
+    };
+
+    render(<DailyCloseHistoryView />);
+
+    const detail = screen.getByRole("region", {
+      name: "Historical Daily Close detail",
+    });
+
+    expect(within(detail).getAllByText("Thursday, May 7, 2026")[0])
+      .toBeInTheDocument();
+    expect(within(detail).getByText("Clean close.")).toBeInTheDocument();
   });
 
   it("renders the empty state when there are no completed records", () => {

--- a/packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseHistoryView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Link, useParams, useSearch } from "@tanstack/react-router";
+import { Link, useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
 import { ArrowUpRight, History } from "lucide-react";
 
@@ -220,6 +220,10 @@ function sortNewestFirst(
   return right.operatingDate.localeCompare(left.operatingDate);
 }
 
+function getSearchString(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
 function DailyCloseHistoryApiPendingView({
   showBackButton,
 }: {
@@ -290,6 +294,12 @@ function DailyCloseHistoryConnectedView({
     orgUrlSlug: string;
     storeUrlSlug: string;
   };
+  const navigate = useNavigate();
+  const search = useSearch({ strict: false }) as {
+    day?: unknown;
+    o?: unknown;
+  };
+  const selectedOperatingDateFromSearch = getSearchString(search.day);
   const [selectedRecordId, setSelectedRecordId] = useState<string | null>(null);
   const historyResult = useExpectedDailyCloseHistoryQuery(
     listCompletedDailyCloseHistory,
@@ -303,6 +313,9 @@ function DailyCloseHistoryConnectedView({
   );
   const selectedRecord =
     completedRecords.find((record) => getHistoryRecordId(record) === selectedRecordId) ??
+    completedRecords.find(
+      (record) => record.operatingDate === selectedOperatingDateFromSearch,
+    ) ??
     completedRecords[0];
   const selectedDailyCloseId = selectedRecord ? getHistoryRecordId(selectedRecord) : null;
   const detailResult = useExpectedDailyCloseHistoryQuery(
@@ -318,10 +331,24 @@ function DailyCloseHistoryConnectedView({
   const currency = activeStore?.currency ?? "GHS";
 
   useEffect(() => {
-    if (!selectedRecordId && selectedRecord) {
-      setSelectedRecordId(getHistoryRecordId(selectedRecord));
+    if (!selectedRecord) return;
+
+    const nextRecordId = getHistoryRecordId(selectedRecord);
+
+    if (selectedRecordId !== nextRecordId) {
+      setSelectedRecordId(nextRecordId);
     }
-  }, [selectedRecord, selectedRecordId]);
+
+    if (selectedOperatingDateFromSearch !== selectedRecord.operatingDate) {
+      void navigate({
+        replace: true,
+        search: ((current: Record<string, unknown>) => ({
+          ...current,
+          day: selectedRecord.operatingDate,
+        })) as never,
+      });
+    }
+  }, [navigate, selectedOperatingDateFromSearch, selectedRecord, selectedRecordId]);
 
   if (isLoadingAccess) {
     return null;
@@ -401,7 +428,15 @@ function DailyCloseHistoryConnectedView({
                             isSelected && "bg-muted/25",
                           )}
                           key={recordId}
-                          onClick={() => setSelectedRecordId(recordId)}
+                          onClick={() => {
+                            setSelectedRecordId(recordId);
+                            void navigate({
+                              search: ((current: Record<string, unknown>) => ({
+                                ...current,
+                                day: record.operatingDate,
+                              })) as never,
+                            });
+                          }}
                           type="button"
                         >
                           <div className="flex items-start justify-between gap-layout-sm">

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.test.tsx
@@ -296,6 +296,7 @@ function renderContent(
   return render(
     <DailyCloseViewContent
       currency="GHS"
+      hasFinancialDetailsAccess
       hasFullAdminAccess
       isAuthenticated
       isCompleting={false}
@@ -1076,6 +1077,37 @@ describe("DailyCloseViewContent", () => {
     );
   });
 
+  it("redacts EOD Review financial details without manager access", async () => {
+    const user = userEvent.setup();
+    renderContent(blockedSnapshot, {
+      hasFinancialDetailsAccess: false,
+    });
+
+    const detailsButton = screen.getAllByRole("button", {
+      name: /show details/i,
+    })[0];
+
+    if (detailsButton) {
+      await user.click(detailsButton);
+    }
+
+    expect(screen.queryByText("GH₵1,255")).not.toBeInTheDocument();
+    expect(screen.queryByText("GH₵450")).not.toBeInTheDocument();
+    expect(screen.queryByText("GH₵25")).not.toBeInTheDocument();
+    expect(screen.queryByText("GH₵400")).not.toBeInTheDocument();
+    expect(screen.queryByText("GH₵-200")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Variance of GH₵-200 exceeded the closeout approval threshold",
+      ),
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByText("Manager only")).not.toHaveLength(0);
+    expect(
+      screen.getByText("Register session is still open"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("2 cash transactions")).toBeInTheDocument();
+  });
+
   it("omits operating date from transaction links for the current operating day", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-07T12:00:00"));
@@ -1327,6 +1359,7 @@ describe("DailyCloseViewContent", () => {
     rerender(
       <DailyCloseViewContent
         currency="GHS"
+        hasFinancialDetailsAccess
         hasFullAdminAccess
         isAuthenticated
         isCompleting={false}
@@ -1399,6 +1432,7 @@ describe("DailyCloseViewContent", () => {
     renderResult.rerender(
       <DailyCloseViewContent
         currency="GHS"
+        hasFinancialDetailsAccess
         hasFullAdminAccess
         isAuthenticated
         isCompleting={false}

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -43,6 +43,7 @@ import type { ApprovalRequirement } from "~/shared/approvalPolicy";
 import { currencyFormatter } from "~/shared/currencyFormatter";
 import View from "../View";
 import { FadeIn } from "../common/FadeIn";
+import { FinancialValue } from "../common/FinancialValue";
 import { ListPagination } from "../common/ListPagination";
 import {
   PageLevelHeader,
@@ -245,6 +246,7 @@ type BucketConfig = {
 
 type DailyCloseViewContentProps = {
   currency: string;
+  hasFinancialDetailsAccess: boolean;
   hasFullAdminAccess: boolean;
   isAuthenticated: boolean;
   isCompleting: boolean;
@@ -524,6 +526,24 @@ export function formatDailyCloseMoney(
   });
 }
 
+function DailyCloseFinancialValue({
+  amount,
+  canView,
+  currency,
+  label,
+}: {
+  amount?: number | null;
+  canView: boolean;
+  currency: string;
+  label: string;
+}) {
+  return (
+    <FinancialValue canView={canView} label={label}>
+      {formatDailyCloseMoney(currency, amount)}
+    </FinancialValue>
+  );
+}
+
 export function formatDailyCloseOperatingDate(operatingDate: string) {
   const parsed = new Date(`${operatingDate}T00:00:00`);
 
@@ -737,6 +757,8 @@ const moneyMetadataLabels = new Set([
   "variance",
 ]);
 
+const financialNarrativeMetadataLabels = new Set(["reason"]);
+
 const timestampMetadataLabels = new Set([
   "completedat",
   "createdat",
@@ -872,6 +894,15 @@ function normalizeMetadataLabel(label: string) {
 
 function isMoneyMetadataLabel(label: string) {
   return moneyMetadataLabels.has(normalizeMetadataLabel(label));
+}
+
+function isFinancialMetadataLabel(label: string) {
+  const normalizedLabel = normalizeMetadataLabel(label);
+
+  return (
+    moneyMetadataLabels.has(normalizedLabel) ||
+    financialNarrativeMetadataLabels.has(normalizedLabel)
+  );
 }
 
 function isTimestampMetadataLabel(label: string) {
@@ -1026,6 +1057,7 @@ function formatMetadataValue(label: string, value: unknown, currency: string) {
 }
 
 function formatMetadataDisplayValue({
+  canViewFinancialDetails,
   currency,
   item,
   label,
@@ -1033,6 +1065,7 @@ function formatMetadataDisplayValue({
   storeUrlSlug,
   value,
 }: {
+  canViewFinancialDetails: boolean;
   currency: string;
   item: DailyCloseItem;
   label: string;
@@ -1041,6 +1074,17 @@ function formatMetadataDisplayValue({
   value: unknown;
 }): ReactNode {
   const formattedValue = formatMetadataValue(label, value, currency);
+  const isFinancialValue = isFinancialMetadataLabel(label);
+  const visibleValue = isFinancialValue ? (
+    <FinancialValue
+      canView={canViewFinancialDetails}
+      label={getDisplayMetadataLabel(label, value)}
+    >
+      {formattedValue}
+    </FinancialValue>
+  ) : (
+    formattedValue
+  );
   const transactionId =
     getMetadataStringValue(item.metadata, "transactionId") ??
     (item.subject?.type === "pos_transaction" ? item.subject.id : undefined);
@@ -1064,7 +1108,7 @@ function formatMetadataDisplayValue({
         search={{ o: getOrigin() } as never}
         to="/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId"
       >
-        {formattedValue}
+        {visibleValue}
         <ArrowUpRight aria-hidden="true" className="h-3 w-3" />
       </Link>
     );
@@ -1084,7 +1128,7 @@ function formatMetadataDisplayValue({
         search={{ o: getOrigin() } as never}
         to="/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId"
       >
-        {formattedValue}
+        {visibleValue}
         <ArrowUpRight aria-hidden="true" className="h-3 w-3" />
       </Link>
     );
@@ -1098,16 +1142,17 @@ function formatMetadataDisplayValue({
         <span
           className={cn("font-numeric tabular-nums", getVarianceTone(variance))}
         >
-          {formattedValue}
+          {visibleValue}
         </span>
       );
     }
   }
 
-  return formattedValue;
+  return visibleValue;
 }
 
 function getMetadataEntries(
+  canViewFinancialDetails: boolean,
   item: DailyCloseItem,
   currency: string,
   orgUrlSlug: string,
@@ -1218,6 +1263,7 @@ function getMetadataEntries(
           .map((entry) => ({
             label: getDisplayMetadataLabel(entry.label, entry.value),
             value: formatMetadataDisplayValue({
+              canViewFinancialDetails,
               currency,
               item,
               label: entry.label,
@@ -1245,6 +1291,7 @@ function getMetadataEntries(
           return {
             label: getDisplayMetadataLabel(label, value),
             value: formatMetadataDisplayValue({
+              canViewFinancialDetails,
               currency,
               item,
               label,
@@ -1262,6 +1309,7 @@ function getMetadataEntries(
         .map(([label, value]) => ({
           label: getDisplayMetadataLabel(label, value),
           value: formatMetadataDisplayValue({
+            canViewFinancialDetails,
             currency,
             item,
             label,
@@ -1790,6 +1838,7 @@ function ItemLink({
 }
 
 function DailyCloseItemCard({
+  canViewFinancialDetails,
   currency,
   item,
   orgUrlSlug,
@@ -1798,6 +1847,7 @@ function DailyCloseItemCard({
   storeUrlSlug,
   onSelectedChange,
 }: {
+  canViewFinancialDetails: boolean;
   currency: string;
   item: DailyCloseItem;
   onSelectedChange?: (selected: boolean) => void;
@@ -1811,6 +1861,7 @@ function DailyCloseItemCard({
   const description = getItemDescription(item);
   const showCollapsedDescription = shouldShowCollapsedDescription(description);
   const metadataEntries = getMetadataEntries(
+    canViewFinancialDetails,
     item,
     currency,
     orgUrlSlug,
@@ -1860,6 +1911,7 @@ function DailyCloseItemCard({
 
 function BucketSection({
   ariaLabel,
+  canViewFinancialDetails,
   currency,
   description,
   emptyText,
@@ -1875,6 +1927,7 @@ function BucketSection({
   onSelectedIdsChange,
 }: {
   ariaLabel: string;
+  canViewFinancialDetails: boolean;
   currency: string;
   description: string;
   emptyText: string;
@@ -1956,6 +2009,7 @@ function BucketSection({
 
             return (
               <DailyCloseItemCard
+                canViewFinancialDetails={canViewFinancialDetails}
                 currency={currency}
                 item={item}
                 key={getItemId(item)}
@@ -1992,6 +2046,7 @@ function BucketSection({
 
 function BucketTabs({
   buckets,
+  canViewFinancialDetails,
   currency,
   value,
   orgUrlSlug,
@@ -2003,6 +2058,7 @@ function BucketTabs({
   onSelectedIdsChange,
 }: {
   buckets: BucketConfig[];
+  canViewFinancialDetails: boolean;
   currency: string;
   value: BucketStatus;
   onPageChange: (page: number) => void;
@@ -2051,6 +2107,7 @@ function BucketTabs({
         <TabsContent className="mt-0" key={bucket.value} value={bucket.value}>
           <BucketSection
             ariaLabel={bucket.ariaLabel}
+            canViewFinancialDetails={canViewFinancialDetails}
             currency={currency}
             description={bucket.description}
             emptyText={bucket.emptyText}
@@ -2076,11 +2133,13 @@ function BucketTabs({
 }
 
 function TransactionReportAction({
+  canViewFinancialDetails,
   currency,
   orgUrlSlug,
   snapshot,
   storeUrlSlug,
 }: {
+  canViewFinancialDetails: boolean;
   currency: string;
   orgUrlSlug: string;
   snapshot: DailyCloseSnapshot;
@@ -2166,7 +2225,12 @@ function TransactionReportAction({
                           {getTransactionReportTime(item)}
                         </div>
                         <div className="font-numeric font-semibold text-foreground tabular-nums md:text-right">
-                          {getTransactionReportAmount(item, currency)}
+                          <FinancialValue
+                            canView={canViewFinancialDetails}
+                            label="Transaction amount"
+                          >
+                            {getTransactionReportAmount(item, currency)}
+                          </FinancialValue>
                         </div>
                       </div>
                     );
@@ -2182,11 +2246,13 @@ function TransactionReportAction({
 }
 
 export function DailyCloseReadOnlyReport({
+  canViewFinancialDetails = true,
   currency,
   orgUrlSlug,
   snapshot,
   storeUrlSlug,
 }: {
+  canViewFinancialDetails?: boolean;
   currency: string;
   orgUrlSlug: string;
   snapshot: DailyCloseSnapshot;
@@ -2221,6 +2287,7 @@ export function DailyCloseReadOnlyReport({
           </div>
           <div className="flex flex-col gap-layout-sm sm:flex-row sm:items-center">
             <TransactionReportAction
+              canViewFinancialDetails={canViewFinancialDetails}
               currency={currency}
               orgUrlSlug={orgUrlSlug}
               snapshot={displaySnapshot}
@@ -2255,14 +2322,18 @@ export function DailyCloseReadOnlyReport({
               storeUrlSlug,
               to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions",
             }}
-            value={formatDailyCloseMoney(
-              currency,
-              getSummaryAmount(
-                displaySnapshot.summary,
-                "totalSales",
-                "salesTotal",
-              ),
-            )}
+            value={
+              <DailyCloseFinancialValue
+                amount={getSummaryAmount(
+                  displaySnapshot.summary,
+                  "totalSales",
+                  "salesTotal",
+                )}
+                canView={canViewFinancialDetails}
+                currency={currency}
+                label={salesMetricLabels.netSales}
+              />
+            }
           />
           <OperationsSummaryMetric
             helper={formatTodayCashTransactionCount(
@@ -2283,14 +2354,18 @@ export function DailyCloseReadOnlyReport({
               storeUrlSlug,
               to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions",
             }}
-            value={formatDailyCloseMoney(
-              currency,
-              getSummaryAmount(
-                displaySnapshot.summary,
-                "currentDayCashTotal",
-                "cashExpected",
-              ),
-            )}
+            value={
+              <DailyCloseFinancialValue
+                amount={getSummaryAmount(
+                  displaySnapshot.summary,
+                  "currentDayCashTotal",
+                  "cashExpected",
+                )}
+                canView={canViewFinancialDetails}
+                currency={currency}
+                label={salesMetricLabels.cash}
+              />
+            }
           />
           {otherPaymentTotals.map((paymentTotal) => (
             <OperationsSummaryMetric
@@ -2307,7 +2382,14 @@ export function DailyCloseReadOnlyReport({
                 storeUrlSlug,
                 to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions",
               }}
-              value={formatDailyCloseMoney(currency, paymentTotal.amount)}
+              value={
+                <DailyCloseFinancialValue
+                  amount={paymentTotal.amount}
+                  canView={canViewFinancialDetails}
+                  currency={currency}
+                  label={formatPaymentMethodLabel(paymentTotal.method)}
+                />
+              }
             />
           ))}
           <OperationsSummaryMetric
@@ -2319,14 +2401,18 @@ export function DailyCloseReadOnlyReport({
               ),
             )}
             label="Carried-over cash"
-            value={formatDailyCloseMoney(
-              currency,
-              getSummaryAmount(
-                displaySnapshot.summary,
-                "carriedOverCashTotal",
-                "carriedOverCashTotal",
-              ),
-            )}
+            value={
+              <DailyCloseFinancialValue
+                amount={getSummaryAmount(
+                  displaySnapshot.summary,
+                  "carriedOverCashTotal",
+                  "carriedOverCashTotal",
+                )}
+                canView={canViewFinancialDetails}
+                currency={currency}
+                label="Carried-over cash"
+              />
+            }
           />
           {shouldShowExpenseMetric(displaySnapshot.summary) ? (
             <OperationsSummaryMetric
@@ -2334,10 +2420,14 @@ export function DailyCloseReadOnlyReport({
                 getExpenseTransactionCount(displaySnapshot.summary),
               )}
               label="Expenses"
-              value={formatDailyCloseMoney(
-                currency,
-                displaySnapshot.summary.expenseTotal,
-              )}
+              value={
+                <DailyCloseFinancialValue
+                  amount={displaySnapshot.summary.expenseTotal}
+                  canView={canViewFinancialDetails}
+                  currency={currency}
+                  label="Expenses"
+                />
+              }
             />
           ) : null}
           {shouldShowVarianceMetric(displaySnapshot.summary) ? (
@@ -2346,14 +2436,18 @@ export function DailyCloseReadOnlyReport({
                 getSummaryRegisterVarianceCount(displaySnapshot.summary),
               )}
               label="Variance"
-              value={formatDailyCloseMoney(
-                currency,
-                getSummaryAmount(
-                  displaySnapshot.summary,
-                  "varianceTotal",
-                  "netCashVariance",
-                ),
-              )}
+              value={
+                <DailyCloseFinancialValue
+                  amount={getSummaryAmount(
+                    displaySnapshot.summary,
+                    "varianceTotal",
+                    "netCashVariance",
+                  )}
+                  canView={canViewFinancialDetails}
+                  currency={currency}
+                  label="Variance"
+                />
+              }
             />
           ) : null}
         </div>
@@ -2397,6 +2491,7 @@ export function DailyCloseReadOnlyReport({
             <TabsContent className="mt-0" value={selectedBucket.value}>
               <BucketSection
                 ariaLabel={selectedBucket.ariaLabel}
+                canViewFinancialDetails={canViewFinancialDetails}
                 currency={currency}
                 description={selectedBucket.description}
                 emptyText={selectedBucket.emptyText}
@@ -2718,6 +2813,7 @@ function CompletionRail({
 
 export function DailyCloseViewContent({
   currency,
+  hasFinancialDetailsAccess,
   hasFullAdminAccess,
   isAuthenticated,
   isCompleting,
@@ -2961,6 +3057,7 @@ export function DailyCloseViewContent({
         displaySnapshot ? (
           <>
             <TransactionReportAction
+              canViewFinancialDetails={hasFinancialDetailsAccess}
               currency={currency}
               orgUrlSlug={orgUrlSlug}
               snapshot={displaySnapshot}
@@ -2982,6 +3079,7 @@ export function DailyCloseViewContent({
         displaySnapshot ? (
           <BucketTabs
             buckets={buckets}
+            canViewFinancialDetails={hasFinancialDetailsAccess}
             currency={currency}
             onPageChange={handleBucketPageChange}
             onSelectedIdsChange={setSelectedCarryForwardIds}
@@ -3016,14 +3114,18 @@ export function DailyCloseViewContent({
                 storeUrlSlug,
                 to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions",
               }}
-              value={formatDailyCloseMoney(
-                currency,
-                getSummaryAmount(
-                  displaySnapshot.summary,
-                  "totalSales",
-                  "salesTotal",
-                ),
-              )}
+              value={
+                <DailyCloseFinancialValue
+                  amount={getSummaryAmount(
+                    displaySnapshot.summary,
+                    "totalSales",
+                    "salesTotal",
+                  )}
+                  canView={hasFinancialDetailsAccess}
+                  currency={currency}
+                  label={salesMetricLabels?.netSales ?? "Net sales"}
+                />
+              }
             />
             <OperationsSummaryMetric
               helper={formatTodayCashTransactionCount(
@@ -3044,14 +3146,18 @@ export function DailyCloseViewContent({
                 storeUrlSlug,
                 to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions",
               }}
-              value={formatDailyCloseMoney(
-                currency,
-                getSummaryAmount(
-                  displaySnapshot.summary,
-                  "currentDayCashTotal",
-                  "cashExpected",
-                ),
-              )}
+              value={
+                <DailyCloseFinancialValue
+                  amount={getSummaryAmount(
+                    displaySnapshot.summary,
+                    "currentDayCashTotal",
+                    "cashExpected",
+                  )}
+                  canView={hasFinancialDetailsAccess}
+                  currency={currency}
+                  label={salesMetricLabels?.cash ?? "Cash"}
+                />
+              }
             />
             {otherPaymentTotals.map((paymentTotal) => (
               <OperationsSummaryMetric
@@ -3068,7 +3174,14 @@ export function DailyCloseViewContent({
                   storeUrlSlug,
                   to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions",
                 }}
-                value={formatDailyCloseMoney(currency, paymentTotal.amount)}
+                value={
+                  <DailyCloseFinancialValue
+                    amount={paymentTotal.amount}
+                    canView={hasFinancialDetailsAccess}
+                    currency={currency}
+                    label={formatPaymentMethodLabel(paymentTotal.method)}
+                  />
+                }
               />
             ))}
             <OperationsSummaryMetric
@@ -3080,14 +3193,18 @@ export function DailyCloseViewContent({
                 ),
               )}
               label="Carried-over cash"
-              value={formatDailyCloseMoney(
-                currency,
-                getSummaryAmount(
-                  displaySnapshot.summary,
-                  "carriedOverCashTotal",
-                  "carriedOverCashTotal",
-                ),
-              )}
+              value={
+                <DailyCloseFinancialValue
+                  amount={getSummaryAmount(
+                    displaySnapshot.summary,
+                    "carriedOverCashTotal",
+                    "carriedOverCashTotal",
+                  )}
+                  canView={hasFinancialDetailsAccess}
+                  currency={currency}
+                  label="Carried-over cash"
+                />
+              }
             />
             {shouldShowExpenseMetric(displaySnapshot.summary) ? (
               <OperationsSummaryMetric
@@ -3095,10 +3212,14 @@ export function DailyCloseViewContent({
                   getExpenseTransactionCount(displaySnapshot.summary),
                 )}
                 label="Expenses"
-                value={formatDailyCloseMoney(
-                  currency,
-                  displaySnapshot.summary.expenseTotal,
-                )}
+                value={
+                  <DailyCloseFinancialValue
+                    amount={displaySnapshot.summary.expenseTotal}
+                    canView={hasFinancialDetailsAccess}
+                    currency={currency}
+                    label="Expenses"
+                  />
+                }
               />
             ) : null}
             {shouldShowVarianceMetric(displaySnapshot.summary) ? (
@@ -3107,14 +3228,18 @@ export function DailyCloseViewContent({
                   getSummaryRegisterVarianceCount(displaySnapshot.summary),
                 )}
                 label="Variance"
-                value={formatDailyCloseMoney(
-                  currency,
-                  getSummaryAmount(
-                    displaySnapshot.summary,
-                    "varianceTotal",
-                    "netCashVariance",
-                  ),
-                )}
+                value={
+                  <DailyCloseFinancialValue
+                    amount={getSummaryAmount(
+                      displaySnapshot.summary,
+                      "varianceTotal",
+                      "netCashVariance",
+                    )}
+                    canView={hasFinancialDetailsAccess}
+                    currency={currency}
+                    label="Variance"
+                  />
+                }
               />
             ) : null}
           </>
@@ -3184,6 +3309,7 @@ function DailyCloseConnectedView({
     activeStore,
     canAccessProtectedSurface,
     canQueryProtectedData,
+    hasFinancialDetailsAccess,
     hasFullAdminAccess,
     isAuthenticated,
     isLoadingAccess,
@@ -3294,6 +3420,7 @@ function DailyCloseConnectedView({
   return (
     <DailyCloseViewContent
       currency={activeStore?.currency || "USD"}
+      hasFinancialDetailsAccess={hasFinancialDetailsAccess}
       hasFullAdminAccess={canAccessSurface}
       isAuthenticated={isAuthenticated}
       isCompleting={isCompleting}

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -400,6 +400,7 @@ function renderContent(
     <DailyOperationsViewContent
       currency="GHS"
       hasFullAdminAccess
+      hasFinancialDetailsAccess
       isAuthenticated
       isLoadingAccess={false}
       isLoadingSnapshot={snapshot === undefined}
@@ -523,6 +524,19 @@ describe("DailyOperationsViewContent", () => {
     expect(
       screen.queryByRole("link", { name: "Open Open work" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("redacts financial metrics when a POS-only user has no manager elevation", () => {
+    renderContent(operatingSnapshot, {
+      hasFinancialDetailsAccess: false,
+    });
+
+    expect(screen.queryByText("GH₵15,331")).not.toBeInTheDocument();
+    expect(screen.queryByText("GH₵3,491")).not.toBeInTheDocument();
+    expect(screen.queryByText("GH₵17,461")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Manager only")).not.toHaveLength(0);
+    expect(screen.getAllByText("3 transactions")).not.toHaveLength(0);
+    expect(screen.getByText("2 cash transactions")).toBeInTheDocument();
   });
 
   it("uses today labels and current-day transaction links for the current operating date", () => {

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -30,6 +30,7 @@ import type { Id } from "~/convex/_generated/dataModel";
 import { currencyFormatter } from "~/shared/currencyFormatter";
 import View from "../View";
 import { FadeIn } from "../common/FadeIn";
+import { FinancialValue } from "../common/FinancialValue";
 import {
   PageLevelHeader,
   PageWorkspace,
@@ -188,6 +189,7 @@ export type DailyOperationsSnapshot = {
 type DailyOperationsViewContentProps = {
   currency: string;
   hasFullAdminAccess: boolean;
+  hasFinancialDetailsAccess: boolean;
   isAuthenticated: boolean;
   isLoadingAccess: boolean;
   isLoadingSnapshot: boolean;
@@ -834,11 +836,13 @@ function OperatingDatePicker({
 
 function WeekMetricsStrip({
   currency,
+  hasFinancialDetailsAccess,
   metrics,
   orgUrlSlug,
   storeUrlSlug,
 }: {
   currency: string;
+  hasFinancialDetailsAccess: boolean;
   metrics: DailyOperationsSnapshot["weekMetrics"];
   orgUrlSlug: string;
   storeUrlSlug: string;
@@ -882,7 +886,9 @@ function WeekMetricsStrip({
           <p className="flex items-baseline gap-2 text-sm text-muted-foreground">
             <span>Week sales</span>
             <span className="font-numeric text-base font-semibold tabular-nums text-foreground">
-              {formatMoney(currency, weekSalesTotal)}
+              <FinancialValue canView={hasFinancialDetailsAccess} label="Week sales">
+                {formatMoney(currency, weekSalesTotal)}
+              </FinancialValue>
             </span>
           </p>
           <div className="flex items-center gap-1">
@@ -979,7 +985,14 @@ function WeekMetricsStrip({
                 <p className="mt-layout-sm font-numeric text-lg tabular-nums text-foreground">
                   {isFutureDate
                     ? "-"
-                    : formatMoney(currency, metric.salesTotal)}
+                    : (
+                        <FinancialValue
+                          canView={hasFinancialDetailsAccess}
+                          label={`${formatOperatingDate(metric.operatingDate)} sales`}
+                        >
+                          {formatMoney(currency, metric.salesTotal)}
+                        </FinancialValue>
+                      )}
                 </p>
                 <p className="mt-1 text-xs text-muted-foreground">
                   {isFutureDate
@@ -1028,6 +1041,7 @@ function WeekMetricsStrip({
 export function DailyOperationsViewContent({
   currency,
   hasFullAdminAccess,
+  hasFinancialDetailsAccess,
   isAuthenticated,
   isLoadingAccess,
   isLoadingSnapshot,
@@ -1157,10 +1171,17 @@ export function DailyOperationsViewContent({
                       storeUrlSlug,
                       to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions",
                     }}
-                    value={formatMoney(
-                      snapshot.currency ?? currency,
-                      snapshot.closeSummary.salesTotal,
-                    )}
+                    value={
+                      <FinancialValue
+                        canView={hasFinancialDetailsAccess}
+                        label={metricLabels?.netSales ?? "Net sales"}
+                      >
+                        {formatMoney(
+                          snapshot.currency ?? currency,
+                          snapshot.closeSummary.salesTotal,
+                        )}
+                      </FinancialValue>
+                    }
                   />
                   <OperationsSummaryMetric
                     helper={formatTodayCashTransactionCount(
@@ -1177,20 +1198,34 @@ export function DailyOperationsViewContent({
                       storeUrlSlug,
                       to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions",
                     }}
-                    value={formatMoney(
-                      snapshot.currency ?? currency,
-                      snapshot.closeSummary.currentDayCashTotal,
-                    )}
+                    value={
+                      <FinancialValue
+                        canView={hasFinancialDetailsAccess}
+                        label={metricLabels?.cash ?? "Cash"}
+                      >
+                        {formatMoney(
+                          snapshot.currency ?? currency,
+                          snapshot.closeSummary.currentDayCashTotal,
+                        )}
+                      </FinancialValue>
+                    }
                   />
                   <OperationsSummaryMetric
                     helper={formatCarriedOverRegisterCount(
                       snapshot.closeSummary.carriedOverRegisterCount,
                     )}
                     label="Carried-over cash"
-                    value={formatMoney(
-                      snapshot.currency ?? currency,
-                      snapshot.closeSummary.carriedOverCashTotal,
-                    )}
+                    value={
+                      <FinancialValue
+                        canView={hasFinancialDetailsAccess}
+                        label="Carried-over cash"
+                      >
+                        {formatMoney(
+                          snapshot.currency ?? currency,
+                          snapshot.closeSummary.carriedOverCashTotal,
+                        )}
+                      </FinancialValue>
+                    }
                   />
                   <OperationsSummaryMetric
                     helper={formatEntityCount(
@@ -1198,25 +1233,40 @@ export function DailyOperationsViewContent({
                       "expense transaction",
                     )}
                     label="Expenses"
-                    value={formatMoney(
-                      snapshot.currency ?? currency,
-                      snapshot.closeSummary.expenseTotal,
-                    )}
+                    value={
+                      <FinancialValue
+                        canView={hasFinancialDetailsAccess}
+                        label="Expenses"
+                      >
+                        {formatMoney(
+                          snapshot.currency ?? currency,
+                          snapshot.closeSummary.expenseTotal,
+                        )}
+                      </FinancialValue>
+                    }
                   />
                   <OperationsSummaryMetric
                     helper={formatRegisterVarianceCount(
                       snapshot.closeSummary.registerVarianceCount,
                     )}
                     label="Variance"
-                    value={formatMoney(
-                      snapshot.currency ?? currency,
-                      snapshot.closeSummary.netCashVariance,
-                    )}
+                    value={
+                      <FinancialValue
+                        canView={hasFinancialDetailsAccess}
+                        label="Variance"
+                      >
+                        {formatMoney(
+                          snapshot.currency ?? currency,
+                          snapshot.closeSummary.netCashVariance,
+                        )}
+                      </FinancialValue>
+                    }
                   />
                 </div>
 
                 <WeekMetricsStrip
                   currency={snapshot.currency ?? currency}
+                  hasFinancialDetailsAccess={hasFinancialDetailsAccess}
                   metrics={snapshot.weekMetrics}
                   orgUrlSlug={orgUrlSlug}
                   storeUrlSlug={storeUrlSlug}
@@ -1367,6 +1417,7 @@ function DailyOperationsConnectedView({
     activeStore,
     canAccessProtectedSurface,
     canQueryProtectedData,
+    hasFinancialDetailsAccess,
     hasFullAdminAccess,
     isAuthenticated,
     isLoadingAccess,
@@ -1424,6 +1475,7 @@ function DailyOperationsConnectedView({
     <DailyOperationsViewContent
       currency={activeStore?.currency ?? "GHS"}
       hasFullAdminAccess={canAccessSurface}
+      hasFinancialDetailsAccess={hasFinancialDetailsAccess}
       isAuthenticated={isAuthenticated}
       isLoadingAccess={isLoadingAccess}
       isLoadingSnapshot={snapshot === undefined}

--- a/packages/athena-webapp/src/components/operations/OperationsSummaryMetric.tsx
+++ b/packages/athena-webapp/src/components/operations/OperationsSummaryMetric.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { ArrowUpRight } from "lucide-react";
+import type { ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
 import { Button } from "../ui/button";
@@ -35,7 +36,7 @@ export function OperationsSummaryMetric({
   label: string;
   link?: OperationsSummaryMetricLink;
   tone?: "default" | "quiet";
-  value: string | number;
+  value: ReactNode;
 }) {
   return (
     <div

--- a/packages/athena-webapp/src/components/pos/OrderSummary.test.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.test.tsx
@@ -2,9 +2,13 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { render as renderEmail } from "@react-email/components";
+import type { ComponentProps } from "react";
 
 import { currencyFormatter } from "~/shared/currencyFormatter";
-import { OrderSummary } from "./OrderSummary";
+import {
+  clearAttemptedOrderSummaryAutoPrintReceiptKeysForTest,
+  OrderSummary,
+} from "./OrderSummary";
 
 const mockStoreState = vi.hoisted(() => ({
   activeStore: {
@@ -12,7 +16,8 @@ const mockStoreState = vi.hoisted(() => ({
     currency: "GHS",
     name: "Wig Club",
     config: {},
-  } as Record<string, unknown>,
+  } as Record<string, unknown> | null,
+  printReceipt: vi.fn(),
 }));
 
 vi.mock("@react-email/components", () => ({
@@ -27,11 +32,14 @@ vi.mock("~/src/hooks/useGetActiveStore", () => ({
 
 vi.mock("~/src/hooks/usePrint", () => ({
   usePrint: () => ({
-    printReceipt: vi.fn(),
+    printReceipt: mockStoreState.printReceipt,
   }),
 }));
 
 const formatter = currencyFormatter("GHS");
+type CompletedTransactionData = NonNullable<
+  ComponentProps<typeof OrderSummary>["completedTransactionData"]
+>;
 
 function stripWhitespace(value: string) {
   return value.replace(/\s/g, "");
@@ -69,13 +77,202 @@ function getBalanceDuePanel() {
 
 describe("OrderSummary completed transaction summary", () => {
   beforeEach(() => {
+    clearAttemptedOrderSummaryAutoPrintReceiptKeysForTest();
     vi.mocked(renderEmail).mockClear();
+    vi.mocked(renderEmail).mockResolvedValue("<receipt />");
     mockStoreState.activeStore = {
       _id: "store-1",
       currency: "GHS",
       name: "Wig Club",
       config: {},
     };
+    mockStoreState.printReceipt.mockClear();
+  });
+
+  it("opens the print window when a POS sale completes", async () => {
+    render(
+      <OrderSummary
+        cartItems={[]}
+        completedOrderNumber="404927"
+        completedTransactionData={{
+          paymentMethod: "cash",
+          transactionId: "txn-1",
+          completedAt: new Date("2026-04-25T18:08:00.000Z"),
+          cartItems: [],
+          customerInfo: undefined,
+          subtotal: 1000,
+          tax: 0,
+          total: 1000,
+          payments: [
+            { id: "payment-1", method: "cash", amount: 1000, timestamp: 1 },
+          ],
+        }}
+        isTransactionCompleted
+      />,
+    );
+
+    await waitFor(() => {
+      expect(renderEmail).toHaveBeenCalledTimes(1);
+      expect(mockStoreState.printReceipt).toHaveBeenCalledWith("<receipt />");
+    });
+  });
+
+  it("opens the print window after POS completion once store data is available", async () => {
+    mockStoreState.activeStore = null;
+    const completedTransactionData = {
+      paymentMethod: "cash",
+      transactionId: "txn-1",
+      completedAt: new Date("2026-04-25T18:08:00.000Z"),
+      cartItems: [],
+      customerInfo: undefined,
+      subtotal: 1000,
+      tax: 0,
+      total: 1000,
+      payments: [
+        { id: "payment-1", method: "cash", amount: 1000, timestamp: 1 },
+      ],
+    } satisfies CompletedTransactionData;
+
+    const { rerender } = render(
+      <OrderSummary
+        cartItems={[]}
+        completedOrderNumber="404927"
+        completedTransactionData={completedTransactionData}
+        isTransactionCompleted
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockStoreState.printReceipt).not.toHaveBeenCalled();
+    });
+
+    mockStoreState.activeStore = {
+      _id: "store-1",
+      currency: "GHS",
+      name: "Wig Club",
+      config: {},
+    };
+    rerender(
+      <OrderSummary
+        cartItems={[]}
+        completedOrderNumber="404927"
+        completedTransactionData={completedTransactionData}
+        isTransactionCompleted
+      />,
+    );
+
+    await waitFor(() => {
+      expect(renderEmail).toHaveBeenCalledTimes(1);
+      expect(mockStoreState.printReceipt).toHaveBeenCalledWith("<receipt />");
+    });
+  });
+
+  it("does not auto-open the print window again after the completed POS sale remounts", async () => {
+    const completedTransactionData = {
+      paymentMethod: "cash",
+      transactionId: "txn-remount",
+      completedAt: new Date("2026-04-25T18:08:00.000Z"),
+      cartItems: [],
+      customerInfo: undefined,
+      subtotal: 1000,
+      tax: 0,
+      total: 1000,
+      payments: [
+        { id: "payment-1", method: "cash", amount: 1000, timestamp: 1 },
+      ],
+    } satisfies CompletedTransactionData;
+
+    const { unmount } = render(
+      <OrderSummary
+        cartItems={[]}
+        completedOrderNumber="404930"
+        completedTransactionData={completedTransactionData}
+        isTransactionCompleted
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockStoreState.printReceipt).toHaveBeenCalledTimes(1);
+    });
+
+    unmount();
+    render(
+      <OrderSummary
+        cartItems={[]}
+        completedOrderNumber="404930"
+        completedTransactionData={completedTransactionData}
+        isTransactionCompleted
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockStoreState.printReceipt).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not auto-print when a completed POS sale has change to give", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <OrderSummary
+        cartItems={[]}
+        completedOrderNumber="404927"
+        completedTransactionData={{
+          paymentMethod: "cash",
+          transactionId: "txn-1",
+          completedAt: new Date("2026-04-25T18:08:00.000Z"),
+          cartItems: [],
+          customerInfo: undefined,
+          subtotal: 1000,
+          tax: 0,
+          total: 1000,
+          payments: [
+            { id: "payment-1", method: "cash", amount: 2000, timestamp: 1 },
+          ],
+        }}
+        isTransactionCompleted
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockStoreState.printReceipt).not.toHaveBeenCalled();
+    });
+    expect(screen.getAllByText("Change given").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("GH₵10").length).toBeGreaterThan(0);
+
+    await user.click(screen.getByRole("button", { name: /Print receipt/i }));
+
+    await waitFor(() => {
+      expect(mockStoreState.printReceipt).toHaveBeenCalledWith("<receipt />");
+    });
+  });
+
+  it("does not auto-print read-only POS receipts", async () => {
+    render(
+      <OrderSummary
+        cartItems={[]}
+        completedOrderNumber="404927"
+        completedTransactionData={{
+          paymentMethod: "cash",
+          transactionId: "txn-1",
+          completedAt: new Date("2026-04-25T18:08:00.000Z"),
+          cartItems: [],
+          customerInfo: undefined,
+          subtotal: 1000,
+          tax: 0,
+          total: 1000,
+          payments: [
+            { id: "payment-1", method: "cash", amount: 1000, timestamp: 1 },
+          ],
+        }}
+        isTransactionCompleted
+        readOnly
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockStoreState.printReceipt).not.toHaveBeenCalled();
+    });
   });
 
   it("does not render the tax line in the completed sale totals", () => {
@@ -782,9 +979,7 @@ describe("OrderSummary completed transaction summary", () => {
     );
 
     expect(
-      screen.getByText(
-        "Customer required",
-      ).closest("button"),
+      screen.getByText("Customer required").closest("button"),
     ).toBeDisabled();
   });
 
@@ -899,9 +1094,9 @@ describe("OrderSummary completed transaction summary", () => {
 
     expect(onPaymentsExpandedChange).toHaveBeenCalledWith(false);
     expect(onRemovePayment).toHaveBeenCalledWith("payment-1");
-    expect(onPaymentsExpandedChange.mock.invocationCallOrder[0]).toBeGreaterThan(
-      onRemovePayment.mock.invocationCallOrder[0],
-    );
+    expect(
+      onPaymentsExpandedChange.mock.invocationCallOrder[0],
+    ).toBeGreaterThan(onRemovePayment.mock.invocationCallOrder[0]);
   });
 
   it("collapses payment-summary state after clearing all payments succeeds", async () => {
@@ -949,9 +1144,9 @@ describe("OrderSummary completed transaction summary", () => {
 
     expect(onPaymentsExpandedChange).toHaveBeenCalledWith(false);
     expect(onClearPayments).toHaveBeenCalled();
-    expect(onPaymentsExpandedChange.mock.invocationCallOrder[0]).toBeGreaterThan(
-      onClearPayments.mock.invocationCallOrder[0],
-    );
+    expect(
+      onPaymentsExpandedChange.mock.invocationCallOrder[0],
+    ).toBeGreaterThan(onClearPayments.mock.invocationCallOrder[0]);
   });
 
   it("keeps payment-summary state when clearing all payments fails", async () => {
@@ -991,7 +1186,9 @@ describe("OrderSummary completed transaction summary", () => {
     await user.click(screen.getByRole("button", { name: /clear all/i }));
 
     expect(onClearPayments).toHaveBeenCalled();
-    expect(screen.getByRole("button", { name: /clear all/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear all/i }),
+    ).toBeInTheDocument();
     expect(onPaymentFlowChange).not.toHaveBeenCalledWith(false);
   });
 
@@ -1141,9 +1338,9 @@ describe("OrderSummary completed transaction summary", () => {
     expect(onPaymentsExpandedChange).toHaveBeenCalledWith(false);
     expect(onUpdatePayment).toHaveBeenCalledWith("payment-1", 1700);
     expect(onEditingPaymentChange).toHaveBeenCalledWith(false);
-    expect(onPaymentsExpandedChange.mock.invocationCallOrder[0]).toBeGreaterThan(
-      onUpdatePayment.mock.invocationCallOrder[0],
-    );
+    expect(
+      onPaymentsExpandedChange.mock.invocationCallOrder[0],
+    ).toBeGreaterThan(onUpdatePayment.mock.invocationCallOrder[0]);
     expect(onUpdatePayment.mock.invocationCallOrder[0]).toBeLessThan(
       onEditingPaymentChange.mock.invocationCallOrder[0],
     );

--- a/packages/athena-webapp/src/components/pos/OrderSummary.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { render } from "@react-email/components";
 import {
   Ban,
@@ -157,6 +157,12 @@ interface OrderSummaryProps {
   onPaymentsExpandedChange?: (isExpanded: boolean) => void;
 }
 
+const attemptedAutoPrintReceiptKeys = new Set<string>();
+
+export function clearAttemptedOrderSummaryAutoPrintReceiptKeysForTest() {
+  attemptedAutoPrintReceiptKeys.clear();
+}
+
 export function OrderSummary({
   cartItems,
   customerInfo,
@@ -203,13 +209,15 @@ export function OrderSummary({
   const [paymentAmountDraft, setPaymentAmountDraft] = useState<
     number | undefined
   >(undefined);
+  const printedReceiptKeyRef = useRef<string | null>(null);
 
   const effectiveCartItems =
     completedTransactionData?.cartItems && (readOnly || isTransactionCompleted)
       ? completedTransactionData.cartItems
       : cartItems;
   const effectiveServiceLines =
-    completedTransactionData?.serviceLines && (readOnly || isTransactionCompleted)
+    completedTransactionData?.serviceLines &&
+    (readOnly || isTransactionCompleted)
       ? completedTransactionData.serviceLines
       : serviceLines;
   const completedServiceLines = completedTransactionData?.serviceLines ?? [];
@@ -232,7 +240,8 @@ export function OrderSummary({
       ? completedTransactionAmountPaid - total
       : 0;
   const hasCompletedTransactionChangeGiven =
-    completedTransactionData !== undefined && completedTransactionChangeGiven > 0;
+    completedTransactionData !== undefined &&
+    completedTransactionChangeGiven > 0;
   const completedTransactionPayments = completedTransactionData
     ? (completedTransactionData.payments ?? payments)
     : payments;
@@ -271,10 +280,9 @@ export function OrderSummary({
     ? "Adjusted total"
     : "Total";
   const isEditingPaymentAmount = editingPaymentId !== null;
-  const cartItemsCount = effectiveCartItems.reduce(
-    (sum, item) => sum + item.quantity,
-    0,
-  ) + serviceLinesCount;
+  const cartItemsCount =
+    effectiveCartItems.reduce((sum, item) => sum + item.quantity, 0) +
+    serviceLinesCount;
   const completedAtDate = completedTransactionData?.completedAt
     ? completedTransactionData.completedAt instanceof Date
       ? completedTransactionData.completedAt
@@ -330,8 +338,8 @@ export function OrderSummary({
           customerPhone: effectiveCustomerInfo?.phone,
           transactionId: completedTransactionData.transactionId ?? null,
           transactionNumber: completedOrderNumber,
-      }
-    : null;
+        }
+      : null;
   void effectiveReceiptMessaging;
   const summaryRows = [
     { label: "Transaction", value: `#${receiptLabel}` },
@@ -402,7 +410,8 @@ export function OrderSummary({
         const [title, ...detailParts] = completionBlockMessage.split(". ");
         return [
           title.replace(/\.$/, ""),
-          detailParts.join(". ").replace(/\.$/, "") || "Add a customer to continue.",
+          detailParts.join(". ").replace(/\.$/, "") ||
+            "Add a customer to continue.",
         ];
       })()
     : [null, null];
@@ -507,10 +516,16 @@ export function OrderSummary({
     onEditingPaymentChange?.(paymentId !== null);
   };
 
-  const handlePrintReceipt = async () => {
+  const completedReceiptKey =
+    completedOrderNumber ??
+    completedTransactionData?.transactionId ??
+    completedAtDate?.toISOString() ??
+    null;
+
+  const handlePrintReceipt = useCallback(async () => {
     const completedData = completedTransactionData;
     if (!completedData || !activeStore) {
-      return;
+      return false;
     }
 
     try {
@@ -548,16 +563,17 @@ export function OrderSummary({
           skuOrBarcode: line.serviceCaseId
             ? `Service case ${line.serviceCaseId}`
             : undefined,
-          attributes: [
-            line.serviceMode
-              ? `Service mode: ${formatServiceLabel(line.serviceMode)}`
-              : null,
-            line.servicePaymentStatus
-              ? `Payment: ${formatServiceLabel(line.servicePaymentStatus)}`
-              : null,
-          ]
-            .filter(Boolean)
-            .join(" • ") || undefined,
+          attributes:
+            [
+              line.serviceMode
+                ? `Service mode: ${formatServiceLabel(line.serviceMode)}`
+                : null,
+              line.servicePaymentStatus
+                ? `Payment: ${formatServiceLabel(line.servicePaymentStatus)}`
+                : null,
+            ]
+              .filter(Boolean)
+              .join(" • ") || undefined,
         }),
       );
       const receiptItems = [...receiptProductItems, ...receiptServiceItems];
@@ -637,17 +653,67 @@ export function OrderSummary({
           paymentMethodLabel={paymentMethodLabel}
           payments={formattedPayments}
           changeGiven={changeGiven}
-          statusLabel={
-            completedData.status === "voided" ? "Voided" : undefined
-          }
+          statusLabel={completedData.status === "voided" ? "Voided" : undefined}
         />,
       );
 
       printReceipt(receiptHTML);
+      return true;
     } catch (error) {
       console.error("Error in handlePrintReceipt:", error);
+      return false;
     }
-  };
+  }, [
+    activeStore,
+    cashierName,
+    cartItemsCount,
+    completedOrderNumber,
+    completedTransactionData,
+    formatter,
+    payments,
+    printReceipt,
+    readOnly,
+    receiptNumberOverride,
+    registerNumber,
+  ]);
+
+  useEffect(() => {
+    if (
+      readOnly ||
+      !isTransactionCompleted ||
+      !completedTransactionData ||
+      !completedReceiptKey ||
+      hasCompletedTransactionChangeGiven
+    ) {
+      printedReceiptKeyRef.current = null;
+      return;
+    }
+
+    if (
+      printedReceiptKeyRef.current === completedReceiptKey ||
+      attemptedAutoPrintReceiptKeys.has(completedReceiptKey)
+    ) {
+      return;
+    }
+
+    printedReceiptKeyRef.current = completedReceiptKey;
+    attemptedAutoPrintReceiptKeys.add(completedReceiptKey);
+    void handlePrintReceipt().then((didPrint) => {
+      if (!didPrint) {
+        attemptedAutoPrintReceiptKeys.delete(completedReceiptKey);
+        if (printedReceiptKeyRef.current === completedReceiptKey) {
+          printedReceiptKeyRef.current = null;
+        }
+      }
+    });
+  }, [
+    completedReceiptKey,
+    completedTransactionData,
+    handlePrintReceipt,
+    hasCompletedTransactionChangeGiven,
+    isTransactionCompleted,
+    readOnly,
+  ]);
 
   if ((readOnly || isTransactionCompleted) && presentation === "rail") {
     return (
@@ -1138,43 +1204,45 @@ export function OrderSummary({
           isPaymentFlowActive && "gap-3",
         )}
       >
-        {showPaymentEditor && payments.length === 0 && !hideActiveSummaryCards && (
-          <div
-            className={cn(
-              "grid gap-3",
-              hidePaymentItemCountSummary ? "grid-cols-1" : "grid-cols-2",
-            )}
-          >
-            {!hidePaymentItemCountSummary && (
-              <div className="rounded-xl border border-border bg-surface-raised p-4 shadow-surface">
-                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  Items
-                </p>
-                <p className="mt-2 text-2xl font-semibold leading-none text-foreground">
-                  {cartItemsCount}
-                </p>
-              </div>
-            )}
+        {showPaymentEditor &&
+          payments.length === 0 &&
+          !hideActiveSummaryCards && (
             <div
               className={cn(
-                "rounded-xl border p-4 shadow-sm",
-                balanceDueToneClass,
+                "grid gap-3",
+                hidePaymentItemCountSummary ? "grid-cols-1" : "grid-cols-2",
               )}
             >
-              <p
+              {!hidePaymentItemCountSummary && (
+                <div className="rounded-xl border border-border bg-surface-raised p-4 shadow-surface">
+                  <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Items
+                  </p>
+                  <p className="mt-2 text-2xl font-semibold leading-none text-foreground">
+                    {cartItemsCount}
+                  </p>
+                </div>
+              )}
+              <div
                 className={cn(
-                  "text-xs font-medium uppercase tracking-wide",
-                  balanceDueLabelClass,
+                  "rounded-xl border p-4 shadow-sm",
+                  balanceDueToneClass,
                 )}
               >
-                {balanceDueLabel}
-              </p>
-              <p className="mt-2 text-2xl font-semibold leading-none text-foreground">
-                {formatStoredAmount(formatter, balanceDueAmount)}
-              </p>
+                <p
+                  className={cn(
+                    "text-xs font-medium uppercase tracking-wide",
+                    balanceDueLabelClass,
+                  )}
+                >
+                  {balanceDueLabel}
+                </p>
+                <p className="mt-2 text-2xl font-semibold leading-none text-foreground">
+                  {formatStoredAmount(formatter, balanceDueAmount)}
+                </p>
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
         {payments.length > 0 && (
           <PaymentsAddedList

--- a/packages/athena-webapp/src/components/pos/register/ExpenseCompletionPanel.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/ExpenseCompletionPanel.test.tsx
@@ -2,13 +2,27 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ExpenseCompletionPanel } from "./ExpenseCompletionPanel";
+import {
+  clearAttemptedExpenseAutoPrintReceiptKeysForTest,
+  ExpenseCompletionPanel,
+} from "./ExpenseCompletionPanel";
 import type { RegisterCheckoutState } from "@/lib/pos/presentation/register/registerUiState";
 import type { Id } from "~/convex/_generated/dataModel";
 
 const mocks = vi.hoisted(() => ({
   buildExpenseReceiptHtml: vi.fn().mockResolvedValue("<expense-receipt />"),
   printReceipt: vi.fn(),
+  activeStore: {
+    _id: "store-1",
+    name: "Wig Club",
+    currency: "GHS",
+    config: {},
+  } as {
+    _id: string;
+    name: string;
+    currency: string;
+    config: Record<string, unknown>;
+  } | null,
 }));
 
 vi.mock("@/lib/pos/expenseReceipt", () => ({
@@ -23,12 +37,7 @@ vi.mock("@/hooks/usePrint", () => ({
 
 vi.mock("@/hooks/useGetActiveStore", () => ({
   default: () => ({
-    activeStore: {
-      _id: "store-1",
-      name: "Wig Club",
-      currency: "GHS",
-      config: {},
-    },
+    activeStore: mocks.activeStore,
   }),
 }));
 
@@ -80,9 +89,16 @@ function buildCheckout(
 
 describe("ExpenseCompletionPanel", () => {
   beforeEach(() => {
+    clearAttemptedExpenseAutoPrintReceiptKeysForTest();
     mocks.buildExpenseReceiptHtml.mockClear();
     mocks.buildExpenseReceiptHtml.mockResolvedValue("<expense-receipt />");
     mocks.printReceipt.mockClear();
+    mocks.activeStore = {
+      _id: "store-1",
+      name: "Wig Club",
+      currency: "GHS",
+      config: {},
+    };
   });
 
   it("prints the expense receipt once when completion data appears", async () => {
@@ -113,10 +129,75 @@ describe("ExpenseCompletionPanel", () => {
       expect(mocks.printReceipt).toHaveBeenCalledTimes(1);
     });
 
-    await userEvent.click(screen.getByRole("button", { name: /print receipt/i }));
+    await userEvent.click(
+      screen.getByRole("button", { name: /print receipt/i }),
+    );
 
     await waitFor(() => {
       expect(mocks.printReceipt).toHaveBeenCalledTimes(2);
     });
+  });
+
+  it("opens the print window after completion once store data is available", async () => {
+    mocks.activeStore = null;
+    const checkout = buildCheckout();
+
+    const { rerender } = render(<ExpenseCompletionPanel checkout={checkout} />);
+
+    await waitFor(() => {
+      expect(mocks.printReceipt).not.toHaveBeenCalled();
+    });
+
+    mocks.activeStore = {
+      _id: "store-1",
+      name: "Wig Club",
+      currency: "GHS",
+      config: {},
+    };
+    rerender(<ExpenseCompletionPanel checkout={checkout} />);
+
+    await waitFor(() => {
+      expect(mocks.printReceipt).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not auto-open the print window again after the completed expense remounts", async () => {
+    const checkout = buildCheckout();
+
+    const { unmount } = render(<ExpenseCompletionPanel checkout={checkout} />);
+
+    await waitFor(() => {
+      expect(mocks.printReceipt).toHaveBeenCalledTimes(1);
+    });
+
+    unmount();
+    render(<ExpenseCompletionPanel checkout={checkout} />);
+
+    await waitFor(() => {
+      expect(mocks.printReceipt).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("matches the POS completed register surface while keeping expense facts", async () => {
+    const checkout = buildCheckout();
+
+    render(<ExpenseCompletionPanel checkout={checkout} />);
+
+    expect(screen.getByText("Expense complete")).toBeInTheDocument();
+    expect(screen.getByText("Ready for next expense")).toBeInTheDocument();
+    expect(screen.getByText("Total value")).toBeInTheDocument();
+    expect(screen.getByText("GH₵130")).toBeInTheDocument();
+    expect(screen.getByText("Items")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("Report")).toBeInTheDocument();
+    expect(screen.getByText("#EXP-1001")).toBeInTheDocument();
+    expect(screen.getByText("Recorded by")).toBeInTheDocument();
+    expect(screen.getByText("Ato K.")).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /start new expense/i }),
+    );
+
+    expect(checkout.onStartNewTransaction).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/athena-webapp/src/components/pos/register/ExpenseCompletionPanel.tsx
+++ b/packages/athena-webapp/src/components/pos/register/ExpenseCompletionPanel.tsx
@@ -10,6 +10,12 @@ interface ExpenseCompletionPanelProps {
   checkout: RegisterCheckoutState;
 }
 
+const attemptedAutoPrintReceiptKeys = new Set<string>();
+
+export function clearAttemptedExpenseAutoPrintReceiptKeysForTest() {
+  attemptedAutoPrintReceiptKeys.clear();
+}
+
 export function ExpenseCompletionPanel({
   checkout,
 }: ExpenseCompletionPanelProps) {
@@ -51,7 +57,7 @@ export function ExpenseCompletionPanel({
 
   const handlePrintReceipt = useCallback(async () => {
     if (!activeStore || !completedTransactionData) {
-      return;
+      return false;
     }
 
     try {
@@ -68,8 +74,10 @@ export function ExpenseCompletionPanel({
       });
 
       printReceipt(receiptHtml);
+      return true;
     } catch (error) {
       console.error("Error printing expense receipt:", error);
+      return false;
     }
   }, [
     activeStore,
@@ -91,12 +99,23 @@ export function ExpenseCompletionPanel({
       return;
     }
 
-    if (printedReceiptKeyRef.current === completedReceiptKey) {
+    if (
+      printedReceiptKeyRef.current === completedReceiptKey ||
+      attemptedAutoPrintReceiptKeys.has(completedReceiptKey)
+    ) {
       return;
     }
 
     printedReceiptKeyRef.current = completedReceiptKey;
-    void handlePrintReceipt();
+    attemptedAutoPrintReceiptKeys.add(completedReceiptKey);
+    void handlePrintReceipt().then((didPrint) => {
+      if (!didPrint) {
+        attemptedAutoPrintReceiptKeys.delete(completedReceiptKey);
+        if (printedReceiptKeyRef.current === completedReceiptKey) {
+          printedReceiptKeyRef.current = null;
+        }
+      }
+    });
   }, [
     checkout.isTransactionCompleted,
     completedReceiptKey,
@@ -133,7 +152,10 @@ export function ExpenseCompletionPanel({
       isCompleted={checkout.isTransactionCompleted}
       completedTransactionData={completedTransactionData}
       reportNumber={checkout.completedOrderNumber}
-      onPrintReceipt={handlePrintReceipt}
+      recordedBy={checkout.cashierName}
+      onPrintReceipt={() => {
+        void handlePrintReceipt();
+      }}
     />
   );
 }

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.test.tsx
@@ -1,12 +1,45 @@
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { POSRegisterOpeningGuard } from "./POSRegisterOpeningGuard";
 
 const useQueryMock = vi.fn();
 const getActiveStoreMock = vi.fn();
+const startStoreDayMock = vi.fn();
+const authenticateStaffCredentialMock = vi.fn();
 const useLocalPosEntryContextMock = vi.fn();
 const useLocalPosReadinessMock = vi.fn();
+
+vi.mock("@/components/staff-auth/StaffAuthenticationDialog", () => ({
+  StaffAuthenticationDialog: ({
+    onAuthenticate,
+    onAuthenticated,
+    open,
+  }: {
+    onAuthenticate: (args: {
+      pinHash: string;
+      username: string;
+    }) => Promise<unknown>;
+    onAuthenticated: (result: { staffProfileId: string }) => void;
+    open: boolean;
+  }) =>
+    open ? (
+      <div role="dialog" aria-label="Confirm staff credentials">
+        <button
+          type="button"
+          onClick={async () => {
+            await onAuthenticate({
+              pinHash: "hashed-pin",
+              username: "frontdesk",
+            });
+            onAuthenticated({ staffProfileId: "staff-1" });
+          }}
+        >
+          Confirm staff
+        </button>
+      </div>
+    ) : null,
+}));
 
 vi.mock("@tanstack/react-router", () => ({
   Link: ({
@@ -64,7 +97,18 @@ vi.mock("@/components/common/PageHeader", () => ({
 }));
 
 vi.mock("convex/react", () => ({
+  useMutation: (mutationName: string) =>
+    mutationName === "authenticateStaffCredential"
+      ? authenticateStaffCredentialMock
+      : startStoreDayMock,
   useQuery: (...args: unknown[]) => useQueryMock(...args),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
 }));
 
 vi.mock("@/hooks/useGetActiveStore", () => ({
@@ -87,6 +131,10 @@ vi.mock("~/convex/_generated/api", () => ({
       },
       dailyOpening: {
         getDailyOpeningSnapshot: "getDailyOpeningSnapshot",
+        startStoreDay: "startStoreDay",
+      },
+      staffCredentials: {
+        authenticateStaffCredential: "authenticateStaffCredential",
       },
     },
   },
@@ -97,6 +145,18 @@ describe("POSRegisterOpeningGuard", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(2026, 4, 9, 12));
     vi.clearAllMocks();
+    startStoreDayMock.mockResolvedValue({
+      data: { action: "started" },
+      kind: "ok",
+    });
+    authenticateStaffCredentialMock.mockResolvedValue({
+      data: {
+        activeRoles: ["cashier"],
+        staffProfile: { fullName: "Ama Mensah" },
+        staffProfileId: "staff-1",
+      },
+      kind: "ok",
+    });
     getActiveStoreMock.mockReturnValue({
       activeStore: {
         _id: "store-1",
@@ -185,16 +245,102 @@ describe("POSRegisterOpeningGuard", () => {
     expect(screen.queryByText("Register workspace")).not.toBeInTheDocument();
     expect(screen.getByText("Store day not started")).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "Opening Handoff needs to be completed before sales can begin. Ask a manager to start the store day.",
-      ),
+      screen.getByText("Start the day when Opening Handoff is ready."),
     ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Start day/i })).toBeEnabled();
     expect(
       screen.getByRole("link", { name: /Opening Handoff/i }),
     ).toHaveAttribute(
       "href",
       "/wigclub/store/wigclub/operations/opening",
     );
+  });
+
+  it("authenticates staff and starts the store day from the POS gate when opening is ready", async () => {
+    useQueryMock.mockImplementation((queryName: string) => {
+      if (queryName === "getDailyOpeningSnapshot") {
+        return { status: "ready" };
+      }
+
+      if (queryName === "getDailyCloseSnapshot") {
+        return { status: "ready" };
+      }
+
+      return undefined;
+    });
+    useLocalPosReadinessMock.mockReturnValue({
+      status: "blocked",
+      reason: "not_started",
+      message:
+        "Store day not started. Complete Opening Handoff before starting sales.",
+    });
+
+    render(
+      <POSRegisterOpeningGuard>
+        <div>Register workspace</div>
+      </POSRegisterOpeningGuard>,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Start day/i }));
+      await Promise.resolve();
+    });
+
+    expect(
+      screen.getByRole("dialog", { name: "Confirm staff credentials" }),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Confirm staff/i }));
+      await Promise.resolve();
+    });
+
+    expect(authenticateStaffCredentialMock).toHaveBeenCalledWith({
+      allowedRoles: ["cashier", "manager"],
+      pinHash: "hashed-pin",
+      storeId: "store-1",
+      username: "frontdesk",
+    });
+    expect(startStoreDayMock).toHaveBeenCalledWith({
+      actorStaffProfileId: "staff-1",
+      endAt: new Date(2026, 4, 10).getTime(),
+      operatingDate: "2026-05-09",
+      startAt: new Date(2026, 4, 9).getTime(),
+      storeId: "store-1",
+    });
+  });
+
+  it("keeps the POS start action disabled when Opening Handoff needs review", () => {
+    useQueryMock.mockImplementation((queryName: string) => {
+      if (queryName === "getDailyOpeningSnapshot") {
+        return { status: "needs_attention" };
+      }
+
+      if (queryName === "getDailyCloseSnapshot") {
+        return { status: "ready" };
+      }
+
+      return undefined;
+    });
+    useLocalPosReadinessMock.mockReturnValue({
+      status: "blocked",
+      reason: "not_started",
+      message:
+        "Store day not started. Complete Opening Handoff before starting sales.",
+    });
+
+    render(
+      <POSRegisterOpeningGuard>
+        <div>Register workspace</div>
+      </POSRegisterOpeningGuard>,
+    );
+
+    expect(screen.getByRole("button", { name: /Start day/i })).toBeDisabled();
+    expect(
+      screen.getByText(
+        "Opening Handoff needs review before the store day can start from POS.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("directs the operator to EOD Review when the store day is closed", () => {

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx
@@ -1,15 +1,27 @@
-import { type ReactNode, useMemo } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 import { Link, useParams } from "@tanstack/react-router";
-import { useQuery } from "convex/react";
-import { ArrowUpRight, Store } from "lucide-react";
+import { useMutation, useQuery } from "convex/react";
+import { ArrowUpRight, CheckCircle2, Store } from "lucide-react";
+import { toast } from "sonner";
 
 import { ComposedPageHeader } from "@/components/common/PageHeader";
 import { FadeIn } from "@/components/common/FadeIn";
+import {
+  StaffAuthenticationDialog,
+  type StaffAuthenticationResult,
+} from "@/components/staff-auth/StaffAuthenticationDialog";
 import { Button } from "@/components/ui/button";
+import { LoadingButton } from "@/components/ui/loading-button";
 import View from "@/components/View";
 import useGetActiveStore from "@/hooks/useGetActiveStore";
+import { presentCommandToast } from "@/lib/errors/presentCommandToast";
+import {
+  type NormalizedCommandResult,
+  runCommand,
+} from "@/lib/errors/runCommand";
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
+import type { CommandResult } from "~/shared/commandResult";
 import { useLocalPosEntryContext } from "@/lib/pos/infrastructure/local/localPosEntryContext";
 import { useLocalPosReadiness } from "@/lib/pos/infrastructure/local/localPosReadiness";
 
@@ -109,7 +121,13 @@ export function POSRegisterOpeningGuard({
     localReadiness.status === "blocked" &&
     localReadiness.reason === "not_started"
   ) {
-    return <StoreDayNotStartedState />;
+    return (
+      <StoreDayNotStartedState
+        operatingDateRange={operatingDateRange}
+        snapshot={snapshot}
+        storeId={storeId}
+      />
+    );
   }
 
   if (
@@ -133,7 +151,15 @@ export function POSRegisterOpeningGuard({
   return <>{children}</>;
 }
 
-function StoreDayNotStartedState() {
+function StoreDayNotStartedState({
+  operatingDateRange,
+  snapshot,
+  storeId,
+}: {
+  operatingDateRange: ReturnType<typeof getLocalOperatingDateRange>;
+  snapshot?: DailyOpeningSnapshot;
+  storeId?: Id<"store">;
+}) {
   const params = useParams({ strict: false }) as
     | {
         orgUrlSlug?: string;
@@ -141,6 +167,65 @@ function StoreDayNotStartedState() {
       }
     | undefined;
   const canLinkToOpening = Boolean(params?.orgUrlSlug && params.storeUrlSlug);
+  const startStoreDay = useMutation(api.operations.dailyOpening.startStoreDay);
+  const authenticateStaffCredential = useMutation(
+    api.operations.staffCredentials.authenticateStaffCredential,
+  );
+  const [isStarting, setIsStarting] = useState(false);
+  const [isStaffAuthOpen, setIsStaffAuthOpen] = useState(false);
+  const canStartFromGate = Boolean(storeId && snapshot?.status === "ready");
+
+  const handleStartDay = async (staff: StaffAuthenticationResult) => {
+    if (!storeId || isStarting) {
+      return;
+    }
+
+    setIsStaffAuthOpen(false);
+    setIsStarting(true);
+
+    try {
+      const result = await runCommand(() =>
+        startStoreDay({
+          ...operatingDateRange,
+          actorStaffProfileId: staff.staffProfileId,
+          storeId,
+        }) as Promise<CommandResult<unknown>>,
+      );
+
+      if (result.kind === "ok") {
+        toast.success("Store day started");
+        return;
+      }
+
+      presentCommandToast(result);
+    } finally {
+      setIsStarting(false);
+    }
+  };
+
+  const handleAuthenticateStaff = async (args: {
+    pinHash: string;
+    username: string;
+  }): Promise<NormalizedCommandResult<StaffAuthenticationResult>> => {
+    if (!storeId) {
+      return {
+        kind: "user_error",
+        error: {
+          code: "validation_failed",
+          message: "Select a store before confirming staff credentials.",
+        },
+      };
+    }
+
+    return runCommand(() =>
+      authenticateStaffCredential({
+        allowedRoles: ["cashier", "manager"],
+        pinHash: args.pinHash,
+        storeId,
+        username: args.username,
+      }) as Promise<CommandResult<StaffAuthenticationResult>>,
+    );
+  };
 
   return (
     <View
@@ -171,30 +256,62 @@ function StoreDayNotStartedState() {
             Store day not started
           </h2>
           <p className="mt-3 max-w-lg text-base leading-7 text-muted-foreground">
-            Opening Handoff needs to be completed before sales can begin. Ask a
-            manager to start the store day.
+            Start the day when Opening Handoff is ready.
           </p>
-          {canLinkToOpening ? (
-            <Button
-              asChild
-              className="mt-8 bg-background/80 text-muted-foreground hover:text-foreground"
-              size="lg"
-              variant="outline"
+          <div className="mt-8 flex flex-wrap items-center justify-center gap-layout-sm">
+            <LoadingButton
+              className="min-w-40"
+              disabled={!canStartFromGate || isStarting}
+              isLoading={isStarting}
+              onClick={() => setIsStaffAuthOpen(true)}
+              type="button"
+              variant="workflow"
             >
-              <Link
-                params={{
-                  orgUrlSlug: params!.orgUrlSlug!,
-                  storeUrlSlug: params!.storeUrlSlug!,
-                }}
-                to="/$orgUrlSlug/store/$storeUrlSlug/operations/opening"
+              Start day
+              <CheckCircle2 className="h-4 w-4" />
+            </LoadingButton>
+            {canLinkToOpening ? (
+              <Button
+                asChild
+                className="bg-background/80 text-muted-foreground hover:text-foreground"
+                size="lg"
+                variant="outline"
               >
-                Opening Handoff
-                <ArrowUpRight className="h-4 w-4" />
-              </Link>
-            </Button>
+                <Link
+                  params={{
+                    orgUrlSlug: params!.orgUrlSlug!,
+                    storeUrlSlug: params!.storeUrlSlug!,
+                  }}
+                  to="/$orgUrlSlug/store/$storeUrlSlug/operations/opening"
+                >
+                  Opening Handoff
+                  <ArrowUpRight className="h-4 w-4" />
+                </Link>
+              </Button>
+            ) : null}
+          </div>
+          {!canStartFromGate ? (
+            <p className="mt-layout-md max-w-md text-sm leading-6 text-muted-foreground">
+              Opening Handoff needs review before the store day can start from
+              POS.
+            </p>
           ) : null}
         </div>
       </FadeIn>
+      <StaffAuthenticationDialog
+        copy={{
+          title: "Confirm staff credentials",
+          description: "Start the store day with your staff sign-in.",
+          submitLabel: "Start day",
+        }}
+        getSuccessMessage={() => null}
+        onAuthenticate={(args) => handleAuthenticateStaff(args)}
+        onAuthenticated={(result) => {
+          void handleStartDay(result);
+        }}
+        onDismiss={() => setIsStaffAuthOpen(false)}
+        open={isStaffAuthOpen}
+      />
     </View>
   );
 }

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
@@ -132,10 +138,10 @@ vi.mock("@/components/pos/ProductEntry", async () => {
         },
         ref,
       ) => {
-      React.useImperativeHandle(ref, () => ({
-        focusProductSearchInput: () => true,
-        openQuickAddProduct: mockOpenQuickAddProduct,
-      }));
+        React.useImperativeHandle(ref, () => ({
+          focusProductSearchInput: () => true,
+          openQuickAddProduct: mockOpenQuickAddProduct,
+        }));
 
         return (
           <div>
@@ -221,7 +227,9 @@ vi.mock("./RegisterActionBar", () => ({
       register-action-bar
       <div>
         Cashier {cashierCard?.cashierName ?? "Unassigned"}
-        {cashierCard ? <button onClick={cashierCard.onSignOut}>Sign out</button> : null}
+        {cashierCard ? (
+          <button onClick={cashierCard.onSignOut}>Sign out</button>
+        ) : null}
       </div>
       {closeoutControl ? (
         <>
@@ -372,7 +380,9 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("product-search-input")).toBeInTheDocument();
     expect(screen.getByText("Ready for product lookup")).toBeInTheDocument();
     expect(screen.getByText("⌘+K")).toBeInTheDocument();
-    expect(screen.getByRole("region", { name: "Sale summary" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: "Sale summary" }),
+    ).toBeInTheDocument();
     expect(screen.getByText("Balance due")).toBeInTheDocument();
     expect(screen.getByText("GH₵0")).toBeInTheDocument();
     expect(screen.getByText("cart-items")).toBeInTheDocument();
@@ -443,7 +453,9 @@ describe("POSRegisterView", () => {
     searchInput.blur();
     expect(searchInput).not.toHaveFocus();
 
-    await userEvent.click(screen.getByRole("button", { name: "mock-add-service" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "mock-add-service" }),
+    );
 
     await waitFor(() => expect(searchInput).toHaveFocus());
     expect(onAddService).toHaveBeenCalledWith(
@@ -648,7 +660,9 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("2026-05-15T12:35:01Z")).toBeInTheDocument();
     expect(screen.getByText("check-in note")).toBeInTheDocument();
     expect(
-      screen.getByText("You do not have access to update this POS terminal status."),
+      screen.getByText(
+        "You do not have access to update this POS terminal status.",
+      ),
     ).toBeInTheDocument();
     expect(screen.getByText("local-only events")).toBeInTheDocument();
     expect(screen.getByText("oldest pending")).toBeInTheDocument();
@@ -902,11 +916,19 @@ describe("POSRegisterView", () => {
         "This register was closed locally. Athena will reconcile the closeout after sync.",
       ),
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /retry sync/i })).toBeInTheDocument();
-    expect(screen.queryByText("register-customer-panel")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /retry sync/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("register-customer-panel"),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText("register-action-bar")).not.toBeInTheDocument();
-    expect(screen.queryByText("register-checkout-panel")).not.toBeInTheDocument();
-    expect(screen.queryByText("Ready for product lookup")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("register-checkout-panel"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Ready for product lookup"),
+    ).not.toBeInTheDocument();
   });
 
   it("focuses the product lookup entry when the empty lookup workspace is clicked", async () => {
@@ -1247,7 +1269,9 @@ describe("POSRegisterView", () => {
     render(<POSRegisterView />);
 
     expect(screen.getByText("Onboarding")).toBeInTheDocument();
-    expect(screen.getByText("Finish setup before your first checkout")).toBeInTheDocument();
+    expect(
+      screen.getByText("Finish setup before your first checkout"),
+    ).toBeInTheDocument();
     expect(screen.getByText("Set up this register")).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /open register setup/i }),
@@ -1362,9 +1386,13 @@ describe("POSRegisterView", () => {
     render(<POSRegisterView />);
 
     expect(screen.queryByText("Onboarding")).not.toBeInTheDocument();
-    expect(screen.queryByText("Ready for product lookup")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Ready for product lookup"),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText("product-search-input")).not.toBeInTheDocument();
-    expect(screen.queryByText("register-customer-panel")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("register-customer-panel"),
+    ).not.toBeInTheDocument();
     expect(screen.queryByText("cart-items")).not.toBeInTheDocument();
     expect(
       screen.queryByText("register-checkout-panel"),
@@ -1469,6 +1497,16 @@ describe("POSRegisterView", () => {
     render(<POSRegisterView workflowMode="expense" />);
 
     expect(screen.getByText("expense-completion-panel")).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("register-workspace-sidebar")).getByText(
+        "expense-completion-panel",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("register-main-workspace")).queryByText(
+        "expense-completion-panel",
+      ),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("cart-items")).toBeInTheDocument();
     expect(screen.queryByText("register-action-bar")).not.toBeInTheDocument();
     expect(
@@ -1569,10 +1607,22 @@ describe("POSRegisterView", () => {
     const { POSRegisterView } = await import("./POSRegisterView");
     render(<POSRegisterView />);
 
-    expect(screen.getByText("Ready for expense entry")).toBeInTheDocument();
     expect(
-      screen.getByText("Search or scan products to add expense items"),
+      within(screen.getByTestId("register-main-workspace")).getByText(
+        "expense-completion-panel",
+      ),
     ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("register-workspace-sidebar")).queryByText(
+        "expense-completion-panel",
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Ready for expense entry"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Search or scan products to add expense items"),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("cart-items")).toBeInTheDocument();
     expect(screen.getByText("expense-completion-panel")).toBeInTheDocument();
     expect(screen.getByText("Cashier")).toBeInTheDocument();

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -280,7 +280,9 @@ function RegisterSyncStatusChip({
           ? "text-warning"
           : "text-muted-foreground";
   const canRetry =
-    !isOperableReview && syncStatus.status !== "synced" && syncStatus.onRetrySync;
+    !isOperableReview &&
+    syncStatus.status !== "synced" &&
+    syncStatus.onRetrySync;
   const label = getRegisterSyncStatusChipLabel(syncStatus.status, {
     isRegisterOperable,
   });
@@ -473,8 +475,7 @@ function usePosDebugPanelToggle() {
 
   useEffect(() => {
     function isDebugShortcut(event: KeyboardEvent) {
-      const isDebugShortcut =
-        event.key === "/" || event.code === "Slash";
+      const isDebugShortcut = event.key === "/" || event.code === "Slash";
       return (event.metaKey || event.ctrlKey) && isDebugShortcut;
     }
 
@@ -887,9 +888,9 @@ function POSOnboardingWorkspace({
                     "rounded-lg border p-layout-md transition-colors",
                     step.isComplete && "border-border bg-surface",
                     step.isCurrent &&
-                    "border-action-commit/40 bg-background shadow-sm",
+                      "border-action-commit/40 bg-background shadow-sm",
                     isWaiting &&
-                    "border-transparent bg-transparent py-layout-sm opacity-55",
+                      "border-transparent bg-transparent py-layout-sm opacity-55",
                   )}
                 >
                   <div className="flex gap-layout-md">
@@ -897,12 +898,12 @@ function POSOnboardingWorkspace({
                       className={cn(
                         "mt-1 flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-border bg-background text-muted-foreground",
                         step.isComplete &&
-                        "border-success/30 bg-success/10 text-success",
+                          "border-success/30 bg-success/10 text-success",
                         step.isCurrent &&
-                        !step.isComplete &&
-                        "border-action-commit/30 bg-action-neutral-soft text-action-commit",
+                          !step.isComplete &&
+                          "border-action-commit/30 bg-action-neutral-soft text-action-commit",
                         isWaiting &&
-                        "h-8 w-8 border-border/60 bg-transparent text-muted-foreground",
+                          "h-8 w-8 border-border/60 bg-transparent text-muted-foreground",
                       )}
                     >
                       {step.isComplete ? (
@@ -1047,7 +1048,12 @@ export function POSRegisterView({
   const shouldRenderSaleSurface = isPosWorkflow
     ? !viewModel.checkout.isTransactionCompleted && !isLocallyClosedPendingSync
     : true;
-  const shouldRenderExpenseCompletionPanel = !isPosWorkflow;
+  const shouldRenderExpenseCompletionWorkspace =
+    !isPosWorkflow &&
+    viewModel.checkout.isTransactionCompleted &&
+    !isAwaitingCashierAuth;
+  const shouldRenderExpenseCompletionPanel =
+    !isPosWorkflow && !shouldRenderExpenseCompletionWorkspace;
   const shouldRenderCheckoutPanel =
     isPosWorkflow || shouldRenderExpenseCompletionPanel;
   const shouldShowPaymentWorkspace =
@@ -1414,7 +1420,9 @@ export function POSRegisterView({
                   ref={headerProductSearchInputRef}
                   disabled={!isHeaderProductSearchSupported}
                   productSearchQuery={viewModel.productEntry.productSearchQuery}
-                  setProductSearchQuery={viewModel.productEntry.setProductSearchQuery}
+                  setProductSearchQuery={
+                    viewModel.productEntry.setProductSearchQuery
+                  }
                   onBarcodeSubmit={viewModel.productEntry.onBarcodeSubmit}
                   className="max-w-[800px] flex-1"
                   inputClassName="h-14"
@@ -1423,7 +1431,9 @@ export function POSRegisterView({
             </div>
           }
           trailingContent={
-            (canSearchProducts && isPosWorkflow && !isLocallyClosedPendingSync) ||
+            (canSearchProducts &&
+              isPosWorkflow &&
+              !isLocallyClosedPendingSync) ||
             shouldShowDrawerRecoveryActionBar ? (
               <RegisterActionBar
                 cashierCard={viewModel.cashierCard}
@@ -1465,10 +1475,13 @@ export function POSRegisterView({
           <div className="grid min-h-0 flex-1 grid-cols-1 gap-6 overflow-hidden lg:grid-cols-[minmax(0,2fr)_minmax(340px,1fr)]">
             {isLocallyClosedPendingSync && viewModel.syncStatus ? (
               <div className="lg:col-span-2">
-                <LocalRegisterClosedWorkspace syncStatus={viewModel.syncStatus} />
+                <LocalRegisterClosedWorkspace
+                  syncStatus={viewModel.syncStatus}
+                />
               </div>
             ) : shouldRenderSaleSurface ? (
               <div
+                data-testid="register-main-workspace"
                 className={cn(
                   "flex min-h-0 flex-col overflow-hidden pr-1",
                   !shouldRenderWorkspaceSidebar && "lg:col-span-2",
@@ -1482,6 +1495,10 @@ export function POSRegisterView({
                   <DrawerGateWorkspace drawerGate={viewModel.drawerGate} />
                 ) : isAwaitingCashierAuth && viewModel.authDialog ? (
                   <CashierAuthWorkspace authDialog={viewModel.authDialog} />
+                ) : shouldRenderExpenseCompletionWorkspace ? (
+                  <div className="min-h-0 flex-1 overflow-y-auto rounded-lg bg-surface p-4">
+                    <ExpenseCompletionPanel checkout={viewModel.checkout} />
+                  </div>
                 ) : shouldShowPaymentWorkspace ? (
                   <CartItems
                     cartItems={viewModel.cart.items}
@@ -1494,9 +1511,7 @@ export function POSRegisterView({
                     density="comfortable"
                   />
                 ) : hasLookupIntent ? (
-                  <div className="min-h-0 flex-1">
-                    {renderProductEntry()}
-                  </div>
+                  <div className="min-h-0 flex-1">{renderProductEntry()}</div>
                 ) : shouldShowIdleLookupCartSplit ? (
                   <div className="grid h-full min-h-0 grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(20rem,0.72fr)]">
                     <ProductLookupEmptyState
@@ -1521,7 +1536,9 @@ export function POSRegisterView({
                       serviceItems={viewModel.cart.serviceItems}
                       onUpdateQuantity={viewModel.cart.onUpdateQuantity}
                       onRemoveItem={viewModel.cart.onRemoveItem}
-                      onUpdateServiceAmount={viewModel.cart.onUpdateServiceAmount}
+                      onUpdateServiceAmount={
+                        viewModel.cart.onUpdateServiceAmount
+                      }
                       onRemoveService={viewModel.cart.onRemoveService}
                       clearCart={viewModel.cart.onClearCart}
                       density="compact"
@@ -1569,6 +1586,7 @@ export function POSRegisterView({
 
             {shouldRenderWorkspaceSidebar ? (
               <div
+                data-testid="register-workspace-sidebar"
                 className={cn(
                   "flex h-full min-h-0 overflow-hidden",
                   shouldRenderSaleSurface ? "lg:col-span-1" : "lg:col-span-2",
@@ -1581,7 +1599,9 @@ export function POSRegisterView({
                       serviceItems={viewModel.cart.serviceItems}
                       onUpdateQuantity={viewModel.cart.onUpdateQuantity}
                       onRemoveItem={viewModel.cart.onRemoveItem}
-                      onUpdateServiceAmount={viewModel.cart.onUpdateServiceAmount}
+                      onUpdateServiceAmount={
+                        viewModel.cart.onUpdateServiceAmount
+                      }
                       onRemoveService={viewModel.cart.onRemoveService}
                       clearCart={viewModel.cart.onClearCart}
                       density="compact"

--- a/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
@@ -128,6 +128,15 @@ vi.mock("sonner", () => ({
 import { registerAndProvisionPosTerminal } from "@/lib/pos/application/registerAndProvisionPosTerminal";
 import { POSSettingsView } from "./POSSettingsView";
 
+async function waitForFingerprintEffect() {
+  await waitFor(() =>
+    expect(window.localStorage.setItem).toHaveBeenCalledWith(
+      "athena.pos.fingerprint",
+      expect.any(String),
+    ),
+  );
+}
+
 describe("registerAndProvisionPosTerminal", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -154,6 +163,7 @@ describe("registerAndProvisionPosTerminal", () => {
             failedAttemptCount: 0,
             lastUsedAt: undefined,
             lockedUntil: undefined,
+            plaintextCode: "mintlamp42",
             rotatedAt: 1,
             status: "active",
           }
@@ -309,7 +319,16 @@ describe("registerAndProvisionPosTerminal", () => {
     );
   });
 
-  it("lets full admins rotate the POS recovery code and shows plaintext once", async () => {
+  it("shows the current POS recovery code from status", async () => {
+    render(<POSSettingsView />);
+
+    expect(await screen.findByText("mintlamp42")).toBeInTheDocument();
+    expect(
+      screen.getByText("Current recovery code"),
+    ).toBeInTheDocument();
+  });
+
+  it("lets full admins rotate the POS recovery code and keeps plaintext visible", async () => {
     const user = userEvent.setup();
 
     render(<POSSettingsView />);
@@ -390,6 +409,7 @@ describe("registerAndProvisionPosTerminal", () => {
     });
 
     render(<POSSettingsView />);
+    await waitForFingerprintEffect();
 
     expect(screen.queryByText("POS recovery code")).not.toBeInTheDocument();
     expect(mocks.useQuery).toHaveBeenCalledWith(

--- a/packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx
+++ b/packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx
@@ -204,6 +204,7 @@ function POSRecoveryCodeAdminPanel({
         failedAttemptCount: number;
         lastUsedAt?: number;
         lockedUntil?: number;
+        plaintextCode?: string;
         rotatedAt: number;
         status: "active" | "locked" | "revoked";
       }
@@ -280,6 +281,7 @@ function POSRecoveryCodeAdminPanel({
   }
 
   const statusLabel = status?.status ?? "not configured";
+  const currentRecoveryCode = revealedCode ?? status?.plaintextCode ?? null;
 
   return (
     <section className="grid gap-layout-xl border-b border-border py-layout-2xl lg:grid-cols-[17rem_minmax(0,1fr)]">
@@ -288,8 +290,8 @@ function POSRecoveryCodeAdminPanel({
           POS recovery code
         </h2>
         <p className="text-sm leading-6 text-muted-foreground">
-          Manage the recovery code for the shared POS app account. Athena shows
-          a new code only when it is created or rotated.
+          Manage the recovery code for the shared POS app account. The current
+          code stays visible to full admins.
         </p>
       </div>
 
@@ -306,20 +308,20 @@ function POSRecoveryCodeAdminPanel({
           </span>
         </div>
 
-        {revealedCode ? (
+        {currentRecoveryCode ? (
           <div
             className="rounded-md border border-signal/30 bg-signal/10 px-layout-md py-layout-sm"
             role="status"
           >
             <p className="text-sm font-medium text-foreground">
-              New recovery code
+              Current recovery code
             </p>
             <p className="mt-layout-xs font-mono text-lg tracking-wide text-foreground">
-              {revealedCode}
+              {currentRecoveryCode}
             </p>
             <p className="mt-layout-xs text-sm text-muted-foreground">
-              Store this with the field operations runbook. It will not be shown
-              again.
+              Keep this with the field operations runbook. Rotate it when staff
+              need a new code.
             </p>
           </div>
         ) : null}
@@ -335,7 +337,7 @@ function POSRecoveryCodeAdminPanel({
           </div>
           <div>
             <p className="font-medium text-foreground">Plaintext</p>
-            <p>Shown only after rotate</p>
+            <p>{currentRecoveryCode ? "Visible" : "Rotate to show"}</p>
           </div>
         </div>
 
@@ -553,10 +555,12 @@ export function POSSettingsView({
         browserInfo: fingerprintResult.browserInfo,
         displayName: registrationState.trimmedDisplayName,
         fingerprintHash: fingerprintResult.fingerprintHash,
-	        registerNumber: registrationState.trimmedRegisterNumber,
-	        registerTerminalMutation,
-	        storeFactory,
-	      });
+        orgUrlSlug: routeParams?.orgUrlSlug,
+        registerNumber: registrationState.trimmedRegisterNumber,
+        registerTerminalMutation,
+        storeFactory,
+        storeUrlSlug: routeParams?.storeUrlSlug,
+      });
       if (result.kind === "user_error") {
         toast.error(result.error.message);
         return;
@@ -596,10 +600,12 @@ export function POSSettingsView({
         browserInfo: fingerprintResult.browserInfo,
         displayName: registrationState.trimmedDisplayName,
         fingerprintHash: fingerprintResult.fingerprintHash,
-	        registerNumber: existingTerminal.registerNumber ?? "",
-	        registerTerminalMutation,
-	        storeFactory,
-	      });
+        orgUrlSlug: routeParams?.orgUrlSlug,
+        registerNumber: existingTerminal.registerNumber ?? "",
+        registerTerminalMutation,
+        storeFactory,
+        storeUrlSlug: routeParams?.storeUrlSlug,
+      });
       if (result.kind === "user_error") {
         toast.error(result.error.message);
         return;

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
@@ -336,8 +336,11 @@ describe("terminal health presentation", () => {
       getSnapshotAgeSummary({
         availabilityAgeMs: 90_000,
         catalogAgeMs: 12 * 60_000,
+        serviceCatalogAgeMs: 3 * 60_000,
       }),
-    ).toBe("Availability 2 minutes old / Catalog 12 minutes old");
+    ).toBe(
+      "Availability 2 minutes old / Catalog 12 minutes old / Service catalog 3 minutes old",
+    );
 
     vi.useRealTimers();
   });

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
@@ -97,6 +97,9 @@ export function getSnapshotAgeSummary(
     snapshots.catalogAgeMs !== undefined
       ? `Catalog ${formatAge(snapshots.catalogAgeMs)}`
       : null,
+    snapshots.serviceCatalogAgeMs !== undefined
+      ? `Service catalog ${formatAge(snapshots.serviceCatalogAgeMs)}`
+      : null,
     snapshots.registerReadModelAgeMs !== undefined
       ? `Register read model ${formatAge(snapshots.registerReadModelAgeMs)}`
       : null,

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
@@ -54,6 +54,7 @@ export type TerminalRuntimeStatus = {
   snapshots: {
     availabilityAgeMs?: number;
     catalogAgeMs?: number;
+    serviceCatalogAgeMs?: number;
     registerReadModelAgeMs?: number;
   };
   source:

--- a/packages/athena-webapp/src/hooks/usePermissions.ts
+++ b/packages/athena-webapp/src/hooks/usePermissions.ts
@@ -3,6 +3,7 @@ import { useOptionalManagerElevation } from "../contexts/ManagerElevationContext
 import {
   canAccessFullAdminSurface,
   canAccessStoreDaySurface,
+  canViewFinancialDetails,
 } from "@/lib/access/capabilities";
 import { Role } from "~/types";
 
@@ -13,6 +14,7 @@ interface UsePermissionsReturn {
   canAccessStoreDaySurfaces: () => boolean;
   canAccessFullAdminSurfaces: () => boolean;
   hasFullAdminAccess: boolean;
+  hasFinancialDetailsAccess: boolean;
   hasStoreDaySurfaceAccess: boolean;
   role: Role | null;
   isLoading: boolean;
@@ -28,6 +30,10 @@ export function usePermissions(): UsePermissionsReturn {
     activeManagerElevation,
     role,
   });
+  const hasFinancialDetailsAccess = canViewFinancialDetails({
+    activeManagerElevation,
+    role,
+  });
 
   return {
     canAccessOperations: () => hasStoreDaySurfaceAccess,
@@ -36,6 +42,7 @@ export function usePermissions(): UsePermissionsReturn {
     canAccessStoreDaySurfaces: () => hasStoreDaySurfaceAccess,
     canAccessFullAdminSurfaces: () => hasFullAdminAccess,
     hasFullAdminAccess,
+    hasFinancialDetailsAccess,
     hasStoreDaySurfaceAccess,
     role,
     isLoading,

--- a/packages/athena-webapp/src/hooks/useProtectedAdminPageState.ts
+++ b/packages/athena-webapp/src/hooks/useProtectedAdminPageState.ts
@@ -11,6 +11,7 @@ export function useProtectedAdminPageState(
   const { activeStore, isLoadingStores } = useGetActiveStore();
   const {
     canAccessOperations,
+    hasFinancialDetailsAccess,
     hasFullAdminAccess,
     hasStoreDaySurfaceAccess,
     isLoading: isLoadingPermissions,
@@ -36,6 +37,7 @@ export function useProtectedAdminPageState(
     activeStore,
     canAccessProtectedSurface: canAccessSurface,
     canQueryProtectedData,
+    hasFinancialDetailsAccess,
     hasFullAdminAccess: fullAdminAccess,
     hasStoreDaySurfaceAccess: storeDaySurfaceAccess,
     isAuthenticated: hasReadyAuthenticatedUser,

--- a/packages/athena-webapp/src/lib/access/capabilities.test.ts
+++ b/packages/athena-webapp/src/lib/access/capabilities.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   canAccessFullAdminSurface,
   canAccessStoreDaySurface,
+  canViewFinancialDetails,
   getSurfaceAccess,
   type ManagerElevationAccessState,
 } from "./capabilities";
@@ -30,7 +31,7 @@ describe("surface capability access", () => {
     ).toBe(false);
   });
 
-  it("allows active manager elevation to unlock only store-day surfaces", () => {
+  it("allows POS-only accounts to open store-day surfaces", () => {
     expect(
       canAccessStoreDaySurface({
         role: "pos_only",
@@ -38,29 +39,41 @@ describe("surface capability access", () => {
       }),
     ).toBe(true);
     expect(canAccessStoreDaySurface({ role: "full_admin" })).toBe(true);
-    expect(canAccessStoreDaySurface({ role: "pos_only" })).toBe(false);
+    expect(canAccessStoreDaySurface({ role: "pos_only" })).toBe(true);
+    expect(canAccessStoreDaySurface({ role: null })).toBe(false);
   });
 
   it("keeps excluded admin surfaces full-admin only", () => {
-    const elevatedPosOnly = {
+    const posOnly = {
       role: "pos_only" as const,
-      activeManagerElevation: activeElevation,
     };
 
-    expect(getSurfaceAccess("cash_controls", elevatedPosOnly)).toBe(true);
-    expect(getSurfaceAccess("daily_operations", elevatedPosOnly)).toBe(true);
-    expect(getSurfaceAccess("open_work", elevatedPosOnly)).toBe(true);
-    expect(getSurfaceAccess("approvals", elevatedPosOnly)).toBe(true);
-    expect(getSurfaceAccess("stock_adjustments", elevatedPosOnly)).toBe(true);
+    expect(getSurfaceAccess("cash_controls", posOnly)).toBe(true);
+    expect(getSurfaceAccess("daily_operations", posOnly)).toBe(true);
+    expect(getSurfaceAccess("open_work", posOnly)).toBe(true);
+    expect(getSurfaceAccess("approvals", posOnly)).toBe(true);
+    expect(getSurfaceAccess("stock_adjustments", posOnly)).toBe(true);
 
-    expect(getSurfaceAccess("procurement", elevatedPosOnly)).toBe(false);
-    expect(getSurfaceAccess("analytics", elevatedPosOnly)).toBe(false);
-    expect(getSurfaceAccess("configuration", elevatedPosOnly)).toBe(false);
-    expect(getSurfaceAccess("members", elevatedPosOnly)).toBe(false);
-    expect(getSurfaceAccess("storefront_admin", elevatedPosOnly)).toBe(false);
-    expect(getSurfaceAccess("bulk_operations", elevatedPosOnly)).toBe(false);
-    expect(getSurfaceAccess("promo_codes", elevatedPosOnly)).toBe(false);
-    expect(getSurfaceAccess("reviews_admin", elevatedPosOnly)).toBe(false);
-    expect(getSurfaceAccess("services_admin", elevatedPosOnly)).toBe(false);
+    expect(getSurfaceAccess("procurement", posOnly)).toBe(false);
+    expect(getSurfaceAccess("analytics", posOnly)).toBe(false);
+    expect(getSurfaceAccess("configuration", posOnly)).toBe(false);
+    expect(getSurfaceAccess("members", posOnly)).toBe(false);
+    expect(getSurfaceAccess("storefront_admin", posOnly)).toBe(false);
+    expect(getSurfaceAccess("bulk_operations", posOnly)).toBe(false);
+    expect(getSurfaceAccess("promo_codes", posOnly)).toBe(false);
+    expect(getSurfaceAccess("reviews_admin", posOnly)).toBe(false);
+    expect(getSurfaceAccess("services_admin", posOnly)).toBe(false);
+  });
+
+  it("gates financial details to admins or active manager elevation", () => {
+    expect(canViewFinancialDetails({ role: "full_admin" })).toBe(true);
+    expect(canViewFinancialDetails({ role: "pos_only" })).toBe(false);
+    expect(
+      canViewFinancialDetails({
+        role: "pos_only",
+        activeManagerElevation: activeElevation,
+      }),
+    ).toBe(true);
+    expect(canViewFinancialDetails({ role: null })).toBe(false);
   });
 });

--- a/packages/athena-webapp/src/lib/access/capabilities.ts
+++ b/packages/athena-webapp/src/lib/access/capabilities.ts
@@ -49,6 +49,17 @@ export function canAccessStoreDaySurface({
   activeManagerElevation,
   role,
 }: SurfaceAccessContext): boolean {
+  return (
+    role === "pos_only" ||
+    canAccessFullAdminSurface({ role }) ||
+    Boolean(activeManagerElevation)
+  );
+}
+
+export function canViewFinancialDetails({
+  activeManagerElevation,
+  role,
+}: SurfaceAccessContext): boolean {
   return canAccessFullAdminSurface({ role }) || Boolean(activeManagerElevation);
 }
 

--- a/packages/athena-webapp/src/lib/pos/application/registerAndProvisionPosTerminal.ts
+++ b/packages/athena-webapp/src/lib/pos/application/registerAndProvisionPosTerminal.ts
@@ -38,6 +38,7 @@ export async function registerAndProvisionPosTerminal(input: {
   browserInfo: BrowserInfo;
   displayName: string;
   fingerprintHash: string;
+  orgUrlSlug?: string;
   registerNumber: string;
   registerTerminalMutation: (args: {
     browserInfo: BrowserInfo;
@@ -51,6 +52,7 @@ export async function registerAndProvisionPosTerminal(input: {
     | { kind: "user_error"; error: { message: string } }
   >;
   storeFactory?: () => ReturnType<typeof createPosLocalStore>;
+  storeUrlSlug?: string;
   now?: () => number;
 }) {
   const syncSecretToken = await createTerminalSyncSecretToken();
@@ -74,10 +76,12 @@ export async function registerAndProvisionPosTerminal(input: {
     cloudTerminalId: result.data._id,
     syncSecretHash: result.data.syncSecretHash ?? syncSecretToken,
     storeId: input.activeStoreId,
+    orgUrlSlug: input.orgUrlSlug,
     registerNumber: result.data.registerNumber,
     displayName: result.data.displayName,
     provisionedAt: input.now?.() ?? Date.now(),
     schemaVersion: POS_LOCAL_STORE_SCHEMA_VERSION,
+    storeUrlSlug: input.storeUrlSlug,
   };
   const seedWrite = store.writeProvisionedTerminalSeedAndClearTerminalIntegrity
     ? await store.writeProvisionedTerminalSeedAndClearTerminalIntegrity({

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
@@ -51,10 +51,12 @@ export interface PosProvisionedTerminalSeed {
   cloudTerminalId: string;
   syncSecretHash: string;
   storeId: string;
+  orgUrlSlug?: string;
   registerNumber?: string;
   displayName: string;
   provisionedAt: number;
   schemaVersion: number;
+  storeUrlSlug?: string;
 }
 
 export interface PosLocalEventRecord {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts
@@ -571,6 +571,14 @@ function snapshotAges(
     ...(snapshots?.catalogRefreshedAt
       ? { catalogAgeMs: Math.max(0, now - snapshots.catalogRefreshedAt) }
       : {}),
+    ...(snapshots?.serviceCatalogRefreshedAt
+      ? {
+          serviceCatalogAgeMs: Math.max(
+            0,
+            now - snapshots.serviceCatalogRefreshedAt,
+          ),
+        }
+      : {}),
     ...(snapshots?.registerReadModelRefreshedAt
       ? {
           registerReadModelAgeMs: Math.max(

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -2398,9 +2398,11 @@ export function useRegisterViewModel(): RegisterViewModel {
         browserInfo: fingerprint.browserInfo,
         displayName: terminal.displayName || seed.displayName,
         fingerprintHash: fingerprint.fingerprintHash,
+        orgUrlSlug: seed.orgUrlSlug,
         registerNumber: repairRegisterNumber,
         registerTerminalMutation,
         storeFactory: () => localStore,
+        storeUrlSlug: seed.storeUrlSlug,
       });
 
       if (result.kind === "user_error") {

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close-history.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/daily-close-history.tsx
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { DailyCloseHistoryView } from "~/src/components/operations/DailyCloseHistoryView";
 
 const dailyCloseHistorySearchSchema = z.object({
+  day: z.string().optional(),
   o: z.string().optional(),
 });
 


### PR DESCRIPTION
## Summary
- allow POS-only users into store-day operations/cash-control workspaces while redacting financial details unless manager access is active
- deliver the transferred POS recovery/register dirty-set changes
- align terminal runtime status schema with service catalog snapshot age data

## Validation
- bun run pr:athena
- pre-push reused current pr:athena proof for tree f3f03d43e2aa36df6c70dad0f29447c2bcaede09
