### PR TITLE
[V26-660,V26-661,V26-662,V26-663,V26-664,V26-665]: POS offline route access

### DIFF
--- a/docs/plans/2026-06-03-002-feat-pos-offline-route-access-plan.html
+++ b/docs/plans/2026-06-03-002-feat-pos-offline-route-access-plan.html
@@ -1,0 +1,321 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Plan: Make POS route accessible with no network</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f8fa;
+      --panel: #ffffff;
+      --text: #1f2937;
+      --muted: #5f6b7a;
+      --border: #d8dee8;
+      --accent: #166534;
+      --accent-soft: #e8f5ed;
+      --warn-soft: #fff7ed;
+      --warn: #9a3412;
+    }
+
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.55;
+    }
+
+    main {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 40px 24px 64px;
+    }
+
+    header {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 28px;
+      margin-bottom: 24px;
+    }
+
+    h1, h2, h3 {
+      margin: 0;
+      line-height: 1.2;
+    }
+
+    h1 {
+      font-size: 2rem;
+      letter-spacing: 0;
+    }
+
+    h2 {
+      margin-top: 32px;
+      font-size: 1.3rem;
+      border-bottom: 1px solid var(--border);
+      padding-bottom: 8px;
+    }
+
+    h3 {
+      margin-top: 20px;
+      font-size: 1rem;
+    }
+
+    p {
+      margin: 12px 0 0;
+    }
+
+    a {
+      color: #1d4ed8;
+      text-decoration: none;
+    }
+
+    a:hover {
+      text-decoration: underline;
+    }
+
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 16px;
+      color: var(--muted);
+      font-size: 0.92rem;
+    }
+
+    .pill {
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      background: #fbfcfd;
+      padding: 4px 10px;
+    }
+
+    nav {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 18px 22px;
+      margin-bottom: 24px;
+    }
+
+    nav ul, section ul {
+      margin: 10px 0 0;
+      padding-left: 22px;
+    }
+
+    section {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 24px;
+      margin-top: 18px;
+    }
+
+    .callout {
+      background: var(--accent-soft);
+      border: 1px solid #b7dfc4;
+      border-radius: 8px;
+      padding: 16px;
+      margin-top: 16px;
+    }
+
+    .warning {
+      background: var(--warn-soft);
+      border-color: #fed7aa;
+      color: var(--warn);
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 12px;
+      font-size: 0.94rem;
+    }
+
+    th, td {
+      border: 1px solid var(--border);
+      padding: 10px;
+      vertical-align: top;
+      text-align: left;
+    }
+
+    th {
+      background: #f1f5f9;
+    }
+
+    code {
+      background: #f1f5f9;
+      border-radius: 4px;
+      padding: 1px 4px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.92em;
+    }
+
+    .unit {
+      border-left: 4px solid var(--accent);
+      padding-left: 16px;
+      margin-top: 20px;
+    }
+
+    .unit h3 {
+      color: var(--accent);
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 14px;
+      margin-top: 14px;
+    }
+
+    .card {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 14px;
+      background: #fbfcfd;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>feat: Make POS route accessible with no network</h1>
+      <p>This plan closes the remaining route-access gap in Athena's local-first POS work: an already-provisioned terminal should be able to open or hard reload the POS route after total network loss.</p>
+      <div class="meta">
+        <span class="pill">Type: feat</span>
+        <span class="pill">Status: active</span>
+        <span class="pill">Date: 2026-06-03</span>
+        <span class="pill">Source: <a href="2026-06-03-002-feat-pos-offline-route-access-plan.md">Markdown plan</a></span>
+      </div>
+    </header>
+
+    <nav>
+      <strong>Review sections</strong>
+      <ul>
+        <li><a href="#scope">Scope</a></li>
+        <li><a href="#requirements">Requirements</a></li>
+        <li><a href="#decisions">Key decisions</a></li>
+        <li><a href="#units">Implementation units</a></li>
+        <li><a href="#risks">Risks</a></li>
+        <li><a href="#verification">Verification strategy</a></li>
+      </ul>
+    </nav>
+
+    <section id="scope">
+      <h2>Scope</h2>
+      <div class="callout">
+        The minimum offline route contract is <code>/pos</code> plus <code>/pos/register</code>. The service worker provides the static app shell; POS business state remains in the existing IndexedDB local stores.
+      </div>
+      <ul>
+        <li>Already-provisioned terminals only; the terminal must load POS online once after this feature is deployed so the browser can install the service worker and cache the static app shell.</li>
+        <li>POS remains the only offline-first Athena workflow.</li>
+        <li>Cache Storage must not hold staff proofs, sync secrets, payments, customer data, or POS event payloads.</li>
+        <li>Expense POS and offline-friendly POS history/report subroutes are deferred unless later requirements include them.</li>
+      </ul>
+    </section>
+
+    <section id="requirements">
+      <h2>Requirements</h2>
+      <ul>
+        <li>Previously provisioned POS terminals can load POS with no active network after POS has loaded online once, giving the browser a chance to install the service worker and cache the static app shell.</li>
+        <li><code>/pos</code> and <code>/pos/register</code> render from route slugs and local terminal seed when live reads are unavailable.</li>
+        <li>Offline route continuity does not widen POS app-session recovery into generic Athena access.</li>
+        <li>Register behavior continues through local staff authority, local readiness, local command gateway, catalog snapshots, and sync status.</li>
+        <li>Browser-level verification proves hard reload with network blocked reaches the local register/sign-in path.</li>
+      </ul>
+    </section>
+
+    <section id="decisions">
+      <h2>Key Decisions</h2>
+      <div class="grid">
+        <div class="card">
+          <strong>Focused service worker</strong>
+          <p>Add POS app-shell caching rather than making every Athena route offline-first.</p>
+        </div>
+        <div class="card">
+          <strong>Static shell only</strong>
+          <p>Cache HTML, JS, CSS, and static assets; keep business data in POS IndexedDB.</p>
+        </div>
+        <div class="card">
+          <strong>Route-scoped continuity</strong>
+          <p>POS app-session recovery remains limited to POS hub/register routes.</p>
+        </div>
+        <div class="card">
+          <strong>Browser proof</strong>
+          <p>Hard-reload no-network coverage is required because unit tests cannot prove app-shell delivery.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="units">
+      <h2>Implementation Units</h2>
+      <article class="unit">
+        <h3>U1. Add POS app-shell service worker infrastructure</h3>
+        <p>Add build/runtime service-worker support, route policy helpers, and startup registration. Test POS navigation classification and excluded request types.</p>
+      </article>
+      <article class="unit">
+        <h3>U2. Make POS hub and register route entry local-first under offline shell</h3>
+        <p>Use local entry context for POS-critical links and preserve non-POS route protection. Test hub/register render paths without live org/store reads.</p>
+      </article>
+      <article class="unit">
+        <h3>U3. Surface offline readiness for app shell and POS local prerequisites</h3>
+        <p>Expose app-shell, terminal seed, staff authority, catalog, and availability readiness without leaking sensitive diagnostics.</p>
+      </article>
+      <article class="unit">
+        <h3>U4. Harden register reload continuity around local staff and drawer state</h3>
+        <p>Characterize and protect the offline reload path through local staff sign-in, drawer state, register readiness, and local command gates.</p>
+      </article>
+      <article class="unit">
+        <h3>U5. Add no-network browser regression coverage for POS route accessibility</h3>
+        <p>Prepare online, block network, hard reload POS, and assert the local register/sign-in shell renders without server access.</p>
+      </article>
+      <article class="unit">
+        <h3>U6. Document the POS offline route boundary and validation map</h3>
+        <p>Record the service-worker app-shell versus IndexedDB business-state boundary and wire future validation to the new test slice.</p>
+      </article>
+    </section>
+
+    <section id="risks">
+      <h2>Risks</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Risk</th>
+            <th>Mitigation</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Service worker caches sensitive data.</td>
+            <td>Restrict caching to static app-shell assets and exclude API/Convex/fetch payloads.</td>
+          </tr>
+          <tr>
+            <td>Stale cached chunks break POS after deploy.</td>
+            <td>Use build/precache manifests and clean outdated caches coherently.</td>
+          </tr>
+          <tr>
+            <td>Offline shell is mistaken for sale authority.</td>
+            <td>Keep app shell separate from terminal, drawer, staff proof, and local command gates.</td>
+          </tr>
+          <tr>
+            <td>POS continuity leaks to non-POS routes.</td>
+            <td>Preserve route-scope tests in <code>_authed.test.tsx</code>.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="verification">
+      <h2>Verification Strategy</h2>
+      <ul>
+        <li>Unit-test service-worker route policy and excluded request types.</li>
+        <li>Unit-test POS hub/register route rendering from local entry context when live reads are absent.</li>
+        <li>Characterize register reload behavior around staff authority, drawer state, and local command gates.</li>
+        <li>Add a browser regression that blocks network and hard reloads <code>/pos/register</code>.</li>
+        <li>Validate the HTML review artifact with <code>scripts/validate-plan-html.ts</code>.</li>
+      </ul>
+      <p class="warning callout">The plan intentionally does not implement code in this planning pass.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/plans/2026-06-03-002-feat-pos-offline-route-access-plan.md
+++ b/docs/plans/2026-06-03-002-feat-pos-offline-route-access-plan.md
@@ -1,0 +1,469 @@
+---
+title: feat: Make POS route accessible with no network
+type: feat
+status: active
+date: 2026-06-03
+origin: docs/brainstorms/2026-05-13-pos-local-first-register-requirements.md
+---
+
+# feat: Make POS route accessible with no network
+
+## Summary
+
+This plan closes the remaining route-access gap in Athena's local-first POS work: an already-provisioned terminal should be able to open or hard reload the POS route after total network loss. The approach adds a focused POS app-shell service worker, keeps business data in the existing POS IndexedDB stores, tightens POS hub/register offline entry, and adds browser regression coverage for no-network reloads.
+
+---
+
+## Problem Frame
+
+The current POS register runtime has substantial local-first infrastructure, but the browser still needs the web app shell to load before any of that local state can help. Without a service worker/app-shell cache, a hard reload or cold navigation to POS during a network outage can fail before React, local entry context, staff authority, catalog snapshots, or the register read model are reached.
+
+---
+
+## Requirements
+
+- R1. A previously provisioned POS terminal can load the POS route with no active network after it has loaded POS online once, giving the browser a chance to install the service worker and cache the static app shell. Origin: R1, R2, R6, AE1.
+- R2. `/pos` and `/pos/register` remain POS-local entry surfaces when live organization, store, auth, or daily-operation reads are unavailable. Origin: R2, R6, R8, AE1.
+- R3. The offline app-shell cache stores only static shell assets and support metadata; POS business data remains in the existing IndexedDB local stores. Origin: R3, R4, R5.
+- R4. Offline route continuity does not widen POS app-session recovery into generic Athena app access. Origin: R3, R4, R5, AE2.
+- R5. The register continues to use local staff authority, local register readiness, catalog/availability snapshots, local command gateway, and sync status instead of introducing an online-primary fallback. Origin: R6, R7, R8, R9, R10, AE3.
+- R6. Operators get explicit readiness/status signals when the app shell, terminal seed, staff authority, or catalog snapshots are not ready for offline use. Origin: R2, R7, R10, R31.
+- R7. Browser-level validation proves an online-prepared terminal can hard reload POS with all network requests blocked and reach the local register/sign-in path. Origin: AE1, AE3.
+
+**Origin actors:** A1 Cashier, A2 Store manager, A3 Athena POS terminal, A4 Athena cloud.
+**Origin flows:** F1 Provision a POS terminal for offline use, F2 Operate the register while offline, F3 Complete checkout with any payment method offline, F5 Sync and reconcile local POS history.
+**Origin acceptance examples:** AE1, AE2, AE3, AE4, AE5, AE7, AE10.
+
+---
+
+## Scope Boundaries
+
+- This plan covers an already-provisioned terminal that has loaded POS online at least once after this feature is deployed, so the app shell can be installed and cached. Brand-new offline business creation, terminal provisioning, or first install without any prior online visit remains out of scope.
+- POS remains the only offline-first Athena workflow. Procurement, analytics, products, services, admin, cash-controls review, and operations surfaces may remain unavailable, stale, or read-only while offline.
+- Cache Storage is for app-shell assets only. Staff proofs, sync secrets, cart events, payments, receipts, catalog rows, and availability snapshots stay in the existing POS local store.
+- Payment-provider-specific offline authorization behavior is unchanged.
+- Peer-to-peer terminal sync and real-time multi-terminal stock coordination while offline remain out of scope.
+- Visual validation is not part of this plan; browser verification should assert route accessibility and core readiness, not final visual polish.
+
+### Deferred to Follow-Up Work
+
+- Native install prompts, branded PWA icons, and install analytics can follow after route-level offline reliability is proven.
+- Offline-friendly transaction history, expense reports, terminal health detail, and sessions list can follow as separate POS subroute work if operators need those surfaces during outages.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/vite.config.ts` already code-splits the TanStack router output and vendor chunks, but has no service-worker/PWA plugin.
+- `packages/athena-webapp/src/main.tsx` creates the React, Router, Convex Auth, and Query providers, but does not register a service worker.
+- `packages/athena-webapp/src/routes/_authed.tsx` has a POS-only shell path for offline auth rehydration and route-scoped app-session recovery.
+- `packages/athena-webapp/src/routes/_authed.test.tsx` already verifies POS shell behavior while Convex auth is reconnecting and route-scoped app-session recovery for POS routes.
+- `packages/athena-webapp/src/components/pos/PointOfSaleView.tsx` can prewarm POS offline snapshots from local entry context, but several hub links still depend on live org/store params.
+- `packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/register.index.tsx` wraps the register in `POSRegisterOpeningGuard`.
+- `packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx` and `packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts` keep store-day readiness local-first.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/localPosEntryContext.ts`, `packages/athena-webapp/src/hooks/useGetTerminal.ts`, and `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts` provide the local terminal seed and terminal fallback that route reloads must reach.
+- `packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx` already supports local staff authority when `navigator.onLine` is false.
+- `packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts` already persists and reads register catalog, service catalog, and availability snapshots from IndexedDB.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md`: POS local events are the first durable cashier record; do not move the core ledger into `localStorage` or Cache Storage.
+- `docs/solutions/architecture/athena-pos-always-local-first-register-2026-05-14.md`: cashier commands must append local register events before returning success, independent of browser online state.
+- `docs/solutions/architecture/athena-pos-local-first-entry-readiness-2026-05-14.md`: POS entry should use route slugs plus the provisioned terminal seed; unresolved live reads should not suppress local POS entry.
+- `docs/solutions/architecture/athena-pos-local-staff-authority-2026-05-14.md`: offline staff sign-in uses terminal-scoped verifiers and wrapped local staff proofs, not online PIN hashes.
+- `docs/solutions/architecture/athena-pos-offline-inventory-snapshot-2026-05-15.md`: catalog metadata and availability snapshots stay separate, and missing availability remains an offline readiness gap.
+- `docs/solutions/architecture/athena-pos-hub-app-session-continuity-2026-06-02.md`: POS app-session continuity is route scoped and must not become full app access.
+- `docs/solutions/harness/athena-qa-smoke-live-navigation-readiness-2026-06-01.md`: browser smoke tests should assert meaningful DOM and network conditions rather than relying only on `networkidle`.
+
+### External References
+
+- MDN Service Worker API: service workers can intercept navigation and populate Cache Storage during install for offline use.
+- MDN Using Service Workers: install/activate/fetch lifecycle and navigation preload are the standard browser model for offline app shells.
+- Vite PWA documentation: `vite-plugin-pwa` can generate or inject a service worker and precache build output; `injectManifest` supports custom service-worker behavior when route-specific handling is needed.
+
+---
+
+## Key Technical Decisions
+
+- Use a focused POS app-shell service worker rather than broad product offline caching: this satisfies POS route access while preserving the origin boundary that non-POS workspaces need not become offline-first.
+- Prefer `injectManifest`-style service-worker control over a generic all-routes network strategy: POS needs route-specific navigation fallback, no API response caching, and a clear separation between static shell assets and business data.
+- Cache generated HTML, JS, CSS, and static app assets needed to mount POS, but never cache Convex/API responses or POS business payloads in Cache Storage.
+- Treat `/pos` and `/pos/register` as the minimum offline-access route contract: `/pos` gives a local entry surface, and `/pos/register` gives the cashier path. Other POS subroutes should render intentional offline-safe states or stay deferred.
+- Keep POS route-scoped app-session recovery intact: offline shell access should mount POS continuity only for POS routes and must not enable generic Athena chrome or protected non-POS surfaces.
+- Make offline readiness observable before outages: provisioning/settings and POS hub should show whether app shell cache, terminal seed, staff authority, catalog metadata, and availability snapshots are ready enough for offline selling.
+- Validate with a browser hard-reload no-network scenario, not only unit tests: app-shell failures happen before unit-tested React code can run.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should this plan cover only `/pos/register`? Resolution: no. `/pos/register` is the selling path, but `/pos` is the natural POS entry surface and already prewarms offline snapshots, so both routes are in scope.
+- Should Cache Storage hold POS business data? Resolution: no. Cache Storage is limited to static app-shell assets; POS business data remains in IndexedDB local POS stores.
+- Should expense POS be made offline-first in this plan? Resolution: no. The origin document scopes offline-first to POS register selling. Expense currently uses POS register UI but separate expense session infrastructure and is deferred unless later requirements make it offline-first.
+
+### Deferred to Implementation
+
+- Exact service-worker helper names and test harness utilities: implementation can choose names while preserving the route, cache, and verification contract.
+- Exact route chunk precache list: implementation should use the Vite build manifest/service-worker precache manifest rather than hand-maintaining hashed asset names.
+- Exact Playwright fixture setup for local POS seed data: implementation should use the existing local POS store and app-session test helpers where possible.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+  OnlineVisit["Online POS visit or provisioning"]
+  ServiceWorker["POS app-shell service worker"]
+  CacheStorage["Cache Storage: HTML, JS, CSS, static shell assets"]
+  IndexedDB["POS IndexedDB: terminal seed, staff authority, catalog, events"]
+  OfflineNavigation["No-network navigation or hard reload"]
+  PosShell["Route-scoped POS shell"]
+  Register["Local-first register runtime"]
+
+  OnlineVisit --> ServiceWorker
+  ServiceWorker --> CacheStorage
+  OnlineVisit --> IndexedDB
+  OfflineNavigation --> ServiceWorker
+  ServiceWorker --> CacheStorage
+  CacheStorage --> PosShell
+  PosShell --> IndexedDB
+  IndexedDB --> Register
+```
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1["U1 App-shell service worker"]
+  U2["U2 POS offline route contract"]
+  U3["U3 Offline readiness signals"]
+  U4["U4 Register reload continuity"]
+  U5["U5 No-network browser regression"]
+  U6["U6 Docs and validation map"]
+
+  U1 --> U2
+  U1 --> U3
+  U2 --> U4
+  U3 --> U4
+  U4 --> U5
+  U5 --> U6
+```
+
+- U1. **Add POS app-shell service worker infrastructure**
+
+**Goal:** Add build-time and runtime support for a service worker that can serve the POS app shell during total network loss.
+
+**Requirements:** R1, R3, R4, R7.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `packages/athena-webapp/package.json`
+- Modify: `packages/athena-webapp/vite.config.ts`
+- Modify: `packages/athena-webapp/src/main.tsx`
+- Create: `packages/athena-webapp/src/offline/posAppShellServiceWorker.ts`
+- Create: `packages/athena-webapp/src/offline/posAppShellRoutes.ts`
+- Test: `packages/athena-webapp/src/offline/posAppShellRoutes.test.ts`
+
+**Approach:**
+- Add a Vite service-worker integration that precaches generated app-shell assets and supports a custom POS navigation fallback.
+- Register the service worker from app startup without forcing a reload loop during offline operation.
+- Keep route matching and cache policy helpers pure enough to unit test outside the service-worker runtime.
+- Do not cache Convex endpoints, API responses, staff proofs, sync secrets, event payloads, payment data, or customer data.
+
+**Patterns to follow:**
+- `packages/athena-webapp/vite.config.ts` for existing build/plugin structure and code-splitting conventions.
+- `packages/athena-webapp/src/main.tsx` for app startup integration.
+- `docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md` for keeping the POS event ledger out of Cache Storage.
+
+**Test scenarios:**
+- Happy path: POS route path plus same-origin navigation request is classified as an app-shell navigation eligible for cached fallback.
+- Edge case: non-POS protected routes are not classified as POS app-shell fallbacks.
+- Error path: Convex/API/fetch requests are excluded from app-shell cache handling even if they occur under a POS route.
+- Integration: service-worker registration helper is invoked at app startup only in browser contexts that support service workers.
+
+**Verification:**
+- The built app emits/registers a service worker and has deterministic route policy coverage for POS navigations and excluded request types.
+
+---
+
+- U2. **Make POS hub and register route entry local-first under offline shell**
+
+**Goal:** Ensure `/pos` and `/pos/register` render from route slugs and local terminal seed when live organization/store reads are absent.
+
+**Requirements:** R1, R2, R4, R5. Origin flow: F2. Origin examples: AE1, AE2.
+
+**Dependencies:** U1.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/routes/_authed.tsx`
+- Modify: `packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/index.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/PointOfSaleView.tsx`
+- Modify: `packages/athena-webapp/src/hooks/useGetActiveStore.ts`
+- Test: `packages/athena-webapp/src/routes/_authed.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/PointOfSaleView.test.tsx`
+- Test: `packages/athena-webapp/src/hooks/useGetActiveStore.test.ts`
+
+**Approach:**
+- Preserve the existing POS-only `_authed` exception for route-scoped app-session recovery.
+- Make POS hub link generation use `localEntryContext` for POS-critical links when live org/store values are unavailable.
+- Keep non-POS links unavailable or read-only while offline rather than synthesizing full app access.
+- Adjust active-store resolution so route-matched live data wins when available, while POS-local entry remains available through the terminal seed when live data is absent.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/localPosEntryContext.ts` for route slug plus seed authority.
+- `docs/solutions/architecture/athena-pos-local-first-entry-readiness-2026-05-14.md` for not gating POS entry on live analytics/store summary reads.
+- `docs/solutions/architecture/athena-pos-hub-app-session-continuity-2026-06-02.md` for keeping POS continuity route scoped.
+
+**Test scenarios:**
+- Happy path: `/pos` renders the POS tile and link to `/pos/register` from local entry context when live active store and organization are unavailable.
+- Happy path: `/pos/register` mounts the POS shell without app sidebar/header when offline auth is still rehydrating.
+- Edge case: non-POS hub links are absent, disabled, or explicitly unavailable when only local POS context exists.
+- Error path: missing or mismatched terminal seed renders existing POS setup/mismatch copy instead of generic login or blank output.
+- Integration: signed-out non-POS routes still redirect to login even when a POS terminal seed exists.
+
+**Verification:**
+- POS hub and register route tests prove local route entry without live org/store reads while non-POS route protections remain unchanged.
+
+---
+
+- U3. **Surface offline readiness for app shell and POS local prerequisites**
+
+**Goal:** Make offline preparedness visible before an outage and actionable when a prerequisite is missing.
+
+**Requirements:** R1, R3, R5, R6.
+
+**Dependencies:** U1.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/pos/PointOfSaleView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts`
+- Create: `packages/athena-webapp/src/offline/posOfflineReadiness.ts`
+- Test: `packages/athena-webapp/src/offline/posOfflineReadiness.test.ts`
+- Test: `packages/athena-webapp/src/components/pos/PointOfSaleView.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx`
+
+**Approach:**
+- Add a small readiness model that reports app-shell cache, terminal seed, staff authority, register catalog, service catalog, and availability snapshot posture.
+- Reuse existing local-store reads where possible; do not invent a second readiness database.
+- Show readiness as support/operator diagnostics, not as a new sale authority that bypasses existing register gates.
+- Avoid raw backend or secret-bearing diagnostics in UI copy.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts` for support-safe runtime reporting.
+- `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts` for summarized terminal health copy.
+- `docs/product-copy-tone.md` for calm operator-facing copy.
+
+**Test scenarios:**
+- Happy path: all prerequisites present returns an offline-ready state with support-safe labels.
+- Edge case: app shell ready but staff authority missing returns a readiness warning without claiming the terminal cannot ever sell online.
+- Edge case: catalog metadata present but availability snapshot missing is reported as an offline inventory readiness gap.
+- Error path: local store read failure returns local-store-unavailable copy without exposing raw IndexedDB/backend details.
+- Integration: terminal health and POS settings display readiness state without exposing sync secrets, staff proof tokens, payment data, or customer data.
+
+**Verification:**
+- POS hub/settings/terminal health surfaces show offline readiness status that matches local store state and preserves security redaction.
+
+---
+
+- U4. **Harden register reload continuity around local staff and drawer state**
+
+**Goal:** Ensure the register can recover its local selling path after a hard reload served from the offline app shell.
+
+**Requirements:** R1, R2, R5, R6, R7. Origin flows: F2, F3. Origin examples: AE1, AE3, AE4, AE5, AE10.
+
+**Dependencies:** U2, U3.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Modify: `packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- Test: `packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.test.tsx`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.test.ts`
+
+**Approach:**
+- Characterize the current offline reload path first: local terminal seed, local staff authority, active/closed local drawer, local catalog, and pending sync state.
+- Keep staff proof, drawer authority, terminal integrity, and local command preconditions separate from app-shell availability.
+- Ensure local staff sign-in failure modes remain explicit when a terminal was not prepared for offline staff authority.
+- Confirm locally completed sales and local receipt numbers remain available after reload through the existing local register read model.
+
+**Execution note:** Add characterization coverage before changing register behavior; this area already has many local-first tests, and the risk is accidental widening of authority.
+
+**Patterns to follow:**
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts` for local command invariants.
+- `packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx` for offline staff verifier/proof handling.
+- `docs/solutions/architecture/athena-pos-local-staff-authority-2026-05-14.md` for proof boundaries.
+
+**Test scenarios:**
+- Happy path: after offline reload, a locally authorized cashier signs in and opens or resumes the local register path without Convex availability.
+- Happy path: an existing local active drawer remains sellable when local readiness permits it.
+- Edge case: locally closed drawer blocks selling until the existing reopen path records a local reopen event.
+- Error path: missing local staff authority shows reconnect-required copy and does not attempt server authentication while offline.
+- Error path: terminal integrity or drawer authority blocks remain blocks even though the app shell is available offline.
+- Integration: completing a sale after offline reload appends local events and leaves sync status pending/offline, not failed due to network absence.
+
+**Verification:**
+- Register view-model tests prove offline app-shell reload reaches the same local-first command boundaries as ordinary offline operation.
+
+---
+
+- U5. **Add no-network browser regression coverage for POS route accessibility**
+
+**Goal:** Prove the complete route delivery path works in a real browser: prepare online, block network, hard reload POS, and reach the local register/sign-in path.
+
+**Requirements:** R1, R2, R4, R5, R7.
+
+**Dependencies:** U1, U2, U4.
+
+**Files:**
+- Create: `packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts`
+- Modify: `packages/athena-webapp/src/tests/pos/README.md`
+- Modify: `packages/athena-webapp/src/tests/harness` or existing browser-test harness files as needed
+- Test: `packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts`
+
+**Approach:**
+- Use a browser test because the failure mode occurs before React unit tests can execute.
+- Seed or provision the local POS terminal state using existing helpers where possible.
+- Visit POS online once so service worker installation and asset caching complete.
+- Block network at the browser context level, hard reload `/pos/register`, and assert route mount plus local cashier sign-in/register gate readiness.
+- Assert same-origin document/script/style requests are satisfied without server access; do not use `networkidle` as the sole readiness condition.
+
+**Patterns to follow:**
+- Existing POS local tests under `packages/athena-webapp/src/lib/pos/infrastructure/local/`.
+- `docs/solutions/harness/athena-qa-smoke-live-navigation-readiness-2026-06-01.md` for DOM/response assertions over `networkidle`.
+
+**Test scenarios:**
+- Happy path: provisioned terminal loads POS register online, then hard reloads with network blocked and reaches the local sign-in/register shell.
+- Edge case: direct offline navigation to `/pos` after preparation renders the POS hub with the register entry available from local context.
+- Error path: offline reload without terminal seed renders POS setup-required copy instead of a blank page.
+- Error path: blocked network does not cause the test to pass through stale live responses; the test observes blocked/absent server access after reload.
+- Integration: non-POS protected route with network blocked does not gain POS continuity access.
+
+**Verification:**
+- Browser regression fails before this work and passes after app-shell caching, route contract, and reload continuity are in place.
+
+---
+
+- U6. **Document the POS offline route boundary and validation map**
+
+**Goal:** Preserve the app-shell and POS-only offline boundary for future work and changed-file validation.
+
+**Requirements:** R3, R4, R6, R7.
+
+**Dependencies:** U5.
+
+**Files:**
+- Create: `docs/solutions/architecture/athena-pos-offline-route-access-2026-06-03.md`
+- Modify: `packages/athena-webapp/src/tests/README.md`
+- Modify: validation-map or harness registry files if this repo's changed-file validation requires them for new offline/service-worker/browser-test paths
+
+**Approach:**
+- Document the distinction between Cache Storage app-shell assets and IndexedDB POS business state.
+- Capture the POS-only route contract and explicitly defer broader offline subroute/workspace behavior.
+- Register the new test slice so future service-worker, route shell, local entry, and browser harness changes run relevant validation.
+
+**Patterns to follow:**
+- Existing `docs/solutions/architecture/athena-pos-*.md` notes.
+- Existing test/harness summary docs under `packages/athena-webapp/src/tests/`.
+
+**Test scenarios:**
+- Test expectation: none -- this unit is documentation and validation-map maintenance. Its behavioral proof is covered by U1-U5 tests.
+
+**Verification:**
+- Future maintainers can identify the offline route boundary, the required regression tests, and why POS app-shell caching must not cache business data.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Browser navigation now passes through a service worker before React, `_authed`, POS hub, and POS register runtime. The service worker must be treated as an app-shell delivery layer, not an authorization or data layer.
+- **Error propagation:** Offline navigation failures should produce cached POS shell or explicit POS setup/readiness copy. They should not surface raw network failures as sale outcomes.
+- **State lifecycle risks:** Service-worker update lifecycle can strand stale chunks if old caches are not cleaned coherently. POS local store schema changes can still block local entry; the service worker should not hide unsupported local-store states.
+- **API surface parity:** POS app-session recovery remains route scoped. Non-POS authenticated routes do not receive the POS offline continuity exception.
+- **Integration coverage:** Unit tests cannot prove hard-reload offline delivery. Browser tests must cover service-worker installation, cache availability, network blocking, and route mount.
+- **Unchanged invariants:** Local command gateway remains the cashier-path write boundary; local staff proofs remain separate from app shell access; sync/reconciliation still projects POS events into cloud records after reconnect.
+
+```mermaid
+flowchart TB
+  Navigation["Browser navigation"]
+  SW["Service worker app-shell cache"]
+  AuthShell["_authed route-scoped POS shell"]
+  PosHub["POS hub"]
+  Register["POS register view model"]
+  LocalStore["POS IndexedDB local store"]
+  Convex["Convex/cloud when online"]
+
+  Navigation --> SW
+  SW --> AuthShell
+  AuthShell --> PosHub
+  AuthShell --> Register
+  PosHub --> LocalStore
+  Register --> LocalStore
+  Register -.sync when online.-> Convex
+```
+
+---
+
+## Risks & Dependencies
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Service worker caches sensitive business/API data | Medium | High | Limit service worker to static app-shell assets and explicitly exclude Convex/API/fetch payloads from cache strategies. |
+| Stale cached chunks break POS after deploy | Medium | High | Use build-manifest/precache-driven asset lists, cleanup outdated caches, and avoid forced reloads while offline. |
+| Offline shell is mistaken for sale authority | Medium | High | Keep app-shell readiness separate from terminal integrity, drawer authority, staff proof, and local command preconditions. |
+| POS route continuity leaks to non-POS routes | Low | High | Preserve `_authed` route matching tests for POS vs non-POS signed-out/offline behavior. |
+| Browser no-network test becomes flaky | Medium | Medium | Assert DOM mount and request/response observations rather than relying on `networkidle`; seed local state deterministically. |
+| Existing dirty receipt/print work complicates execution | Medium | Low | Execution should preserve unrelated current work and avoid reverting prior uncommitted changes. |
+
+---
+
+## Documentation / Operational Notes
+
+- This work should include a solution note because it adds a new architectural boundary: service-worker app shell vs POS IndexedDB business state.
+- Operators should be told that a terminal must be prepared online before no-network use; first-time install with no prior online visit remains unsupported.
+- Support/terminal health should expose offline-readiness signals without leaking raw backend errors, staff proof tokens, sync secrets, payment details, or customer data.
+- After implementation changes code, run `bun run graphify:rebuild` per repo guidance.
+
+---
+
+## Alternative Approaches Considered
+
+- Custom hand-written service worker without Vite integration: maximizes control, but risks brittle manual asset lists for hashed route chunks.
+- Generic PWA/offline-all-routes behavior: simpler configuration, but violates the POS-only offline scope and may cache or expose non-POS surfaces unintentionally.
+- Register-only offline route access: smaller, but `/pos` is the natural POS launcher and already owns snapshot prewarming, so excluding it would leave a confusing offline entry gap.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-05-13-pos-local-first-register-requirements.md](../brainstorms/2026-05-13-pos-local-first-register-requirements.md)
+- Related learning: [docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md](../solutions/architecture/athena-pos-local-first-sync-2026-05-13.md)
+- Related learning: [docs/solutions/architecture/athena-pos-always-local-first-register-2026-05-14.md](../solutions/architecture/athena-pos-always-local-first-register-2026-05-14.md)
+- Related learning: [docs/solutions/architecture/athena-pos-local-first-entry-readiness-2026-05-14.md](../solutions/architecture/athena-pos-local-first-entry-readiness-2026-05-14.md)
+- Related learning: [docs/solutions/architecture/athena-pos-local-staff-authority-2026-05-14.md](../solutions/architecture/athena-pos-local-staff-authority-2026-05-14.md)
+- Related learning: [docs/solutions/architecture/athena-pos-offline-inventory-snapshot-2026-05-15.md](../solutions/architecture/athena-pos-offline-inventory-snapshot-2026-05-15.md)
+- Related learning: [docs/solutions/architecture/athena-pos-hub-app-session-continuity-2026-06-02.md](../solutions/architecture/athena-pos-hub-app-session-continuity-2026-06-02.md)
+- Related learning: [docs/solutions/harness/athena-qa-smoke-live-navigation-readiness-2026-06-01.md](../solutions/harness/athena-qa-smoke-live-navigation-readiness-2026-06-01.md)
+- Related code: `packages/athena-webapp/vite.config.ts`
+- Related code: `packages/athena-webapp/src/main.tsx`
+- Related code: `packages/athena-webapp/src/routes/_authed.tsx`
+- Related code: `packages/athena-webapp/src/components/pos/PointOfSaleView.tsx`
+- Related code: `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`
+- External docs: [MDN Service Worker API](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API)
+- External docs: [MDN Using Service Workers](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers)
+- External docs: [Vite PWA Service Worker Precache](https://vite-pwa-org.netlify.app/guide/service-worker-precache)

--- a/docs/solutions/architecture/athena-pos-offline-route-access-2026-06-03.md
+++ b/docs/solutions/architecture/athena-pos-offline-route-access-2026-06-03.md
@@ -1,0 +1,115 @@
+---
+title: Athena POS Offline Route Access Uses A Static App Shell
+date: 2026-06-03
+category: architecture
+module: athena-webapp
+problem_type: pos_offline_route_access
+component: pos
+symptoms:
+  - "A provisioned POS terminal can hard reload into an empty browser page during total network loss"
+  - "Offline POS work can be confused with broad offline access to all Athena routes"
+  - "Service-worker app-shell caching can be mistaken for POS business-state storage"
+root_cause: local_pos_state_was_ready_but_the_browser_app_shell_was_not_available_after_hard_reload
+resolution_type: route_scoped_static_app_shell
+severity: high
+tags:
+  - pos
+  - offline
+  - service-worker
+  - app-shell
+  - local-first
+---
+
+# Athena POS Offline Route Access Uses A Static App Shell
+
+## Problem
+
+Athena's POS register can keep terminal seed, staff authority, catalog
+snapshots, availability snapshots, drawer state, and local events in browser
+storage. That local POS state still cannot help when a hard reload fails before
+React mounts. A provisioned terminal needs the static app shell available after
+it has loaded POS online once.
+
+The app-shell fix must stay route scoped. POS offline route continuity is for
+`/pos` and `/pos/register` surfaces only. It must not turn Operations, Products,
+Services, Admin, Cash Controls, analytics, or generic authenticated app chrome
+into offline-capable routes.
+
+## Solution
+
+Keep offline POS route access as a static shell plus local POS state:
+
+- `public/pos-app-shell-sw.js` serves the POS app shell for same-origin POS
+  navigations and caches same-origin static JS, CSS, font, and image assets.
+- `src/offline/posAppShellRoutes.ts` owns the tested route/request policy:
+  POS navigations are eligible, non-POS routes are not, API/data payloads are
+  excluded, and generated Convex client modules remain cacheable as static app
+  code.
+- `src/offline/registerPosAppShellServiceWorker.ts` registers the worker from
+  `src/main.tsx` only in browsers that support service workers and avoids
+  duplicate registration loops.
+- POS route entry remains local-first through `_authed.tsx`,
+  `useGetActiveStore.ts`, local terminal seed, and existing register guards.
+- Offline readiness copy is diagnostic only. It distinguishes app shell,
+  terminal setup, staff authority, register catalog, service catalog, and
+  availability snapshot readiness without becoming sale authority.
+
+## Storage Boundary
+
+Cache Storage is for the static browser shell only:
+
+- HTML, JS, CSS, fonts, images, generated client modules, and route chunks can
+  be cached so React can mount after a hard reload.
+- Convex/API responses, sync secrets, staff proof tokens, cart events, payment
+  payloads, customer data, local receipt state, catalog rows, service catalog
+  rows, and availability snapshots must not move into Cache Storage.
+- POS business state stays in the existing IndexedDB/local POS stores such as
+  terminal entry context, staff authority, catalog snapshots, availability
+  snapshots, local register events, and pending sync state.
+
+Service-worker availability is not permission to sell. Sale-affecting commands
+still depend on terminal integrity, staff proof, drawer authority, local command
+preconditions, and existing register read-model state.
+
+## Regression Targets
+
+Use the focused route-access validation slice when service-worker, POS offline
+route entry, readiness diagnostics, or register hard-reload behavior changes:
+
+- `src/offline/posAppShellRoutes.test.ts` proves route and request policy.
+- `src/offline/registerPosAppShellServiceWorker.test.ts` proves browser-only
+  registration and duplicate-registration protection.
+- `src/offline/posOfflineReadiness.test.ts` proves readiness classification and
+  support-safe descriptions.
+- `src/routes/_authed.test.tsx`, `src/hooks/useGetActiveStore.test.ts`,
+  `src/components/pos/PointOfSaleView.test.tsx`,
+  `src/components/pos/register/POSRegisterOpeningGuard.test.tsx`, and
+  `src/lib/pos/presentation/register/useRegisterViewModel.test.ts` prove POS
+  route entry and register readiness remain local-first.
+- `src/tests/pos/offlineRouteAccess.spec.ts` proves a production-built app can
+  load POS online, install/cache the app shell, block network, hard reload, and
+  still mount the POS register shell.
+
+The Athena harness registry now includes "POS offline route access and app-shell
+edits" so future changed-file validation points to these commands and the
+production-build Playwright regression.
+
+## Prevention
+
+- Do not widen the service-worker navigation fallback beyond POS routes without
+  a separate product and security review.
+- Do not cache API, Convex data, staff proof, payment, customer, or POS local
+  business payloads in Cache Storage.
+- Do not treat app-shell readiness as terminal integrity, drawer authority,
+  local staff authority, or command permission.
+- Run browser validation against production build/preview rather than Vite dev
+  HMR modules; dev-only clients can create false offline failures.
+- Rebuild graphify after code changes and regenerate harness docs after
+  changing `scripts/harness-app-registry.ts`.
+
+## Related
+
+- [Athena POS Local-First Sync Uses Event Logs](./athena-pos-local-first-sync-2026-05-13.md)
+- [Athena POS Entry And Readiness Are Local First](./athena-pos-local-first-entry-readiness-2026-05-14.md)
+- [Athena POS Hub App-Session Continuity Is Route Scoped](./athena-pos-hub-app-session-continuity-2026-06-02.md)
+- [Athena QA Smoke Uses DOM Readiness Instead Of Network Idle](../harness/athena-qa-smoke-live-navigation-readiness-2026-06-01.md)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1814 files · ~0 words
+- 1824 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6058 nodes · 6495 edges · 1742 communities detected
+- 6108 nodes · 6561 edges · 1752 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1752,6 +1752,16 @@
 - [[_COMMUNITY_Community 1739|Community 1739]]
 - [[_COMMUNITY_Community 1740|Community 1740]]
 - [[_COMMUNITY_Community 1741|Community 1741]]
+- [[_COMMUNITY_Community 1742|Community 1742]]
+- [[_COMMUNITY_Community 1743|Community 1743]]
+- [[_COMMUNITY_Community 1744|Community 1744]]
+- [[_COMMUNITY_Community 1745|Community 1745]]
+- [[_COMMUNITY_Community 1746|Community 1746]]
+- [[_COMMUNITY_Community 1747|Community 1747]]
+- [[_COMMUNITY_Community 1748|Community 1748]]
+- [[_COMMUNITY_Community 1749|Community 1749]]
+- [[_COMMUNITY_Community 1750|Community 1750]]
+- [[_COMMUNITY_Community 1751|Community 1751]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -2036,584 +2046,584 @@ Cohesion: 0.17
 Nodes (6): buildServerPricedCheckoutProducts(), calculateItemsSubtotal(), deriveDeliveryOptionFromAddress(), isDeliveryFeeWaived(), normalizeDeliveryOption(), resolveServerDeliveryFee()
 
 ### Community 64 - "Community 64"
+Cohesion: 0.27
+Nodes (14): cacheAssetRequest(), cacheFirstAsset(), cacheLinkedShellAssets(), cacheModuleDependencies(), isExcluded(), isHtmlResponse(), isJavaScriptLikeResponse(), isPosNavigation() (+6 more)
+
+### Community 65 - "Community 65"
 Cohesion: 0.15
 Nodes (4): formatCurrency(), formatFinancialLabel(), formatTimelineRange(), formatTimelineTime()
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.24
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.26
 Nodes (11): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), getReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), mapSyncStatus(), normalizeStaffAuthorityStatus(), snapshotAges() (+3 more)
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.22
 Nodes (10): extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isBarcodeShapedInput(), normalizeIdentifier(), parseCatalogSearchInput(), searchByText(), searchRegisterCatalog() (+2 more)
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.14
 Nodes (2): getBlockedPosTerminalShellCopy(), PosTerminalBlockedShell()
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.22
 Nodes (10): createApp(), createHandlers(), createRedisClient(), createRedisCluster(), deleteKeysIndividually(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline(), scanNodeForPattern() (+2 more)
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.31
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getOperationalWorkItemStatus() (+5 more)
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 73 - "Community 73"
+### Community 74 - "Community 74"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 74 - "Community 74"
+### Community 75 - "Community 75"
 Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.23
 Nodes (7): buildTerminalHealthSummary(), deriveTerminalHealth(), deriveTerminalHealthAttentionReasons(), getTerminalHealthSummary(), resolveAttentionReasonActionTargets(), resolveCloudRegisterSessionTargets(), stripRuntimeStatusIdentity()
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
 
-### Community 79 - "Community 79"
+### Community 80 - "Community 80"
 Cohesion: 0.15
 Nodes (0):
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.17
 Nodes (2): handleKeyDown(), isDebugShortcut()
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
 
-### Community 85 - "Community 85"
+### Community 86 - "Community 86"
 Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.31
 Nodes (12): collectFilesUnder(), collectProofSnapshot(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof(), hashValidationWiring(), normalizeRepoPath(), readPrAthenaScript(), recordPrePushValidationProof() (+4 more)
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.24
 Nodes (7): classifyTerminalHealth(), formatAge(), formatStatusLabel(), getPrimaryTerminalAttentionReason(), getReviewEvidenceCount(), getSnapshotAgeSummary(), getTerminalAttentionReasons()
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.2
 Nodes (3): handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.21
 Nodes (5): formatDeposit(), formatMoney(), handleCancelEdit(), handleSaveEdit(), summarizeService()
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.24
 Nodes (7): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), useConvexRegisterServiceCatalog(), usePrewarmRegisterCatalogOfflineSnapshots()
 
-### Community 92 - "Community 92"
+### Community 93 - "Community 93"
 Cohesion: 0.29
 Nodes (10): bestFuzzyTokenScore(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreFuzzySearchEntry(), scoreFuzzyTokenMatch(), scoreQueryTokenForEntry() (+2 more)
 
-### Community 93 - "Community 93"
+### Community 94 - "Community 94"
 Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
-### Community 94 - "Community 94"
+### Community 95 - "Community 95"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
+
+### Community 96 - "Community 96"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 95 - "Community 95"
+### Community 97 - "Community 97"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 96 - "Community 96"
+### Community 98 - "Community 98"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 97 - "Community 97"
+### Community 99 - "Community 99"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 98 - "Community 98"
+### Community 100 - "Community 100"
 Cohesion: 0.2
 Nodes (2): formatServiceLabel(), formatServiceLineMeta()
 
-### Community 99 - "Community 99"
+### Community 101 - "Community 101"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 100 - "Community 100"
+### Community 102 - "Community 102"
 Cohesion: 0.24
 Nodes (5): blocked(), evaluateLocalPosReadiness(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 101 - "Community 101"
+### Community 103 - "Community 103"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
-
-### Community 102 - "Community 102"
-Cohesion: 0.18
-Nodes (0):
-
-### Community 103 - "Community 103"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 104 - "Community 104"
 Cohesion: 0.18
 Nodes (0):
 
 ### Community 105 - "Community 105"
+Cohesion: 0.24
+Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
+
+### Community 106 - "Community 106"
+Cohesion: 0.18
+Nodes (0):
+
+### Community 107 - "Community 107"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 106 - "Community 106"
+### Community 108 - "Community 108"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 107 - "Community 107"
+### Community 109 - "Community 109"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 108 - "Community 108"
+### Community 110 - "Community 110"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 109 - "Community 109"
+### Community 111 - "Community 111"
 Cohesion: 0.24
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
-### Community 110 - "Community 110"
+### Community 112 - "Community 112"
 Cohesion: 0.22
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 111 - "Community 111"
+### Community 113 - "Community 113"
 Cohesion: 0.31
 Nodes (7): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), parseVariantDisplayMoney(), saveProduct(), updateVariantSku()
 
-### Community 112 - "Community 112"
+### Community 114 - "Community 114"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 113 - "Community 113"
+### Community 115 - "Community 115"
 Cohesion: 0.29
 Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
 
-### Community 114 - "Community 114"
+### Community 116 - "Community 116"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 115 - "Community 115"
+### Community 117 - "Community 117"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 116 - "Community 116"
+### Community 118 - "Community 118"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 117 - "Community 117"
-Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
-
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.42
 Nodes (7): getRegisterCatalogPrice(), listRegisterCatalog(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
+Cohesion: 0.39
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+
+### Community 122 - "Community 122"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 121 - "Community 121"
+### Community 123 - "Community 123"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 122 - "Community 122"
+### Community 124 - "Community 124"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 123 - "Community 123"
+### Community 125 - "Community 125"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 124 - "Community 124"
+### Community 126 - "Community 126"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 125 - "Community 125"
+### Community 127 - "Community 127"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 126 - "Community 126"
+### Community 128 - "Community 128"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 127 - "Community 127"
+### Community 129 - "Community 129"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 128 - "Community 128"
+### Community 130 - "Community 130"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 129 - "Community 129"
+### Community 131 - "Community 131"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 130 - "Community 130"
+### Community 132 - "Community 132"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 131 - "Community 131"
+### Community 133 - "Community 133"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 132 - "Community 132"
+### Community 134 - "Community 134"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 133 - "Community 133"
+### Community 135 - "Community 135"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 134 - "Community 134"
+### Community 136 - "Community 136"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 135 - "Community 135"
+### Community 137 - "Community 137"
 Cohesion: 0.43
 Nodes (6): assertActiveTerminal(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 136 - "Community 136"
+### Community 138 - "Community 138"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 137 - "Community 137"
+### Community 139 - "Community 139"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 138 - "Community 138"
-Cohesion: 0.25
-Nodes (0):
-
-### Community 139 - "Community 139"
-Cohesion: 0.25
-Nodes (0):
-
 ### Community 140 - "Community 140"
-Cohesion: 0.39
-Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 141 - "Community 141"
 Cohesion: 0.25
-Nodes (1): DataTableRowActions()
+Nodes (0):
 
 ### Community 142 - "Community 142"
-Cohesion: 0.32
-Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
+Cohesion: 0.39
+Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
 ### Community 143 - "Community 143"
 Cohesion: 0.25
-Nodes (0):
+Nodes (1): DataTableRowActions()
 
 ### Community 144 - "Community 144"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.32
+Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
 ### Community 145 - "Community 145"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 146 - "Community 146"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 147 - "Community 147"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.39
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 148 - "Community 148"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 149 - "Community 149"
-Cohesion: 0.46
-Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
-
-### Community 150 - "Community 150"
-Cohesion: 0.43
-Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
-
-### Community 151 - "Community 151"
 Cohesion: 0.25
 Nodes (0):
 
+### Community 150 - "Community 150"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 151 - "Community 151"
+Cohesion: 0.43
+Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
+
 ### Community 152 - "Community 152"
+Cohesion: 0.46
+Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
+
+### Community 153 - "Community 153"
+Cohesion: 0.43
+Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
+
+### Community 154 - "Community 154"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 155 - "Community 155"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 153 - "Community 153"
+### Community 156 - "Community 156"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 154 - "Community 154"
+### Community 157 - "Community 157"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 155 - "Community 155"
+### Community 158 - "Community 158"
 Cohesion: 0.33
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 156 - "Community 156"
+### Community 159 - "Community 159"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 157 - "Community 157"
+### Community 160 - "Community 160"
 Cohesion: 0.33
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 158 - "Community 158"
+### Community 161 - "Community 161"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 159 - "Community 159"
+### Community 162 - "Community 162"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 160 - "Community 160"
+### Community 163 - "Community 163"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 161 - "Community 161"
-Cohesion: 0.29
-Nodes (0):
-
-### Community 162 - "Community 162"
-Cohesion: 0.48
-Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
-
-### Community 163 - "Community 163"
-Cohesion: 0.52
-Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
 ### Community 164 - "Community 164"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 165 - "Community 165"
-Cohesion: 0.33
-Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
+Cohesion: 0.48
+Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
 ### Community 166 - "Community 166"
-Cohesion: 0.38
-Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
+Cohesion: 0.52
+Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
 ### Community 167 - "Community 167"
-Cohesion: 0.57
-Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
-
-### Community 168 - "Community 168"
-Cohesion: 0.33
-Nodes (2): appendTransition(), applyOnlineOrderUpdate()
-
-### Community 169 - "Community 169"
-Cohesion: 0.38
-Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
-
-### Community 170 - "Community 170"
-Cohesion: 0.38
-Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
-
-### Community 171 - "Community 171"
-Cohesion: 0.33
-Nodes (2): handlePinChange(), normalizeOtpCode()
-
-### Community 172 - "Community 172"
-Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
-
-### Community 173 - "Community 173"
 Cohesion: 0.29
 Nodes (0):
 
+### Community 168 - "Community 168"
+Cohesion: 0.33
+Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
+
+### Community 169 - "Community 169"
+Cohesion: 0.38
+Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
+
+### Community 170 - "Community 170"
+Cohesion: 0.57
+Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
+
+### Community 171 - "Community 171"
+Cohesion: 0.33
+Nodes (2): appendTransition(), applyOnlineOrderUpdate()
+
+### Community 172 - "Community 172"
+Cohesion: 0.38
+Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
+
+### Community 173 - "Community 173"
+Cohesion: 0.38
+Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
+
 ### Community 174 - "Community 174"
-Cohesion: 0.48
-Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
+Cohesion: 0.33
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 175 - "Community 175"
 Cohesion: 0.33
-Nodes (2): handleReset(), handleSubmit()
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 176 - "Community 176"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 177 - "Community 177"
-Cohesion: 0.52
-Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+Cohesion: 0.48
+Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
 ### Community 178 - "Community 178"
 Cohesion: 0.33
-Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
+Nodes (2): handleReset(), handleSubmit()
 
 ### Community 179 - "Community 179"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 180 - "Community 180"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
+Cohesion: 0.52
+Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
 ### Community 181 - "Community 181"
+Cohesion: 0.33
+Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
+
+### Community 182 - "Community 182"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 184 - "Community 184"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 185 - "Community 185"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 183 - "Community 183"
+### Community 186 - "Community 186"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 184 - "Community 184"
+### Community 187 - "Community 187"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 185 - "Community 185"
+### Community 188 - "Community 188"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 186 - "Community 186"
+### Community 189 - "Community 189"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 187 - "Community 187"
+### Community 190 - "Community 190"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
-
-### Community 188 - "Community 188"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 189 - "Community 189"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 190 - "Community 190"
-Cohesion: 0.47
-Nodes (4): buildOperationalEvent(), matchesExistingEvent(), metadataDedupeKeysMatch(), recordOperationalEventWithCtx()
 
 ### Community 191 - "Community 191"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 192 - "Community 192"
-Cohesion: 0.4
-Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 193 - "Community 193"
-Cohesion: 0.4
-Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
+Cohesion: 0.47
+Nodes (4): buildOperationalEvent(), matchesExistingEvent(), metadataDedupeKeysMatch(), recordOperationalEventWithCtx()
 
 ### Community 194 - "Community 194"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 195 - "Community 195"
+Cohesion: 0.4
+Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
+
+### Community 196 - "Community 196"
+Cohesion: 0.4
+Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
+
+### Community 197 - "Community 197"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 198 - "Community 198"
 Cohesion: 0.53
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 196 - "Community 196"
+### Community 199 - "Community 199"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 197 - "Community 197"
+### Community 200 - "Community 200"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 198 - "Community 198"
+### Community 201 - "Community 201"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 199 - "Community 199"
+### Community 202 - "Community 202"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 200 - "Community 200"
+### Community 203 - "Community 203"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 201 - "Community 201"
+### Community 204 - "Community 204"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 202 - "Community 202"
+### Community 205 - "Community 205"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 203 - "Community 203"
+### Community 206 - "Community 206"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 204 - "Community 204"
+### Community 207 - "Community 207"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 205 - "Community 205"
+### Community 208 - "Community 208"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 206 - "Community 206"
-Cohesion: 0.33
-Nodes (1): ResizeObserverStub
-
-### Community 207 - "Community 207"
-Cohesion: 0.4
-Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
-
-### Community 208 - "Community 208"
-Cohesion: 0.47
-Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
 ### Community 209 - "Community 209"
 Cohesion: 0.33
@@ -2621,47 +2631,47 @@ Nodes (1): ResizeObserverStub
 
 ### Community 210 - "Community 210"
 Cohesion: 0.4
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
 ### Community 211 - "Community 211"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
 ### Community 212 - "Community 212"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 213 - "Community 213"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
 ### Community 214 - "Community 214"
 Cohesion: 0.33
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 215 - "Community 215"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 216 - "Community 216"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 217 - "Community 217"
+Cohesion: 0.33
+Nodes (1): ResizeObserverStub
+
+### Community 218 - "Community 218"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 219 - "Community 219"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 217 - "Community 217"
+### Community 220 - "Community 220"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
-
-### Community 218 - "Community 218"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 219 - "Community 219"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 220 - "Community 220"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 221 - "Community 221"
 Cohesion: 0.33
@@ -2676,16 +2686,16 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 224 - "Community 224"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 225 - "Community 225"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 226 - "Community 226"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 227 - "Community 227"
 Cohesion: 0.33
@@ -2696,84 +2706,84 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 229 - "Community 229"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 230 - "Community 230"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
 ### Community 231 - "Community 231"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 232 - "Community 232"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 233 - "Community 233"
-Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 234 - "Community 234"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 235 - "Community 235"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
+Cohesion: 0.47
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 236 - "Community 236"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 237 - "Community 237"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
+
+### Community 239 - "Community 239"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 240 - "Community 240"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+
+### Community 241 - "Community 241"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 238 - "Community 238"
+### Community 242 - "Community 242"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 239 - "Community 239"
+### Community 243 - "Community 243"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 240 - "Community 240"
+### Community 244 - "Community 244"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 241 - "Community 241"
+### Community 245 - "Community 245"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 242 - "Community 242"
+### Community 246 - "Community 246"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 243 - "Community 243"
+### Community 247 - "Community 247"
 Cohesion: 0.5
 Nodes (2): createAuthorizedRegisterDepositCtx(), createQueryCtx()
 
-### Community 244 - "Community 244"
+### Community 248 - "Community 248"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 245 - "Community 245"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 246 - "Community 246"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 247 - "Community 247"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
-
-### Community 248 - "Community 248"
-Cohesion: 0.7
-Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
 ### Community 249 - "Community 249"
 Cohesion: 0.4
@@ -2784,12 +2794,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 251 - "Community 251"
-Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 252 - "Community 252"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
 
 ### Community 253 - "Community 253"
 Cohesion: 0.4
@@ -2801,43 +2811,43 @@ Nodes (0):
 
 ### Community 255 - "Community 255"
 Cohesion: 0.7
-Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
 ### Community 256 - "Community 256"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 257 - "Community 257"
-Cohesion: 0.6
-Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
-
-### Community 258 - "Community 258"
-Cohesion: 0.5
-Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
-
-### Community 259 - "Community 259"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 258 - "Community 258"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 259 - "Community 259"
+Cohesion: 0.7
+Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
 ### Community 260 - "Community 260"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 261 - "Community 261"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
 ### Community 262 - "Community 262"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
 ### Community 263 - "Community 263"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 264 - "Community 264"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 265 - "Community 265"
 Cohesion: 0.4
@@ -2852,12 +2862,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 268 - "Community 268"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 269 - "Community 269"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 270 - "Community 270"
 Cohesion: 0.4
@@ -2869,11 +2879,11 @@ Nodes (0):
 
 ### Community 272 - "Community 272"
 Cohesion: 0.4
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 273 - "Community 273"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 274 - "Community 274"
 Cohesion: 0.4
@@ -2884,144 +2894,144 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 276 - "Community 276"
-Cohesion: 0.7
-Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+Cohesion: 0.4
+Nodes (1): ResizeObserverStub
 
 ### Community 277 - "Community 277"
-Cohesion: 0.8
-Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 278 - "Community 278"
-Cohesion: 0.7
-Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 279 - "Community 279"
 Cohesion: 0.4
-Nodes (1): MockImage
+Nodes (0):
 
 ### Community 280 - "Community 280"
+Cohesion: 0.7
+Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
+
+### Community 281 - "Community 281"
+Cohesion: 0.8
+Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
+
+### Community 282 - "Community 282"
+Cohesion: 0.7
+Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
+
+### Community 283 - "Community 283"
+Cohesion: 0.4
+Nodes (1): MockImage
+
+### Community 284 - "Community 284"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 281 - "Community 281"
+### Community 285 - "Community 285"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 282 - "Community 282"
+### Community 286 - "Community 286"
 Cohesion: 0.6
 Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
-### Community 283 - "Community 283"
+### Community 287 - "Community 287"
 Cohesion: 0.6
 Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
-### Community 284 - "Community 284"
+### Community 288 - "Community 288"
 Cohesion: 0.6
 Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
-
-### Community 285 - "Community 285"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 286 - "Community 286"
-Cohesion: 0.6
-Nodes (3): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier()
-
-### Community 287 - "Community 287"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 288 - "Community 288"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 289 - "Community 289"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 290 - "Community 290"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
+Cohesion: 0.6
+Nodes (3): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier()
 
 ### Community 291 - "Community 291"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 292 - "Community 292"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 293 - "Community 293"
-Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 294 - "Community 294"
-Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Cohesion: 0.5
+Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 295 - "Community 295"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 296 - "Community 296"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 297 - "Community 297"
 Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 298 - "Community 298"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 299 - "Community 299"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 300 - "Community 300"
-Cohesion: 0.6
-Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 301 - "Community 301"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 302 - "Community 302"
+### Community 301 - "Community 301"
 Cohesion: 0.7
-Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+
+### Community 302 - "Community 302"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 303 - "Community 303"
-Cohesion: 0.5
+Cohesion: 0.4
 Nodes (0):
 
 ### Community 304 - "Community 304"
-Cohesion: 0.67
-Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
+Cohesion: 0.6
+Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
 ### Community 305 - "Community 305"
-Cohesion: 0.83
-Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 306 - "Community 306"
-Cohesion: 0.83
-Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
+Cohesion: 0.7
+Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
 ### Community 307 - "Community 307"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 308 - "Community 308"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
 ### Community 309 - "Community 309"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
+Cohesion: 0.83
+Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
 ### Community 310 - "Community 310"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
 
 ### Community 311 - "Community 311"
 Cohesion: 0.5
@@ -3033,43 +3043,43 @@ Nodes (0):
 
 ### Community 313 - "Community 313"
 Cohesion: 0.67
-Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 314 - "Community 314"
-Cohesion: 0.83
-Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 315 - "Community 315"
-Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 316 - "Community 316"
-Cohesion: 0.67
-Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 317 - "Community 317"
 Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
 ### Community 318 - "Community 318"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
 ### Community 319 - "Community 319"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
 ### Community 320 - "Community 320"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
+Cohesion: 0.67
+Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
 ### Community 321 - "Community 321"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 322 - "Community 322"
-Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 323 - "Community 323"
 Cohesion: 0.5
@@ -3077,95 +3087,95 @@ Nodes (0):
 
 ### Community 324 - "Community 324"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 325 - "Community 325"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 326 - "Community 326"
+Cohesion: 0.83
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+
+### Community 327 - "Community 327"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 328 - "Community 328"
+Cohesion: 0.83
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+
+### Community 329 - "Community 329"
 Cohesion: 0.83
 Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
-### Community 326 - "Community 326"
+### Community 330 - "Community 330"
 Cohesion: 0.67
 Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
-### Community 327 - "Community 327"
+### Community 331 - "Community 331"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
-### Community 328 - "Community 328"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 329 - "Community 329"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 330 - "Community 330"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 331 - "Community 331"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 332 - "Community 332"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 333 - "Community 333"
-Cohesion: 0.83
-Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 334 - "Community 334"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 335 - "Community 335"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 336 - "Community 336"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 337 - "Community 337"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
 ### Community 338 - "Community 338"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 339 - "Community 339"
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+
+### Community 340 - "Community 340"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 340 - "Community 340"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
-
 ### Community 341 - "Community 341"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 342 - "Community 342"
-Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 343 - "Community 343"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 344 - "Community 344"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 345 - "Community 345"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 346 - "Community 346"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 347 - "Community 347"
 Cohesion: 0.5
@@ -3176,32 +3186,32 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 349 - "Community 349"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 350 - "Community 350"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 351 - "Community 351"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 352 - "Community 352"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 353 - "Community 353"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 354 - "Community 354"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 355 - "Community 355"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 355 - "Community 355"
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 356 - "Community 356"
 Cohesion: 0.5
@@ -3212,20 +3222,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 358 - "Community 358"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 359 - "Community 359"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 359 - "Community 359"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 360 - "Community 360"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 361 - "Community 361"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 362 - "Community 362"
 Cohesion: 0.5
@@ -3233,11 +3243,11 @@ Nodes (0):
 
 ### Community 363 - "Community 363"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 364 - "Community 364"
-Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 365 - "Community 365"
 Cohesion: 0.5
@@ -3245,7 +3255,7 @@ Nodes (0):
 
 ### Community 366 - "Community 366"
 Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 367 - "Community 367"
 Cohesion: 0.5
@@ -3253,87 +3263,87 @@ Nodes (0):
 
 ### Community 368 - "Community 368"
 Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 369 - "Community 369"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
 
 ### Community 370 - "Community 370"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 371 - "Community 371"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 372 - "Community 372"
-Cohesion: 0.67
-Nodes (2): mapActiveSessionDto(), normalizeCartItems()
-
-### Community 373 - "Community 373"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 373 - "Community 373"
+Cohesion: 0.67
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 374 - "Community 374"
 Cohesion: 0.67
-Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 375 - "Community 375"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 376 - "Community 376"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 377 - "Community 377"
+Cohesion: 0.67
+Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+
+### Community 378 - "Community 378"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 379 - "Community 379"
+Cohesion: 0.67
+Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
+
+### Community 380 - "Community 380"
 Cohesion: 0.83
 Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 376 - "Community 376"
+### Community 381 - "Community 381"
 Cohesion: 0.83
 Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
-### Community 377 - "Community 377"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 378 - "Community 378"
-Cohesion: 0.83
-Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
-
-### Community 379 - "Community 379"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 380 - "Community 380"
-Cohesion: 0.67
-Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
-
-### Community 381 - "Community 381"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
-
 ### Community 382 - "Community 382"
-Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 383 - "Community 383"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
 ### Community 384 - "Community 384"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 385 - "Community 385"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
 ### Community 386 - "Community 386"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 387 - "Community 387"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 388 - "Community 388"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 389 - "Community 389"
 Cohesion: 0.5
@@ -3348,75 +3358,75 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 392 - "Community 392"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 393 - "Community 393"
-Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 394 - "Community 394"
-Cohesion: 0.83
-Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 395 - "Community 395"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 396 - "Community 396"
-Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
-
-### Community 397 - "Community 397"
-Cohesion: 0.83
-Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
-
-### Community 398 - "Community 398"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 399 - "Community 399"
+### Community 397 - "Community 397"
 Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
+
+### Community 398 - "Community 398"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 399 - "Community 399"
+Cohesion: 0.83
+Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
 ### Community 400 - "Community 400"
-Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 401 - "Community 401"
 Cohesion: 0.83
-Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 402 - "Community 402"
-Cohesion: 0.67
-Nodes (2): collectHarnessTestTargets(), runHarnessTest()
+Cohesion: 0.83
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
 ### Community 403 - "Community 403"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 404 - "Community 404"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 405 - "Community 405"
 Cohesion: 0.67
-Nodes (0):
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
 ### Community 406 - "Community 406"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
 ### Community 407 - "Community 407"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+Cohesion: 0.67
+Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
 ### Community 408 - "Community 408"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 409 - "Community 409"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 410 - "Community 410"
@@ -3428,8 +3438,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 412 - "Community 412"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 413 - "Community 413"
 Cohesion: 0.67
@@ -3448,8 +3458,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 417 - "Community 417"
-Cohesion: 1.0
-Nodes (2): buildCtx(), createDb()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 418 - "Community 418"
 Cohesion: 0.67
@@ -3468,12 +3478,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 422 - "Community 422"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildCtx(), createDb()
 
 ### Community 423 - "Community 423"
-Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 424 - "Community 424"
 Cohesion: 0.67
@@ -3481,7 +3491,7 @@ Nodes (0):
 
 ### Community 425 - "Community 425"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 426 - "Community 426"
 Cohesion: 0.67
@@ -3492,16 +3502,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 428 - "Community 428"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 429 - "Community 429"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 430 - "Community 430"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+Cohesion: 0.67
+Nodes (1): PosServerError
 
 ### Community 431 - "Community 431"
 Cohesion: 0.67
@@ -3512,16 +3522,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 433 - "Community 433"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 434 - "Community 434"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 435 - "Community 435"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 436 - "Community 436"
 Cohesion: 0.67
@@ -3533,15 +3543,15 @@ Nodes (0):
 
 ### Community 438 - "Community 438"
 Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 439 - "Community 439"
-Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 440 - "Community 440"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 441 - "Community 441"
 Cohesion: 0.67
@@ -3553,15 +3563,15 @@ Nodes (0):
 
 ### Community 443 - "Community 443"
 Cohesion: 1.0
-Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 444 - "Community 444"
-Cohesion: 0.67
-Nodes (1): View()
+Cohesion: 1.0
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 445 - "Community 445"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 446 - "Community 446"
 Cohesion: 0.67
@@ -3572,12 +3582,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 448 - "Community 448"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
 ### Community 449 - "Community 449"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (1): View()
 
 ### Community 450 - "Community 450"
 Cohesion: 0.67
@@ -3592,12 +3602,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 453 - "Community 453"
-Cohesion: 1.0
-Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 454 - "Community 454"
-Cohesion: 0.67
-Nodes (1): FadeIn()
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 455 - "Community 455"
 Cohesion: 0.67
@@ -3609,15 +3619,15 @@ Nodes (0):
 
 ### Community 457 - "Community 457"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 458 - "Community 458"
 Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
 ### Community 459 - "Community 459"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 460 - "Community 460"
 Cohesion: 0.67
@@ -3629,11 +3639,11 @@ Nodes (0):
 
 ### Community 462 - "Community 462"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 463 - "Community 463"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 464 - "Community 464"
 Cohesion: 0.67
@@ -3693,95 +3703,95 @@ Nodes (0):
 
 ### Community 478 - "Community 478"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 479 - "Community 479"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (0):
 
 ### Community 480 - "Community 480"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (0):
 
 ### Community 481 - "Community 481"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (0):
 
 ### Community 482 - "Community 482"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (0):
 
 ### Community 483 - "Community 483"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 484 - "Community 484"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): ErrorPage()
 
 ### Community 485 - "Community 485"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
+Cohesion: 0.67
+Nodes (1): AppSkeleton()
 
 ### Community 486 - "Community 486"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (1): DashboardSkeleton()
 
 ### Community 487 - "Community 487"
 Cohesion: 0.67
-Nodes (1): Badge()
+Nodes (1): TableSkeleton()
 
 ### Community 488 - "Community 488"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): TransactionsSkeleton()
 
 ### Community 489 - "Community 489"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): NotFound()
 
 ### Community 490 - "Community 490"
-Cohesion: 0.67
-Nodes (1): onChange()
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
 ### Community 491 - "Community 491"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): AppContextMenu()
 
 ### Community 492 - "Community 492"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): Badge()
 
 ### Community 493 - "Community 493"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (0):
 
 ### Community 494 - "Community 494"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): LoadingButton()
 
 ### Community 495 - "Community 495"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): onChange()
 
 ### Community 496 - "Community 496"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): AlertModal()
 
 ### Community 497 - "Community 497"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): OverlayModal()
 
 ### Community 498 - "Community 498"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Skeleton()
 
 ### Community 499 - "Community 499"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 500 - "Community 500"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 501 - "Community 501"
 Cohesion: 0.67
@@ -3797,7 +3807,7 @@ Nodes (0):
 
 ### Community 504 - "Community 504"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 505 - "Community 505"
 Cohesion: 0.67
@@ -3812,20 +3822,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 508 - "Community 508"
-Cohesion: 1.0
-Nodes (2): getApprovalGuidance(), presentCommandToast()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 509 - "Community 509"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (1): useAuth()
 
 ### Community 510 - "Community 510"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 511 - "Community 511"
-Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 512 - "Community 512"
 Cohesion: 0.67
@@ -3833,27 +3843,27 @@ Nodes (0):
 
 ### Community 513 - "Community 513"
 Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+Nodes (2): getApprovalGuidance(), presentCommandToast()
 
 ### Community 514 - "Community 514"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 515 - "Community 515"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 516 - "Community 516"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 517 - "Community 517"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 518 - "Community 518"
 Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 519 - "Community 519"
 Cohesion: 0.67
@@ -3864,48 +3874,48 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 521 - "Community 521"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 522 - "Community 522"
-Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 523 - "Community 523"
 Cohesion: 0.67
-Nodes (1): hashPassword()
+Nodes (0):
 
 ### Community 524 - "Community 524"
-Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 525 - "Community 525"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (0):
 
 ### Community 526 - "Community 526"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 527 - "Community 527"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 528 - "Community 528"
 Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 529 - "Community 529"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 530 - "Community 530"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (1): createVersionChecker()
 
 ### Community 531 - "Community 531"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Cohesion: 0.67
+Nodes (1): manualChunks()
 
 ### Community 532 - "Community 532"
 Cohesion: 0.67
@@ -3916,8 +3926,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 534 - "Community 534"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 535 - "Community 535"
 Cohesion: 0.67
@@ -3925,11 +3935,11 @@ Nodes (0):
 
 ### Community 536 - "Community 536"
 Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 537 - "Community 537"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 538 - "Community 538"
 Cohesion: 0.67
@@ -3940,16 +3950,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 540 - "Community 540"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 541 - "Community 541"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 542 - "Community 542"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 543 - "Community 543"
 Cohesion: 0.67
@@ -3964,8 +3974,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 546 - "Community 546"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 547 - "Community 547"
 Cohesion: 0.67
@@ -4012,68 +4022,68 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 558 - "Community 558"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 559 - "Community 559"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 560 - "Community 560"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 561 - "Community 561"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 562 - "Community 562"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 563 - "Community 563"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 564 - "Community 564"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
 
 ### Community 565 - "Community 565"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 566 - "Community 566"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 567 - "Community 567"
 Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 568 - "Community 568"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 569 - "Community 569"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 570 - "Community 570"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 571 - "Community 571"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 572 - "Community 572"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 573 - "Community 573"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 574 - "Community 574"
 Cohesion: 1.0
@@ -8747,2356 +8757,2404 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1742 - "Community 1742"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1743 - "Community 1743"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1744 - "Community 1744"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1745 - "Community 1745"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1746 - "Community 1746"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1747 - "Community 1747"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1748 - "Community 1748"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1749 - "Community 1749"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1750 - "Community 1750"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1751 - "Community 1751"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 568`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 574`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 569`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 575`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 570`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 576`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 571`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 577`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 572`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 578`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 573`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 579`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 574`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 580`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 581`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 582`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 583`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 584`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 585`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 586`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 587`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 588`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 589`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 590`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 591`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 592`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 593`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 594`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 595`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 596`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 597`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 598`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 599`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 600`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 601`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 602`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 603`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 604`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 605`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 606`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 607`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 608`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 609`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 610`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 611`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 612`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 613`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 614`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 615`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 616`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 617`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 618`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 619`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 620`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 621`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 622`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
+- **Thin community `Community 623`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
+- **Thin community `Community 624`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 625`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 626`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 627`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 628`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 629`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
+- **Thin community `Community 630`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 631`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 632`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 633`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 634`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 635`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 636`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 637`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 638`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 639`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 640`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 641`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 642`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 643`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 644`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 645`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 646`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 647`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 648`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 649`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 650`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 651`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 652`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 653`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 654`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 655`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 656`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 657`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 658`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 659`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 660`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 661`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 662`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 663`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 664`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 665`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 666`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 667`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 668`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 669`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 670`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 671`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 672`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 673`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 674`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 675`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 676`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 677`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 678`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 679`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 680`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 681`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 682`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 683`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 684`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 685`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 686`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 687`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 688`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 689`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 690`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 691`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 692`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 693`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 694`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 695`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 696`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 697`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 698`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 699`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 700`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 701`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 702`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 703`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 704`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 705`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 706`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 707`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 708`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 709`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 710`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 711`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 712`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 713`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 714`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
+- **Thin community `Community 715`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 716`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 717`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 718`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 719`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 720`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 721`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 722`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 723`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 724`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 725`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 726`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 727`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 728`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 729`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 730`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 731`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 732`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 733`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 734`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 735`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 736`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 737`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 738`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 739`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 740`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 741`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 742`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 743`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 744`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 745`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 746`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 747`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 748`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 749`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 750`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 751`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 752`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 753`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 754`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 755`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 756`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 757`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 758`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 759`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
+- **Thin community `Community 760`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 761`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 762`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 763`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 764`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 765`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 766`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 767`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 768`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 769`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 770`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 771`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 772`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 773`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 774`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 775`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 776`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 777`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 778`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 779`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 780`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 781`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 782`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 783`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 784`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 785`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 786`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 787`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 788`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 789`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 790`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 791`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 792`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 793`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 794`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 795`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 796`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 797`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 798`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 799`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 800`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 801`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 802`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 803`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 804`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 805`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 806`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 807`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 808`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 809`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 810`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 811`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 812`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 813`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 814`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 815`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 816`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 817`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 818`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 819`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 820`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 821`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 822`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 823`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 824`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 825`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 826`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 827`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 828`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 829`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 830`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 831`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 832`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 833`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 834`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 835`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 836`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 837`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 838`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 839`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 840`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 841`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 842`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 843`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 844`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 845`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 846`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 847`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 848`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 849`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 850`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 851`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 852`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 853`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 854`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 855`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 856`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 857`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 858`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 859`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 860`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 861`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 862`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 863`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 864`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 865`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 866`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 867`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 868`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 869`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 870`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 871`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 872`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 873`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 874`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 875`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 876`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 877`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 878`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 879`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 880`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 881`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 882`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 883`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 884`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 885`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 886`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 887`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 888`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 889`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 890`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 891`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 892`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 893`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 894`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 895`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 896`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 897`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 898`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 899`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 900`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 901`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 902`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 903`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 904`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 905`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 906`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 907`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 908`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 909`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 910`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 911`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 912`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 913`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 914`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 915`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 916`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 917`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 918`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 919`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 920`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 921`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 922`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 923`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 924`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 925`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 926`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 927`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 928`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 929`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 930`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 931`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 932`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 933`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 934`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 935`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 936`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 937`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 938`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 939`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 940`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 941`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 942`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 943`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 944`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 945`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 946`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 947`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 948`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 949`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 950`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 951`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 952`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 953`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 954`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 955`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 956`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 957`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 958`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 959`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 960`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 961`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 962`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 963`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 964`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 965`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 966`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 967`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 968`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 969`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 970`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 971`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 972`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 973`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 974`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 975`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 976`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 977`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 978`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 979`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 980`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 981`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 982`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 983`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 984`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 985`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 986`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 987`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 988`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 989`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 990`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 991`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (1 nodes): `api.d.ts`
+- **Thin community `Community 992`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (1 nodes): `api.js`
+- **Thin community `Community 993`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 994`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (1 nodes): `server.d.ts`
+- **Thin community `Community 995`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (1 nodes): `server.js`
+- **Thin community `Community 996`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `app.ts`
+- **Thin community `Community 997`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 998`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 999`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1000`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1001`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `auth.ts`
+- **Thin community `Community 1002`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1003`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1004`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1005`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `countries.ts`
+- **Thin community `Community 1006`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `email.ts`
+- **Thin community `Community 1007`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1008`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `payment.ts`
+- **Thin community `Community 1009`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `crons.ts`
+- **Thin community `Community 1010`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1011`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `internal.ts`
+- **Thin community `Community 1012`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1013`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1014`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1015`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1016`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1017`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1018`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1019`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1020`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1021`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1022`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1023`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `env.ts`
+- **Thin community `Community 1024`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1025`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `auth.ts`
+- **Thin community `Community 1026`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1027`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `colors.ts`
+- **Thin community `Community 1028`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `index.ts`
+- **Thin community `Community 1029`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1030`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `products.ts`
+- **Thin community `Community 1031`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1032`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `stores.ts`
+- **Thin community `Community 1033`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `bag.ts`
+- **Thin community `Community 1034`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `guest.ts`
+- **Thin community `Community 1035`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `index.ts`
+- **Thin community `Community 1036`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `me.ts`
+- **Thin community `Community 1037`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `offers.ts`
+- **Thin community `Community 1038`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1039`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1040`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1041`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1042`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1043`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1044`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1045`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1046`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1047`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `user.ts`
+- **Thin community `Community 1048`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1049`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `index.ts`
+- **Thin community `Community 1050`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1051`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `http.ts`
+- **Thin community `Community 1052`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1053`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1054`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1055`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `categories.ts`
+- **Thin community `Community 1056`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `colors.ts`
+- **Thin community `Community 1057`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1058`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 1059`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1060`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1061`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1062`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1063`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `pos.ts`
+- **Thin community `Community 1064`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1065`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1066`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1067`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1068`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1069`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1070`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1071`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1072`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1073`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1074`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1075`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1076`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1077`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1078`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1079`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1080`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `types.ts`
+- **Thin community `Community 1081`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1082`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1083`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1084`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1085`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1086`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1087`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `dto.ts`
+- **Thin community `Community 1088`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1089`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1090`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `types.ts`
+- **Thin community `Community 1091`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `types.ts`
+- **Thin community `Community 1092`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1093`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `customers.ts`
+- **Thin community `Community 1094`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `register.ts`
+- **Thin community `Community 1095`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `sync.ts`
+- **Thin community `Community 1096`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `schema.ts`
+- **Thin community `Community 1097`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1098`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `index.ts`
+- **Thin community `Community 1099`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1100`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1101`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1102`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1103`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1104`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `category.ts`
+- **Thin community `Community 1105`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `color.ts`
+- **Thin community `Community 1106`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1107`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1108`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `index.ts`
+- **Thin community `Community 1109`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1110`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1111`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `organization.ts`
+- **Thin community `Community 1112`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1113`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `product.ts`
+- **Thin community `Community 1114`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1115`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1116`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `store.ts`
+- **Thin community `Community 1117`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1118`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `index.ts`
+- **Thin community `Community 1119`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1120`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1121`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1122`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1123`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1124`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1125`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1126`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `index.ts`
+- **Thin community `Community 1127`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1128`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1129`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1130`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1131`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1132`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1133`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1134`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1135`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1136`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1137`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1138`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `customer.ts`
+- **Thin community `Community 1139`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1140`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1141`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1142`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1143`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `index.ts`
+- **Thin community `Community 1144`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1145`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1146`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1147`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1148`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1149`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1150`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1151`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1152`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1153`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1154`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1155`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1156`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1157`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1158`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1159`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1160`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1161`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `index.ts`
+- **Thin community `Community 1162`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1163`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1164`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1165`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1166`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1167`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1168`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `index.ts`
+- **Thin community `Community 1169`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1170`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1171`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1172`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1173`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1174`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1175`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `bag.ts`
+- **Thin community `Community 1176`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1177`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1178`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1179`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `guest.ts`
+- **Thin community `Community 1180`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `index.ts`
+- **Thin community `Community 1181`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `offer.ts`
+- **Thin community `Community 1182`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1183`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1184`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `review.ts`
+- **Thin community `Community 1185`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1186`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1187`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1188`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1189`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1190`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1191`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1192`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1193`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1194`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `bag.ts`
+- **Thin community `Community 1195`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1196`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `customer.ts`
+- **Thin community `Community 1197`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `guest.ts`
+- **Thin community `Community 1198`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1199`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1200`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `orderOperations.test.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `payment.test.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `payment.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `paystackActions.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `savedBagItem.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `supportTicket.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `users.ts`
+- **Thin community `Community 1201`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1202`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1203`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1204`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1205`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1206`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1207`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `index.ts`
+- **Thin community `Community 1208`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1209`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1210`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `auth.ts`
+- **Thin community `Community 1211`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1212`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1213`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1214`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1215`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1216`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1217`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1218`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1219`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1220`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1221`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1222`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1223`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1224`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1225`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `constants.ts`
+- **Thin community `Community 1226`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1227`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1228`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1229`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `types.ts`
+- **Thin community `Community 1230`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1231`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1232`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1233`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1234`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1235`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1236`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1237`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1238`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1239`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1240`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1241`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1242`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1243`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1244`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1245`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1246`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1247`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1248`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1249`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1250`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `constants.ts`
+- **Thin community `Community 1251`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1252`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1253`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1254`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `data.ts`
+- **Thin community `Community 1255`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1256`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1257`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1258`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1259`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1260`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1261`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1262`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1263`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1264`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `constants.ts`
+- **Thin community `Community 1265`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1266`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1267`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1268`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `data.ts`
+- **Thin community `Community 1269`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1270`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1271`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1272`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1273`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1274`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1275`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1276`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1277`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1278`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1279`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1280`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1281`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `constants.ts`
+- **Thin community `Community 1282`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1283`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1284`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1285`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1286`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1287`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1288`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1289`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1290`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1291`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1292`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1293`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1294`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1295`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1296`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1297`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1298`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1299`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1300`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1301`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1302`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1303`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1304`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1305`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1306`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1307`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1308`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1309`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1310`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1311`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1312`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1313`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `constants.ts`
+- **Thin community `Community 1314`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1315`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1316`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1317`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `data.ts`
+- **Thin community `Community 1318`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1319`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1320`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `constants.ts`
+- **Thin community `Community 1321`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1322`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1323`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1324`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1325`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `data.ts`
+- **Thin community `Community 1326`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1327`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `constants.ts`
+- **Thin community `Community 1328`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1329`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1330`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1331`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1332`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `data.ts`
+- **Thin community `Community 1333`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1334`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1335`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1336`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1337`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1338`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1339`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1340`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1341`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1342`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1343`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1344`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1345`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1346`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1347`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1348`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1349`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1350`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1351`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1352`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1353`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1354`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1355`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1356`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1357`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1358`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `POSSettingsView.test.tsx`
+- **Thin community `Community 1359`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1360`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `POSTerminalHealthView.test.tsx`
+- **Thin community `Community 1361`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1362`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1363`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1364`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `types.ts`
+- **Thin community `Community 1365`** (1 nodes): `POSSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1366`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1367`** (1 nodes): `POSTerminalHealthView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1368`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1369`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1370`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1371`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1372`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1373`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1374`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1375`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1376`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1377`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1378`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1379`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1380`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `data.ts`
+- **Thin community `Community 1381`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1382`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1383`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1384`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1385`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1386`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1387`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1388`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1389`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1390`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1391`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1392`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1393`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `constants.ts`
+- **Thin community `Community 1394`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1395`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1396`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1397`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `data.ts`
+- **Thin community `Community 1398`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `types.ts`
+- **Thin community `Community 1399`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1400`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1401`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1402`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1403`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1404`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `index.tsx`
+- **Thin community `Community 1405`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1406`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1407`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1408`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1409`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1410`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1411`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1412`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1413`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `index.tsx`
+- **Thin community `Community 1414`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1415`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1416`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1417`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `button.tsx`
+- **Thin community `Community 1418`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1419`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `card.tsx`
+- **Thin community `Community 1420`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1421`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1422`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `command.tsx`
+- **Thin community `Community 1423`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1424`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1425`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1426`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `form.tsx`
+- **Thin community `Community 1427`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1428`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1429`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `input.tsx`
+- **Thin community `Community 1430`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1431`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1432`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1433`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1434`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1435`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1436`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `select.tsx`
+- **Thin community `Community 1437`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1438`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1439`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1440`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `table.tsx`
+- **Thin community `Community 1441`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1442`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1443`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1444`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1445`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1446`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1447`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1448`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1449`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `constants.ts`
+- **Thin community `Community 1450`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1451`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1452`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1453`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `data.ts`
+- **Thin community `Community 1454`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1455`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1456`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1457`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1458`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1459`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1460`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1461`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1462`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1463`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1464`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1465`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `index.ts`
+- **Thin community `Community 1466`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1467`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1468`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1469`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1470`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1471`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1472`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1473`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1474`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1475`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1476`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `aws.ts`
+- **Thin community `Community 1477`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `constants.ts`
+- **Thin community `Community 1478`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `countries.ts`
+- **Thin community `Community 1479`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1480`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1481`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1482`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1483`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1484`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1485`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `dto.ts`
+- **Thin community `Community 1486`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `ports.ts`
+- **Thin community `Community 1487`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `constants.ts`
+- **Thin community `Community 1488`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1489`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1490`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `index.ts`
+- **Thin community `Community 1491`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1492`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `types.ts`
+- **Thin community `Community 1493`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1494`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1495`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1496`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1497`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1498`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1499`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1500`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1501`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1502`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1503`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `category.ts`
+- **Thin community `Community 1504`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `product.ts`
+- **Thin community `Community 1505`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `store.ts`
+- **Thin community `Community 1506`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1507`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `user.ts`
+- **Thin community `Community 1508`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1509`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1510`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1511`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1512`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1513`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1514`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1515`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `index.tsx`
+- **Thin community `Community 1516`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `index.tsx`
+- **Thin community `Community 1517`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `index.tsx`
+- **Thin community `Community 1518`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1519`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1520`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1521`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1522`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1523`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `index.tsx`
+- **Thin community `Community 1524`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1525`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1526`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1527`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `home.tsx`
+- **Thin community `Community 1528`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1529`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1530`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1531`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `index.tsx`
+- **Thin community `Community 1532`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1533`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1534`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1535`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1536`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1537`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `index.tsx`
+- **Thin community `Community 1538`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1539`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1540`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1541`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1542`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1543`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1544`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `index.tsx`
+- **Thin community `Community 1545`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1546`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1547`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1548`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1549`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1550`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1551`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1552`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1553`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1554`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1555`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1556`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `index.tsx`
+- **Thin community `Community 1557`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `new.tsx`
+- **Thin community `Community 1558`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `index.tsx`
+- **Thin community `Community 1559`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `new.tsx`
+- **Thin community `Community 1560`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1561`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1562`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `index.tsx`
+- **Thin community `Community 1563`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `new.tsx`
+- **Thin community `Community 1564`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1565`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1566`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1567`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1568`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1569`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `index.tsx`
+- **Thin community `Community 1570`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1571`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1572`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1573`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `index.tsx`
+- **Thin community `Community 1574`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1575`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1576`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1577`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1578`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1579`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1580`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1581`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1582`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1583`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1584`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1585`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1586`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1587`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1588`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1589`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1590`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1591`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1592`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1593`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1594`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1595`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1596`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1597`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1598`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `setup.ts`
+- **Thin community `Community 1599`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1600`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `types.ts`
+- **Thin community `Community 1601`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1602`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1603`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1604`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1605`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1606`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `types.ts`
+- **Thin community `Community 1607`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1608`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1609`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1610`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1611`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1612`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1613`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1614`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1615`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1616`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `schema.ts`
+- **Thin community `Community 1617`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1618`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1619`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1620`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1621`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1622`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1623`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1624`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1625`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1626`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `types.ts`
+- **Thin community `Community 1627`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1628`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1629`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1630`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1631`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1632`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1633`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1634`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `constants.ts`
+- **Thin community `Community 1635`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1636`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `About.tsx`
+- **Thin community `Community 1637`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1638`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1639`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1640`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1641`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1642`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1643`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1644`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1645`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1646`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1647`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `types.ts`
+- **Thin community `Community 1648`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1649`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1650`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1651`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1652`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1653`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1654`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1655`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1656`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1657`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1658`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1659`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `button.tsx`
+- **Thin community `Community 1660`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `card.tsx`
+- **Thin community `Community 1661`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1662`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `command.tsx`
+- **Thin community `Community 1663`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1664`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1665`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1666`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `form.tsx`
+- **Thin community `Community 1667`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1668`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1669`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1670`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1671`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `input.tsx`
+- **Thin community `Community 1672`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `label.tsx`
+- **Thin community `Community 1673`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1674`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1675`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1676`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `index.ts`
+- **Thin community `Community 1677`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `types.ts`
+- **Thin community `Community 1678`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1679`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1680`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1681`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1682`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `select.tsx`
+- **Thin community `Community 1683`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1684`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1685`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `table.tsx`
+- **Thin community `Community 1686`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1687`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1688`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1689`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1690`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1691`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `config.ts`
+- **Thin community `Community 1692`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1693`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1694`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1695`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1696`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `constants.ts`
+- **Thin community `Community 1697`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `countries.ts`
+- **Thin community `Community 1698`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1699`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1700`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1701`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1702`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `index.ts`
+- **Thin community `Community 1703`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `store.ts`
+- **Thin community `Community 1704`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `bag.ts`
+- **Thin community `Community 1705`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1706`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `category.ts`
+- **Thin community `Community 1707`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `organization.ts`
+- **Thin community `Community 1708`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `product.ts`
+- **Thin community `Community 1709`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `store.ts`
+- **Thin community `Community 1710`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1711`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `user.ts`
+- **Thin community `Community 1712`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `states.ts`
+- **Thin community `Community 1713`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1714`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1715`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1716`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1717`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1718`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1719`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1720`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `index.tsx`
+- **Thin community `Community 1721`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1722`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `index.tsx`
+- **Thin community `Community 1723`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1724`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1725`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1726`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1727`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1728`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `index.tsx`
+- **Thin community `Community 1729`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1730`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1731`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1732`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1733`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1734`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `index.js`
+- **Thin community `Community 1735`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1736`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1737`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1738`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1739`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1740`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1741`** (1 nodes): `tailwind.config.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1742`** (1 nodes): `storefront-boot.e2e.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1743`** (1 nodes): `vitest.config.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1744`** (1 nodes): `vitest.setup.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1745`** (1 nodes): `index.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1746`** (1 nodes): `harness-app-registry.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1747`** (1 nodes): `athena-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1748`** (1 nodes): `storefront-runtime-api.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1749`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1750`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1751`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1814
-- Graph nodes: 6058
-- Graph edges: 6495
-- Communities: 1742
+- Code files discovered: 1824
+- Graph nodes: 6108
+- Graph edges: 6561
+- Communities: 1752
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (84 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -17,11 +17,11 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 - [validation-map.json](../../../packages/valkey-proxy-server/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `app.js` (14 edges, Community 69) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 128) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
-- `createRedisClient()` (4 edges, Community 69) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `createRedisCluster()` (3 edges, Community 69) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `deleteKeysIndividually()` (3 edges, Community 69) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.js` (14 edges, Community 70) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.test.js` (6 edges, Community 130) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `createRedisClient()` (4 edges, Community 70) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisCluster()` (3 edges, Community 70) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `deleteKeysIndividually()` (3 edges, Community 70) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/pos/application/commands/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/terminals.ts
@@ -265,8 +265,8 @@ export type TerminalRuntimeStatusInput = {
   };
   snapshots: {
     catalogAgeMs?: number;
-    availabilityAgeMs?: number;
     serviceCatalogAgeMs?: number;
+    availabilityAgeMs?: number;
     registerReadModelAgeMs?: number;
   };
 };
@@ -403,11 +403,11 @@ export async function submitTerminalRuntimeStatus(
     }),
     snapshots: omitUndefined({
       catalogAgeMs: nonNegativeInteger(args.status.snapshots.catalogAgeMs),
-      availabilityAgeMs: nonNegativeInteger(
-        args.status.snapshots.availabilityAgeMs,
-      ),
       serviceCatalogAgeMs: nonNegativeInteger(
         args.status.snapshots.serviceCatalogAgeMs,
+      ),
+      availabilityAgeMs: nonNegativeInteger(
+        args.status.snapshots.availabilityAgeMs,
       ),
       registerReadModelAgeMs: nonNegativeInteger(
         args.status.snapshots.registerReadModelAgeMs,

--- a/packages/athena-webapp/convex/pos/application/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminals.test.ts
@@ -1248,6 +1248,7 @@ function buildRuntimeStatus() {
     },
     snapshots: {
       catalogAgeMs: 10,
+      serviceCatalogAgeMs: 15,
       availabilityAgeMs: 20,
       registerReadModelAgeMs: 30,
     },

--- a/packages/athena-webapp/convex/pos/public/terminalAppSessions.test.ts
+++ b/packages/athena-webapp/convex/pos/public/terminalAppSessions.test.ts
@@ -326,7 +326,7 @@ describe("terminal app-session recovery validation", () => {
         metadata: {
           otp: "111222",
           rawToken: "secret-token",
-          staffPin: "1234",
+          staffPin: "staff-pin-should-not-leak",
         },
       }),
     );
@@ -339,7 +339,7 @@ describe("terminal app-session recovery validation", () => {
       "terminal-proof-1",
       "111222",
       "secret-token",
-      "1234",
+      "staff-pin-should-not-leak",
       "syncSecretHash",
       "terminalProof",
       "staffPin",

--- a/packages/athena-webapp/convex/pos/public/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.test.ts
@@ -686,6 +686,7 @@ function buildRuntimeStatus(extra: Record<string, unknown> = {}) {
     },
     snapshots: {
       catalogAgeMs: 10,
+      serviceCatalogAgeMs: 15,
       availabilityAgeMs: 20,
       registerReadModelAgeMs: 30,
     },

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -324,8 +324,8 @@ function stripRuntimeStatusInput(
       : undefined,
     snapshots: {
       catalogAgeMs: status.snapshots.catalogAgeMs,
-      availabilityAgeMs: status.snapshots.availabilityAgeMs,
       serviceCatalogAgeMs: status.snapshots.serviceCatalogAgeMs,
+      availabilityAgeMs: status.snapshots.availabilityAgeMs,
       registerReadModelAgeMs: status.snapshots.registerReadModelAgeMs,
     },
   };

--- a/packages/athena-webapp/convex/schemas/pos/posTerminalRuntimeStatus.ts
+++ b/packages/athena-webapp/convex/schemas/pos/posTerminalRuntimeStatus.ts
@@ -89,8 +89,8 @@ export const posTerminalRuntimeStaffAuthorityValidator = v.object({
 
 export const posTerminalRuntimeSnapshotsValidator = v.object({
   catalogAgeMs: v.optional(v.number()),
-  availabilityAgeMs: v.optional(v.number()),
   serviceCatalogAgeMs: v.optional(v.number()),
+  availabilityAgeMs: v.optional(v.number()),
   registerReadModelAgeMs: v.optional(v.number()),
 });
 

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -11,7 +11,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`src/components/traces`](../../src/components/traces) — Shared workflow trace screens, ordered timelines, and trace detail primitives. Currently 3 file(s); key children: WorkflowTraceRouteLink.tsx, WorkflowTraceView.test.tsx, WorkflowTraceView.tsx.
 - [`src/components/operations`](../../src/components/operations) — Manager-queue and stock-adjustment workflows that share approval rails with other operational surfaces. Currently 24 file(s); key children: CommandApprovalDialog.test.tsx, CommandApprovalDialog.tsx, DailyCloseHistoryView.test.tsx, DailyCloseHistoryView.tsx, DailyCloseView.test.tsx.
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.
-- [`src/hooks`](../../src/hooks) — React hooks that fan out auth, shell, and feature state. Currently 42 file(s); key children: use-image-upload.ts, use-mobile.tsx, use-navigate-back.ts, use-navigation-keyboard-shortcuts.ts, use-pagination-persistence.ts.
+- [`src/hooks`](../../src/hooks) — React hooks that fan out auth, shell, and feature state. Currently 43 file(s); key children: use-image-upload.ts, use-mobile.tsx, use-navigate-back.ts, use-navigation-keyboard-shortcuts.ts, use-pagination-persistence.ts.
 - [`src/contexts`](../../src/contexts) — Context providers for app-wide state and wiring. Currently 8 file(s); key children: AppShellFullscreenContext.tsx, ManagerElevationContext.test.tsx, ManagerElevationContext.tsx, OnlineOrderContext.tsx, PermissionsContext.tsx.
 - [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 124 file(s); key children: access, aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts.
 - [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 14 file(s); key children: approvalPolicy.ts, auth.ts, commandResult.test.ts, commandResult.ts, currencyFormatter.test.ts.
@@ -23,6 +23,6 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 6 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCases.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 11 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
 - [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 475 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
-- [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 6 file(s); key children: README.md, SUMMARY.md, pos.
+- [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 7 file(s); key children: README.md, SUMMARY.md, pos.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -7,12 +7,14 @@ This index enumerates the current automated test files and ties them back to the
 ## Package-level commands
 
 - `bun run --filter '@athena/webapp' test`
+- `bun run --filter '@athena/webapp' test:e2e`
 
 ## Detected test surfaces
 
 - `convex`
 - `shared`
 - `src`
+- `src/tests`
 
 ## Section `convex`
 
@@ -251,6 +253,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/hooks/useAuth.test.tsx`](../../src/hooks/useAuth.test.tsx)
 - [`src/hooks/useBulkOperations.test.ts`](../../src/hooks/useBulkOperations.test.ts)
 - [`src/hooks/useExpenseSessions.test.ts`](../../src/hooks/useExpenseSessions.test.ts)
+- [`src/hooks/useGetActiveStore.test.ts`](../../src/hooks/useGetActiveStore.test.ts)
 - [`src/hooks/useGetTerminal.test.ts`](../../src/hooks/useGetTerminal.test.ts)
 - [`src/hooks/useProtectedAdminPageState.test.tsx`](../../src/hooks/useProtectedAdminPageState.test.tsx)
 - [`src/lib/access/capabilities.test.ts`](../../src/lib/access/capabilities.test.ts)
@@ -291,6 +294,9 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/lib/storeConfig.test.ts`](../../src/lib/storeConfig.test.ts)
 - [`src/lib/traces/createWorkflowTraceId.test.ts`](../../src/lib/traces/createWorkflowTraceId.test.ts)
 - [`src/lib/utils.test.ts`](../../src/lib/utils.test.ts)
+- [`src/offline/posAppShellRoutes.test.ts`](../../src/offline/posAppShellRoutes.test.ts)
+- [`src/offline/posOfflineReadiness.test.ts`](../../src/offline/posOfflineReadiness.test.ts)
+- [`src/offline/registerPosAppShellServiceWorker.test.ts`](../../src/offline/registerPosAppShellServiceWorker.test.ts)
 - [`src/routeTree.browser-boundary.test.ts`](../../src/routeTree.browser-boundary.test.ts)
 - [`src/routes/_authed.test.tsx`](../../src/routes/_authed.test.tsx)
 - [`src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.test.tsx`](../../src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/sku-activity.test.tsx)
@@ -309,6 +315,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/stories/storybook-theme-decorator.test.ts`](../../src/stories/storybook-theme-decorator.test.ts)
 - [`src/tests/pos/backend.test.ts`](../../src/tests/pos/backend.test.ts)
 - [`src/tests/pos/inventoryValidationLogic.test.ts`](../../src/tests/pos/inventoryValidationLogic.test.ts)
+- [`src/tests/pos/offlineRouteAccess.spec.ts`](../../src/tests/pos/offlineRouteAccess.spec.ts)
 - [`src/tests/pos/simple.test.ts`](../../src/tests/pos/simple.test.ts)
 - [`src/tests/pos/usePrint.test.ts`](../../src/tests/pos/usePrint.test.ts)
 

--- a/packages/athena-webapp/docs/agent/testing.md
+++ b/packages/athena-webapp/docs/agent/testing.md
@@ -8,6 +8,8 @@ Use the repo-root harness commands together:
 - `bun run harness:inferential-review` is the blocking inferential pass. It emits human-readable remediation plus a machine-readable inferential review artifact in the repo-level artifacts directory.
 - `bun run harness:behavior --scenario <name>` runs shared runtime behavior scenarios that boot app processes, wait for readiness, drive browser interactions, assert runtime signals, and clean up automatically.
 - `bun run harness:behavior --scenario <name> --record-video` captures browser-flow evidence for handoff under `artifacts/harness-behavior/videos/<scenario>/<run-stamp>/`.
+- `bun run --filter '@athena/webapp' test:e2e` builds the Athena webapp, serves the production build with Vite preview, and runs package-local Playwright specs.
+- `bun run --filter '@athena/webapp' test:e2e -- <spec>` limits that Playwright run to a specific spec such as `src/tests/pos/offlineRouteAccess.spec.ts`.
 
 Behavior runs emit `[harness:behavior:report]` JSON with per-phase latency and runtime-signal diagnostics. Thresholds are configured per scenario through `runtimeSignals[].minMatches` / `runtimeSignals[].maxMatches` and `thresholds.latency` in [scripts/harness-behavior-scenarios.ts](../../../../scripts/harness-behavior-scenarios.ts).
 

--- a/packages/athena-webapp/docs/agent/validation-guide.md
+++ b/packages/athena-webapp/docs/agent/validation-guide.md
@@ -212,6 +212,19 @@ Behavior scenarios:
 
 Use this when POS hub app-session recovery, route-shell continuity, terminal recovery validation, or app-session diagnostics change. It proves the recovery assertion stays POS-hub scoped, non-POS routes still require normal app auth, server validation rejects unsafe scopes, recovery retries stay bounded, terminal diagnostics redact raw recovery data, and sale authority still depends on terminal integrity, drawer authority, local command invariants, and staff proof.
 
+## POS offline route access and app-shell edits
+
+Touched surfaces: `public/pos-app-shell-sw.js`, `playwright.config.ts`, `src/main.tsx`, `src/offline`, `src/routes/_authed.tsx`, `src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos`, `src/components/pos/PointOfSaleView.tsx`, `src/components/pos/register`, `src/components/pos/settings/POSSettingsView.tsx`, `src/components/pos/terminals/POSTerminalHealthView.tsx`, `src/lib/pos/infrastructure/local`, `src/lib/pos/presentation/register`, `src/tests/pos/offlineRouteAccess.spec.ts`
+
+Run:
+
+- `bun run --filter '@athena/webapp' test -- src/offline/posAppShellRoutes.test.ts src/offline/registerPosAppShellServiceWorker.test.ts src/offline/posOfflineReadiness.test.ts src/routes/_authed.test.tsx src/components/pos/PointOfSaleView.test.tsx src/components/pos/settings/POSSettingsView.test.tsx src/components/pos/terminals/POSTerminalHealthView.test.tsx src/components/pos/register/POSRegisterOpeningGuard.test.tsx src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- `bun run --filter '@athena/webapp' test:e2e -- src/tests/pos/offlineRouteAccess.spec.ts`
+- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
+- `bun run --filter '@athena/webapp' build`
+
+Use this when POS service-worker app-shell caching, POS-only offline route entry, offline readiness diagnostics, or hard-reload register continuity changes. Cache Storage must stay limited to static shell assets; POS business state, staff authority, cart events, payments, and catalog snapshots remain in IndexedDB/local POS stores.
+
 ## POS terminal health visibility and diagnostics edits
 
 Touched surfaces: `convex/schemas/pos/posTerminal.ts`, `convex/schemas/pos/posTerminalRuntimeStatus.ts`, `convex/pos/application/commands/terminals.ts`, `convex/pos/application/queries/terminals.ts`, `convex/pos/infrastructure/repositories/terminalRepository.ts`, `convex/pos/public/terminals.ts`, `convex/inventory/posTerminal.ts`, `src/components/pos/settings/POSSettingsView.tsx`, `src/hooks/useGetTerminal.ts`, `src/lib/pos/application/registerAndProvisionPosTerminal.ts`, `src/lib/pos/infrastructure/terminal`, `src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts`, `src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`, `src/lib/pos/presentation/syncStatusPresentation.ts`, `src/components/pos/register/POSRegisterView.tsx`, `src/components/pos/terminals`, `src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos/terminals`, `src/components/cash-controls/CashControlsDashboard.tsx`, `src/components/cash-controls/RegisterSessionView.tsx`

--- a/packages/athena-webapp/docs/agent/validation-map.json
+++ b/packages/athena-webapp/docs/agent/validation-map.json
@@ -503,6 +503,43 @@
       ]
     },
     {
+      "name": "pos-offline-route-access-and-app-shell-edits",
+      "pathPrefixes": [
+        "packages/athena-webapp/public/pos-app-shell-sw.js",
+        "packages/athena-webapp/playwright.config.ts",
+        "packages/athena-webapp/src/main.tsx",
+        "packages/athena-webapp/src/offline",
+        "packages/athena-webapp/src/routes/_authed.tsx",
+        "packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos",
+        "packages/athena-webapp/src/components/pos/PointOfSaleView.tsx",
+        "packages/athena-webapp/src/components/pos/register",
+        "packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx",
+        "packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx",
+        "packages/athena-webapp/src/lib/pos/infrastructure/local",
+        "packages/athena-webapp/src/lib/pos/presentation/register",
+        "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts"
+      ],
+      "commands": [
+        {
+          "kind": "raw",
+          "command": "bun run --filter '@athena/webapp' test -- src/offline/posAppShellRoutes.test.ts src/offline/registerPosAppShellServiceWorker.test.ts src/offline/posOfflineReadiness.test.ts src/routes/_authed.test.tsx src/components/pos/PointOfSaleView.test.tsx src/components/pos/settings/POSSettingsView.test.tsx src/components/pos/terminals/POSTerminalHealthView.test.tsx src/components/pos/register/POSRegisterOpeningGuard.test.tsx src/lib/pos/presentation/register/useRegisterViewModel.test.ts"
+        },
+        {
+          "kind": "raw",
+          "command": "bun run --filter '@athena/webapp' test:e2e -- src/tests/pos/offlineRouteAccess.spec.ts"
+        },
+        {
+          "kind": "raw",
+          "command": "bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json"
+        },
+        {
+          "kind": "script",
+          "script": "build"
+        }
+      ],
+      "behaviorScenarios": []
+    },
+    {
       "name": "pos-terminal-health-visibility-and-diagnostics-edits",
       "pathPrefixes": [
         "packages/athena-webapp/convex/schemas/pos/posTerminal.ts",

--- a/packages/athena-webapp/package.json
+++ b/packages/athena-webapp/package.json
@@ -21,7 +21,9 @@
     "email:dev": "email dev --dir convex/emails",
     "storybook": "storybook dev -p 6006 --config-dir ../../.storybook-athena",
     "storybook:build": "storybook build --config-dir ../../.storybook-athena",
-    "build-storybook": "bun run storybook:build"
+    "build-storybook": "bun run storybook:build",
+    "test:e2e": "playwright test --config playwright.config.ts",
+    "test:e2e:headed": "playwright test --config playwright.config.ts --headed"
   },
   "devDependencies": {
     "@convex-dev/eslint-plugin": "^1.2.2",
@@ -29,6 +31,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/bun": "latest",
+    "@playwright/test": "^1.58.2",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.2",

--- a/packages/athena-webapp/playwright.config.ts
+++ b/packages/athena-webapp/playwright.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const port = Number(process.env.PLAYWRIGHT_PORT || 4174);
+const baseURL = process.env.PLAYWRIGHT_APP_URL || `http://127.0.0.1:${port}`;
+const convexUrl =
+  process.env.VITE_CONVEX_URL || "https://playwright-athena.convex.cloud";
+const apiGatewayUrl =
+  process.env.VITE_API_GATEWAY_URL || "https://playwright-athena.convex.site";
+
+export default defineConfig({
+  testDir: "./src/tests",
+  testMatch: "**/*.spec.ts",
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: false,
+  retries: process.env.CI ? 2 : 0,
+  outputDir:
+    process.env.PLAYWRIGHT_OUTPUT_DIR ||
+    "/tmp/athena-webapp-playwright-results",
+  reporter: process.env.CI ? [["github"], ["html"]] : [["list"]],
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: `bun run build && bun run serve --host 127.0.0.1 --port ${port}`,
+    env: {
+      VITE_CONVEX_URL: convexUrl,
+      VITE_API_GATEWAY_URL: apiGatewayUrl,
+    },
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/packages/athena-webapp/public/pos-app-shell-sw.js
+++ b/packages/athena-webapp/public/pos-app-shell-sw.js
@@ -1,0 +1,300 @@
+const POS_APP_SHELL_CACHE = "athena-pos-app-shell-v6";
+const STATIC_DESTINATIONS = new Set(["script", "style", "font", "image"]);
+const PRODUCTION_ASSET_PREFIX = "/assets/";
+const EXCLUDED_PREFIXES = ["/api", "/convex", "/_convex", "/auth", "/.well-known"];
+const EXCLUDED_EXTENSIONS = [".json", ".map", ".txt", ".xml"];
+const SHELL_ASSET_EXTENSIONS = [
+  ".css",
+  ".js",
+  ".mjs",
+  ".woff",
+  ".woff2",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".svg",
+  ".webp",
+];
+const SHELL_ASSET_PREFIXES = ["/assets/", "/src/", "/@vite/", "/node_modules/"];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key.startsWith("athena-pos-app-shell-") && key !== POS_APP_SHELL_CACHE)
+            .map((key) => caches.delete(key)),
+        ),
+      )
+      .then(() => self.clients.claim()),
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const request = event.request;
+  const url = new URL(request.url);
+
+  if (isPosNavigation(request, url)) {
+    event.respondWith(networkFirstShell(request));
+    return;
+  }
+
+  if (isStaticShellAsset(request, url)) {
+    event.respondWith(cacheFirstAsset(request));
+  }
+});
+
+self.addEventListener("message", (event) => {
+  const message = event.data;
+  if (!message || message.type !== "athena-pos-app-shell:warm") return;
+
+  event.waitUntil(
+    warmPosAppShell(message.url)
+      .then((result) => {
+        event.source?.postMessage({
+          type: "athena-pos-app-shell:warm-complete",
+          id: message.id,
+          result,
+        });
+      })
+      .catch((error) => {
+        event.source?.postMessage({
+          type: "athena-pos-app-shell:warm-error",
+          id: message.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }),
+  );
+});
+
+function isPosNavigation(request, url) {
+  if (url.origin !== self.location.origin) return false;
+  if (request.method !== "GET") return false;
+  if (request.mode !== "navigate") return false;
+  if (isExcluded(url)) return false;
+
+  return url.pathname.split("/").filter(Boolean).includes("pos");
+}
+
+function isStaticShellAsset(request, url) {
+  if (url.origin !== self.location.origin) return false;
+  if (request.method !== "GET") return false;
+  if (isExcluded(url)) return false;
+
+  return (
+    STATIC_DESTINATIONS.has(request.destination) ||
+    SHELL_ASSET_EXTENSIONS.some((extension) =>
+      url.pathname.toLowerCase().endsWith(extension),
+    ) ||
+    SHELL_ASSET_PREFIXES.some((prefix) => url.pathname.startsWith(prefix))
+  );
+}
+
+function isExcluded(url) {
+  const pathname = url.pathname.toLowerCase();
+  if (pathname.startsWith("/convex/_generated/")) return false;
+
+  return (
+    EXCLUDED_PREFIXES.some((prefix) => pathname.startsWith(prefix)) ||
+    EXCLUDED_EXTENSIONS.some((extension) => pathname.endsWith(extension)) ||
+    pathname.includes("/api/") ||
+    pathname.includes("/convex/")
+  );
+}
+
+async function networkFirstShell(request) {
+  const cache = await caches.open(POS_APP_SHELL_CACHE);
+
+  try {
+    const response = await fetch(request);
+    if (response.ok && isHtmlResponse(response)) {
+      await cache.put(request, response.clone());
+      await cache.put("/", response.clone());
+      await cacheLinkedShellAssets(response.clone(), request.url, cache);
+    }
+    return response;
+  } catch (error) {
+    const cachedRoute = await matchCached(cache, request);
+    if (cachedRoute) return cachedRoute;
+
+    const cachedRoot = await matchCached(cache, "/");
+    if (cachedRoot) return cachedRoot;
+
+    throw error;
+  }
+}
+
+async function warmPosAppShell(url) {
+  const routeUrl = new URL(url, self.location.origin);
+  const request = new Request(routeUrl.toString(), {
+    headers: { accept: "text/html" },
+  });
+
+  const isPosRoute = routeUrl.pathname.split("/").filter(Boolean).includes("pos");
+  if (!isPosRoute) {
+    throw new Error(`Refusing to warm non-POS shell route: ${routeUrl.pathname}`);
+  }
+
+  const cache = await caches.open(POS_APP_SHELL_CACHE);
+  const response = await fetch(request);
+  if (!response.ok || !isHtmlResponse(response)) {
+    throw new Error(`Unable to warm POS shell route: ${response.status}`);
+  }
+
+  await cache.put(routeUrl.toString(), response.clone());
+  await cache.put("/", response.clone());
+  await cacheLinkedShellAssets(response.clone(), routeUrl.toString(), cache);
+
+  const keys = await cache.keys();
+  return { cacheName: POS_APP_SHELL_CACHE, cachedRequests: keys.length };
+}
+
+async function cacheFirstAsset(request) {
+  const cache = await caches.open(POS_APP_SHELL_CACHE);
+  const cached = await matchCached(cache, request);
+  if (cached) return cached;
+
+  return cacheAssetRequest(request, cache);
+}
+
+async function cacheAssetRequest(request, cache, visited = new Set()) {
+  if (visited.has(request.url)) {
+    const cached = await matchCached(cache, request);
+    if (cached) return cached;
+  }
+  visited.add(request.url);
+
+  const response = await fetch(request);
+  if (response.ok) {
+    await cache.put(request, response.clone());
+    await cacheModuleDependencies(response.clone(), request.url, cache, visited);
+  }
+  return response;
+}
+
+function isHtmlResponse(response) {
+  return response.headers.get("content-type")?.includes("text/html");
+}
+
+async function cacheLinkedShellAssets(response, baseUrl, cache) {
+  const html = await response.text();
+  const linkedUrls = new Set();
+  const scriptPattern = /<script[^>]+src=["']([^"']+)["']/g;
+  const linkPattern = /<link[^>]+href=["']([^"']+)["'][^>]*>/g;
+
+  for (const match of html.matchAll(scriptPattern)) {
+    linkedUrls.add(new URL(match[1], baseUrl).toString());
+  }
+
+  for (const match of html.matchAll(linkPattern)) {
+    const tag = match[0];
+    if (!/\b(rel=["'](?:modulepreload|preload|stylesheet)["']|as=["'](?:script|style)["'])/.test(tag)) {
+      continue;
+    }
+    linkedUrls.add(new URL(match[1], baseUrl).toString());
+  }
+
+  await Promise.all(
+    Array.from(linkedUrls).map(async (url) => {
+      const request = new Request(url);
+      const parsedUrl = new URL(url);
+      if (!isStaticShellAsset(request, parsedUrl)) return;
+      if (await matchCached(cache, request)) return;
+      await cacheAssetRequest(request, cache);
+    }),
+  );
+}
+
+async function cacheModuleDependencies(response, baseUrl, cache, visited) {
+  if (!isJavaScriptLikeResponse(response, baseUrl)) return;
+  if (!shouldScanModuleImports(new URL(baseUrl))) return;
+
+  const source = await response.text();
+  const dependencyUrls = new Set();
+  const importPatterns = [
+    /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["']([^"']+)["']/g,
+    /\bimport\(\s*["']([^"']+)["']\s*\)/g,
+    /["']([^"']*assets\/[^"']+)["']/g,
+  ];
+
+  for (const pattern of importPatterns) {
+    for (const match of source.matchAll(pattern)) {
+      const specifier = match[1];
+      const resolvedUrl = resolveShellAssetReference(specifier, baseUrl);
+      if (!resolvedUrl) continue;
+      dependencyUrls.add(resolvedUrl);
+    }
+  }
+
+  await Promise.all(
+    Array.from(dependencyUrls).map(async (url) => {
+      const request = new Request(url);
+      const parsedUrl = new URL(url);
+      if (!isStaticShellAsset(request, parsedUrl)) return;
+      if (visited.has(request.url)) return;
+      if (await matchCached(cache, request)) return;
+      try {
+        await cacheAssetRequest(request, cache, visited);
+      } catch (_error) {
+        // Dev-optimized dependencies can contain example import strings. Ignore
+        // those misses; real module requests still fail visibly at runtime.
+      }
+    }),
+  );
+}
+
+async function matchCached(cache, request) {
+  const cached = await cache.match(request);
+  if (cached) return cached;
+
+  const url = typeof request === "string" ? request : request.url;
+  return await cache.match(url, { ignoreVary: true });
+}
+
+function resolveShellAssetReference(specifier, baseUrl) {
+  if (specifier.startsWith("/")) {
+    return new URL(specifier, self.location.origin).toString();
+  }
+
+  if (specifier.startsWith("assets/")) {
+    return new URL(`/${specifier}`, self.location.origin).toString();
+  }
+
+  if (specifier.startsWith(".")) {
+    return new URL(specifier, baseUrl).toString();
+  }
+
+  return null;
+}
+
+function shouldScanModuleImports(url) {
+  return (
+    url.pathname.startsWith(PRODUCTION_ASSET_PREFIX) ||
+    url.pathname.startsWith("/src/") ||
+    url.pathname.startsWith("/shared/") ||
+    url.pathname.startsWith("/convex/_generated/") ||
+    url.pathname.startsWith("/@fs/") ||
+    url.pathname === "/@vite/client" ||
+    url.pathname === "/@react-refresh"
+  );
+}
+
+function isJavaScriptLikeResponse(response, baseUrl) {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("javascript")) return true;
+  if (contentType.includes("typescript")) return true;
+
+  const pathname = new URL(baseUrl).pathname.toLowerCase();
+  return (
+    pathname.endsWith(".js") ||
+    pathname.endsWith(".mjs") ||
+    pathname.endsWith(".ts") ||
+    pathname.endsWith(".tsx")
+  );
+}

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.test.tsx
@@ -120,7 +120,8 @@ vi.mock("@/lib/pos/infrastructure/local/localPosEntryContext", () => ({
 }));
 
 vi.mock("@/lib/pos/infrastructure/local/localPosReadiness", () => ({
-  useLocalPosReadiness: () => useLocalPosReadinessMock(),
+  useLocalPosReadiness: (...args: unknown[]) =>
+    useLocalPosReadinessMock(...args),
 }));
 
 vi.mock("~/convex/_generated/api", () => ({
@@ -448,6 +449,67 @@ describe("POSRegisterOpeningGuard", () => {
     );
 
     expect(screen.getByText("Register workspace")).toBeInTheDocument();
+  });
+
+  it("keeps a reloaded register route open from local entry context while live state rehydrates", () => {
+    getActiveStoreMock.mockReturnValue({
+      activeStore: null,
+      isLoadingStores: false,
+    });
+    useLocalPosEntryContextMock.mockReturnValue({
+      status: "ready",
+      orgUrlSlug: "wigclub",
+      storeUrlSlug: "wigclub",
+      storeId: "store-from-local-seed",
+      terminalSeed: {
+        registeredAt: 1_778_000_000_000,
+        registeredByUserId: "user-1",
+        storeId: "store-from-local-seed",
+        terminalId: "terminal-1",
+      },
+      source: "local",
+    });
+    useQueryMock.mockReturnValue(undefined);
+    useLocalPosReadinessMock.mockImplementation((input) => {
+      expect(input).toMatchObject({
+        closeSnapshot: undefined,
+        entryContext: {
+          source: "local",
+          status: "ready",
+          storeId: "store-from-local-seed",
+        },
+        openingSnapshot: undefined,
+        operatingDate: "2026-05-09",
+      });
+
+      return {
+        status: "ready",
+        source: "local",
+        storeDayStatus: "started",
+      };
+    });
+
+    render(
+      <POSRegisterOpeningGuard>
+        <div>Register workspace</div>
+      </POSRegisterOpeningGuard>,
+    );
+
+    expect(screen.getByText("Register workspace")).toBeInTheDocument();
+    expect(useQueryMock).toHaveBeenCalledWith(
+      "getDailyOpeningSnapshot",
+      expect.objectContaining({
+        operatingDate: "2026-05-09",
+        storeId: "store-from-local-seed",
+      }),
+    );
+    expect(useQueryMock).toHaveBeenCalledWith(
+      "getDailyCloseSnapshot",
+      expect.objectContaining({
+        operatingDate: "2026-05-09",
+        storeId: "store-from-local-seed",
+      }),
+    );
   });
 
   it("shows setup-required guidance when local authority is missing", () => {

--- a/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
@@ -422,6 +422,15 @@ describe("registerAndProvisionPosTerminal", () => {
     render(<POSSettingsView />);
 
     expect(await screen.findByText("Terminal health")).toBeInTheDocument();
+    expect(screen.getByText("Offline diagnostics need attention")).toBeInTheDocument();
+    expect(
+      screen.getByText((_content, element) =>
+        Boolean(element?.textContent?.trim() === "0 of 6 ready"),
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("App shell readiness has not reported from this checkout station."),
+    ).toBeInTheDocument();
     expect(
       screen.getByText(
         "This settings page only changes the current checkout station.",

--- a/packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx
+++ b/packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx
@@ -21,6 +21,10 @@ import {
   type ProvisionedTerminalRecord,
 } from "@/lib/pos/application/registerAndProvisionPosTerminal";
 import { usePermissions } from "@/hooks/usePermissions";
+import {
+  buildPosOfflineReadinessSummary,
+  type PosOfflineReadinessSummary,
+} from "@/offline/posOfflineReadiness";
 
 type HealthLinkProps = {
   children: ReactNode;
@@ -50,6 +54,7 @@ type FingerprintRegistrationCardProps = {
   fingerprintError: string | null;
   existingTerminalName?: string | null;
   existingTerminalRegisterNumber?: string | null;
+  offlineReadiness: PosOfflineReadinessSummary;
 };
 
 function FingerprintRegistrationCard({
@@ -68,6 +73,7 @@ function FingerprintRegistrationCard({
   fingerprintError,
   existingTerminalName,
   existingTerminalRegisterNumber,
+  offlineReadiness,
 }: FingerprintRegistrationCardProps) {
   const terminalStatusLabel = fingerprintError
     ? "Needs attention"
@@ -171,6 +177,39 @@ function FingerprintRegistrationCard({
               {primaryActionLabel}
             </LoadingButton>
           )}
+        </div>
+
+        <div className="border-t border-border pt-layout-md">
+          <div className="flex flex-wrap items-center justify-between gap-layout-sm">
+            <div>
+              <p className="text-sm font-medium text-foreground">
+                {offlineReadiness.title}
+              </p>
+              <p className="mt-layout-2xs text-sm text-muted-foreground">
+                {offlineReadiness.description}
+              </p>
+            </div>
+            <span className="inline-flex rounded-full border border-border bg-background px-layout-sm py-layout-2xs text-sm text-muted-foreground">
+              {offlineReadiness.readyCount} of{" "}
+              {offlineReadiness.signals.length} ready
+            </span>
+          </div>
+
+          <dl className="mt-layout-md grid gap-layout-sm sm:grid-cols-2">
+            {offlineReadiness.signals.map((signal) => (
+              <div
+                className="rounded-md border border-border bg-background px-layout-sm py-layout-xs"
+                key={signal.domain}
+              >
+                <dt className="text-xs font-medium uppercase text-muted-foreground">
+                  {signal.label}
+                </dt>
+                <dd className="mt-layout-2xs text-sm text-foreground">
+                  {signal.description}
+                </dd>
+              </div>
+            ))}
+          </dl>
         </div>
       </div>
     </section>
@@ -530,6 +569,23 @@ export function POSSettingsView({
     registerNumber,
   ]);
 
+  const offlineReadiness = useMemo(
+    () =>
+      buildPosOfflineReadinessSummary({
+        appShell: null,
+        terminalSeed: existingTerminal
+          ? { ready: true }
+          : fingerprintError
+            ? { ready: false }
+            : { ready: false },
+        staffAuthority: null,
+        registerCatalog: null,
+        serviceCatalog: null,
+        availabilitySnapshot: null,
+      }),
+    [existingTerminal, fingerprintError],
+  );
+
   const handleRegisterTerminal = async () => {
     if (!activeStore?._id) {
       toast.error("Missing active store context");
@@ -656,6 +712,7 @@ export function POSSettingsView({
               existingTerminalRegisterNumber={
                 registrationState.existingTerminalRegisterNumber
               }
+              offlineReadiness={offlineReadiness}
             />
           </section>
 

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx
@@ -106,6 +106,7 @@ const baseSummary: TerminalHealthSummary = {
       availabilityAgeMs: 120_000,
       catalogAgeMs: 240_000,
       registerReadModelAgeMs: 60_000,
+      serviceCatalogAgeMs: 180_000,
     },
     source: "pos-hub",
     staffAuthority: {
@@ -253,6 +254,17 @@ describe("POSTerminalHealthViewContent", () => {
     expect(screen.getAllByText("Staff authority ready").length).toBeGreaterThan(0);
     expect(
       screen.getAllByText("Register session evidence is shown in cash controls").length,
+    ).toBeGreaterThan(0);
+    expect(screen.getAllByText("Offline diagnostics incomplete").length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(
+        "Service catalog data is available locally. Last refreshed 3 minutes ago.",
+      ).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(
+        "App shell readiness has not reported from this checkout station.",
+      ).length,
     ).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: /Front counter/i })).toHaveAttribute(
       "href",

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx
@@ -19,6 +19,10 @@ import { usePermissions } from "@/hooks/usePermissions";
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
 import {
+  buildPosOfflineReadinessSummary,
+  type PosOfflineReadinessSummary,
+} from "@/offline/posOfflineReadiness";
+import {
   classifyTerminalHealth,
   formatRegisterNumber,
   formatTerminalTimestamp,
@@ -64,6 +68,80 @@ function CountMetric({
       </p>
     </div>
   );
+}
+
+function OfflineReadinessDiagnostic({
+  readiness,
+}: {
+  readiness: PosOfflineReadinessSummary;
+}) {
+  return (
+    <div className="mt-layout-md border-t border-border pt-layout-md">
+      <div className="flex flex-wrap items-start justify-between gap-layout-sm">
+        <div>
+          <p className="text-sm font-medium text-foreground">
+            {readiness.title}
+          </p>
+          <p className="mt-layout-2xs text-sm text-muted-foreground">
+            {readiness.description}
+          </p>
+        </div>
+        <span className="inline-flex rounded-full border border-border bg-background px-layout-sm py-layout-2xs text-sm text-muted-foreground">
+          {readiness.readyCount} of {readiness.signals.length} ready
+        </span>
+      </div>
+
+      <dl className="mt-layout-md grid gap-layout-sm md:grid-cols-2 xl:grid-cols-3">
+        {readiness.signals.map((signal) => (
+          <div
+            className="rounded-md border border-border bg-background px-layout-sm py-layout-xs"
+            key={signal.domain}
+          >
+            <dt className="text-xs font-medium uppercase text-muted-foreground">
+              {signal.label}
+            </dt>
+            <dd className="mt-layout-2xs text-sm text-foreground">
+              {signal.description}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+function buildTerminalOfflineReadiness(
+  summary: TerminalHealthSummary,
+): PosOfflineReadinessSummary {
+  const runtimeStatus = summary.runtimeStatus;
+  const snapshots = runtimeStatus?.snapshots;
+  const appSessionRecovery = runtimeStatus?.appSessionRecovery?.status;
+
+  return buildPosOfflineReadinessSummary({
+    appShell: appSessionRecovery
+      ? {
+          ready: appSessionRecovery === "ready",
+        }
+      : null,
+    terminalSeed: runtimeStatus
+      ? { ready: runtimeStatus.localStore.terminalSeedReady }
+      : null,
+    staffAuthority: runtimeStatus
+      ? { ready: runtimeStatus.staffAuthority.status === "ready" }
+      : null,
+    registerCatalog:
+      snapshots?.catalogAgeMs !== undefined
+        ? { ageMs: snapshots.catalogAgeMs, ready: true }
+        : null,
+    serviceCatalog:
+      snapshots?.serviceCatalogAgeMs !== undefined
+        ? { ageMs: snapshots.serviceCatalogAgeMs, ready: true }
+        : null,
+    availabilitySnapshot:
+      snapshots?.availabilityAgeMs !== undefined
+        ? { ageMs: snapshots.availabilityAgeMs, ready: true }
+        : null,
+  });
 }
 
 export function POSTerminalHealthViewContent({
@@ -131,6 +209,8 @@ export function POSTerminalHealthViewContent({
                     const runtimeStatus = summary.runtimeStatus;
                     const primaryReason =
                       getPrimaryTerminalAttentionReason(summary);
+                    const offlineReadiness =
+                      buildTerminalOfflineReadiness(summary);
 
                     return (
                       <article
@@ -221,6 +301,10 @@ export function POSTerminalHealthViewContent({
                             </p>
                           </div>
                         </div>
+
+                        <OfflineReadinessDiagnostic
+                          readiness={offlineReadiness}
+                        />
                       </article>
                     );
                   })}

--- a/packages/athena-webapp/src/hooks/useGetActiveStore.test.ts
+++ b/packages/athena-webapp/src/hooks/useGetActiveStore.test.ts
@@ -1,0 +1,73 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import useGetActiveStore from "./useGetActiveStore";
+
+const useQueryMock = vi.fn();
+const useParamsMock = vi.fn();
+const useGetActiveOrganizationMock = vi.fn();
+const getStoresActionMock = vi.fn();
+
+vi.mock("convex/react", () => ({
+  useAction: () => getStoresActionMock,
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useParams: (...args: unknown[]) => useParamsMock(...args),
+}));
+
+vi.mock("./useGetOrganizations", () => ({
+  useGetActiveOrganization: () => useGetActiveOrganizationMock(),
+}));
+
+vi.mock("~/convex/_generated/api", () => ({
+  api: {
+    inventory: {
+      stores: {
+        getAll: "inventory.stores.getAll",
+        getAllByOrganization: "inventory.stores.getAllByOrganization",
+      },
+    },
+  },
+}));
+
+describe("useGetActiveStore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useGetActiveOrganizationMock.mockReturnValue({
+      activeOrganization: { _id: "org-1" },
+    });
+    useParamsMock.mockReturnValue({ storeUrlSlug: "downtown" });
+    useQueryMock.mockReturnValue([
+      { _id: "store-1", name: "Warehouse", slug: "warehouse" },
+      { _id: "store-2", name: "Downtown", slug: "downtown" },
+    ]);
+  });
+
+  it("returns the store matching the current route slug from the store query", () => {
+    const { result } = renderHook(() => useGetActiveStore());
+
+    expect(result.current.activeStore).toEqual({
+      _id: "store-2",
+      name: "Downtown",
+      slug: "downtown",
+    });
+    expect(result.current.isLoadingStores).toBe(false);
+    expect(getStoresActionMock).not.toHaveBeenCalled();
+  });
+
+  it("skips live store reads when the active organization is unavailable", () => {
+    useGetActiveOrganizationMock.mockReturnValue({
+      activeOrganization: null,
+    });
+    useQueryMock.mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useGetActiveStore());
+
+    expect(useQueryMock).toHaveBeenCalledWith("inventory.stores.getAll", "skip");
+    expect(result.current.activeStore).toBeNull();
+    expect(result.current.isLoadingStores).toBe(false);
+    expect(getStoresActionMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/athena-webapp/src/hooks/useGetActiveStore.ts
+++ b/packages/athena-webapp/src/hooks/useGetActiveStore.ts
@@ -1,15 +1,12 @@
-import { useAction, useQuery } from "convex/react";
+import { useQuery } from "convex/react";
 // import { useQuery } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
 import { useGetActiveOrganization } from "./useGetOrganizations";
 import { api } from "~/convex/_generated/api";
-import { useEffect, useState } from "react";
 import { Store } from "~/types";
 
 export default function useGetActiveStore() {
   const { activeOrganization } = useGetActiveOrganization();
-
-  const [store, setStore] = useState<Store | null>();
 
   const stores = useQuery(
     api.inventory.stores.getAll,
@@ -20,30 +17,15 @@ export default function useGetActiveStore() {
       : "skip"
   );
 
-  const getStores = useAction(api.inventory.stores.getAllByOrganization);
-
-  useEffect(() => {
-    const fetchStores = async () => {
-      if (activeOrganization?._id) {
-        const { storesWithReelVersions } = await getStores({
-          organizationId: activeOrganization._id,
-        });
-
-        setStore(storesWithReelVersions[0] ?? null);
-
-        // console.log("s", s);
-      }
-    };
-    fetchStores();
-  }, [activeOrganization?._id, getStores]);
-
   const { storeUrlSlug } = useParams({ strict: false });
 
-  const activeStore = stores?.find((store: any) => store.slug == storeUrlSlug);
+  const activeStore = (stores?.find(
+    (store: Store) => store.slug === storeUrlSlug,
+  ) ?? null) as Store | null;
 
   return {
-    activeStore: store,
-    isLoadingStores: Boolean(activeOrganization?._id && store === undefined),
+    activeStore,
+    isLoadingStores: Boolean(activeOrganization?._id && stores === undefined),
   };
 }
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts
@@ -55,6 +55,11 @@ describe("terminalRuntimeStatus", () => {
       ],
       localStoreFailureMessage:
         "syncSecretHash abcdef1234567890abcdef1234567890 failed",
+      snapshots: {
+        availabilityRefreshedAt: 1_880,
+        catalogRefreshedAt: 1_760,
+        serviceCatalogRefreshedAt: 1_820,
+      },
       source: "register",
       staffAuthorityStatus: "ready",
       staffProfileId: "staff-1",
@@ -111,7 +116,11 @@ describe("terminalRuntimeStatus", () => {
         terminalSeedReady: true,
       },
       reportedAt: 2_000,
-      snapshots: {},
+      snapshots: {
+        availabilityAgeMs: 120,
+        catalogAgeMs: 240,
+        serviceCatalogAgeMs: 180,
+      },
       source: "register",
       staffAuthority: {
         staffProfileId: "staff-1",

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -1090,7 +1090,9 @@ describe("usePosLocalSyncRuntimeStatus", () => {
       }),
     );
 
-    await waitFor(() => expect(mocks.ingestLocalEvents).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.ingestLocalEvents).toHaveBeenCalled(), {
+      timeout: 3_000,
+    });
     expect(store.writeTerminalIntegrityState).toHaveBeenCalledWith(
       expect.objectContaining({
         cloudTerminalId: "terminal-cloud-1",
@@ -1163,7 +1165,9 @@ describe("usePosLocalSyncRuntimeStatus", () => {
       }),
     );
 
-    await waitFor(() => expect(mocks.ingestLocalEvents).toHaveBeenCalled());
+    await waitFor(() => expect(mocks.ingestLocalEvents).toHaveBeenCalled(), {
+      timeout: 5_000,
+    });
     expect(store.markEventsNeedsReview).not.toHaveBeenCalled();
     expect(store.markEventsSynced).not.toHaveBeenCalled();
     expect(store.writeDrawerAuthorityState).not.toHaveBeenCalled();

--- a/packages/athena-webapp/src/main.tsx
+++ b/packages/athena-webapp/src/main.tsx
@@ -7,6 +7,7 @@ import { ConvexAuthProvider } from "@convex-dev/auth/react";
 import "./index.css";
 import { useEffect } from "react";
 import { createVersionChecker } from "./utils/versionChecker";
+import { registerPosAppShellServiceWorker } from "./offline/registerPosAppShellServiceWorker";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -61,6 +62,7 @@ function App() {
 const rootElement = document.getElementById("app")!;
 
 if (!rootElement.innerHTML) {
+  registerPosAppShellServiceWorker();
   const root = ReactDOM.createRoot(rootElement);
   root.render(<App />);
 }

--- a/packages/athena-webapp/src/offline/posAppShellRoutes.test.ts
+++ b/packages/athena-webapp/src/offline/posAppShellRoutes.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  isExcludedFromPosAppShellCache,
+  isPosAppShellNavigationRequest,
+  isPosAppShellRoutePath,
+  isPosAppShellStaticAssetRequest,
+} from "./posAppShellRoutes";
+
+const origin = "https://athena.example";
+
+describe("POS app-shell route policy", () => {
+  it("matches POS hub and register route paths", () => {
+    expect(isPosAppShellRoutePath("/acme/store/main/pos")).toBe(true);
+    expect(isPosAppShellRoutePath("/acme/store/main/pos/register")).toBe(true);
+    expect(isPosAppShellRoutePath("/acme/store/main/operations")).toBe(false);
+  });
+
+  it("allows same-origin POS navigation fallback requests", () => {
+    expect(
+      isPosAppShellNavigationRequest(
+        {
+          url: `${origin}/acme/store/main/pos/register`,
+          mode: "navigate",
+        },
+        origin,
+      ),
+    ).toBe(true);
+  });
+
+  it("does not classify non-POS protected routes as POS app-shell fallback", () => {
+    expect(
+      isPosAppShellNavigationRequest(
+        {
+          url: `${origin}/acme/store/main/operations/daily-close-history`,
+          mode: "navigate",
+        },
+        origin,
+      ),
+    ).toBe(false);
+  });
+
+  it("excludes Convex and API requests even when they originate from POS routes", () => {
+    expect(
+      isPosAppShellNavigationRequest(
+        {
+          url: `${origin}/api/pos/register`,
+          mode: "navigate",
+        },
+        origin,
+      ),
+    ).toBe(false);
+
+    expect(
+      isExcludedFromPosAppShellCache(
+        new URL(`${origin}/acme/store/main/pos/convex/query`),
+      ),
+    ).toBe(true);
+  });
+
+  it("allows generated Convex client modules as static shell assets", () => {
+    expect(
+      isExcludedFromPosAppShellCache(
+        new URL(`${origin}/convex/_generated/api.js`),
+      ),
+    ).toBe(false);
+  });
+
+  it("allows same-origin static shell assets but excludes data payloads", () => {
+    expect(
+      isPosAppShellStaticAssetRequest(
+        {
+          url: `${origin}/assets/register.js`,
+          destination: "script",
+        },
+        origin,
+      ),
+    ).toBe(true);
+
+    expect(
+      isPosAppShellStaticAssetRequest(
+        {
+          url: `${origin}/assets/register.json`,
+          destination: "script",
+        },
+        origin,
+      ),
+    ).toBe(false);
+  });
+
+  it("allows production bundle assets when request destination is unavailable", () => {
+    expect(
+      isPosAppShellStaticAssetRequest(
+        {
+          url: `${origin}/assets/register-BTL1OY3E.js`,
+        },
+        origin,
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/athena-webapp/src/offline/posAppShellRoutes.ts
+++ b/packages/athena-webapp/src/offline/posAppShellRoutes.ts
@@ -1,0 +1,121 @@
+const POS_SEGMENT = "pos";
+
+const excludedPathPrefixes = [
+  "/api",
+  "/convex",
+  "/_convex",
+  "/auth",
+  "/.well-known",
+];
+
+const excludedStaticExtensions = [
+  ".json",
+  ".map",
+  ".txt",
+  ".xml",
+];
+
+const shellAssetExtensions = [
+  ".css",
+  ".js",
+  ".mjs",
+  ".woff",
+  ".woff2",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".svg",
+  ".webp",
+];
+
+const shellAssetPrefixes = [
+  "/assets/",
+  "/src/",
+  "/@vite/",
+  "/node_modules/",
+];
+
+export type PosAppShellRequestLike = {
+  url: string;
+  method?: string;
+  mode?: string;
+  destination?: string;
+  headers?: Pick<Headers, "get"> | PosAppShellHeaderRecord;
+};
+
+type PosAppShellHeaderRecord = Record<string, string | undefined>;
+
+export function isPosAppShellRoutePath(pathname: string): boolean {
+  const segments = pathname.split("/").filter(Boolean);
+  return segments.includes(POS_SEGMENT);
+}
+
+export function isExcludedFromPosAppShellCache(url: URL): boolean {
+  const pathname = url.pathname.toLowerCase();
+
+  if (pathname.startsWith("/convex/_generated/")) {
+    return false;
+  }
+
+  if (excludedPathPrefixes.some((prefix) => pathname.startsWith(prefix))) {
+    return true;
+  }
+
+  if (excludedStaticExtensions.some((extension) => pathname.endsWith(extension))) {
+    return true;
+  }
+
+  return pathname.includes("/api/") || pathname.includes("/convex/");
+}
+
+export function isPosAppShellNavigationRequest(
+  request: PosAppShellRequestLike,
+  origin: string,
+): boolean {
+  const url = new URL(request.url, origin);
+
+  if (url.origin !== origin) return false;
+  if ((request.method ?? "GET").toUpperCase() !== "GET") return false;
+  if (isExcludedFromPosAppShellCache(url)) return false;
+  if (!isPosAppShellRoutePath(url.pathname)) return false;
+
+  if (request.mode === "navigate") return true;
+
+  const accept = readHeader(request.headers, "accept");
+  return Boolean(accept?.includes("text/html"));
+}
+
+export function isPosAppShellStaticAssetRequest(
+  request: PosAppShellRequestLike,
+  origin: string,
+): boolean {
+  const url = new URL(request.url, origin);
+
+  if (url.origin !== origin) return false;
+  if ((request.method ?? "GET").toUpperCase() !== "GET") return false;
+  if (isExcludedFromPosAppShellCache(url)) return false;
+
+  return (
+    ["script", "style", "font", "image"].includes(request.destination ?? "") ||
+    shellAssetExtensions.some((extension) =>
+      url.pathname.toLowerCase().endsWith(extension),
+    ) ||
+    shellAssetPrefixes.some((prefix) => url.pathname.startsWith(prefix))
+  );
+}
+
+function readHeader(
+  headers: PosAppShellRequestLike["headers"],
+  name: string,
+): string | undefined {
+  if (!headers) return undefined;
+  if ("get" in headers && typeof headers.get === "function") {
+    return headers.get(name) ?? undefined;
+  }
+
+  const headerRecord = headers as PosAppShellHeaderRecord;
+  const direct = headerRecord[name];
+  if (direct) return direct;
+
+  return headerRecord[name.toLowerCase()];
+}

--- a/packages/athena-webapp/src/offline/posOfflineReadiness.test.ts
+++ b/packages/athena-webapp/src/offline/posOfflineReadiness.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPosOfflineReadinessSummary } from "./posOfflineReadiness";
+
+describe("buildPosOfflineReadinessSummary", () => {
+  it("keeps each offline readiness domain distinct", () => {
+    const summary = buildPosOfflineReadinessSummary({
+      appShell: { ready: true },
+      availabilitySnapshot: { ready: true, ageMs: 10 * 60_000 },
+      registerCatalog: { ready: true, ageMs: 20 * 60_000 },
+      serviceCatalog: { ready: true, ageMs: 30 * 60_000 },
+      staffAuthority: { ready: true },
+      terminalSeed: { ready: true },
+    });
+
+    expect(summary.status).toBe("ready");
+    expect(summary.readyCount).toBe(6);
+    expect(summary.signals.map((signal) => signal.domain)).toEqual([
+      "app_shell",
+      "terminal_seed",
+      "staff_authority",
+      "register_catalog",
+      "service_catalog",
+      "availability_snapshot",
+    ]);
+    expect(summary.description).toContain("diagnostic view");
+  });
+
+  it("reports stale snapshots as diagnostic attention without authorizing sales", () => {
+    const summary = buildPosOfflineReadinessSummary({
+      appShell: { ready: true },
+      availabilitySnapshot: { ready: true, ageMs: 49 * 60 * 60_000 },
+      registerCatalog: { ready: true, ageMs: 5 * 60_000 },
+      serviceCatalog: { ready: true, ageMs: 5 * 60_000 },
+      staffAuthority: { ready: true },
+      terminalSeed: { ready: true },
+    });
+
+    expect(summary.status).toBe("needs_attention");
+    expect(summary.description).toBe(
+      "One or more offline readiness signals need attention. This view is diagnostic only.",
+    );
+    expect(
+      summary.signals.find(
+        (signal) => signal.domain === "availability_snapshot",
+      ),
+    ).toMatchObject({
+      description: "Availability snapshot is 2 days old.",
+      status: "needs_attention",
+    });
+  });
+
+  it("keeps app shell readiness unknown when it has not integrated yet", () => {
+    const summary = buildPosOfflineReadinessSummary({
+      terminalSeed: { ready: true },
+    });
+
+    expect(summary.status).toBe("unknown");
+    expect(summary.readyCount).toBe(1);
+    expect(summary.signals[0]).toMatchObject({
+      domain: "app_shell",
+      status: "unknown",
+    });
+  });
+});

--- a/packages/athena-webapp/src/offline/posOfflineReadiness.ts
+++ b/packages/athena-webapp/src/offline/posOfflineReadiness.ts
@@ -1,0 +1,269 @@
+export type PosOfflineReadinessDomain =
+  | "app_shell"
+  | "terminal_seed"
+  | "staff_authority"
+  | "register_catalog"
+  | "service_catalog"
+  | "availability_snapshot";
+
+export type PosOfflineReadinessSignalStatus =
+  | "ready"
+  | "needs_attention"
+  | "unknown";
+
+export type PosOfflineReadinessSignalInput = {
+  ageMs?: number | null;
+  label?: string;
+  ready?: boolean | null;
+  status?: PosOfflineReadinessSignalStatus;
+};
+
+export type PosOfflineReadinessInput = {
+  appShell?: PosOfflineReadinessSignalInput | null;
+  availabilitySnapshot?: PosOfflineReadinessSignalInput | null;
+  registerCatalog?: PosOfflineReadinessSignalInput | null;
+  serviceCatalog?: PosOfflineReadinessSignalInput | null;
+  staffAuthority?: PosOfflineReadinessSignalInput | null;
+  terminalSeed?: PosOfflineReadinessSignalInput | null;
+};
+
+export type PosOfflineReadinessSignal = {
+  description: string;
+  domain: PosOfflineReadinessDomain;
+  label: string;
+  status: PosOfflineReadinessSignalStatus;
+};
+
+export type PosOfflineReadinessSummary = {
+  description: string;
+  readyCount: number;
+  signals: PosOfflineReadinessSignal[];
+  status: PosOfflineReadinessSignalStatus;
+  title: string;
+};
+
+type DomainDefinition = {
+  domain: PosOfflineReadinessDomain;
+  label: string;
+  missingDescription: string;
+  needsAttentionDescription: string;
+  readyDescription: string;
+  staleAfterMs?: number;
+};
+
+const DAY_MS = 24 * 60 * 60_000;
+
+const DOMAIN_DEFINITIONS: Array<{
+  definition: DomainDefinition;
+  getInput: (
+    input: PosOfflineReadinessInput,
+  ) => PosOfflineReadinessSignalInput | null | undefined;
+}> = [
+  {
+    definition: {
+      domain: "app_shell",
+      label: "App shell",
+      missingDescription:
+        "App shell readiness has not reported from this checkout station.",
+      needsAttentionDescription:
+        "App shell recovery needs attention before offline route access is reliable.",
+      readyDescription: "App shell recovery is ready.",
+    },
+    getInput: (input) => input.appShell,
+  },
+  {
+    definition: {
+      domain: "terminal_seed",
+      label: "Terminal setup",
+      missingDescription:
+        "Terminal setup has not reported from this checkout station.",
+      needsAttentionDescription:
+        "Terminal setup data is missing on this checkout station.",
+      readyDescription: "Terminal setup data is stored locally.",
+    },
+    getInput: (input) => input.terminalSeed,
+  },
+  {
+    definition: {
+      domain: "staff_authority",
+      label: "Staff authority",
+      missingDescription: "Staff authority readiness has not reported yet.",
+      needsAttentionDescription:
+        "Local staff authority is missing or expired on this checkout station.",
+      readyDescription: "Local staff authority is ready.",
+      staleAfterMs: DAY_MS,
+    },
+    getInput: (input) => input.staffAuthority,
+  },
+  {
+    definition: {
+      domain: "register_catalog",
+      label: "Register catalog",
+      missingDescription: "Register catalog freshness has not reported yet.",
+      needsAttentionDescription:
+        "Register catalog data needs a fresh local snapshot.",
+      readyDescription: "Register catalog data is available locally.",
+      staleAfterMs: DAY_MS,
+    },
+    getInput: (input) => input.registerCatalog,
+  },
+  {
+    definition: {
+      domain: "service_catalog",
+      label: "Service catalog",
+      missingDescription: "Service catalog freshness has not reported yet.",
+      needsAttentionDescription:
+        "Service catalog data needs a fresh local snapshot.",
+      readyDescription: "Service catalog data is available locally.",
+      staleAfterMs: DAY_MS,
+    },
+    getInput: (input) => input.serviceCatalog,
+  },
+  {
+    definition: {
+      domain: "availability_snapshot",
+      label: "Availability snapshot",
+      missingDescription:
+        "Availability snapshot freshness has not reported yet.",
+      needsAttentionDescription:
+        "Availability data needs a fresh local snapshot.",
+      readyDescription: "Availability data is available locally.",
+      staleAfterMs: DAY_MS,
+    },
+    getInput: (input) => input.availabilitySnapshot,
+  },
+];
+
+export function buildPosOfflineReadinessSummary(
+  input: PosOfflineReadinessInput,
+): PosOfflineReadinessSummary {
+  const signals = DOMAIN_DEFINITIONS.map(({ definition, getInput }) =>
+    buildSignal(definition, getInput(input)),
+  );
+  const readyCount = signals.filter((signal) => signal.status === "ready").length;
+  const needsAttentionCount = signals.filter(
+    (signal) => signal.status === "needs_attention",
+  ).length;
+  const status =
+    needsAttentionCount > 0
+      ? "needs_attention"
+      : readyCount === signals.length
+        ? "ready"
+        : "unknown";
+
+  return {
+    description: getSummaryDescription(status, readyCount, signals.length),
+    readyCount,
+    signals,
+    status,
+    title: getSummaryTitle(status),
+  };
+}
+
+function buildSignal(
+  definition: DomainDefinition,
+  input: PosOfflineReadinessSignalInput | null | undefined,
+): PosOfflineReadinessSignal {
+  if (!input) {
+    return {
+      description: definition.missingDescription,
+      domain: definition.domain,
+      label: definition.label,
+      status: "unknown",
+    };
+  }
+
+  const status = getSignalStatus(definition, input);
+
+  return {
+    description: input.label ?? getSignalDescription(definition, input, status),
+    domain: definition.domain,
+    label: definition.label,
+    status,
+  };
+}
+
+function getSignalStatus(
+  definition: DomainDefinition,
+  input: PosOfflineReadinessSignalInput,
+): PosOfflineReadinessSignalStatus {
+  if (input.status) return input.status;
+  if (input.ready === false) return "needs_attention";
+  if (input.ready === true) {
+    if (
+      definition.staleAfterMs &&
+      typeof input.ageMs === "number" &&
+      Number.isFinite(input.ageMs) &&
+      input.ageMs > definition.staleAfterMs
+    ) {
+      return "needs_attention";
+    }
+    return "ready";
+  }
+  return "unknown";
+}
+
+function getSignalDescription(
+  definition: DomainDefinition,
+  input: PosOfflineReadinessSignalInput,
+  status: PosOfflineReadinessSignalStatus,
+) {
+  if (status === "needs_attention") {
+    if (
+      definition.staleAfterMs &&
+      typeof input.ageMs === "number" &&
+      input.ageMs > definition.staleAfterMs
+    ) {
+      return `${definition.label} is ${formatAge(input.ageMs)} old.`;
+    }
+    return definition.needsAttentionDescription;
+  }
+
+  if (status === "ready") {
+    if (typeof input.ageMs === "number" && Number.isFinite(input.ageMs)) {
+      return `${definition.readyDescription} Last refreshed ${formatAge(
+        input.ageMs,
+      )} ago.`;
+    }
+    return definition.readyDescription;
+  }
+
+  return definition.missingDescription;
+}
+
+function getSummaryTitle(status: PosOfflineReadinessSignalStatus) {
+  if (status === "ready") return "Offline diagnostics ready";
+  if (status === "needs_attention") return "Offline diagnostics need attention";
+  return "Offline diagnostics incomplete";
+}
+
+function getSummaryDescription(
+  status: PosOfflineReadinessSignalStatus,
+  readyCount: number,
+  totalCount: number,
+) {
+  if (status === "ready") {
+    return "This diagnostic view has all offline readiness signals. Sale authorization still comes from the register workflow.";
+  }
+
+  if (status === "needs_attention") {
+    return "One or more offline readiness signals need attention. This view is diagnostic only.";
+  }
+
+  return `${readyCount} of ${totalCount} offline readiness signals have reported. This view is diagnostic only.`;
+}
+
+function formatAge(ageMs: number) {
+  const minutes = Math.max(1, Math.round(ageMs / 60_000));
+  if (minutes < 60) {
+    return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) {
+    return `${hours} hour${hours === 1 ? "" : "s"}`;
+  }
+
+  const days = Math.round(hours / 24);
+  return `${days} day${days === 1 ? "" : "s"}`;
+}

--- a/packages/athena-webapp/src/offline/registerPosAppShellServiceWorker.test.ts
+++ b/packages/athena-webapp/src/offline/registerPosAppShellServiceWorker.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  registerPosAppShellServiceWorker,
+  resetPosAppShellServiceWorkerRegistrationForTest,
+} from "./registerPosAppShellServiceWorker";
+
+describe("registerPosAppShellServiceWorker", () => {
+  afterEach(() => {
+    resetPosAppShellServiceWorkerRegistrationForTest();
+    vi.restoreAllMocks();
+  });
+
+  it("registers the POS app-shell service worker when supported", () => {
+    const register = vi.fn().mockResolvedValue({});
+    const win = {
+      navigator: {
+        serviceWorker: { register },
+      },
+    } as unknown as Window;
+
+    registerPosAppShellServiceWorker(win);
+
+    expect(register).toHaveBeenCalledWith("/pos-app-shell-sw.js", { scope: "/" });
+  });
+
+  it("does not register when service workers are unavailable", () => {
+    const win = { navigator: {} } as Window;
+
+    expect(() => registerPosAppShellServiceWorker(win)).not.toThrow();
+  });
+
+  it("does not start duplicate registrations", () => {
+    const register = vi.fn().mockResolvedValue({});
+    const win = {
+      navigator: {
+        serviceWorker: { register },
+      },
+    } as unknown as Window;
+
+    registerPosAppShellServiceWorker(win);
+    registerPosAppShellServiceWorker(win);
+
+    expect(register).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a later retry after registration fails", async () => {
+    const register = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockResolvedValueOnce({});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const win = {
+      navigator: {
+        serviceWorker: { register },
+      },
+    } as unknown as Window;
+
+    registerPosAppShellServiceWorker(win);
+    await vi.waitFor(() => expect(warn).toHaveBeenCalled());
+
+    registerPosAppShellServiceWorker(win);
+
+    expect(register).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/athena-webapp/src/offline/registerPosAppShellServiceWorker.ts
+++ b/packages/athena-webapp/src/offline/registerPosAppShellServiceWorker.ts
@@ -1,0 +1,21 @@
+const POS_APP_SHELL_SERVICE_WORKER_URL = "/pos-app-shell-sw.js";
+
+let registrationStarted = false;
+
+export function registerPosAppShellServiceWorker(win: Window = window): void {
+  if (registrationStarted) return;
+  if (!("serviceWorker" in win.navigator)) return;
+
+  registrationStarted = true;
+
+  win.navigator.serviceWorker
+    .register(POS_APP_SHELL_SERVICE_WORKER_URL, { scope: "/" })
+    .catch((error: unknown) => {
+      registrationStarted = false;
+      console.warn("POS offline app shell is not available.", error);
+    });
+}
+
+export function resetPosAppShellServiceWorkerRegistrationForTest(): void {
+  registrationStarted = false;
+}

--- a/packages/athena-webapp/src/routes/_authed.test.tsx
+++ b/packages/athena-webapp/src/routes/_authed.test.tsx
@@ -487,6 +487,26 @@ describe("Authed layout", () => {
     expect(screen.getByTestId("authed-outlet")).toBeInTheDocument();
   });
 
+  it("mounts the signed-in POS register through the POS-only shell when a terminal seed is ready", () => {
+    mocked.useAuth.mockReturnValue({
+      user: { _id: "user-1", email: "cashier@example.com" },
+      isLoading: false,
+    });
+    mocked.useLocalPosEntryContext.mockReturnValue(readyLocalPosEntryContext());
+    mocked.useRouterState.mockImplementation(({ select }) =>
+      select({ location: { pathname: "/wigclub/store/wigclub/pos/register" } }),
+    );
+
+    render(<Layout />);
+
+    expect(screen.getByTestId("authed-outlet")).toBeInTheDocument();
+    expect(screen.queryByTestId("app-sidebar")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("app-header")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("store-modal")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("organization-modal")).not.toBeInTheDocument();
+    expect(mocked.navigate).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["/wigclub/store/wigclub/pos", "POS hub"],
     ["/wigclub/store/wigclub/pos/register", "POS register child"],

--- a/packages/athena-webapp/src/routes/_authed.tsx
+++ b/packages/athena-webapp/src/routes/_authed.tsx
@@ -457,8 +457,18 @@ export default function Layout() {
     isLoading &&
     isBrowserOffline() &&
     hasStoredLocalSession();
+  const routeWantsFullscreen =
+    isPosRegisterPath(pathname) ||
+    (isUnknownRouterPath(pathname) && isPosRegisterPath(browserPathname));
+  const canRenderSignedInPosRegisterShell =
+    Boolean(user) &&
+    routeWantsFullscreen &&
+    localPosEntryContext.status === "ready" &&
+    Boolean(localPosEntryContext.terminalSeed);
   const shouldRenderPosTerminalShell =
-    canRenderRehydratingPosShell || isRecoveredPosAppSession;
+    canRenderRehydratingPosShell ||
+    isRecoveredPosAppSession ||
+    canRenderSignedInPosRegisterShell;
   const shouldRenderPendingPosTerminalShell =
     isPendingPosAppSessionRecovery || isClassifyingPosAppSession;
   const userEmail =
@@ -466,9 +476,6 @@ export default function Layout() {
     (shouldRenderPosTerminalShell || shouldRenderPendingPosTerminalShell
       ? "POS terminal"
       : "");
-  const routeWantsFullscreen =
-    isPosRegisterPath(pathname) ||
-    (isUnknownRouterPath(pathname) && isPosRegisterPath(browserPathname));
   const isFullscreenActive = fullscreenOverride ?? routeWantsFullscreen;
 
   // useEffect(() => {

--- a/packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts
+++ b/packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts
@@ -1,0 +1,258 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const POS_REGISTER_PATH = "/wigclub/store/wigclub/pos/register";
+
+async function waitForPosAppShellServiceWorkerReady(page: Page) {
+  await page.waitForFunction(async () => {
+    if (!("serviceWorker" in navigator) || !("caches" in window)) {
+      return false;
+    }
+
+    const registration = await navigator.serviceWorker.ready;
+    if (!registration.active) return false;
+
+    const cacheNames = await caches.keys();
+    const hasPosShellCache = cacheNames.some((name) =>
+      name.startsWith("athena-pos-app-shell-"),
+    );
+    if (!hasPosShellCache) return false;
+
+    if (navigator.serviceWorker.controller) return true;
+
+    await new Promise<void>((resolve) => {
+      navigator.serviceWorker.addEventListener("controllerchange", () => resolve(), {
+        once: true,
+      });
+    });
+
+    return Boolean(navigator.serviceWorker.controller);
+  });
+}
+
+async function waitForPosAppShellCache(page: Page) {
+  await page.waitForFunction(async () => {
+    const cacheNames = await caches.keys();
+    const posShellCacheName = cacheNames.find((name) =>
+      name.startsWith("athena-pos-app-shell-"),
+    );
+    if (!posShellCacheName) return false;
+
+    const cache = await caches.open(posShellCacheName);
+    const cachedRoute = await cache.match(window.location.href);
+
+    return Boolean(cachedRoute);
+  });
+}
+
+async function waitForLoadedShellAssetsCached(page: Page) {
+  await page.waitForFunction(async () => {
+    const cacheNames = await caches.keys();
+    const posShellCacheName = cacheNames.find((name) =>
+      name.startsWith("athena-pos-app-shell-"),
+    );
+    if (!posShellCacheName) return false;
+
+    const cache = await caches.open(posShellCacheName);
+    const loadedShellAssetUrls = performance
+      .getEntriesByType("resource")
+      .map((entry) => entry.name)
+      .filter((url) => {
+        const parsedUrl = new URL(url, window.location.href);
+        return (
+          parsedUrl.origin === window.location.origin &&
+          parsedUrl.pathname.startsWith("/assets/")
+        );
+      });
+
+    if (loadedShellAssetUrls.length === 0) return false;
+
+    const cachedAssets = await Promise.all(
+      loadedShellAssetUrls.map((url) => cache.match(url)),
+    );
+
+    return cachedAssets.every(Boolean);
+  });
+}
+
+async function warmCurrentPosAppShell(page: Page) {
+  const result = await page.evaluate(async () => {
+    const controller = navigator.serviceWorker.controller;
+    if (!controller) {
+      throw new Error("POS app-shell service worker is not controlling the page");
+    }
+
+    const id = `warm-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+    return await new Promise<{ cacheName: string; cachedRequests: number }>(
+      (resolve, reject) => {
+        const timeout = window.setTimeout(() => {
+          navigator.serviceWorker.removeEventListener("message", handleMessage);
+          reject(new Error("Timed out warming the POS app shell"));
+        }, 20_000);
+
+        function handleMessage(event: MessageEvent) {
+          const data = event.data;
+          if (!data || data.id !== id) return;
+
+          window.clearTimeout(timeout);
+          navigator.serviceWorker.removeEventListener("message", handleMessage);
+
+          if (data.type === "athena-pos-app-shell:warm-complete") {
+            resolve(data.result);
+            return;
+          }
+
+          reject(new Error(data.error ?? "Failed to warm the POS app shell"));
+        }
+
+        navigator.serviceWorker.addEventListener("message", handleMessage);
+        controller.postMessage({
+          type: "athena-pos-app-shell:warm",
+          id,
+          url: window.location.href,
+        });
+      },
+    );
+  });
+
+  expect(result.cacheName).toMatch(/^athena-pos-app-shell-/);
+  expect(result.cachedRequests).toBeGreaterThan(0);
+}
+
+async function expectNoBusinessPayloadsCached(page: Page) {
+  const cachedUrls = await page.evaluate(async () => {
+    const cacheNames = await caches.keys();
+    const urls: string[] = [];
+
+    for (const cacheName of cacheNames) {
+      if (!cacheName.startsWith("athena-pos-app-shell-")) continue;
+      const cache = await caches.open(cacheName);
+      const keys = await cache.keys();
+      urls.push(...keys.map((request) => request.url));
+    }
+
+    return urls;
+  });
+
+  expect(cachedUrls).not.toContainEqual(expect.stringMatching(/\/api(?:\/|$)/));
+  expect(cachedUrls).not.toContainEqual(
+    expect.stringMatching(/\/convex\/(?!_generated\/)/),
+  );
+  expect(cachedUrls).not.toContainEqual(expect.stringMatching(/\.json(?:\?|$)/));
+}
+
+async function expectPosRegisterRouteChunksCached(page: Page) {
+  const cachedUrls = await getPosAppShellCachedUrls(page);
+
+  expect(cachedUrls).toContainEqual(expect.stringMatching(/\/assets\/register\.index-/));
+  expect(cachedUrls).toContainEqual(expect.stringMatching(/\/assets\/POSRegisterView-/));
+}
+
+async function getPosAppShellCachedUrls(page: Page) {
+  return await page.evaluate(async () => {
+    const cacheNames = await caches.keys();
+    const urls: string[] = [];
+
+    for (const cacheName of cacheNames) {
+      if (!cacheName.startsWith("athena-pos-app-shell-")) continue;
+      const cache = await caches.open(cacheName);
+      const keys = await cache.keys();
+      urls.push(...keys.map((request) => request.url));
+    }
+
+    return urls;
+  });
+}
+
+async function collectOfflineAppShellDiagnostics(page: Page) {
+  return await page.evaluate(async () => {
+    const cacheNames = await caches.keys();
+    const cachedUrls: string[] = [];
+
+    for (const cacheName of cacheNames) {
+      if (!cacheName.startsWith("athena-pos-app-shell-")) continue;
+      const cache = await caches.open(cacheName);
+      const keys = await cache.keys();
+      cachedUrls.push(...keys.map((request) => request.url));
+    }
+
+    return {
+      appHtml: document.querySelector("#app")?.innerHTML.slice(0, 500) ?? null,
+      cachedAssetCount: cachedUrls.filter((url) => new URL(url).pathname.startsWith("/assets/"))
+        .length,
+      cachedRouteCount: cachedUrls.filter((url) => !new URL(url).pathname.startsWith("/assets/"))
+        .length,
+      readyState: document.readyState,
+    };
+  });
+}
+
+function formatRuntimeSignals(runtimeSignals: string[]) {
+  return runtimeSignals.slice(-20).join(" | ") || "none";
+}
+
+async function waitForRenderedAppShell(page: Page, runtimeSignals: string[] = []) {
+  try {
+    await expect(page.locator("#app")).not.toBeEmpty({ timeout: 30_000 });
+  } catch (error) {
+    const diagnostics = await collectOfflineAppShellDiagnostics(page);
+    throw new Error(
+      `${error instanceof Error ? error.message : String(error)}\nPOS app-shell diagnostics: ${JSON.stringify(diagnostics)}\nPOS app-shell runtime signals: ${formatRuntimeSignals(runtimeSignals)}`,
+    );
+  }
+  await expect(page.locator("body")).toContainText(/POS|Athena|checkout|sign in/i, {
+    timeout: 30_000,
+  });
+}
+
+test.describe("POS offline route access", () => {
+  test("serves the POS register app shell after a no-network hard reload", async ({
+    context,
+    page,
+  }) => {
+    const runtimeSignals: string[] = [];
+    page.on("console", (message) => {
+      if (["error", "warning"].includes(message.type())) {
+        runtimeSignals.push(`console:${message.type()}:${message.text()}`);
+      }
+    });
+    page.on("pageerror", (error) => {
+      runtimeSignals.push(`pageerror:${error.message}`);
+    });
+    page.on("requestfailed", (request) => {
+      const url = new URL(request.url());
+      if (url.origin === new URL(page.url()).origin && url.pathname.startsWith("/assets/")) {
+        runtimeSignals.push(
+          `requestfailed:${url.pathname}:${request.failure()?.errorText ?? "unknown"}`,
+        );
+      }
+    });
+
+    await page.goto(POS_REGISTER_PATH, { waitUntil: "load" });
+    await waitForRenderedAppShell(page, runtimeSignals);
+    await waitForPosAppShellServiceWorkerReady(page);
+    await page.reload({ waitUntil: "load" });
+    await waitForRenderedAppShell(page, runtimeSignals);
+    await waitForPosAppShellCache(page);
+    await waitForLoadedShellAssetsCached(page);
+    await warmCurrentPosAppShell(page);
+    await expectPosRegisterRouteChunksCached(page);
+    await expectNoBusinessPayloadsCached(page);
+
+    await context.setOffline(true);
+
+    try {
+      await page.reload({ waitUntil: "domcontentloaded" });
+      try {
+        await waitForRenderedAppShell(page, runtimeSignals);
+      } catch (error) {
+        throw new Error(
+          `${error instanceof Error ? error.message : String(error)}\nPOS app-shell runtime signals: ${formatRuntimeSignals(runtimeSignals)}`,
+        );
+      }
+      await expect(page).toHaveURL(new RegExp(`${POS_REGISTER_PATH}/?$`));
+    } finally {
+      await context.setOffline(false);
+    }
+  });
+});

--- a/scripts/harness-app-registry.test.ts
+++ b/scripts/harness-app-registry.test.ts
@@ -867,6 +867,53 @@ describe("HARNESS_APP_REGISTRY", () => {
     ]);
   });
 
+  it("documents POS offline route access validation coverage in Athena harness docs", () => {
+    const athena = HARNESS_APP_REGISTRY.find(
+      (entry) => entry.appName === "athena-webapp",
+    );
+    const offlineRouteScenario = athena?.validationScenarios.find(
+      (scenario) =>
+        scenario.title === "POS offline route access and app-shell edits",
+    );
+
+    expect(offlineRouteScenario?.touchedPaths).toEqual([
+      "public/pos-app-shell-sw.js",
+      "playwright.config.ts",
+      "src/main.tsx",
+      "src/offline",
+      "src/routes/_authed.tsx",
+      "src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos",
+      "src/components/pos/PointOfSaleView.tsx",
+      "src/components/pos/register",
+      "src/components/pos/settings/POSSettingsView.tsx",
+      "src/components/pos/terminals/POSTerminalHealthView.tsx",
+      "src/lib/pos/infrastructure/local",
+      "src/lib/pos/presentation/register",
+      "src/tests/pos/offlineRouteAccess.spec.ts",
+    ]);
+    expect(offlineRouteScenario?.commands).toEqual([
+      {
+        kind: "raw",
+        command:
+          "bun run --filter '@athena/webapp' test -- src/offline/posAppShellRoutes.test.ts src/offline/registerPosAppShellServiceWorker.test.ts src/offline/posOfflineReadiness.test.ts src/routes/_authed.test.tsx src/components/pos/PointOfSaleView.test.tsx src/components/pos/settings/POSSettingsView.test.tsx src/components/pos/terminals/POSTerminalHealthView.test.tsx src/components/pos/register/POSRegisterOpeningGuard.test.tsx src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+      },
+      {
+        kind: "raw",
+        command:
+          "bun run --filter '@athena/webapp' test:e2e -- src/tests/pos/offlineRouteAccess.spec.ts",
+      },
+      {
+        kind: "raw",
+        command: "bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json",
+      },
+      { kind: "script", script: "build" },
+    ]);
+    expect(offlineRouteScenario?.behaviorScenarios).toBeUndefined();
+    expect(offlineRouteScenario?.note).toBe(
+      "Use this when POS service-worker app-shell caching, POS-only offline route entry, offline readiness diagnostics, or hard-reload register continuity changes. Cache Storage must stay limited to static shell assets; POS business state, staff authority, cart events, payments, and catalog snapshots remain in IndexedDB/local POS stores.",
+    );
+  });
+
   it("documents POS terminal health visibility validation coverage in Athena harness docs", () => {
     const athena = HARNESS_APP_REGISTRY.find(
       (entry) => entry.appName === "athena-webapp"

--- a/scripts/harness-app-registry.ts
+++ b/scripts/harness-app-registry.ts
@@ -702,6 +702,43 @@ export const HARNESS_APP_REGISTRY = [
         note: "Use this when POS hub app-session recovery, route-shell continuity, terminal recovery validation, or app-session diagnostics change. It proves the recovery assertion stays POS-hub scoped, non-POS routes still require normal app auth, server validation rejects unsafe scopes, recovery retries stay bounded, terminal diagnostics redact raw recovery data, and sale authority still depends on terminal integrity, drawer authority, local command invariants, and staff proof.",
       },
       {
+        title: "POS offline route access and app-shell edits",
+        touchedPaths: [
+          "public/pos-app-shell-sw.js",
+          "playwright.config.ts",
+          "src/main.tsx",
+          "src/offline",
+          "src/routes/_authed.tsx",
+          "src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos",
+          "src/components/pos/PointOfSaleView.tsx",
+          "src/components/pos/register",
+          "src/components/pos/settings/POSSettingsView.tsx",
+          "src/components/pos/terminals/POSTerminalHealthView.tsx",
+          "src/lib/pos/infrastructure/local",
+          "src/lib/pos/presentation/register",
+          "src/tests/pos/offlineRouteAccess.spec.ts",
+        ],
+        commands: [
+          {
+            kind: "raw",
+            command:
+              "bun run --filter '@athena/webapp' test -- src/offline/posAppShellRoutes.test.ts src/offline/registerPosAppShellServiceWorker.test.ts src/offline/posOfflineReadiness.test.ts src/routes/_authed.test.tsx src/components/pos/PointOfSaleView.test.tsx src/components/pos/settings/POSSettingsView.test.tsx src/components/pos/terminals/POSTerminalHealthView.test.tsx src/components/pos/register/POSRegisterOpeningGuard.test.tsx src/lib/pos/presentation/register/useRegisterViewModel.test.ts",
+          },
+          {
+            kind: "raw",
+            command:
+              "bun run --filter '@athena/webapp' test:e2e -- src/tests/pos/offlineRouteAccess.spec.ts",
+          },
+          {
+            kind: "raw",
+            command:
+              "bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json",
+          },
+          { kind: "script", script: "build" },
+        ],
+        note: "Use this when POS service-worker app-shell caching, POS-only offline route entry, offline readiness diagnostics, or hard-reload register continuity changes. Cache Storage must stay limited to static shell assets; POS business state, staff authority, cart events, payments, and catalog snapshots remain in IndexedDB/local POS stores.",
+      },
+      {
         title: "POS terminal health visibility and diagnostics edits",
         touchedPaths: [
           "convex/schemas/pos/posTerminal.ts",

--- a/scripts/harness-audit.test.ts
+++ b/scripts/harness-audit.test.ts
@@ -90,6 +90,7 @@ async function createFixtureRepo() {
           "lint:convex:changed": "echo lint",
           "lint:frontend:changed": "echo lint frontend",
           test: "echo test",
+          "test:e2e": "echo e2e",
         },
       },
       null,
@@ -154,6 +155,11 @@ async function createFixtureRepo() {
   await write("packages/athena-webapp/.storybook/main.ts", "export default {};\n", rootDir);
   await write("packages/athena-webapp/index.html", "<div id=\"app\"></div>\n", rootDir);
   await write(
+    "packages/athena-webapp/public/pos-app-shell-sw.js",
+    "self.addEventListener('fetch', () => {});\n",
+    rootDir
+  );
+  await write(
     "packages/athena-webapp/src/stories/Guidance/Introduction.stories.tsx",
     "export default {};\n",
     rootDir
@@ -163,6 +169,7 @@ async function createFixtureRepo() {
   await write("packages/athena-webapp/eslint.config.js", "export default [];\n", rootDir);
   await write("packages/athena-webapp/tailwind.config.js", "export default {};\n", rootDir);
   await write("packages/athena-webapp/postcss.config.js", "export default {};\n", rootDir);
+  await write("packages/athena-webapp/playwright.config.ts", "export default {};\n", rootDir);
   await write(
     "packages/athena-webapp/src/design-system-build-config.test.ts",
     "export {};\n",
@@ -300,6 +307,7 @@ async function createFixtureRepo() {
       "- `storefront-checkout-validation-blocker`",
       "- `storefront-checkout-verification-recovery`",
       "Default regression: `bun run --filter '@athena/webapp' test`.",
+      "POS browser journeys: `bun run --filter '@athena/webapp' test:e2e`.",
       "Convex validation: `bun run --filter '@athena/webapp' audit:convex` and `bun run --filter '@athena/webapp' lint:convex:changed`.",
       "Covered test surfaces include `src/tests` and `convex`.",
     ].join("\n"),
@@ -579,6 +587,36 @@ async function createFixtureRepo() {
   );
 
   await write("packages/athena-webapp/src/main.tsx", "export {};\n", rootDir);
+  await write(
+    "packages/athena-webapp/src/offline/posAppShellRoutes.ts",
+    "export {};\n",
+    rootDir
+  );
+  await write(
+    "packages/athena-webapp/src/offline/posAppShellRoutes.test.ts",
+    "export {};\n",
+    rootDir
+  );
+  await write(
+    "packages/athena-webapp/src/offline/posOfflineReadiness.ts",
+    "export {};\n",
+    rootDir
+  );
+  await write(
+    "packages/athena-webapp/src/offline/posOfflineReadiness.test.ts",
+    "export {};\n",
+    rootDir
+  );
+  await write(
+    "packages/athena-webapp/src/offline/registerPosAppShellServiceWorker.ts",
+    "export {};\n",
+    rootDir
+  );
+  await write(
+    "packages/athena-webapp/src/offline/registerPosAppShellServiceWorker.test.ts",
+    "export {};\n",
+    rootDir
+  );
   await write("packages/athena-webapp/src/assets/placeholder.png", "", rootDir);
   await write("packages/athena-webapp/src/config.ts", "export {};\n", rootDir);
   await write(
@@ -1052,6 +1090,11 @@ async function createFixtureRepo() {
   await write("packages/athena-webapp/src/utils/format.ts", "export {};\n", rootDir);
   await write("packages/athena-webapp/vitest.config.ts", "export default {};\n", rootDir);
   await write("packages/athena-webapp/src/tests/app.test.tsx", "export {};\n", rootDir);
+  await write(
+    "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
+    "export {};\n",
+    rootDir
+  );
   await write("packages/athena-webapp/src/test/setup.ts", "export {};\n", rootDir);
   await write("packages/athena-webapp/convex/http.ts", "export {};\n", rootDir);
   await write("packages/athena-webapp/convex/http/router.ts", "export {};\n", rootDir);


### PR DESCRIPTION
## Summary
- add a POS app-shell service worker and POS-only route entry so cached register shell can survive no-network hard reloads
- surface offline readiness and service-catalog age in POS settings/terminal health
- add production-preview Playwright no-network regression and update harness docs/validation maps

## Validation
- bun run pr:athena
- bun run --filter '@athena/webapp' test:e2e -- src/tests/pos/offlineRouteAccess.spec.ts
- reviewer subagents: correctness, testing, security, standards all approved after fixes

Linear: V26-660, V26-661, V26-662, V26-663, V26-664, V26-665