### PR TITLE
Add terminal-scoped cashier presence

### DIFF
--- a/docs/plans/2026-06-04-001-feat-terminal-scoped-cashier-presence-plan.html
+++ b/docs/plans/2026-06-04-001-feat-terminal-scoped-cashier-presence-plan.html
@@ -1,0 +1,427 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Plan Review - Terminal-Scoped Cashier Store-Day Presence</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f7f7f4;
+        --panel: #ffffff;
+        --ink: #172033;
+        --muted: #5f6b7a;
+        --line: #d8ddd5;
+        --accent: #176b5d;
+        --accent-soft: #e4f2ee;
+        --warn: #9a5a13;
+        --warn-soft: #fff1dd;
+        --danger: #a33a3a;
+        --danger-soft: #fde8e8;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--ink);
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+          "Segoe UI", sans-serif;
+        line-height: 1.55;
+      }
+
+      main {
+        max-width: 1180px;
+        margin: 0 auto;
+        padding: 40px 24px 56px;
+      }
+
+      header {
+        border-bottom: 1px solid var(--line);
+        padding-bottom: 24px;
+        margin-bottom: 28px;
+      }
+
+      .eyebrow {
+        color: var(--accent);
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      h1 {
+        font-size: clamp(32px, 5vw, 56px);
+        line-height: 1.02;
+        margin: 10px 0 14px;
+        max-width: 900px;
+      }
+
+      h2 {
+        font-size: 22px;
+        margin: 0 0 12px;
+      }
+
+      h3 {
+        font-size: 16px;
+        margin: 0 0 8px;
+      }
+
+      p {
+        margin: 0 0 12px;
+      }
+
+      .lead {
+        color: var(--muted);
+        font-size: 18px;
+        max-width: 900px;
+      }
+
+      .grid {
+        display: grid;
+        gap: 18px;
+      }
+
+      .grid.two {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .grid.three {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+
+      section,
+      .card {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 22px;
+      }
+
+      section {
+        margin-bottom: 18px;
+      }
+
+      ul,
+      ol {
+        padding-left: 20px;
+        margin: 0;
+      }
+
+      li + li {
+        margin-top: 8px;
+      }
+
+      code {
+        background: #eef1ee;
+        border-radius: 4px;
+        padding: 2px 5px;
+        font-size: 0.92em;
+      }
+
+      .pill-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-top: 16px;
+      }
+
+      .pill {
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        color: var(--muted);
+        font-size: 12px;
+        padding: 5px 10px;
+      }
+
+      .decision {
+        background: var(--accent-soft);
+        border-color: #b8d8cf;
+      }
+
+      .warning {
+        background: var(--warn-soft);
+        border-color: #eed0a4;
+      }
+
+      .danger {
+        background: var(--danger-soft);
+        border-color: #efb4b4;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 14px;
+      }
+
+      th,
+      td {
+        border-bottom: 1px solid var(--line);
+        padding: 12px;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      th {
+        color: var(--muted);
+        font-size: 12px;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+      }
+
+      .flow {
+        display: grid;
+        grid-template-columns: repeat(6, minmax(120px, 1fr));
+        gap: 10px;
+      }
+
+      .flow div {
+        background: #f9faf8;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 14px;
+        min-height: 96px;
+      }
+
+      .flow strong {
+        display: block;
+        margin-bottom: 6px;
+      }
+
+      .small {
+        color: var(--muted);
+        font-size: 13px;
+      }
+
+      @media (max-width: 900px) {
+        .grid.two,
+        .grid.three,
+        .flow {
+          grid-template-columns: 1fr;
+        }
+
+        main {
+          padding: 28px 16px 40px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div class="eyebrow">Plan review artifact</div>
+        <h1>Terminal-scoped cashier store-day presence</h1>
+        <p class="lead">
+          Persist the active POS cashier through reloads on the same terminal
+          and store day without weakening terminal repair, drawer authority,
+          local staff proof, or manager approval boundaries.
+        </p>
+        <div class="pill-row">
+          <span class="pill">Feature plan</span>
+          <span class="pill">POS register</span>
+          <span class="pill">Local-first</span>
+          <span class="pill">Terminal scoped</span>
+          <span class="pill">Store-day scoped</span>
+        </div>
+      </header>
+
+      <section>
+        <h2>What Changes</h2>
+        <div class="grid three">
+          <div class="card decision">
+            <h3>New local presence record</h3>
+            <p>
+              Add a POS local store record for the active cashier on one
+              terminal and operating date.
+            </p>
+          </div>
+          <div class="card decision">
+            <h3>Fast reload restore</h3>
+            <p>
+              Restore <code>staffProfileId</code>, proof token, roles, and
+              cashier display state before showing the sign-in gate.
+            </p>
+          </div>
+          <div class="card decision">
+            <h3>Quiet validation</h3>
+            <p>
+              Validate existing unexpired proof online without success toasts;
+              proof renewal stays out of the MVP.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2>Boundary Model</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Record</th>
+              <th>Answers</th>
+              <th>Must Not Do</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>staffAuthority</code></td>
+              <td>Can this staff member sign in offline with username and PIN?</td>
+              <td>Represent the active signed-in cashier after reload.</td>
+            </tr>
+            <tr>
+              <td><code>cashierPresence</code></td>
+              <td>Who is currently signed in on this terminal for this store day?</td>
+              <td>Follow to another terminal or approve manager-only actions.</td>
+            </tr>
+            <tr>
+              <td><code>drawerAuthority</code></td>
+              <td>Can this drawer/register session sell right now?</td>
+              <td>Trust cashier presence as drawer authority.</td>
+            </tr>
+            <tr>
+              <td><code>terminalIntegrity</code></td>
+              <td>Is this terminal trusted to keep appending local sale events?</td>
+              <td>Let a restored cashier override terminal repair/reset blocks.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2>Reload Lifecycle</h2>
+        <div class="flow">
+          <div>
+            <strong>1. Sign in</strong>
+            <span class="small">Cashier authenticates online or through valid offline authority.</span>
+          </div>
+          <div>
+            <strong>2. Persist</strong>
+            <span class="small">Write active cashier presence with terminal, store, day, role, credential, and proof scope.</span>
+          </div>
+          <div>
+            <strong>3. Reload</strong>
+            <span class="small">Register boot reads same-terminal, same-day presence.</span>
+          </div>
+          <div>
+            <strong>4. Validate</strong>
+            <span class="small">Resolve local presence to sign-in guidance without granting cashier authority from storage.</span>
+          </div>
+          <div>
+            <strong>5. Validate</strong>
+            <span class="small">When online, confirm staff, terminal, credential, and role state.</span>
+          </div>
+          <div>
+            <strong>6. Sell safely</strong>
+            <span class="small">Local sale events still pass drawer and terminal gates.</span>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2>Store-Day And Repair Rules</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>State</th>
+              <th>Cashier Identity</th>
+              <th>Sellability</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Same operating date reload</td>
+              <td>Restore if proof and freshness are valid</td>
+              <td>Allowed only after drawer, terminal, and proof gates pass</td>
+            </tr>
+            <tr>
+              <td>Ordinary drawer close</td>
+              <td>Preserved</td>
+              <td>Blocked until drawer opens</td>
+            </tr>
+            <tr>
+              <td>Non-destructive terminal repair</td>
+              <td>Preserved only after online validation</td>
+              <td>Blocked until repair and validation pass</td>
+            </tr>
+            <tr>
+              <td>Terminal reset or re-provision</td>
+              <td>Cleared</td>
+              <td>Blocked until sign-in</td>
+            </tr>
+            <tr>
+              <td>Register or store-day close</td>
+              <td>Cleared</td>
+              <td>Blocked until a new ready store day/register</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2>Implementation Units</h2>
+        <ol>
+          <li>Define and expose the POS store-day identity.</li>
+          <li>Add cashier presence storage, migration, proof wrapping, and redaction tests.</li>
+          <li>Write presence on sign-in and clear it on identity-clearing transitions.</li>
+          <li>Rehydrate presence during register boot before the sign-in gate opens.</li>
+          <li>Add online validation for existing unexpired active presence.</li>
+          <li>Update POS UI state, copy, accessibility, and local diagnostics.</li>
+          <li>Add targeted validation, graph maintenance, and a solution note.</li>
+        </ol>
+      </section>
+
+      <section>
+        <h2>Safety Checks</h2>
+        <div class="grid two">
+          <div class="card warning">
+            <h3>Presence can restore identity, not sellability</h3>
+            <p>
+              Terminal repair, drawer authority, closeout, and local review
+              states still block sale-affecting commands.
+            </p>
+          </div>
+          <div class="card warning">
+            <h3>Proof freshness is checked at append</h3>
+            <p>
+              Restore-time validity is not enough. Sale start, cart changes,
+              payment updates, and completion must fail closed if proof expires.
+            </p>
+          </div>
+          <div class="card danger">
+            <h3>No plaintext proof</h3>
+            <p>
+              Persisted POS local staff proof material must be wrapped or
+              encrypted. Raw bearer tokens cannot appear in local serialization.
+            </p>
+          </div>
+          <div class="card danger">
+            <h3>No manager approval shortcut</h3>
+            <p>
+              A restored manager cashier still needs command-boundary approval
+              for protected actions.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2>Success Criteria</h2>
+        <ul>
+          <li>Same-terminal reload resolves presence to validation-pending sign-in guidance for the current store day.</li>
+          <li>Different terminal, store, organization, or date cannot restore the cashier.</li>
+          <li>Explicit sign-out, register closeout, store-day close, terminal reset, and credential changes clear presence.</li>
+          <li>Ordinary drawer close preserves cashier continuity context but blocks sale commands until drawer authority returns.</li>
+          <li>Proof expiry mid-sale preserves the draft and blocks further sale-affecting commands.</li>
+          <li>Warm offline hard reload reaches validation-pending sign-in guidance when the app shell is already available.</li>
+          <li>Offline PIN sign-in still fails closed when local proof truly needs refresh.</li>
+          <li>No success toasts are shown for restore, validation, or non-destructive repair.</li>
+        </ul>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/plans/2026-06-04-001-feat-terminal-scoped-cashier-presence-plan.md
+++ b/docs/plans/2026-06-04-001-feat-terminal-scoped-cashier-presence-plan.md
@@ -1,0 +1,540 @@
+---
+title: "feat: Add terminal-scoped cashier store-day presence"
+type: feat
+status: active
+date: 2026-06-04
+origin: user-feedback-pos-cashier-store-day-persistence
+---
+
+# feat: Add terminal-scoped cashier store-day presence
+
+## Summary
+
+Persist the currently signed-in POS cashier for the active terminal and store day so reloads do not force a new PIN sign-in. The persisted presence is a POS-only cashier session record, not a global Athena login: it is scoped to one provisioned terminal, one store, one operating date, and one staff identity; it clears on explicit sign-out or store-day/terminal reset lifecycle changes; and it never bypasses terminal repair, drawer authority, role revocation, manager approval, or sync review boundaries.
+
+---
+
+## Problem Frame
+
+Operators want a cashier to remain signed in for the whole store day. Today the register can authenticate staff online, cache offline authority, and sign in offline by username/PIN, but the active cashier state in `useRegisterViewModel` is still primarily React state. A reload loses `staffProfileId`, `staffProofToken`, and cashier display state, so the terminal falls back to the sign-in gate even when the same cashier just authenticated on the same register.
+
+The current offline authority layer also explains why operators can see "Offline staff sign-in needs a refresh. Reconnect, then try again.": the local staff-authority record may exist, but its wrapped local staff proof is missing, expired, unreadable, or not refreshed for the terminal. That state is valid as a local PIN sign-in failure, but it is not the right product behavior after an online cashier already signed in for the current store day. The active store-day cashier presence needs its own durable local session record.
+
+### Feedback Evidence
+
+The concrete operator workflow is: a cashier signs into a registered POS terminal, the app reloads during the store day, and the cashier must enter a PIN again even though they did not intentionally sign out or switch terminals. The intended behavior is same-cashier continuity on that terminal through routine reloads. The non-goal is cross-terminal staff roaming or shift/attendance tracking.
+
+---
+
+## Requirements
+
+- R1. After a cashier or manager signs into the POS register on a terminal, a page reload on the same terminal should restore that cashier for the same store day without asking for another PIN.
+- R2. Persistence must be terminal-scoped. It must restore only inside the POS register flow and must not follow the cashier to another terminal, browser profile, store, or organization.
+- R3. Persistence must be store-day-scoped. It must clear or fail closed when the canonical operating date, store-day readiness, daily close, or local closeout state no longer matches the saved presence.
+- R4. Explicit cashier sign-out, replacement sign-in, terminal sign-out, terminal reset, terminal re-provisioning, register closeout, and store-day close must clear the saved presence. Non-destructive terminal repair and ordinary drawer close may preserve cashier identity but must block sale-affecting commands until drawer/terminal authority is restored.
+- R5. Online boot should rehydrate quickly from local presence, then validate the existing unexpired proof when the app can reach Convex. If validation is pending and the presence is outside a short freshness window, the cashier may be displayed but sale-affecting commands stay blocked until validation succeeds. Failed validation clears proof material and shows calm operational copy.
+- R6. Offline boot may rehydrate only from a same-terminal, same-store-day, unexpired local presence record whose last validation is within the explicit offline freshness window. It must not mint, renew, or extend staff proof while offline.
+- R7. Sale-affecting local events must continue to carry staff identity and a valid POS local staff proof. Drawer and terminal command-boundary gates remain mandatory.
+- R8. Manager approval remains a separate command-boundary proof. A persisted cashier presence, even for a manager role, must not silently approve protected actions.
+- R9. Existing offline staff-authority records remain the source for username/PIN offline sign-in. Active cashier presence is a separate record that represents who is already signed in.
+- R10. The UI should show the restored cashier state without noisy "restored" or "terminal setup repaired" toasts. If restoration fails, the sign-in surface should explain the next action without raw backend wording.
+- R11. Persisted POS local staff proof material must be wrapped or encrypted at rest. Tests must fail if raw bearer proof tokens are stored in local-store serialization, logs, diagnostics, or UI copy.
+- R12. Sale-affecting command paths must check proof freshness at append time, not only at restore time. If proof expires mid-sale, preserve the draft and already-appended event evidence, block further sale-affecting commands, and require cashier re-authentication or online validation before continuing.
+
+---
+
+## Scope Boundaries
+
+- This plan does not create cross-terminal cashier sessions.
+- This plan does not keep a cashier signed in after explicit sign-out, register closeout, store-day close, terminal reset, terminal re-provisioning, or credential/role invalidation.
+- This plan does not make POS a global offline-auth platform. It remains POS-only.
+- This plan does not add payroll, shift scheduling, break tracking, or staff attendance.
+- This plan does not change payment-provider behavior or cash-control reconciliation.
+- This plan does not replace existing local staff authority. It adds active cashier presence beside it.
+- Offline reload restore assumes the Athena POS app shell and relevant chunks are already available to the browser. Cold-load app-shell/service-worker guarantees remain follow-up work.
+
+### Deferred to Follow-Up Work
+
+- Hardware-backed local key storage or device-attestation hardening beyond browser-profile local storage.
+- Fleet-level reporting for which cashier stayed signed in on each terminal.
+- Rich manager handoff workflows, such as explicit shift transfer with manager approval.
+- Service-worker cold-start guarantees if the browser has never loaded the Athena app assets before going offline.
+- PIN-less proof renewal. This plan validates existing unexpired proof; renewal is a follow-up unless implementation proves the current proof TTL cannot cover a normal store day.
+- Broader offline staff-authority autohealing. This plan writes active presence after successful sign-in; it does not redesign the offline authority refresh lifecycle.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts` owns the active cashier React state through `staffProfileId`, `staffProofToken`, `localAuthenticatedStaff`, `cashierCard`, drawer gates, local sale commands, and sign-out behavior.
+- `packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx` authenticates staff online, refreshes terminal staff authority, writes local staff authority, verifies local PINs offline, unwraps PIN-protected local proofs, and returns `StaffAuthenticationResult`.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts` already stores POS terminal seed, readiness, terminal integrity, drawer authority, local events, catalog snapshots, availability snapshots, and local staff authority.
+- `packages/athena-webapp/convex/operations/staffCredentials.ts` authenticates staff for a terminal and refreshes terminal staff-authority records with active roles, credential version, verifier metadata, and proof expiry.
+- `packages/athena-webapp/convex/pos/application/sync/staffProof.ts` validates POS local staff proof during event sync projection.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts` already handles foreground sync, runtime health, and terminal repair signals.
+- `packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx` renders the POS register shell, cashier card, drawer gate, product lookup trigger, and payment surface.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md` says the browser event log is the first durable record for POS work, while Convex is the cloud projection boundary.
+- `docs/plans/2026-05-14-003-feat-pos-local-staff-authority-plan.md` separates POS offline staff sign-in authority from global Athena login and manager command approval.
+- `docs/plans/2026-05-29-001-fix-pos-stale-terminal-sale-block-plan.md` separates terminal trust from drawer lifecycle authority and requires sale-blocking at command boundaries, not only UI gates.
+- `docs/product-copy-tone.md` requires restrained operator-facing copy and normalized backend wording.
+
+### Current Failure Mode
+
+The "Offline staff sign-in needs a refresh" state is entered when offline PIN sign-in finds a local authority record but cannot produce a usable local staff proof. Typical causes are:
+
+- `wrappedPosLocalStaffProof` was never stored for that staff record.
+- The wrapped proof cannot be unwrapped with the entered PIN.
+- The local staff proof has expired.
+- The authority record is stale for the terminal, store, role, credential version, or local verifier.
+- The local store read fails or the schema cannot be parsed.
+
+That behavior should remain for offline PIN sign-in. The gap is that a cashier who already completed a valid online sign-in should not need to go through the offline PIN path after a reload during the same store day.
+
+---
+
+## Key Technical Decisions
+
+- Add a new local cashier presence record. Do not overload `PosLocalStaffAuthorityRecord`; that record answers "who may sign in offline with a PIN." The new record answers "who is currently signed in on this terminal for this store day."
+- Store active POS staff proof only as a terminal-scoped, store-day session proof. It is valid for local POS event attribution and sync, not global Athena auth or manager command approval.
+- Wrap or encrypt persisted POS local staff proof material. Raw proof tokens must not be stored in IndexedDB serialization, memory-store snapshots used in tests, diagnostics, logs, or UI copy.
+- Minimum acceptable proof wrapping is a terminal-scoped, non-extractable Web Crypto key stored in IndexedDB and bound to the active provisioned terminal seed/fingerprint. The proof payload is AES-GCM encrypted with a fresh IV per write; export helpers, diagnostics, and tests must only see ciphertext and metadata.
+- Expire presence at the earliest of store-day boundary, proof expiry, offline freshness expiry, terminal reset/re-provisioning, register closeout, store-day close, credential/role invalidation, or explicit sign-out.
+- Check proof freshness at every sale-affecting append. Restore-time validity is not sufficient for sale start, cart mutation, payment update, service add, checkout completion, drawer open, or closeout/reopen actions.
+- Treat persisted cashier presence as continuity evidence, not local authority. On reload, same-terminal presence can move the register into validation-pending sign-in guidance, but it must not restore cashier roles or sale-authorized proof from IndexedDB.
+- Do not include PIN-less proof renewal in the MVP. If proof renewal is needed for a long store day, add a follow-up Convex mutation that requires an unexpired prior POS local staff proof plus current terminal, staff, credential, and role validation. Offline code cannot extend proof lifetime.
+- Keep manager approval separate. The presence can show a manager as the active cashier, but protected manager actions still open their own proof flow.
+- Make clearing explicit and conservative. Identity-clearing lifecycle transitions clear both React state and the local presence record; drawer/terminal repair states block commands without necessarily erasing cashier identity.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should cashier persistence be terminal-scoped or user-scoped? Terminal-scoped.
+- Should persistence survive reloads? Yes, within the same store day and terminal.
+- Should persistence survive explicit sign-out? No.
+- Should persistence allow a cashier to sell if terminal repair or drawer authority is blocked? No.
+- Should active cashier presence replace offline staff authority? No. They are separate local records with different meanings.
+- Should the register auto-start a sale on restore? No. The product lookup trigger remains the intentional start path.
+- Should ordinary drawer close clear cashier identity? No. Drawer close blocks sellability but should not force a PIN prompt by itself. Register closeout, store-day close, explicit sign-out, terminal reset, and credential invalidation clear identity.
+- Should non-destructive terminal repair clear cashier identity? No. It blocks sellability while repair is pending. Terminal reset or re-provisioning clears identity.
+- Should the MVP renew POS local staff proof without PIN? No. It validates existing unexpired proof only. Renewal is a follow-up if TTL requires it.
+
+### Deferred to Implementation
+
+- Exact proof expiry and freshness values: choose explicit constants during implementation. The plan requires both a proof expiry and an offline freshness window; renewal remains follow-up unless TTL makes the MVP unusable.
+- Exact wrapping helper names and storage location: the minimum wrapping invariant is fixed above, but implementation can choose the helper/module shape that best fits existing `localPinVerifier` and `posLocalStore` code.
+
+---
+
+## Store-Day Contract
+
+- Canonical store-day identity is the POS local readiness operating date for the active store and terminal. If the register view model does not currently receive it, U0 must add a small adapter that exposes it before any presence write or restore.
+- The operating date is store-scoped, not browser-local. It should use the same store timezone and daily-opening/daily-close semantics already used by POS readiness.
+- Crossing midnight does not clear presence by itself if the store-day operating date has not changed. Completing daily close or register closeout does clear presence.
+- Offline closeout-pending state blocks sale-affecting commands and clears active cashier presence when it represents the terminal/register day being closed.
+- Missing, unreadable, mismatched, or closed store-day identity means no presence restore. The sign-in gate should wait until this check completes so the PIN dialog does not flicker during IndexedDB reads.
+
+---
+
+## Repair And Drawer Semantics
+
+| Event or state | Cashier identity | Sale-affecting commands | Notes |
+| --- | --- | --- | --- |
+| Ordinary drawer close | Preserved | Blocked until drawer opens | Supports whole-store-day cashier continuity. |
+| Drawer open for a new local register session | Preserved by default | Allowed only after proof freshness and drawer authority pass | UI must keep the cashier card and sign-out/switch affordance visible so operators can correct the active cashier. |
+| Mapped cloud drawer closed/rejected | Cleared if it invalidates the active drawer/session authority | Blocked | Prevents stale IndexedDB drawer authority from resurrecting a cashier session. |
+| Non-destructive terminal self-heal for same terminal seed/fingerprint | Preserved only after online proof validation | Blocked until repair and validation pass | Repair may keep identity, but cannot restore sale authorization by itself. |
+| Terminal reset or re-provisioning | Cleared | Blocked until sign-in | Treat as new terminal authority. |
+| Register closeout or store-day close | Cleared | Blocked until new store-day/register readiness | Store-day identity changed or closed. |
+| Replacement cashier sign-in | Overwritten | Existing pending local events keep original staff attribution | New events use the replacement cashier proof. |
+
+The presence record is not the drawer authority record. The implementation may include the current drawer/register-session id as metadata if it helps detect stale authority, but cashier presence remains terminal/store-day scoped. Event attribution is enforced at command append: each appended local event keeps the staff identity/proof that was active at the time of append.
+
+---
+
+## High-Level Technical Design
+
+```mermaid
+stateDiagram-v2
+  [*] --> SignedOut
+  SignedOut --> Authenticated: Online PIN sign-in
+  SignedOut --> Authenticated: Offline PIN sign-in with valid authority
+  Authenticated --> PresencePersisted: Write same-terminal store-day presence
+  PresencePersisted --> Restored: Reload same terminal and same store day
+  Restored --> Validating: Online validation required
+  Validating --> PresencePersisted: Proof and authority still valid
+  Validating --> SignedOut: Staff, role, terminal, or store scope invalid
+  PresencePersisted --> SignedOut: Explicit sign-out
+  PresencePersisted --> SignedOut: Store day changes or closeout
+  PresencePersisted --> SignedOut: Proof or freshness expires
+  PresencePersisted --> SignedOut: Terminal reset or re-provision
+  PresencePersisted --> Blocked: Terminal or drawer authority blocked
+  Blocked --> PresencePersisted: Non-destructive repair succeeds
+  Blocked --> SignedOut: Reset or closeout clears local presence
+```
+
+```mermaid
+sequenceDiagram
+    participant Cashier
+    participant Dialog as CashierAuthDialog
+    participant VM as Register view model
+    participant Store as POS local store
+    participant Cloud as Convex staff credentials
+    participant Sync as Local sync projection
+
+    Cashier->>Dialog: Enter username and PIN
+    Dialog->>Cloud: Authenticate for terminal
+    Cloud-->>Dialog: Staff profile, roles, local staff proof, authority record
+    Dialog->>Store: Refresh staff authority for offline PIN sign-in
+    Dialog-->>VM: Authenticated staff result
+    VM->>Store: Write active cashier presence for terminal and store day
+    VM-->>Cashier: Register shows cashier card
+    Cashier->>VM: Reload page
+    VM->>Store: Read same-terminal store-day presence
+    Store-->>VM: Staff profile, roles, proof, expiry
+    VM-->>Cashier: Cashier remains signed in
+    VM->>Cloud: Validate unexpired proof when online
+    Cashier->>VM: Complete sale
+    VM->>Sync: Local event carries staff profile and proof
+```
+
+### Cashier Presence Record
+
+The implementation should keep the record small and redacted. A target shape:
+
+```ts
+type PosLocalCashierPresenceRecord = {
+  activeRoles: Array<"cashier" | "manager">;
+  credentialId: string;
+  credentialVersion: number;
+  displayName: string | null;
+  expiresAt: number;
+  issuedAt: number;
+  lastValidatedAt?: number;
+  cashierPresenceId: string;
+  operatingDate: string;
+  organizationId: string;
+  wrappedPosLocalStaffProof: {
+    ciphertext: string;
+    expiresAt: number;
+    iv: string;
+  };
+  staffProfileId: string;
+  status: "active" | "invalidated" | "expired";
+  storeId: string;
+  terminalId: string;
+};
+```
+
+The final storage shape must wrap or encrypt POS local staff proof material before persistence. Tests must inspect the raw local-store serialization and fail if a `posLocalStaffProof.token` value or equivalent bearer material appears in plaintext. Invalidated or expired records must delete proof material; retaining redacted status metadata for diagnostics is acceptable.
+
+---
+
+## Implementation Units
+
+### U0. Define and expose the POS store-day identity
+
+**Goal:** Provide the canonical operating date and store-day readiness state that every cashier presence write and restore must use.
+
+**Requirements:** R1, R3, R6, R10
+
+**Dependencies:** None
+
+**Files:**
+- Modify if needed: `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`
+- Modify if needed: `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+
+**Approach:**
+- Reuse the POS local readiness operating date as the canonical store-day identity for presence.
+- Add a small adapter if `useRegisterViewModel` cannot already read the active operating date from local readiness.
+- Return explicit states for ready, loading, missing readiness, closed store day, mismatched store, unreadable local store, and unsupported schema.
+- Gate cashier-presence restore and sign-in dialog opening until this store-day check has completed.
+- Treat daily close, register closeout, and closed local readiness as identity-clearing states. Treat midnight without operating-date change as same store day.
+
+**Test scenarios:**
+- Same operating date before close allows restore.
+- Crossing midnight with unchanged operating date still allows restore.
+- Completed daily close or register closeout prevents restore and clears presence.
+- Missing/unreadable readiness does not flicker the sign-in dialog; it reaches a deterministic sign-in or blocked state.
+- Store mismatch rejects the presence before any staff state is set.
+
+**Verification:**
+- The view model has a reliable operating date before it writes or restores active cashier presence.
+
+### U1. Add cashier presence storage to the POS local store
+
+**Goal:** Store and restore the active same-terminal cashier presence without mutating staff-authority records or local POS events.
+
+**Requirements:** R1, R2, R3, R6, R9, R11, R12
+
+**Dependencies:** U0
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts`
+
+**Approach:**
+- Add a local store record keyed by organization, store, terminal, and operating date.
+- Provide helpers such as `writeCashierPresence`, `readCashierPresence`, `clearCashierPresence`, and `invalidateCashierPresenceForTerminal`.
+- Validate scope, expiry, offline freshness, active roles, credential version, terminal id, store id, operating date, and wrapped proof shape before returning a sale-authorized record.
+- Provide a command-boundary helper that resolves the current sale-authorized proof and fails closed when proof expiry/freshness has passed since restore.
+- Keep the record separate from `staffAuthority`, `events`, and `drawerAuthority`.
+- Redact the proof/token field from any diagnostic serialization.
+- Bump the IndexedDB schema version, add the object-store/type union, update `onupgradeneeded`, update the in-memory adapter clone/replace helpers, and add migration coverage from the current schema.
+
+**Test scenarios:**
+- Same terminal, same store day restores cashier presence after a new store instance is created.
+- Another terminal, store, organization, or operating date cannot read the record.
+- Expired proof, expired offline freshness, or expired presence returns no usable cashier and deletes proof material.
+- Clearing presence on sign-out leaves staff-authority records intact.
+- Diagnostics do not include proof tokens, verifier material, credentials, PINs, or sync secrets.
+- Opening an existing schema-7 database and writing cashier presence preserves existing events, mappings, readiness, drawer authority, and staff authority.
+- Proof that expires after restore but before a command append fails the helper and deletes active proof material while retaining redacted status.
+
+**Verification:**
+- IndexedDB can persist active cashier presence across reload-like store reconstruction without changing local event history.
+
+### U2. Write presence on successful cashier sign-in and clear it on identity-clearing transitions
+
+**Goal:** Make successful cashier authentication create the active presence record and make sign-out/lifecycle changes remove it.
+
+**Requirements:** R1, R3, R4, R7, R9, R10
+
+**Dependencies:** U0, U1
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- Modify if needed: `packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx`
+- Test if modified: `packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx`
+
+**Approach:**
+- Extend `handleCashierAuthenticated` to write presence after online or offline sign-in returns a usable `posLocalStaffProof`.
+- Wrap or encrypt the proof before persistence. Include active roles, display name, credential version when available, current terminal id, current store id, and current operating date.
+- Update `handleCashierSignOut` to clear presence before or alongside clearing React state.
+- Clear proof material and local presence on explicit sign-out, replacement sign-in, terminal sign-out, terminal reset, terminal re-provisioning, register closeout, store-day close, credential/role invalidation, or store-day mismatch.
+- Preserve cashier identity through ordinary drawer close and same-terminal non-destructive repair, but keep sale-affecting commands blocked until drawer/terminal authority and proof validation are healthy.
+- Clear presence when mapped cloud drawer authority is closed/rejected for the active local drawer, when a new terminal seed/fingerprint is written, or when repair replaces the register/session authority instead of self-healing it.
+- Preserve the existing product lookup trigger behavior; do not auto-start a sale just because cashier presence was restored.
+
+**Test scenarios:**
+- Online sign-in writes cashier presence and still refreshes local staff authority.
+- Offline PIN sign-in with a valid wrapped proof writes cashier presence for later reloads.
+- Sign-out clears the record and reopens the sign-in gate.
+- Replacement sign-in overwrites the previous cashier presence.
+- Ordinary drawer close preserves cashier identity and blocks sale commands until drawer authority returns.
+- Mapped cloud drawer closed/rejected clears presence for the active drawer/session and blocks sale commands.
+- Register closeout clears presence.
+- Non-destructive terminal repair preserves cashier identity and blocks sale commands.
+- Terminal reset or re-provisioning clears presence but does not delete stranded local events.
+- Replacement sign-in preserves existing pending local event attribution and uses the new cashier proof only for subsequent events.
+- Completed sale and product lookup flows still use the current cashier proof.
+- Persisted cashier presence alone is not a current cashier proof.
+
+**Verification:**
+- The active register cannot record local sale events from restored local presence alone; the cashier must sign in to supply current proof.
+
+### U3. Rehydrate cashier presence during register boot
+
+**Goal:** Resolve local presence before the sign-in gate opens, while preserving terminal and drawer gates and never restoring cashier authority from IndexedDB alone.
+
+**Requirements:** R1, R2, R3, R5, R6, R7, R10
+
+**Dependencies:** U0, U1
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- Modify if needed: `packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts`
+- Test if modified: `packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.test.ts`
+
+**Approach:**
+- Add `cashierPresenceRestoreStatus` or equivalent state with at least `pending`, `restored`, `missing`, and `failed`.
+- Gate `authDialog.open` on restore completion, not only on `!staffProfileId`, so IndexedDB reads cannot flash the PIN dialog.
+- During register bootstrap, once store id, terminal id, and operating date are known, read the active presence record.
+- If the record is valid for the current scope, set validation-pending guidance and open sign-in. Do not set active cashier state, role state, or sale-authorized proof from persisted presence.
+- If the record is invalid, expired, mismatched, or unreadable, clear it and show the sign-in gate with normal operational copy.
+- Do not bypass `drawerGate`, terminal-integrity blocks, local closeout blocks, or active sale ownership checks.
+- Avoid restore toasts. The cashier card is the acknowledgement.
+
+**Test scenarios:**
+- Reload with valid presence opens the sign-in dialog in validation-pending mode and does not grant cashier authority.
+- Reload with no record does not flicker the sign-in dialog before restore status resolves.
+- Reload with IndexedDB unavailable reaches one failed restore state and then sign-in guidance.
+- Reload with expired presence clears it and opens sign-in.
+- Reload with presence for a different terminal/store/day ignores and clears it for the current scope.
+- Reload with terminal repair required shows terminal repair state even if cashier presence exists.
+- Reload with drawer authority blocked still blocks sale-affecting commands.
+- Validation-pending presence does not automatically start a sale.
+- Proof expiring after restore but before payment/update/complete blocks the command, preserves the draft, and moves focus/copy to re-authentication.
+
+**Verification:**
+- A same-terminal reload reaches deterministic validation-pending guidance without losing drawer and terminal safety.
+
+### U4. Add online validation for active presence
+
+**Goal:** Keep restored cashier presence from becoming stale while avoiding PIN-less renewal or resurrection of expired staff proof.
+
+**Requirements:** R3, R5, R6, R7, R8
+
+**Dependencies:** U1, U3
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/staffCredentials.ts`
+- Modify: `packages/athena-webapp/convex/operations/staffCredentials.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- Modify if needed: `packages/athena-webapp/convex/pos/application/sync/staffProof.ts`
+- Test if modified: `packages/athena-webapp/convex/pos/application/sync/staffProof.test.ts`
+
+**Approach:**
+- Add a Convex validation mutation, or a narrowly scoped callable wrapper around existing staff-proof validation, that accepts the current unexpired POS local staff proof, staff profile id, store id, terminal id, credential id/version, and operating date.
+- Return explicit states: valid, expired, revoked credential, removed POS role, credential version changed, wrong terminal, wrong store, terminal blocked, and upstream unavailable.
+- Reuse a shared `validatePosLocalStaffProofWithCtx` helper if the existing sync proof validator can be safely exposed without widening the command surface.
+- Confirm the staff credential is active, the credential version still matches, required POS role is active, the terminal is still valid, and the store scope matches.
+- Do not renew proof in this MVP. If validation succeeds, update `lastValidatedAt` and sale-authorized state without extending proof expiry.
+- If validation is pending and `lastValidatedAt` is older than the configured online freshness window, display the cashier but block sale-affecting commands until validation succeeds.
+- On validation failure, delete proof material, clear presence and local React cashier state, and use sign-in copy, not a noisy toast loop.
+- Wire validation status into command-boundary checks so sale start, cart mutation, payment update, service add, checkout completion, drawer open, and closeout/reopen cannot append with expired or stale proof.
+
+**Test scenarios:**
+- Unexpired proof for the same terminal/staff/store validates and keeps cashier restored.
+- Expired proof cannot be validated or renewed without PIN.
+- Revoked credential, removed POS role, changed credential version, wrong terminal, or wrong store clears presence.
+- Validation failure does not delete local sale events or staff-authority records.
+- Online boot with stale `lastValidatedAt` shows the cashier card but blocks add-item/start-sale/complete-sale commands until validation succeeds.
+- Offline proof expiry between sale start and checkout blocks further sale-affecting commands, preserves the draft, and requires sign-in/online validation before continuing.
+
+**Verification:**
+- Restored cashier sessions stay current online and fail closed when staff or terminal authority changes.
+
+### U5. Update POS UI state, copy, and local diagnostics
+
+**Goal:** Make restored cashier presence visible and calm without exposing implementation details or secrets.
+
+**Requirements:** R5, R8, R10, R11
+
+**Dependencies:** U2, U3, U4
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx`
+- Modify if needed: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts`
+- Test if modified: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts`
+- Reference: `docs/product-copy-tone.md`
+
+**Approach:**
+- Use the existing cashier card/header affordance as the restored-state indicator.
+- Keep sign-out visible and explicit. If there is an active cart, payment in progress, or unsynced local sale, preserve the existing "complete or clear this sale" guard before sign-out.
+- Do not show a toast when presence restores, validates, or non-destructive repair completes in the background.
+- If validation clears the cashier, show the sign-in gate and at most one restrained message.
+- Add local-only safe diagnostics such as `cashierPresence: active | validation_pending | expired | invalidated | missing` without proof tokens or credential material. Do not add fleet-level cashier reporting in this plan.
+- Support keyboard access to sign-in/sign-out, focus movement from failed restore to the sign-in form, and a polite screen-reader announcement when cashier identity is cleared.
+
+**Operator copy table:**
+
+| State | UI | Copy | Primary action |
+| --- | --- | --- | --- |
+| Restored and sale-authorized | Cashier card | No toast or banner | Continue selling |
+| Restored, validation pending | Cashier card, sale controls disabled | "Checking cashier access before new sales." | Wait or reconnect |
+| Expired presence | Sign-in gate | "Cashier sign-in expired. Sign in to continue." | Sign in |
+| Offline freshness expired | Sign-in gate | "This terminal needs an online staff refresh before offline sign-in. Reconnect, then sign in once." | Reconnect |
+| Role or credential invalid | Sign-in gate | "Cashier access changed. Sign in with an active cashier or manager." | Sign in |
+| Wrong terminal/store/day | Sign-in gate | "This cashier sign-in is for another register or store day." | Sign in |
+| Local store unreadable | Sign-in gate or setup guidance | "This register could not read cashier sign-in. Sign in again." | Sign in |
+| Terminal repair pending | Repair gate, cashier may remain visible | "Terminal setup needs repair before new sales." | Repair setup |
+| Drawer closed | Drawer gate, cashier remains visible | "Open the drawer before new sales." | Open drawer |
+| Proof expired mid-sale | Sale remains visible, sale controls disabled | "Cashier sign-in expired. Sign in to continue this sale." | Sign in |
+| Stale drawer authority rejected | Repair gate | "Drawer setup changed. Open a current drawer before selling." | Open drawer or repair |
+
+**Test scenarios:**
+- Restored cashier shows the normal cashier card and sign-out control.
+- No restore or validation success toast renders.
+- A failed validation produces one sign-in state, not repeated toasts.
+- Terminal health/local diagnostics redact proof/token fields and do not expose fleet-level cashier reporting.
+- Manager-only action still asks for manager approval proof even when a manager is the restored cashier.
+- Sign-out is keyboard reachable and focus lands on the sign-in form when cashier identity clears.
+- Proof-expired mid-sale copy appears once, preserves draft content, and does not produce repeated toasts.
+
+**Verification:**
+- Operators see who is signed in and what to do next, without noisy background status.
+
+### U6. Add delivery validation and documentation
+
+**Goal:** Lock in the behavior with targeted tests, local build checks, graph maintenance, and a solution note.
+
+**Requirements:** R1-R12
+
+**Dependencies:** U0-U5
+
+**Files:**
+- Modify or create: `docs/solutions/architecture/athena-terminal-scoped-cashier-presence-2026-06-04.md`
+- Run after code changes: `bun run graphify:rebuild`
+
+**Approach:**
+- Add focused unit coverage for store-day identity, local store migration, wrapped proof serialization, view model restore state, auth dialog write path, proof validation, command-boundary proof freshness, UI copy, and diagnostics.
+- Add a production-build browser validation scenario for warm offline reload: load `/pos/register`, sign in, verify cashier presence writes, block network, hard reload, and verify the cashier card restores without opening the PIN dialog. This validates presence restore when the app shell is already available; cold app-shell caching remains a follow-up.
+- Run targeted tests first, then the repo's normal local gates for Athena webapp work.
+- Add a solution note documenting the boundary between staff authority, cashier presence, drawer authority, and manager approval.
+
+**Suggested verification commands:**
+- `bun test packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts`
+- `bun test packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- `bun test packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx`
+- `bun test packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx`
+- `bun test packages/athena-webapp/convex/operations/staffCredentials.test.ts`
+- `bun run typecheck`
+- Production-build Playwright warm-offline reload scenario for `/pos/register`
+- `bun run graphify:rebuild`
+
+**Verification:**
+- Same-terminal reload persistence is proven as continuity evidence without weakening terminal, drawer, or staff-proof safety.
+
+---
+
+## Rollout Strategy
+
+1. Expose store-day identity and add tests for missing/closed/mismatched readiness.
+2. Land local storage, schema migration, proof wrapping, and redaction tests behind no UI behavior change.
+3. Write presence on sign-in and clear on identity-clearing lifecycle transitions.
+4. Enable boot rehydration with restore-pending state, strict scope, expiry, freshness checks, and validation-pending sign-in guidance.
+5. Add online validation and quiet operator copy.
+6. Run full local validation and rebuild graphify after code changes.
+
+---
+
+## Risks And Mitigations
+
+- Risk: A stale cashier identity could misattribute a sale.
+  - Mitigation: Scope presence to terminal, store, operating date, credential version, active role, proof expiry, and drawer/terminal authority.
+- Risk: Proof persistence weakens the prior PIN-on-every-reload behavior.
+  - Mitigation: Wrap or encrypt persisted proof, treat cashier presence as continuity evidence only, never restore authority from local proof fields, and clear proof material aggressively on lifecycle changes.
+- Risk: Long store days outlive the existing proof TTL.
+  - Mitigation: For the MVP, fail closed when proof expires. If TTL is too short for real store days, plan PIN-less renewal as a separate follow-up with explicit server validation.
+- Risk: Online validation could create noisy UI.
+  - Mitigation: Use quiet background validation and show only durable state changes, not success toasts.
+- Risk: Drawer repair and cashier restore could conflict.
+  - Mitigation: Restore cashier identity separately from sellability; drawer and terminal gates still decide whether commands can proceed.
+
+---
+
+## Success Criteria
+
+- Reloading `/pos/register` on the same terminal and store day resolves persisted presence to validation-pending sign-in guidance without granting cashier authority from IndexedDB.
+- The same persisted presence does not restore on another terminal, store, organization, or operating date.
+- Explicit sign-out, register closeout, store-day close, terminal reset, terminal re-provisioning, and credential/role invalidation clear presence.
+- Ordinary drawer close and non-destructive terminal repair preserve cashier continuity context but block sale-affecting commands until authority is restored through sign-in.
+- Terminal repair, drawer authority, local closeout, and manager approval boundaries still block the same commands they block today.
+- Offline PIN sign-in still fails closed when local staff proof truly needs refresh, and reload presence does not bypass that check.
+- Proof expiry before checkout blocks further sale-affecting commands, preserves the draft, and requires re-authentication.
+- Warm offline hard reload reaches validation-pending sign-in guidance when the app shell is already available.
+- No success toasts are shown for background restore, validation, or non-destructive repair.

--- a/docs/solutions/architecture/athena-terminal-scoped-cashier-presence-2026-06-04.md
+++ b/docs/solutions/architecture/athena-terminal-scoped-cashier-presence-2026-06-04.md
@@ -1,0 +1,101 @@
+---
+title: Athena Terminal-Scoped Cashier Presence
+date: 2026-06-04
+category: architecture
+module: athena-webapp
+component: pos-register
+problem_type: local_first_cashier_presence
+symptoms:
+  - "Reloading the POS register can force another cashier PIN prompt during the same store day"
+  - "A restored cashier identity can be confused with sale-authorized proof, drawer authority, or manager approval"
+  - "Local diagnostics can accidentally expose staff proof or credential material when persistence is added"
+root_cause: cashier_identity_was_react_state_without_a_terminal_store_day_presence_boundary
+resolution_type: terminal_scoped_local_presence
+severity: high
+tags:
+  - pos
+  - register
+  - cashier-presence
+  - local-first
+---
+
+# Athena Terminal-Scoped Cashier Presence
+
+## Problem
+
+The POS register can reload while a cashier has a same-terminal, same-store-day
+presence record. If the register opens the PIN dialog before the local read
+finishes, operators can see a sign-in flicker even though the durable state has
+not reached a deterministic missing, expired, invalidated, or validation-needed
+outcome.
+
+## Boundary
+
+Cashier presence is terminal, store, and operating-date scoped. It identifies
+the cashier currently signed in on this browser. It is not drawer authority,
+terminal integrity, staff-authority roster data, or manager approval.
+
+- Staff authority says which cashier or manager credentials may sign in on this
+  terminal.
+- Cashier presence says which staff identity was most recently signed in on this
+  terminal and store day.
+- Sale-authorized proof gates sale-affecting commands. Persisted cashier
+  presence is continuity evidence, not authority; a reload must not reauthorize
+  staff from IndexedDB proof or role fields.
+- Drawer authority and terminal integrity remain independent sale gates.
+- Manager approval remains action scoped. A restored manager cashier does not
+  replace manager approval proof for manager-only commands.
+
+## Solution
+
+Register boot should start in a restore-pending state. The PIN form should open
+only after the local read reaches a deterministic missing, expired, invalidated,
+failed, or validation-needed state. A valid same-terminal record should preserve
+operator context and move to validation-pending sign-in guidance; it must not
+restore active cashier authority from local serialized proof or role material.
+Background checks and non-destructive repair success should stay quiet.
+
+Persist cashier presence as a separate local record keyed by organization,
+store, terminal, and operating date. Keep the POS local staff proof wrapped at
+rest, and treat the stored record as separate from a sale-authorized proof
+token. When proof or freshness is stale or only local continuity evidence is
+available, preserve cashier context only for operator guidance and block
+sale-affecting commands until sign-in supplies a valid proof.
+
+Operator copy stays calm and action-oriented:
+
+- `Checking cashier access before new sales.`
+- `Cashier sign-in expired. Sign in to continue.`
+- `This terminal needs an online staff refresh before offline sign-in. Reconnect, then sign in once.`
+
+Diagnostics may expose redacted state such as `cashierPresence:
+validation_pending`, `expired`, or `invalidated`, but must not include PINs, proof tokens, verifier
+material, credentials, sync secrets, or fleet-level cashier reporting.
+
+## Prevention
+
+Before adding POS local-first cashier or authority behavior, identify which
+boundary owns the state:
+
+- Staff-authority records are for offline username/PIN eligibility.
+- Cashier-presence records are for same-terminal, same-store-day continuity
+  evidence.
+- Drawer authority and terminal integrity decide whether sale commands may run.
+- Manager approval remains a separate command proof for protected actions.
+
+Tests should prove no PIN-dialog flicker while restore is pending, no
+cross-terminal or cross-store authorization, no plaintext proof serialization,
+no stale local proof trust, and no sale-affecting command while presence is
+validation-pending.
+
+## Validation
+
+Warm offline reload validation should use a production build after the app shell
+and chunks are already loaded: open `/pos/register`, sign in, verify presence is
+written, block network, hard reload, and confirm the register reaches a stable
+validation-pending sign-in state without granting cashier authority from local
+storage. This does not promise cold offline startup when the app shell or chunks
+are not already available.
+
+Run targeted register view-model and register UI tests after restore/copy
+changes, then `bun run typecheck` and `bun run graphify:rebuild`.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1824 files · ~0 words
+- 1825 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6108 nodes · 6561 edges · 1752 communities detected
+- 6126 nodes · 6586 edges · 1753 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1762,15 +1762,16 @@
 - [[_COMMUNITY_Community 1749|Community 1749]]
 - [[_COMMUNITY_Community 1750|Community 1750]]
 - [[_COMMUNITY_Community 1751|Community 1751]]
+- [[_COMMUNITY_Community 1752|Community 1752]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
 2. `buildDailyCloseSnapshotWithCtx()` - 28 edges
 3. `projectLocalRegisterReadModel()` - 24 edges
 4. `buildDailyOpeningSnapshotWithCtx()` - 17 edges
-5. `getStoreConfigV2()` - 17 edges
-6. `DataTableViewOptions()` - 16 edges
-7. `useRegisterViewModel()` - 16 edges
+5. `useRegisterViewModel()` - 17 edges
+6. `getStoreConfigV2()` - 17 edges
+7. `DataTableViewOptions()` - 16 edges
 8. `projectSaleCompleted()` - 14 edges
 9. `createConflict()` - 14 edges
 10. `toV2Config()` - 13 edges
@@ -1798,8 +1799,8 @@ Cohesion: 0.06
 Nodes (56): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelongsToRange(), approvalRequestTypeLabel(), buildAdjustmentPaymentTotals(), buildAdjustmentReportTotals(), buildDailyCloseApprovalSubject(), buildDailyCloseCompletionApprovalRequirement() (+48 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.06
-Nodes (29): addLocalAvailabilityConsumption(), addLocalAvailabilityDeltaConsumption(), asCloudOperableSession(), buildCompletedSalePayload(), buildLocalAvailabilityEventIndex(), cartItemsFromLocalRegisterModel(), completedCustomerInfo(), countPendingSyncableLocalEventsForStaff() (+21 more)
+Cohesion: 0.05
+Nodes (31): addLocalAvailabilityConsumption(), addLocalAvailabilityDeltaConsumption(), asCloudOperableSession(), buildCompletedSalePayload(), buildLocalAvailabilityEventIndex(), cartItemsFromLocalRegisterModel(), completedCustomerInfo(), countPendingSyncableLocalEventsForStaff() (+23 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.1
@@ -1842,52 +1843,52 @@ Cohesion: 0.08
 Nodes (20): formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels(), getSkuDetailEntries() (+12 more)
 
 ### Community 13 - "Community 13"
+Cohesion: 0.08
+Nodes (12): createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), normalizeCashierPresenceRecord(), normalizeDrawerAuthorityState(), normalizeStaffAuthorityRecord(), normalizeTerminalIntegrityState(), normalizeUsername(), PosLocalStoreSchemaError (+4 more)
+
+### Community 14 - "Community 14"
 Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
-### Community 14 - "Community 14"
+### Community 15 - "Community 15"
 Cohesion: 0.17
 Nodes (31): asRecord(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale(), getPhase() (+23 more)
 
-### Community 15 - "Community 15"
+### Community 16 - "Community 16"
 Cohesion: 0.12
 Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
 
-### Community 16 - "Community 16"
+### Community 17 - "Community 17"
 Cohesion: 0.15
 Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
 
-### Community 17 - "Community 17"
-Cohesion: 0.15
-Nodes (24): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+16 more)
-
 ### Community 18 - "Community 18"
+Cohesion: 0.14
+Nodes (24): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+16 more)
+
+### Community 19 - "Community 19"
 Cohesion: 0.2
 Nodes (28): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftCreatedMessage(), buildCycleCountDraftSavedMessage(), buildCycleCountDraftSubmissionKey(), buildCycleCountDraftSubmittedMessage(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx() (+20 more)
 
-### Community 19 - "Community 19"
+### Community 20 - "Community 20"
+Cohesion: 0.15
+Nodes (24): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+16 more)
+
+### Community 21 - "Community 21"
 Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
-### Community 20 - "Community 20"
+### Community 22 - "Community 22"
 Cohesion: 0.08
 Nodes (7): buildMissingDraftResult(), getApprovalRequestCopy(), handleDecideApprovalRequest(), handleDiscardCycleCountDraft(), handleRefreshCycleCountDraftLineBaseline(), handleSaveCycleCountDraftLine(), handleSubmitCycleCountDraft()
 
-### Community 21 - "Community 21"
+### Community 23 - "Community 23"
 Cohesion: 0.15
 Nodes (22): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildInferentialSummaryNote(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem() (+14 more)
 
-### Community 22 - "Community 22"
+### Community 24 - "Community 24"
 Cohesion: 0.14
 Nodes (25): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildWeekMetricForDate(), buildWeekMetrics(), compareTimelineEvents(), emptyCloseSummary(), getCloseItemCounts() (+17 more)
-
-### Community 23 - "Community 23"
-Cohesion: 0.15
-Nodes (22): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+14 more)
-
-### Community 24 - "Community 24"
-Cohesion: 0.09
-Nodes (10): createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), normalizeDrawerAuthorityState(), normalizeStaffAuthorityRecord(), normalizeTerminalIntegrityState(), normalizeUsername(), PosLocalStoreSchemaError, preserveWrappedStaffProof() (+2 more)
 
 ### Community 25 - "Community 25"
 Cohesion: 0.1
@@ -2082,40 +2083,40 @@ Cohesion: 0.31
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getOperationalWorkItemStatus() (+5 more)
 
 ### Community 73 - "Community 73"
-Cohesion: 0.18
-Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
+Cohesion: 0.15
+Nodes (2): handleKeyDown(), isDebugShortcut()
 
 ### Community 74 - "Community 74"
 Cohesion: 0.18
-Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
+Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
 ### Community 75 - "Community 75"
-Cohesion: 0.26
-Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
+Cohesion: 0.18
+Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
 ### Community 76 - "Community 76"
 Cohesion: 0.26
-Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
+Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
 ### Community 77 - "Community 77"
+Cohesion: 0.26
+Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
+
+### Community 78 - "Community 78"
 Cohesion: 0.23
 Nodes (7): buildTerminalHealthSummary(), deriveTerminalHealth(), deriveTerminalHealthAttentionReasons(), getTerminalHealthSummary(), resolveAttentionReasonActionTargets(), resolveCloudRegisterSessionTargets(), stripRuntimeStatusIdentity()
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 79 - "Community 79"
+### Community 80 - "Community 80"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.15
 Nodes (0):
-
-### Community 81 - "Community 81"
-Cohesion: 0.17
-Nodes (2): handleKeyDown(), isDebugShortcut()
 
 ### Community 82 - "Community 82"
 Cohesion: 0.17
@@ -2254,136 +2255,136 @@ Cohesion: 0.29
 Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
 
 ### Community 116 - "Community 116"
+Cohesion: 0.22
+Nodes (2): buildCashierPresence(), getTestOperatingDate()
+
+### Community 117 - "Community 117"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.42
 Nodes (7): getRegisterCatalogPrice(), listRegisterCatalog(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.39
 Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.43
 Nodes (6): assertActiveTerminal(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 140 - "Community 140"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 141 - "Community 141"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 142 - "Community 142"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 143 - "Community 143"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
-
-### Community 145 - "Community 145"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 146 - "Community 146"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 147 - "Community 147"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
-
-### Community 148 - "Community 148"
 Cohesion: 0.25
 Nodes (0):
+
+### Community 148 - "Community 148"
+Cohesion: 0.39
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 149 - "Community 149"
 Cohesion: 0.25
@@ -2514,140 +2515,140 @@ Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
 ### Community 181 - "Community 181"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 182 - "Community 182"
 Cohesion: 0.33
 Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 190 - "Community 190"
-Cohesion: 0.33
-Nodes (1): ValkeyClient
-
 ### Community 191 - "Community 191"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ValkeyClient
 
 ### Community 192 - "Community 192"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 193 - "Community 193"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 194 - "Community 194"
 Cohesion: 0.47
 Nodes (4): buildOperationalEvent(), matchesExistingEvent(), metadataDedupeKeysMatch(), recordOperationalEventWithCtx()
 
-### Community 194 - "Community 194"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 195 - "Community 195"
-Cohesion: 0.4
-Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
-
-### Community 196 - "Community 196"
 Cohesion: 0.4
 Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
 
-### Community 197 - "Community 197"
+### Community 196 - "Community 196"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 197 - "Community 197"
+Cohesion: 0.4
+Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
+
 ### Community 198 - "Community 198"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 199 - "Community 199"
 Cohesion: 0.53
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 199 - "Community 199"
+### Community 200 - "Community 200"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 202 - "Community 202"
+### Community 203 - "Community 203"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 203 - "Community 203"
+### Community 204 - "Community 204"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 204 - "Community 204"
+### Community 205 - "Community 205"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 205 - "Community 205"
+### Community 206 - "Community 206"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 206 - "Community 206"
+### Community 207 - "Community 207"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 207 - "Community 207"
+### Community 208 - "Community 208"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 208 - "Community 208"
+### Community 209 - "Community 209"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 209 - "Community 209"
+### Community 210 - "Community 210"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 210 - "Community 210"
+### Community 211 - "Community 211"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 211 - "Community 211"
+### Community 212 - "Community 212"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
-### Community 212 - "Community 212"
+### Community 213 - "Community 213"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 213 - "Community 213"
+### Community 214 - "Community 214"
 Cohesion: 0.4
 Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
-
-### Community 214 - "Community 214"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 215 - "Community 215"
 Cohesion: 0.33
@@ -2659,27 +2660,27 @@ Nodes (0):
 
 ### Community 217 - "Community 217"
 Cohesion: 0.33
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 218 - "Community 218"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 219 - "Community 219"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 220 - "Community 220"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 221 - "Community 221"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 222 - "Community 222"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 223 - "Community 223"
 Cohesion: 0.33
@@ -2694,64 +2695,64 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 226 - "Community 226"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 227 - "Community 227"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 228 - "Community 228"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 229 - "Community 229"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 230 - "Community 230"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 231 - "Community 231"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 231 - "Community 231"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
 ### Community 232 - "Community 232"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 233 - "Community 233"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 234 - "Community 234"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 235 - "Community 235"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 236 - "Community 236"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 237 - "Community 237"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 238 - "Community 238"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 240 - "Community 240"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 241 - "Community 241"
 Cohesion: 0.53
@@ -3090,36 +3091,36 @@ Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 325 - "Community 325"
+Cohesion: 0.67
+Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
+
+### Community 326 - "Community 326"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 326 - "Community 326"
+### Community 327 - "Community 327"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 327 - "Community 327"
+### Community 328 - "Community 328"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 328 - "Community 328"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 329 - "Community 329"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 330 - "Community 330"
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+
+### Community 331 - "Community 331"
 Cohesion: 0.67
 Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
-### Community 331 - "Community 331"
+### Community 332 - "Community 332"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
-
-### Community 332 - "Community 332"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 333 - "Community 333"
 Cohesion: 0.5
@@ -3134,24 +3135,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 336 - "Community 336"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 337 - "Community 337"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 337 - "Community 337"
+### Community 338 - "Community 338"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 338 - "Community 338"
+### Community 339 - "Community 339"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 339 - "Community 339"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 340 - "Community 340"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 341 - "Community 341"
 Cohesion: 0.5
@@ -3166,20 +3167,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 344 - "Community 344"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 345 - "Community 345"
 Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 346 - "Community 346"
 Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 347 - "Community 347"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 348 - "Community 348"
 Cohesion: 0.5
@@ -3202,20 +3203,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 353 - "Community 353"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 354 - "Community 354"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 354 - "Community 354"
+### Community 355 - "Community 355"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 355 - "Community 355"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 356 - "Community 356"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 357 - "Community 357"
 Cohesion: 0.5
@@ -3226,12 +3227,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 359 - "Community 359"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 360 - "Community 360"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 360 - "Community 360"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 361 - "Community 361"
 Cohesion: 0.5
@@ -3242,112 +3243,112 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 363 - "Community 363"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 364 - "Community 364"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 364 - "Community 364"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 365 - "Community 365"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 366 - "Community 366"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 367 - "Community 367"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
 
-### Community 367 - "Community 367"
+### Community 368 - "Community 368"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 368 - "Community 368"
-Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 369 - "Community 369"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 370 - "Community 370"
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+
+### Community 371 - "Community 371"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 371 - "Community 371"
+### Community 372 - "Community 372"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 372 - "Community 372"
+### Community 373 - "Community 373"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 373 - "Community 373"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 374 - "Community 374"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 375 - "Community 375"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 376 - "Community 376"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 377 - "Community 377"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 378 - "Community 378"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 378 - "Community 378"
+### Community 379 - "Community 379"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 379 - "Community 379"
+### Community 380 - "Community 380"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 380 - "Community 380"
+### Community 381 - "Community 381"
 Cohesion: 0.83
 Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 381 - "Community 381"
+### Community 382 - "Community 382"
 Cohesion: 0.83
 Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
-### Community 382 - "Community 382"
+### Community 383 - "Community 383"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 383 - "Community 383"
+### Community 384 - "Community 384"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 384 - "Community 384"
+### Community 385 - "Community 385"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 385 - "Community 385"
+### Community 386 - "Community 386"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 386 - "Community 386"
+### Community 387 - "Community 387"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 387 - "Community 387"
+### Community 388 - "Community 388"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 388 - "Community 388"
+### Community 389 - "Community 389"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 389 - "Community 389"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 390 - "Community 390"
 Cohesion: 0.5
@@ -3378,59 +3379,59 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 397 - "Community 397"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 398 - "Community 398"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 399 - "Community 399"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 400 - "Community 400"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 400 - "Community 400"
+### Community 401 - "Community 401"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 401 - "Community 401"
-Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 402 - "Community 402"
 Cohesion: 0.83
-Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 403 - "Community 403"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
 ### Community 404 - "Community 404"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 405 - "Community 405"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 406 - "Community 406"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 407 - "Community 407"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 407 - "Community 407"
+### Community 408 - "Community 408"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 408 - "Community 408"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 409 - "Community 409"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 410 - "Community 410"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 411 - "Community 411"
@@ -3438,12 +3439,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 412 - "Community 412"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 413 - "Community 413"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 413 - "Community 413"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 414 - "Community 414"
 Cohesion: 0.67
@@ -3478,12 +3479,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 422 - "Community 422"
-Cohesion: 1.0
-Nodes (2): buildCtx(), createDb()
-
-### Community 423 - "Community 423"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 423 - "Community 423"
+Cohesion: 1.0
+Nodes (2): buildCtx(), createDb()
 
 ### Community 424 - "Community 424"
 Cohesion: 0.67
@@ -8797,6 +8798,10 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1752 - "Community 1752"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -8884,2277 +8889,2279 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 615`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 616`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 617`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 618`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 619`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 620`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 621`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 622`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
+- **Thin community `Community 623`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
+- **Thin community `Community 624`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 625`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 626`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 627`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 628`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 629`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
+- **Thin community `Community 630`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 631`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 632`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 633`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 634`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 635`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 636`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 637`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 638`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 639`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 640`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 641`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 642`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 643`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 644`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 645`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 646`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 647`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 648`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 649`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 650`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 651`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 652`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 653`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 654`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 655`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 656`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 657`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 658`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 659`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 660`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 661`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 662`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 663`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 664`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 665`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 666`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 667`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 668`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 669`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 670`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 671`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 672`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 673`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 674`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 675`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 676`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 677`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 678`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 679`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 680`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 681`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 682`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 683`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 684`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 685`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 686`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 687`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 688`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 689`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 690`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 691`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 692`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 693`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 694`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 695`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 696`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 697`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 698`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 699`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 700`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 701`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 702`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 703`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 704`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 705`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 706`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 707`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 708`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 709`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 710`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 711`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 712`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 713`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 714`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
+- **Thin community `Community 715`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 716`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 717`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 718`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 719`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 720`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 721`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 722`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 723`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 724`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 725`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 726`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 727`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 728`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 729`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 730`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 731`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 732`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 733`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 734`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 735`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 736`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 737`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 738`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 739`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 740`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 741`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 742`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 743`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 744`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 745`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 746`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 747`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 748`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 749`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 750`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 751`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 752`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 753`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 754`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 755`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 756`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 757`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 758`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
+- **Thin community `Community 759`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 760`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 761`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 762`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 763`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 764`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 765`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 766`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 767`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 768`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 769`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 770`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 771`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 772`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 773`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 774`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 775`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 776`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 777`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 778`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 779`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 780`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 781`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 782`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 783`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 784`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 785`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 786`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 787`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 788`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 789`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 790`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 791`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 792`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 793`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 794`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 795`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 796`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 797`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 798`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 799`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 800`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 801`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 802`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 803`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 804`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 805`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 806`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 807`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 808`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 809`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 810`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 811`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 812`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 813`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 814`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 815`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 816`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 817`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 818`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 819`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 820`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 821`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 822`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 823`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 824`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 825`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 826`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 827`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 828`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 829`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 830`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 831`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 832`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 833`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 834`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 835`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 836`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 837`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 838`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 839`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 840`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 841`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 842`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 843`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 844`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 845`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 846`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 847`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 848`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 849`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 850`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 851`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 852`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 853`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 854`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 855`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 856`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 857`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 858`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 859`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 860`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 861`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 862`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 863`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 864`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 865`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 866`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 867`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 868`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 869`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 870`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 871`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 872`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 873`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 874`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 875`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 876`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 877`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 878`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 879`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 880`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 881`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 882`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 883`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 884`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 885`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 886`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 887`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 888`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 889`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 890`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 891`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 892`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 893`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 894`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 895`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 896`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 897`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 898`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 899`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 900`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 901`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 902`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 903`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 904`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 905`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 906`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 907`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 908`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 909`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 910`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 911`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 912`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 913`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 914`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 915`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 916`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 917`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 918`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 919`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 920`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 921`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 922`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 923`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 924`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 925`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 926`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 927`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 928`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 929`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 930`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 931`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 932`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 933`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 934`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 935`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 936`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 937`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 938`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 939`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 940`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 941`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 942`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 943`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 944`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 945`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 946`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 947`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 948`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 949`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 950`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 951`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 952`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 953`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 954`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 955`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 956`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 957`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 958`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 959`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 960`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 961`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 962`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 963`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 964`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 965`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 966`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 967`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 968`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 969`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 970`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 971`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 972`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 973`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 974`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 975`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 976`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 977`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 978`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 979`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 980`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 981`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 982`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 983`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 984`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 985`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 986`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 987`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 988`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 989`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 990`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (1 nodes): `api.d.ts`
+- **Thin community `Community 991`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `api.js`
+- **Thin community `Community 992`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 993`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `server.d.ts`
+- **Thin community `Community 994`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `server.js`
+- **Thin community `Community 995`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `app.ts`
+- **Thin community `Community 996`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 997`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 998`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `auth.config.js`
+- **Thin community `Community 999`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1000`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `auth.ts`
+- **Thin community `Community 1001`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1002`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1003`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1004`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `countries.ts`
+- **Thin community `Community 1005`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `email.ts`
+- **Thin community `Community 1006`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1007`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `payment.ts`
+- **Thin community `Community 1008`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `crons.ts`
+- **Thin community `Community 1009`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1010`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `internal.ts`
+- **Thin community `Community 1011`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1012`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1013`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1014`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1015`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1016`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1017`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1018`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1019`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1020`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1021`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1022`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `env.ts`
+- **Thin community `Community 1023`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1024`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `auth.ts`
+- **Thin community `Community 1025`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1026`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `colors.ts`
+- **Thin community `Community 1027`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `index.ts`
+- **Thin community `Community 1028`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1029`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `products.ts`
+- **Thin community `Community 1030`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1031`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `stores.ts`
+- **Thin community `Community 1032`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `bag.ts`
+- **Thin community `Community 1033`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `guest.ts`
+- **Thin community `Community 1034`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `index.ts`
+- **Thin community `Community 1035`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `me.ts`
+- **Thin community `Community 1036`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `offers.ts`
+- **Thin community `Community 1037`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1038`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1039`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1040`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1041`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1042`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1043`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1044`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1045`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1046`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `user.ts`
+- **Thin community `Community 1047`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1048`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `index.ts`
+- **Thin community `Community 1049`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1050`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `http.ts`
+- **Thin community `Community 1051`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1052`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1053`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1054`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `categories.ts`
+- **Thin community `Community 1055`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `colors.ts`
+- **Thin community `Community 1056`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1057`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 1058`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1059`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1060`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1061`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1062`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `pos.ts`
+- **Thin community `Community 1063`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1064`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1065`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1066`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1067`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1068`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1069`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1070`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1071`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1072`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1073`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1074`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1075`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1076`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1077`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1078`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1079`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `types.ts`
+- **Thin community `Community 1080`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1081`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1082`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1083`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1084`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1085`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1086`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `dto.ts`
+- **Thin community `Community 1087`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1088`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1089`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `types.ts`
+- **Thin community `Community 1090`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1091`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1092`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `customers.ts`
+- **Thin community `Community 1093`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `register.ts`
+- **Thin community `Community 1094`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `sync.ts`
+- **Thin community `Community 1095`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `schema.ts`
+- **Thin community `Community 1096`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1097`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `index.ts`
+- **Thin community `Community 1098`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1099`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1100`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1101`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1102`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1103`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `category.ts`
+- **Thin community `Community 1104`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `color.ts`
+- **Thin community `Community 1105`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1106`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1107`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `index.ts`
+- **Thin community `Community 1108`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1109`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1110`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `organization.ts`
+- **Thin community `Community 1111`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1112`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `product.ts`
+- **Thin community `Community 1113`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1114`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1115`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `store.ts`
+- **Thin community `Community 1116`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1117`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `index.ts`
+- **Thin community `Community 1118`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1119`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1120`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1121`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1122`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1123`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1124`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1125`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `index.ts`
+- **Thin community `Community 1126`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1127`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1128`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1129`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1130`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1131`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1132`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1133`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1134`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1135`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1136`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1137`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `customer.ts`
+- **Thin community `Community 1138`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1139`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1140`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1141`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1142`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `index.ts`
+- **Thin community `Community 1143`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1144`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1145`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1146`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1147`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1148`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1149`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1150`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1151`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1152`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1153`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1154`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1155`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1156`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1157`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1158`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1159`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1160`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `index.ts`
+- **Thin community `Community 1161`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1162`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1163`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1164`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1165`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1166`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1167`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `index.ts`
+- **Thin community `Community 1168`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1169`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1170`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1171`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1172`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1173`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1174`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `bag.ts`
+- **Thin community `Community 1175`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1176`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1177`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1178`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `guest.ts`
+- **Thin community `Community 1179`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `index.ts`
+- **Thin community `Community 1180`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `offer.ts`
+- **Thin community `Community 1181`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1182`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1183`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `review.ts`
+- **Thin community `Community 1184`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1185`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1186`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1187`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1188`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1189`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1190`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1191`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1192`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1193`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `bag.ts`
+- **Thin community `Community 1194`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1195`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `customer.ts`
+- **Thin community `Community 1196`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `guest.ts`
+- **Thin community `Community 1197`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1198`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1199`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1200`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1201`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `payment.ts`
+- **Thin community `Community 1202`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1203`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1204`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1205`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `users.ts`
+- **Thin community `Community 1206`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `payment.ts`
+- **Thin community `Community 1207`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1208`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1209`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1210`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1211`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1212`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `index.ts`
+- **Thin community `Community 1213`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1214`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1215`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1216`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `auth.ts`
+- **Thin community `Community 1217`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1218`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1219`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1220`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1221`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1222`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1223`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1224`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1225`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1226`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1227`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1228`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1229`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1230`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1231`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `constants.ts`
+- **Thin community `Community 1232`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1233`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1234`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1235`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `types.ts`
+- **Thin community `Community 1236`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1237`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1238`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1239`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1240`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1241`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1242`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1243`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1244`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1245`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1246`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1247`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1248`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1249`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1250`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1251`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1252`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1253`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1254`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1255`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1256`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `constants.ts`
+- **Thin community `Community 1257`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1258`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1259`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1260`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `data.ts`
+- **Thin community `Community 1261`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1262`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1263`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1264`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1265`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1266`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1267`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1268`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1269`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1270`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `constants.ts`
+- **Thin community `Community 1271`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1272`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1273`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1274`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `data.ts`
+- **Thin community `Community 1275`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1276`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1277`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1278`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1279`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1280`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1281`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1282`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1283`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1284`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1285`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1286`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1287`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `constants.ts`
+- **Thin community `Community 1288`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1289`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1290`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1291`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1292`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1293`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1294`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1295`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1296`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1297`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1298`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1299`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1300`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1301`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1302`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1303`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1304`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1305`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1306`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1307`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1308`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1309`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1310`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1311`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1312`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1313`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1314`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1315`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1316`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1317`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1318`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1319`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `constants.ts`
+- **Thin community `Community 1320`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1321`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1322`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1323`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `data.ts`
+- **Thin community `Community 1324`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1325`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1326`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `constants.ts`
+- **Thin community `Community 1327`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1328`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1329`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1330`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1331`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `data.ts`
+- **Thin community `Community 1332`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1333`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `constants.ts`
+- **Thin community `Community 1334`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1335`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1336`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1337`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1338`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `data.ts`
+- **Thin community `Community 1339`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1340`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1341`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1342`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1343`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1344`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1345`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1346`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1347`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1348`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1349`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1350`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1351`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1352`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1353`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1354`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1355`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1356`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1357`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1358`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1359`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1360`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1361`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1362`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1363`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1364`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `POSSettingsView.test.tsx`
+- **Thin community `Community 1365`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1366`** (1 nodes): `POSSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `POSTerminalHealthView.test.tsx`
+- **Thin community `Community 1367`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1368`** (1 nodes): `POSTerminalHealthView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1369`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1370`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `types.ts`
+- **Thin community `Community 1371`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1372`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1373`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1374`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1375`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1376`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1377`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1378`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1379`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1380`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1381`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1382`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1383`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1384`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1385`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1386`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `data.ts`
+- **Thin community `Community 1387`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1388`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1389`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1390`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1391`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1392`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1393`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1394`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1395`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1396`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1397`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1398`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1399`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `constants.ts`
+- **Thin community `Community 1400`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1401`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1402`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1403`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `data.ts`
+- **Thin community `Community 1404`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `types.ts`
+- **Thin community `Community 1405`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1406`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1407`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1408`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1409`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1410`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `index.tsx`
+- **Thin community `Community 1411`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1412`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1413`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1414`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1415`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1416`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1417`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1418`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1419`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `index.tsx`
+- **Thin community `Community 1420`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1421`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1422`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1423`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `button.tsx`
+- **Thin community `Community 1424`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1425`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `card.tsx`
+- **Thin community `Community 1426`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1427`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1428`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `command.tsx`
+- **Thin community `Community 1429`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1430`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1431`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1432`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `form.tsx`
+- **Thin community `Community 1433`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1434`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1435`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `input.tsx`
+- **Thin community `Community 1436`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1437`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1438`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1439`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1440`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1441`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1442`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `select.tsx`
+- **Thin community `Community 1443`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1444`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1445`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1446`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `table.tsx`
+- **Thin community `Community 1447`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1448`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1449`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1450`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1451`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1452`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1453`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1454`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1455`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `constants.ts`
+- **Thin community `Community 1456`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1457`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1458`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1459`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `data.ts`
+- **Thin community `Community 1460`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1461`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1462`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1463`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1464`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1465`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1466`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1467`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1468`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1469`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1470`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1471`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `index.ts`
+- **Thin community `Community 1472`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1473`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1474`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1475`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1476`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1477`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1478`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1479`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1480`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1481`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1482`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1483`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `aws.ts`
+- **Thin community `Community 1484`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `constants.ts`
+- **Thin community `Community 1485`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `countries.ts`
+- **Thin community `Community 1486`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1487`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1488`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1489`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1490`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1491`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1492`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `dto.ts`
+- **Thin community `Community 1493`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `ports.ts`
+- **Thin community `Community 1494`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `constants.ts`
+- **Thin community `Community 1495`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1496`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1497`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `index.ts`
+- **Thin community `Community 1498`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1499`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `types.ts`
+- **Thin community `Community 1500`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1501`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1502`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1503`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1504`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1505`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1506`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1507`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1508`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1509`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1510`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `category.ts`
+- **Thin community `Community 1511`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `product.ts`
+- **Thin community `Community 1512`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `store.ts`
+- **Thin community `Community 1513`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1514`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `user.ts`
+- **Thin community `Community 1515`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1516`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1517`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1518`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1519`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1520`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1521`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1522`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1523`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1524`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1525`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `index.tsx`
+- **Thin community `Community 1526`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1527`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1528`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1529`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1530`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1531`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1532`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1533`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `index.tsx`
+- **Thin community `Community 1534`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1535`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1536`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1537`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `home.tsx`
+- **Thin community `Community 1538`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1539`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1540`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1541`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `index.tsx`
+- **Thin community `Community 1542`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1543`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `index.tsx`
+- **Thin community `Community 1544`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1545`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1546`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1547`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `index.tsx`
+- **Thin community `Community 1548`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1549`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1550`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1551`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1552`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1553`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1554`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `index.tsx`
+- **Thin community `Community 1555`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1556`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1557`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1558`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1559`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1560`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1561`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1562`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1563`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1564`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `index.tsx`
+- **Thin community `Community 1565`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1566`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `index.tsx`
+- **Thin community `Community 1567`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `new.tsx`
+- **Thin community `Community 1568`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `index.tsx`
+- **Thin community `Community 1569`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `new.tsx`
+- **Thin community `Community 1570`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1571`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1572`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `index.tsx`
+- **Thin community `Community 1573`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `new.tsx`
+- **Thin community `Community 1574`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `index.tsx`
+- **Thin community `Community 1575`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1576`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1577`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1578`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1579`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `index.tsx`
+- **Thin community `Community 1580`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1581`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1582`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1583`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `index.tsx`
+- **Thin community `Community 1584`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1585`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1586`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1587`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1588`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1589`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1590`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1591`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1592`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1593`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1594`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1595`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1596`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1597`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1598`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1599`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1600`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1601`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1602`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1603`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1604`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1605`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1606`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1607`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1608`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `setup.ts`
+- **Thin community `Community 1609`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1610`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `types.ts`
+- **Thin community `Community 1611`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1612`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1613`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1614`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1615`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1616`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `types.ts`
+- **Thin community `Community 1617`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1618`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1619`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1620`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1621`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1622`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1623`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1624`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1625`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1626`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `schema.ts`
+- **Thin community `Community 1627`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1628`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1629`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1630`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1631`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1632`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1633`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1634`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1635`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1636`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `types.ts`
+- **Thin community `Community 1637`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1638`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1639`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1640`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1641`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1642`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1643`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1644`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `constants.ts`
+- **Thin community `Community 1645`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1646`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `About.tsx`
+- **Thin community `Community 1647`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1648`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1649`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1650`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1651`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1652`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1653`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1654`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1655`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1656`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1657`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `types.ts`
+- **Thin community `Community 1658`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1659`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1660`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1661`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1662`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1663`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1664`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1665`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1666`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1667`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1668`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1669`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `button.tsx`
+- **Thin community `Community 1670`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `card.tsx`
+- **Thin community `Community 1671`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1672`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `command.tsx`
+- **Thin community `Community 1673`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1674`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1675`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1676`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `form.tsx`
+- **Thin community `Community 1677`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1678`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1679`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1680`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1681`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `input.tsx`
+- **Thin community `Community 1682`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `label.tsx`
+- **Thin community `Community 1683`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1684`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1685`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1686`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `index.ts`
+- **Thin community `Community 1687`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `types.ts`
+- **Thin community `Community 1688`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1689`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1690`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1691`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1692`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `select.tsx`
+- **Thin community `Community 1693`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1694`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1695`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `table.tsx`
+- **Thin community `Community 1696`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1697`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1698`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1699`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1700`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1701`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `config.ts`
+- **Thin community `Community 1702`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1703`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1704`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1705`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1706`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `constants.ts`
+- **Thin community `Community 1707`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `countries.ts`
+- **Thin community `Community 1708`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1709`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1710`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1711`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1712`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `index.ts`
+- **Thin community `Community 1713`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `store.ts`
+- **Thin community `Community 1714`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `bag.ts`
+- **Thin community `Community 1715`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1716`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `category.ts`
+- **Thin community `Community 1717`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `organization.ts`
+- **Thin community `Community 1718`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `product.ts`
+- **Thin community `Community 1719`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `store.ts`
+- **Thin community `Community 1720`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1721`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `user.ts`
+- **Thin community `Community 1722`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `states.ts`
+- **Thin community `Community 1723`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1724`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1725`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1726`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1727`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1728`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1729`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1730`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `index.tsx`
+- **Thin community `Community 1731`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1732`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `index.tsx`
+- **Thin community `Community 1733`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1734`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1735`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1736`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1737`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1738`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `index.tsx`
+- **Thin community `Community 1739`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1740`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1741`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1742`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1743`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1744`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `index.js`
+- **Thin community `Community 1745`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1746`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1747`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1748`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1749`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1750`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1751`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1752`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -11167,7 +11174,7 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 1` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 2` be split into smaller, more focused modules?**
-  _Cohesion score 0.06 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.05 - nodes in this community are weakly interconnected._
 - **Should `Community 3` be split into smaller, more focused modules?**
   _Cohesion score 0.1 - nodes in this community are weakly interconnected._
 - **Should `Community 4` be split into smaller, more focused modules?**

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,15 +7,15 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1824
-- Graph nodes: 6108
-- Graph edges: 6561
-- Communities: 1752
+- Code files discovered: 1825
+- Graph nodes: 6126
+- Graph edges: 6586
+- Communities: 1753
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (84 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `useRegisterViewModel.ts` (55 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
+- `useRegisterViewModel.ts` (58 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `harness-inferential-review.ts` (46 edges, Community 3) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `RegisterSessionView.tsx` (45 edges, Community 4) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
 - `storefrontJourneyEvents.ts` (45 edges, Community 5) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -19,7 +19,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 ## Graph Hotspots
 - `DailyCloseView.tsx` (84 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `useRegisterViewModel.ts` (55 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
+- `useRegisterViewModel.ts` (58 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `RegisterSessionView.tsx` (45 edges, Community 4) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
 - `usePosLocalSyncRuntime.ts` (44 edges, Community 6) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
 

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (14 edges, Community 70) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 130) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 131) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 70) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `createRedisCluster()` (3 edges, Community 70) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `deleteKeysIndividually()` (3 edges, Community 70) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/_generated/api.d.ts
+++ b/packages/athena-webapp/convex/_generated/api.d.ts
@@ -174,6 +174,7 @@ import type * as pos_application_sync_ingestLocalEvents from "../pos/application
 import type * as pos_application_sync_projectLocalEvents from "../pos/application/sync/projectLocalEvents.js";
 import type * as pos_application_sync_registerSessionSyncReview from "../pos/application/sync/registerSessionSyncReview.js";
 import type * as pos_application_sync_staffProof from "../pos/application/sync/staffProof.js";
+import type * as pos_application_sync_staffProofValidation from "../pos/application/sync/staffProofValidation.js";
 import type * as pos_application_sync_terminalSyncSecret from "../pos/application/sync/terminalSyncSecret.js";
 import type * as pos_application_sync_types from "../pos/application/sync/types.js";
 import type * as pos_domain_errors from "../pos/domain/errors.js";
@@ -518,6 +519,7 @@ declare const fullApi: ApiFromModules<{
   "pos/application/sync/projectLocalEvents": typeof pos_application_sync_projectLocalEvents;
   "pos/application/sync/registerSessionSyncReview": typeof pos_application_sync_registerSessionSyncReview;
   "pos/application/sync/staffProof": typeof pos_application_sync_staffProof;
+  "pos/application/sync/staffProofValidation": typeof pos_application_sync_staffProofValidation;
   "pos/application/sync/terminalSyncSecret": typeof pos_application_sync_terminalSyncSecret;
   "pos/application/sync/types": typeof pos_application_sync_types;
   "pos/domain/errors": typeof pos_domain_errors;

--- a/packages/athena-webapp/convex/operations/staffCredentials.test.ts
+++ b/packages/athena-webapp/convex/operations/staffCredentials.test.ts
@@ -28,6 +28,8 @@ import {
   refreshTerminalStaffAuthority,
   updateStaffCredential,
   updateStaffCredentialWithCtx,
+  validateRestoredPosLocalStaffProof,
+  validateRestoredPosLocalStaffProofWithCtx,
 } from "./staffCredentials";
 import { hashPosLocalStaffProofToken } from "../pos/application/sync/staffProof";
 
@@ -136,6 +138,12 @@ function createStaffCredentialsMutationCtx(seed?: {
 
     return {
       first: async () => matches[0] ?? null,
+      unique: async () => {
+        if (matches.length > 1) {
+          throw new Error(`Expected unique ${table} query result`);
+        }
+        return matches[0] ?? null;
+      },
       take: async (count: number) => matches.slice(0, count),
       collect: async () => matches,
     };
@@ -185,6 +193,83 @@ function createStaffCredentialsMutationCtx(seed?: {
 
 function getHandler(definition: unknown) {
   return (definition as { _handler: Function })._handler;
+}
+
+async function createRestoredProofValidationCtx(overrides: {
+  credential?: Partial<Row> | null;
+  proof?: Partial<Row> | null;
+  profile?: Partial<Row> | null;
+  role?: Partial<Row> | null;
+  token?: string;
+} = {}) {
+  const token = overrides.token ?? "proof-token-1";
+  const tokenHash = await hashPosLocalStaffProofToken(token);
+
+  return createStaffCredentialsMutationCtx({
+    posLocalStaffProofs:
+      overrides.proof === null
+        ? []
+        : [
+            {
+              _id: "proof-1",
+              credentialId: "credential-1",
+              credentialVersion: 2,
+              createdAt: 50,
+              expiresAt: 200,
+              staffProfileId: "staff_profile_1",
+              status: "active",
+              storeId: "store_1",
+              terminalId: "terminal-1",
+              tokenHash,
+              ...overrides.proof,
+            },
+          ],
+    credentials:
+      overrides.credential === null
+        ? []
+        : [
+            {
+              _id: "credential-1",
+              staffProfileId: "staff_profile_1",
+              organizationId: "org_1",
+              storeId: "store_1",
+              username: "frontdesk",
+              pinHash: "hash-1",
+              localVerifierVersion: 2,
+              status: "active",
+              ...overrides.credential,
+            },
+          ],
+    profiles:
+      overrides.profile === null
+        ? []
+        : [
+            {
+              _id: "staff_profile_1",
+              storeId: "store_1",
+              organizationId: "org_1",
+              status: "active",
+              fullName: "Ari Mensah",
+              ...overrides.profile,
+            },
+          ],
+    roles:
+      overrides.role === null
+        ? []
+        : [
+            {
+              _id: "role_1",
+              staffProfileId: "staff_profile_1",
+              organizationId: "org_1",
+              storeId: "store_1",
+              role: "cashier",
+              isPrimary: true,
+              status: "active",
+              assignedAt: 1,
+              ...overrides.role,
+            },
+          ],
+  });
 }
 
 describe("staff credential operations", () => {
@@ -1541,6 +1626,413 @@ describe("staff credential operations", () => {
         userId: "athena-user-1",
       },
     );
+  });
+
+  it("validates a restored POS local staff proof without minting a renewed proof", async () => {
+    const tokenHash = await hashPosLocalStaffProofToken("proof-token-1");
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
+      posLocalStaffProofs: [
+        {
+          _id: "proof-1",
+          credentialId: "credential-1",
+          credentialVersion: 2,
+          createdAt: 50,
+          expiresAt: 200,
+          staffProfileId: "staff_profile_1",
+          status: "active",
+          storeId: "store_1",
+          terminalId: "terminal-1",
+          tokenHash,
+        },
+      ],
+      credentials: [
+        {
+          _id: "credential-1",
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          username: "frontdesk",
+          pinHash: "hash-1",
+          localVerifierVersion: 2,
+          status: "active",
+        },
+      ],
+      profiles: [
+        {
+          _id: "staff_profile_1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Ari Mensah",
+        },
+      ],
+      roles: [
+        {
+          _id: "role_1",
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          role: "cashier",
+          isPrimary: true,
+          status: "active",
+          assignedAt: 1,
+        },
+      ],
+    });
+
+    await expect(
+      validateRestoredPosLocalStaffProofWithCtx(ctx, {
+        allowedRoles: ["cashier"],
+        now: 100,
+        staffProfileId: "staff_profile_1" as Id<"staffProfile">,
+        storeId: "store_1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        token: "proof-token-1",
+      }),
+    ).resolves.toEqual({
+      kind: "ok",
+      data: expect.objectContaining({
+        activeRoles: ["cashier"],
+        credentialId: "credential-1",
+        credentialVersion: 2,
+        posLocalStaffProof: {
+          expiresAt: 200,
+          token: "proof-token-1",
+        },
+        staffProfileId: "staff_profile_1",
+      }),
+    });
+    expect(tables.posLocalStaffProof.size).toBe(1);
+    expect(tables.posLocalStaffProof.get("proof-1")).toEqual(
+      expect.objectContaining({ lastUsedAt: 100 }),
+    );
+  });
+
+  it("returns explicit restored POS local staff proof failure reasons", async () => {
+    const tokenHash = await hashPosLocalStaffProofToken("proof-token-1");
+    const { ctx } = createStaffCredentialsMutationCtx({
+      posLocalStaffProofs: [
+        {
+          _id: "proof-1",
+          credentialId: "credential-1",
+          credentialVersion: 2,
+          createdAt: 50,
+          expiresAt: 200,
+          staffProfileId: "staff_profile_1",
+          status: "active",
+          storeId: "store_1",
+          terminalId: "terminal-1",
+          tokenHash,
+        },
+      ],
+      credentials: [
+        {
+          _id: "credential-1",
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          username: "frontdesk",
+          pinHash: "hash-1",
+          localVerifierVersion: 3,
+          status: "active",
+        },
+      ],
+      profiles: [
+        {
+          _id: "staff_profile_1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Ari Mensah",
+        },
+      ],
+      roles: [
+        {
+          _id: "role_1",
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          role: "cashier",
+          isPrimary: true,
+          status: "active",
+          assignedAt: 1,
+        },
+      ],
+    });
+
+    await expect(
+      validateRestoredPosLocalStaffProofWithCtx(ctx, {
+        allowedRoles: ["cashier"],
+        now: 100,
+        staffProfileId: "staff_profile_1" as Id<"staffProfile">,
+        storeId: "store_1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        token: "proof-token-1",
+      }),
+    ).resolves.toEqual({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Stored staff proof is no longer valid. Sign in again.",
+        metadata: {
+          reason: "credential_version_mismatch",
+        },
+      },
+    });
+  });
+
+  it("returns proof and credential failure reasons without touching proof usage", async () => {
+    const cases: Array<{
+      name: string;
+      overrides: Parameters<typeof createRestoredProofValidationCtx>[0];
+      reason: string;
+      token?: string;
+    }> = [
+      {
+        name: "missing proof",
+        overrides: { proof: null },
+        reason: "proof_not_found",
+      },
+      {
+        name: "inactive proof",
+        overrides: { proof: { status: "revoked" } },
+        reason: "proof_inactive",
+      },
+      {
+        name: "wrong proof terminal",
+        overrides: { proof: { terminalId: "terminal-2" } },
+        reason: "proof_scope_mismatch",
+      },
+      {
+        name: "expired proof",
+        overrides: { proof: { expiresAt: 99 } },
+        reason: "proof_expired",
+      },
+      {
+        name: "missing credential",
+        overrides: { credential: null },
+        reason: "credential_not_found",
+      },
+      {
+        name: "inactive credential",
+        overrides: { credential: { status: "suspended" } },
+        reason: "credential_inactive",
+      },
+      {
+        name: "wrong credential store",
+        overrides: { credential: { storeId: "store_2" } },
+        reason: "credential_scope_mismatch",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const { ctx, tables } = await createRestoredProofValidationCtx(
+        testCase.overrides,
+      );
+
+      await expect(
+        validateRestoredPosLocalStaffProofWithCtx(ctx, {
+          allowedRoles: ["cashier"],
+          now: 100,
+          staffProfileId: "staff_profile_1" as Id<"staffProfile">,
+          storeId: "store_1" as Id<"store">,
+          terminalId: "terminal-1" as Id<"posTerminal">,
+          token: testCase.token ?? "proof-token-1",
+        }),
+      ).resolves.toEqual({
+        kind: "user_error",
+        error: {
+          code: "precondition_failed",
+          message: "Stored staff proof is no longer valid. Sign in again.",
+          metadata: {
+            reason: testCase.reason,
+          },
+        },
+      });
+
+      expect(
+        tables.posLocalStaffProof.get("proof-1")?.lastUsedAt,
+        testCase.name,
+      ).toBeUndefined();
+    }
+  });
+
+  it("fails closed when restored proof token hash matches multiple rows", async () => {
+    const tokenHash = await hashPosLocalStaffProofToken("proof-token-1");
+    const { ctx, tables } = createStaffCredentialsMutationCtx({
+      posLocalStaffProofs: [
+        {
+          _id: "proof-1",
+          credentialId: "credential-1",
+          credentialVersion: 2,
+          createdAt: 50,
+          expiresAt: 200,
+          staffProfileId: "staff_profile_1",
+          status: "active",
+          storeId: "store_1",
+          terminalId: "terminal-1",
+          tokenHash,
+        },
+        {
+          _id: "proof-2",
+          credentialId: "credential-1",
+          credentialVersion: 2,
+          createdAt: 60,
+          expiresAt: 200,
+          staffProfileId: "staff_profile_1",
+          status: "active",
+          storeId: "store_1",
+          terminalId: "terminal-1",
+          tokenHash,
+        },
+      ],
+      credentials: [
+        {
+          _id: "credential-1",
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          username: "frontdesk",
+          pinHash: "hash-1",
+          localVerifierVersion: 2,
+          status: "active",
+        },
+      ],
+      profiles: [
+        {
+          _id: "staff_profile_1",
+          storeId: "store_1",
+          organizationId: "org_1",
+          status: "active",
+          fullName: "Ari Mensah",
+        },
+      ],
+      roles: [
+        {
+          _id: "role_1",
+          staffProfileId: "staff_profile_1",
+          organizationId: "org_1",
+          storeId: "store_1",
+          role: "cashier",
+          isPrimary: true,
+          status: "active",
+          assignedAt: 1,
+        },
+      ],
+    });
+
+    await expect(
+      validateRestoredPosLocalStaffProofWithCtx(ctx, {
+        allowedRoles: ["cashier"],
+        now: 100,
+        staffProfileId: "staff_profile_1" as Id<"staffProfile">,
+        storeId: "store_1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        token: "proof-token-1",
+      }),
+    ).resolves.toEqual({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message: "Stored staff proof is no longer valid. Sign in again.",
+        metadata: {
+          reason: "proof_not_found",
+        },
+      },
+    });
+
+    expect(tables.posLocalStaffProof.get("proof-1")?.lastUsedAt).toBeUndefined();
+    expect(tables.posLocalStaffProof.get("proof-2")?.lastUsedAt).toBeUndefined();
+  });
+
+  it("returns staff profile failure reasons without touching proof usage", async () => {
+    const cases: Array<{
+      name: string;
+      overrides: Parameters<typeof createRestoredProofValidationCtx>[0];
+      reason: string;
+      allowedRoles?: Array<"cashier" | "manager">;
+    }> = [
+      {
+        name: "missing staff profile",
+        overrides: { profile: null },
+        reason: "staff_profile_not_found",
+      },
+      {
+        name: "wrong staff profile store",
+        overrides: { profile: { storeId: "store_2" } },
+        reason: "staff_profile_scope_mismatch",
+      },
+      {
+        name: "inactive staff profile",
+        overrides: { profile: { status: "inactive" } },
+        reason: "staff_profile_inactive",
+      },
+      {
+        name: "no active roles",
+        overrides: { role: null },
+        reason: "staff_profile_no_active_roles",
+      },
+      {
+        name: "role not allowed",
+        overrides: {},
+        allowedRoles: ["manager"],
+        reason: "staff_profile_role_not_allowed",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const { ctx, tables } = await createRestoredProofValidationCtx(
+        testCase.overrides,
+      );
+
+      await expect(
+        validateRestoredPosLocalStaffProofWithCtx(ctx, {
+          allowedRoles: testCase.allowedRoles ?? ["cashier"],
+          now: 100,
+          staffProfileId: "staff_profile_1" as Id<"staffProfile">,
+          storeId: "store_1" as Id<"store">,
+          terminalId: "terminal-1" as Id<"posTerminal">,
+          token: "proof-token-1",
+        }),
+      ).resolves.toEqual({
+        kind: "user_error",
+        error: {
+          code: "precondition_failed",
+          message: "Stored staff proof is no longer valid. Sign in again.",
+          metadata: {
+            reason: testCase.reason,
+          },
+        },
+      });
+
+      expect(
+        tables.posLocalStaffProof.get("proof-1")?.lastUsedAt,
+        testCase.name,
+      ).toBeUndefined();
+    }
+  });
+
+  it("requires POS terminal access before public restored proof validation", async () => {
+    const { ctx } = createStaffCredentialsMutationCtx();
+    authMocks.requireOrganizationMemberRoleWithCtx.mockRejectedValueOnce(
+      new Error("No POS access"),
+    );
+
+    await expect(
+      getHandler(validateRestoredPosLocalStaffProof)(ctx, {
+        allowedRoles: ["cashier"],
+        staffProfileId: "staff_profile_1" as Id<"staffProfile">,
+        storeId: "store_1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        token: "proof-token-1",
+      }),
+    ).resolves.toEqual({
+      kind: "user_error",
+      error: {
+        code: "authorization_failed",
+        message: "This terminal is not available for staff authentication.",
+      },
+    });
   });
 
   it("refreshes terminal-scoped local staff authority without exposing legacy credentials", async () => {

--- a/packages/athena-webapp/convex/operations/staffCredentials.ts
+++ b/packages/athena-webapp/convex/operations/staffCredentials.ts
@@ -17,6 +17,10 @@ import {
   POS_LOCAL_STAFF_PROOF_TTL_MS,
 } from "../pos/application/sync/staffProof";
 import {
+  validatePosLocalStaffProofWithCtx,
+  type PosLocalStaffProofValidationFailureReason,
+} from "../pos/application/sync/staffProofValidation";
+import {
   requireAuthenticatedAthenaUserWithCtx,
   requireOrganizationMemberRoleWithCtx,
 } from "../lib/athenaUserAuth";
@@ -139,6 +143,22 @@ function staffPreconditionFailedResult(
   return userError({
     code: "precondition_failed",
     message,
+  });
+}
+
+function restoredStaffProofInvalidResult(
+  reason:
+    | PosLocalStaffProofValidationFailureReason
+    | "staff_profile_not_found"
+    | "staff_profile_scope_mismatch"
+    | "staff_profile_inactive"
+    | "staff_profile_no_active_roles"
+    | "staff_profile_role_not_allowed",
+): StaffCredentialAuthenticationResult {
+  return userError({
+    code: "precondition_failed",
+    message: "Stored staff proof is no longer valid. Sign in again.",
+    metadata: { reason },
   });
 }
 
@@ -837,6 +857,83 @@ async function issuePosLocalStaffProofWithCtx(
   return { expiresAt, token };
 }
 
+export async function validateRestoredPosLocalStaffProofWithCtx(
+  ctx: Pick<MutationCtx, "db">,
+  args: {
+    allowedRoles?: OperationalRole[];
+    now?: number;
+    staffProfileId: Id<"staffProfile">;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+    token: string;
+  },
+): Promise<StaffCredentialAuthenticationResult> {
+  const now = args.now ?? Date.now();
+  const validation = await validatePosLocalStaffProofWithCtx(ctx, {
+    now,
+    staffProfileId: args.staffProfileId,
+    storeId: args.storeId,
+    terminalId: args.terminalId,
+    token: args.token,
+    touchLastUsed: false,
+  });
+
+  if (validation.kind !== "ok") {
+    return restoredStaffProofInvalidResult(validation.reason);
+  }
+
+  const staffProfile = await ctx.db.get("staffProfile", args.staffProfileId);
+  if (!staffProfile) {
+    return restoredStaffProofInvalidResult("staff_profile_not_found");
+  }
+
+  if (
+    staffProfile.storeId !== args.storeId ||
+    staffProfile.organizationId !== validation.credential.organizationId
+  ) {
+    return restoredStaffProofInvalidResult("staff_profile_scope_mismatch");
+  }
+
+  if (staffProfile.status !== "active") {
+    return restoredStaffProofInvalidResult("staff_profile_inactive");
+  }
+
+  const activeRoles = await getActiveRolesForStaffProfile(ctx, {
+    organizationId: validation.credential.organizationId,
+    staffProfileId: args.staffProfileId,
+    storeId: args.storeId,
+  });
+  if (activeRoles.length === 0) {
+    return restoredStaffProofInvalidResult("staff_profile_no_active_roles");
+  }
+
+  const authorizedRoles =
+    args.allowedRoles && args.allowedRoles.length > 0
+      ? activeRoles.filter((role) => args.allowedRoles!.includes(role.role))
+      : activeRoles;
+  if (authorizedRoles.length === 0) {
+    return restoredStaffProofInvalidResult("staff_profile_role_not_allowed");
+  }
+
+  await ctx.db.patch("posLocalStaffProof", validation.proof._id, {
+    lastUsedAt: now,
+  });
+
+  return ok({
+    activeRoles: authorizedRoles.map((role) => role.role),
+    credentialId: validation.credential._id,
+    ...(validation.proof.credentialVersion !== undefined
+      ? { credentialVersion: validation.proof.credentialVersion }
+      : {}),
+    posLocalStaffProof: {
+      expiresAt: validation.proof.expiresAt,
+      token: args.token,
+    },
+    staffProfile,
+    staffProfileId: args.staffProfileId,
+  });
+}
+
 export async function authenticateStaffCredentialForApprovalWithCtx(
   ctx: Pick<MutationCtx, "db">,
   args: {
@@ -1060,6 +1157,27 @@ export const authenticateStaffCredentialForTerminal = mutation({
     }
 
     return authenticateStaffCredentialForTerminalWithCtx(ctx, args);
+  },
+});
+
+export const validateRestoredPosLocalStaffProof = mutation({
+  args: {
+    allowedRoles: v.optional(v.array(operationalRoleValidator)),
+    staffProfileId: v.id("staffProfile"),
+    storeId: v.id("store"),
+    terminalId: v.id("posTerminal"),
+    token: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const terminalAuthority = await requirePosTerminalAuthorityWithCtx(ctx, {
+      storeId: args.storeId,
+      terminalId: args.terminalId,
+    });
+    if (terminalAuthority.kind !== "ok") {
+      return terminalAuthority;
+    }
+
+    return validateRestoredPosLocalStaffProofWithCtx(ctx, args);
   },
 });
 

--- a/packages/athena-webapp/convex/pos/application/sync/staffProofValidation.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/staffProofValidation.ts
@@ -1,0 +1,95 @@
+import type { Doc, Id } from "../../../_generated/dataModel";
+import type { MutationCtx } from "../../../_generated/server";
+import { hashPosLocalStaffProofToken } from "./staffProof";
+
+export type PosLocalStaffProofValidationFailureReason =
+  | "proof_not_found"
+  | "proof_inactive"
+  | "proof_scope_mismatch"
+  | "proof_expired"
+  | "credential_not_found"
+  | "credential_inactive"
+  | "credential_scope_mismatch"
+  | "credential_version_mismatch";
+
+export type PosLocalStaffProofValidationResult =
+  | {
+      kind: "ok";
+      credential: Doc<"staffCredential">;
+      proof: Doc<"posLocalStaffProof">;
+    }
+  | {
+      kind: "rejected";
+      reason: PosLocalStaffProofValidationFailureReason;
+    };
+
+export async function validatePosLocalStaffProofWithCtx(
+  ctx: Pick<MutationCtx, "db">,
+  args: {
+    now: number;
+    staffProfileId: Id<"staffProfile">;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+    token: string;
+    touchLastUsed?: boolean;
+  },
+): Promise<PosLocalStaffProofValidationResult> {
+  const tokenHash = await hashPosLocalStaffProofToken(args.token);
+  let proof: Doc<"posLocalStaffProof"> | null;
+  try {
+    proof = await ctx.db
+      .query("posLocalStaffProof")
+      .withIndex("by_tokenHash", (q) => q.eq("tokenHash", tokenHash))
+      .unique();
+  } catch {
+    return { kind: "rejected", reason: "proof_not_found" };
+  }
+
+  if (!proof) {
+    return { kind: "rejected", reason: "proof_not_found" };
+  }
+
+  if (proof.status !== "active") {
+    return { kind: "rejected", reason: "proof_inactive" };
+  }
+
+  if (
+    proof.staffProfileId !== args.staffProfileId ||
+    proof.storeId !== args.storeId ||
+    proof.terminalId !== args.terminalId
+  ) {
+    return { kind: "rejected", reason: "proof_scope_mismatch" };
+  }
+
+  if (proof.expiresAt <= args.now) {
+    return { kind: "rejected", reason: "proof_expired" };
+  }
+
+  const credential = await ctx.db.get("staffCredential", proof.credentialId);
+  if (!credential) {
+    return { kind: "rejected", reason: "credential_not_found" };
+  }
+
+  if (credential.status !== "active") {
+    return { kind: "rejected", reason: "credential_inactive" };
+  }
+
+  if (
+    credential.staffProfileId !== args.staffProfileId ||
+    credential.storeId !== args.storeId
+  ) {
+    return { kind: "rejected", reason: "credential_scope_mismatch" };
+  }
+
+  if (credential.localVerifierVersion !== proof.credentialVersion) {
+    return { kind: "rejected", reason: "credential_version_mismatch" };
+  }
+
+  if (args.touchLastUsed !== false) {
+    await ctx.db.patch("posLocalStaffProof", proof._id, {
+      lastUsedAt: args.now,
+    });
+  }
+
+  return { kind: "ok", credential, proof };
+}

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
@@ -20,7 +20,7 @@ import type {
   LocalSyncRepository,
   PosSyncOperationalRole,
 } from "../../application/sync/types";
-import { hashPosLocalStaffProofToken } from "../../application/sync/staffProof";
+import { validatePosLocalStaffProofWithCtx } from "../../application/sync/staffProofValidation";
 
 export function createConvexLocalSyncRepository(
   ctx: MutationCtx,
@@ -66,37 +66,8 @@ export function createConvexLocalSyncRepository(
       );
     },
     async validateLocalStaffProof(args) {
-      const tokenHash = await hashPosLocalStaffProofToken(args.token);
-      const proof = await ctx.db
-        .query("posLocalStaffProof")
-        .withIndex("by_tokenHash", (q) => q.eq("tokenHash", tokenHash))
-        .unique();
-      if (
-        !proof ||
-        proof.status !== "active" ||
-        proof.staffProfileId !== args.staffProfileId ||
-        proof.storeId !== args.storeId ||
-        proof.terminalId !== args.terminalId ||
-        proof.expiresAt <= args.now
-      ) {
-        return false;
-      }
-
-      const credential = await ctx.db.get("staffCredential", proof.credentialId);
-      if (
-        !credential ||
-        credential.status !== "active" ||
-        credential.staffProfileId !== args.staffProfileId ||
-        credential.storeId !== args.storeId ||
-        credential.localVerifierVersion !== proof.credentialVersion
-      ) {
-        return false;
-      }
-
-      await ctx.db.patch("posLocalStaffProof", proof._id, {
-        lastUsedAt: args.now,
-      });
-      return true;
+      const validation = await validatePosLocalStaffProofWithCtx(ctx, args);
+      return validation.kind === "ok";
     },
     getStore(storeId) {
       return ctx.db.get("store", storeId);

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -22,7 +22,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/stockOps`](../../convex/stockOps) — Stock-adjustment, procurement, replenishment, receiving, and vendor flows layered over inventory state. Currently 14 file(s); key children: access.test.ts, access.ts, adjustments.test.ts, adjustments.ts, cycleCountDrafts.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 6 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCases.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 11 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 475 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 476 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 7 file(s); key children: README.md, SUMMARY.md, pos.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx
+++ b/packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx
@@ -77,9 +77,9 @@ export function CashierAuthDialog({
     pin: string;
     posLocalStaffProof?: { expiresAt: number; token: string };
     staffProfileId: Id<"staffProfile">;
-  }) => {
+  }): Promise<PosLocalStaffAuthorityRecord | null> => {
     if (isBrowserOffline()) {
-      return;
+      return null;
     }
 
     let result: CommandResult<PosLocalStaffAuthorityRecord[]>;
@@ -96,7 +96,7 @@ export function CashierAuthDialog({
         storeId,
         terminalId,
       });
-      return;
+      return null;
     }
 
     if (result.kind !== "ok") {
@@ -117,7 +117,7 @@ export function CashierAuthDialog({
           terminalId,
         });
       }
-      return;
+      return null;
     }
 
     const records = await Promise.all(
@@ -161,7 +161,16 @@ export function CashierAuthDialog({
         storeId,
         terminalId,
       });
+      return null;
     }
+
+    return (
+      records.find(
+        (record) =>
+          unlock?.staffProfileId === record.staffProfileId &&
+          Boolean(record.wrappedPosLocalStaffProof),
+      ) ?? null
+    );
   }, [localStore, refreshTerminalStaffAuthority, storeId, terminalId]);
 
   useEffect(() => {
@@ -232,6 +241,7 @@ export function CashierAuthDialog({
 
     return ok({
       activeRoles: authority.activeRoles,
+      localStaffAuthority: authority,
       posLocalStaffProof,
       staffProfile: {
         fullName: authority.displayName ?? null,
@@ -281,14 +291,20 @@ export function CashierAuthDialog({
       return authenticationResult;
     }
 
-    void refreshLocalAuthority({
+    const localStaffAuthority = await refreshLocalAuthority({
       pin: args.pin,
       posLocalStaffProof: authenticationResult.data.posLocalStaffProof,
       staffProfileId: authenticationResult.data.staffProfileId,
     });
+    const authenticationData = localStaffAuthority
+      ? {
+          ...authenticationResult.data,
+          localStaffAuthority,
+        }
+      : authenticationResult.data;
 
     if (args.mode === "authenticate") {
-      return authenticationResult;
+      return ok(authenticationData);
     }
 
     const expireResult = await expireAllSessionsForStaff({
@@ -315,11 +331,17 @@ export function CashierAuthDialog({
       }),
     );
     if (recoveryResult.kind === "ok") {
-      void refreshLocalAuthority({
+      const recoveryLocalStaffAuthority = await refreshLocalAuthority({
         pin: args.pin,
         posLocalStaffProof: recoveryResult.data.posLocalStaffProof,
         staffProfileId: recoveryResult.data.staffProfileId,
       });
+      if (recoveryLocalStaffAuthority) {
+        return ok({
+          ...recoveryResult.data,
+          localStaffAuthority: recoveryLocalStaffAuthority,
+        });
+      }
     }
 
     return recoveryResult;

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -740,6 +740,120 @@ describe("POSRegisterView", () => {
     expect(onRetrySync).toHaveBeenCalled();
   });
 
+  it("shows restrained copy while restored cashier access is validating", async () => {
+    mockUseRegisterViewModel.mockReturnValue({
+      hasActiveStore: true,
+      header: {
+        title: "POS",
+        isSessionActive: false,
+      },
+      registerInfo: {
+        registerLabel: "Front Counter",
+        hasTerminal: true,
+      },
+      customerPanel: {},
+      productEntry: {
+        disabled: true,
+        productSearchQuery: "",
+        setProductSearchQuery: vi.fn(),
+        onBarcodeSubmit: vi.fn(),
+      },
+      cart: {
+        items: [],
+      },
+      checkout: {
+        isTransactionCompleted: false,
+      },
+      sessionPanel: null,
+      cashierCard: null,
+      cashierPresenceRestore: {
+        status: "validation_pending",
+        message: "Checking cashier access before new sales.",
+      },
+      closeoutControl: null,
+      authDialog: {
+        open: true,
+      },
+      drawerGate: null,
+      onNavigateBack: vi.fn(),
+    });
+
+    const { POSRegisterView } = await import("./POSRegisterView");
+    render(<POSRegisterView />);
+
+    expect(
+      screen.getByText("Checking cashier access before new sales."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("cashier-auth-dialog")).toBeInTheDocument();
+    expect(screen.queryByText(/Cashier Ama K\./)).not.toBeInTheDocument();
+  });
+
+  it("shows cashier presence in support diagnostics without proof material", async () => {
+    mockUseRegisterViewModel.mockReturnValue({
+      hasActiveStore: true,
+      header: {
+        title: "POS",
+        isSessionActive: true,
+      },
+      registerInfo: {
+        registerLabel: "Front Counter",
+        hasTerminal: true,
+      },
+      customerPanel: {},
+      productEntry: {
+        disabled: false,
+        productSearchQuery: "",
+        setProductSearchQuery: vi.fn(),
+        onBarcodeSubmit: vi.fn(),
+      },
+      cart: {
+        items: [],
+      },
+      checkout: {
+        isTransactionCompleted: false,
+      },
+      sessionPanel: {},
+      cashierCard: {},
+      cashierPresenceRestore: {
+        status: "restored",
+      },
+      closeoutControl: null,
+      authDialog: {
+        open: false,
+      },
+      drawerGate: null,
+      debug: {
+        activeStoreSource: "live",
+        authDialogOpen: false,
+        cashierPresence: "restored",
+        hasLiveActiveStore: true,
+        localStaffAuthorityStatus: "ready",
+        localEntryStatus: "ready",
+        online: true,
+        staffSignedIn: true,
+        syncFlow: {
+          eventAppendToken: 1,
+          source: "none",
+          staffProof: "present",
+          status: "synced",
+        },
+        terminalSource: "live",
+      },
+      onNavigateBack: vi.fn(),
+    });
+
+    const { POSRegisterView } = await import("./POSRegisterView");
+    render(<POSRegisterView />);
+
+    await userEvent.keyboard("{Meta>}/{/Meta}");
+
+    expect(screen.getByText("cashier presence")).toBeInTheDocument();
+    expect(screen.getByText("Restored")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/proof-token|pin|sync-secret/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows an operable register as ready when manager review exists elsewhere", async () => {
     const onRetrySync = vi.fn();
     mockUseRegisterViewModel.mockReturnValue({

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -202,6 +202,30 @@ function CashierAuthWorkspace({
   );
 }
 
+function CashierPresenceRestoreWorkspace({
+  restore,
+}: {
+  restore: RegisterViewModel["cashierPresenceRestore"];
+}) {
+  if (!restore.message) return null;
+
+  return (
+    <section
+      aria-live="polite"
+      className="flex min-h-[8rem] items-center justify-center rounded-lg border border-border bg-surface-raised px-6 py-6 text-center"
+    >
+      <div className="max-w-xl space-y-2">
+        <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+          Cashier sign-in
+        </p>
+        <h2 className="text-xl font-semibold text-foreground">
+          {restore.message}
+        </h2>
+      </div>
+    </section>
+  );
+}
+
 function DrawerGateWorkspace({
   drawerGate,
 }: {
@@ -515,6 +539,7 @@ function POSLocalDebugStrip({
     ["store record", formatDebugStatus(debug.activeStoreSource)],
     ["register record", formatDebugStatus(debug.terminalSource)],
     ["staff sign-in", debug.staffSignedIn ? "Signed in" : "Not signed in"],
+    ["cashier presence", formatDebugStatus(debug.cashierPresence)],
     [
       "staff authorization",
       debug.syncFlow.staffProof === "present" ? "Ready" : "Needed",
@@ -977,6 +1002,8 @@ export function POSRegisterView({
   const pendingProductLookupFocusAfterSaleStartRef = useRef(false);
   const headerProductSearchInputRef = useRef<HTMLInputElement>(null);
   const isDebugPanelVisible = usePosDebugPanelToggle();
+  const cashierPresenceRestore =
+    viewModel.cashierPresenceRestore ?? ({ status: "missing" } as const);
 
   useCollapseSidebarForPosFlow();
   const isSessionActive = viewModel.header.isSessionActive;
@@ -1494,7 +1521,17 @@ export function POSRegisterView({
                 ) : isPosWorkflow && viewModel.drawerGate ? (
                   <DrawerGateWorkspace drawerGate={viewModel.drawerGate} />
                 ) : isAwaitingCashierAuth && viewModel.authDialog ? (
-                  <CashierAuthWorkspace authDialog={viewModel.authDialog} />
+                  <div className="flex min-h-0 flex-1 flex-col gap-4">
+                    <CashierPresenceRestoreWorkspace
+                      restore={cashierPresenceRestore}
+                    />
+                    <CashierAuthWorkspace authDialog={viewModel.authDialog} />
+                  </div>
+                ) : cashierPresenceRestore.status === "validation_pending" &&
+                  cashierPresenceRestore.message ? (
+                  <CashierPresenceRestoreWorkspace
+                    restore={cashierPresenceRestore}
+                  />
                 ) : shouldRenderExpenseCompletionWorkspace ? (
                   <div className="min-h-0 flex-1 overflow-y-auto rounded-lg bg-surface p-4">
                     <ExpenseCompletionPanel checkout={viewModel.checkout} />

--- a/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx
+++ b/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx
@@ -14,6 +14,7 @@ import { type NormalizedCommandResult } from "@/lib/errors/runCommand";
 import { presentCommandToast } from "@/lib/errors/presentCommandToast";
 import { hashPin } from "@/lib/security/pinHash";
 import type { Id } from "~/convex/_generated/dataModel";
+import type { PosLocalStaffAuthorityRecord } from "@/lib/pos/infrastructure/local/posLocalStore";
 import {
   GENERIC_UNEXPECTED_ERROR_MESSAGE,
   GENERIC_UNEXPECTED_ERROR_TITLE,
@@ -33,6 +34,7 @@ export type StaffAuthenticationResult = {
     expiresAt: number;
     token: string;
   };
+  localStaffAuthority?: PosLocalStaffAuthorityRecord;
   staffProfile: {
     firstName?: string | null;
     fullName?: string | null;

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
@@ -9,6 +9,7 @@ import {
   createIndexedDbPosLocalStorageAdapter,
   createMemoryPosLocalStorageAdapter,
   createPosLocalStore,
+  toSafePosLocalCashierPresenceDiagnostic,
 } from "./posLocalStore";
 import { readProjectedLocalRegisterModel } from "./localRegisterReader";
 
@@ -38,6 +39,31 @@ function buildAuthorityRecord(overrides = {}) {
       iterations: 120000,
       salt: "salt",
       version: 1 as const,
+    },
+    ...overrides,
+  };
+}
+
+function buildCashierPresenceRecord(overrides = {}) {
+  return {
+    activeRoles: ["cashier" as const],
+    credentialId: "credential-1",
+    credentialVersion: 1,
+    displayName: "Ama Mensah",
+    expiresAt: 10_000,
+    lastValidatedAt: 1_500,
+    offlineFreshUntil: 5_000,
+    operatingDate: "2026-06-04",
+    organizationId: "org-1",
+    signedInAt: 1_000,
+    staffProfileId: "staff-1",
+    storeId: "store-1",
+    terminalId: "terminal-1",
+    username: "FrontDesk",
+    wrappedPosLocalStaffProof: {
+      ciphertext: "wrapped-proof-token",
+      expiresAt: 10_000,
+      iv: "proof-iv",
     },
     ...overrides,
   };
@@ -1178,6 +1204,292 @@ describe("posLocalStore", () => {
         username: "broken",
       }),
     ).resolves.toEqual({ ok: true, value: null });
+  });
+
+  it("writes and restores terminal store-day cashier presence across store instances", async () => {
+    const adapter = createMemoryPosLocalStorageAdapter();
+    const store = createPosLocalStore({
+      adapter,
+      clock: () => 2_000,
+    });
+
+    await expect(
+      store.writeCashierPresence(buildCashierPresenceRecord()),
+    ).resolves.toEqual({
+      ok: true,
+      value: expect.objectContaining({
+        organizationId: "org-1",
+        operatingDate: "2026-06-04",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+        username: "frontdesk",
+        wrappedPosLocalStaffProof: {
+          ciphertext: "wrapped-proof-token",
+          expiresAt: 10_000,
+          iv: "proof-iv",
+        },
+      }),
+    });
+
+    const reloadedStore = createPosLocalStore({
+      adapter,
+      clock: () => 2_500,
+    });
+
+    await expect(
+      reloadedStore.readCashierPresence({
+        organizationId: "org-1",
+        operatingDate: "2026-06-04",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      value: expect.objectContaining({
+        staffProfileId: "staff-1",
+        username: "frontdesk",
+        wrappedPosLocalStaffProof: expect.objectContaining({
+          ciphertext: "wrapped-proof-token",
+        }),
+      }),
+    });
+  });
+
+  it("keeps cashier presence isolated by terminal store organization and operating date", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 2_000,
+    });
+
+    await store.writeCashierPresence(buildCashierPresenceRecord());
+
+    for (const input of [
+      {
+        organizationId: "org-2",
+        operatingDate: "2026-06-04",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      },
+      {
+        organizationId: "org-1",
+        operatingDate: "2026-06-04",
+        storeId: "store-2",
+        terminalId: "terminal-1",
+      },
+      {
+        organizationId: "org-1",
+        operatingDate: "2026-06-04",
+        storeId: "store-1",
+        terminalId: "terminal-2",
+      },
+      {
+        organizationId: "org-1",
+        operatingDate: "2026-06-05",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      },
+    ]) {
+      await expect(store.readCashierPresence(input)).resolves.toEqual({
+        ok: true,
+        value: null,
+      });
+    }
+  });
+
+  it("drops expired cashier presence proof material before returning it", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 6_000,
+    });
+
+    await store.writeCashierPresence(buildCashierPresenceRecord());
+
+    await expect(
+      store.readCashierPresence({
+        organizationId: "org-1",
+        operatingDate: "2026-06-04",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).resolves.toEqual({ ok: true, value: null });
+    await expect(
+      store.readCashierPresence({
+        organizationId: "org-1",
+        operatingDate: "2026-06-04",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).resolves.toEqual({ ok: true, value: null });
+  });
+
+  it("clears cashier presence without deleting staff authority", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 2_000,
+    });
+
+    await store.replaceStaffAuthoritySnapshot({
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      records: [buildAuthorityRecord({ expiresAt: 10_000 })],
+    });
+    await store.writeCashierPresence(buildCashierPresenceRecord());
+
+    await expect(
+      store.clearCashierPresence({
+        organizationId: "org-1",
+        operatingDate: "2026-06-04",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).resolves.toEqual({ ok: true, value: null });
+    await expect(
+      store.readCashierPresence({
+        organizationId: "org-1",
+        operatingDate: "2026-06-04",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).resolves.toEqual({ ok: true, value: null });
+    await expect(
+      store.readStaffAuthorityForUsername({
+        storeId: "store-1",
+        terminalId: "terminal-1",
+        username: "frontdesk",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      value: expect.objectContaining({
+        credentialId: "credential-1",
+      }),
+    });
+  });
+
+  it("invalidates cashier presence for one terminal without clearing another terminal", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 2_000,
+    });
+
+    await store.writeCashierPresence(buildCashierPresenceRecord());
+    await store.writeCashierPresence(
+      buildCashierPresenceRecord({
+        terminalId: "terminal-2",
+      }),
+    );
+
+    await expect(
+      store.invalidateCashierPresenceForTerminal({
+        organizationId: "org-1",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).resolves.toEqual({ ok: true, value: 1 });
+    await expect(
+      store.readCashierPresence({
+        organizationId: "org-1",
+        operatingDate: "2026-06-04",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).resolves.toEqual({ ok: true, value: null });
+    await expect(
+      store.readCashierPresence({
+        organizationId: "org-1",
+        operatingDate: "2026-06-04",
+        storeId: "store-1",
+        terminalId: "terminal-2",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      value: expect.objectContaining({
+        terminalId: "terminal-2",
+      }),
+    });
+  });
+
+  it("redacts cashier presence diagnostics without exposing wrapped proof material", () => {
+    const diagnostic = toSafePosLocalCashierPresenceDiagnostic(
+      buildCashierPresenceRecord({
+        wrappedPosLocalStaffProof: {
+          ciphertext: "wrapped-proof-token-secret",
+          expiresAt: 10_000,
+          iv: "proof-iv-secret",
+        },
+      }),
+    );
+    const serialized = JSON.stringify(diagnostic);
+
+    expect(diagnostic).toMatchObject({
+      proof: {
+        expiresAt: 10_000,
+        status: "present",
+      },
+      staffProfileId: "staff-1",
+      username: "frontdesk",
+    });
+    expect(serialized).not.toContain("wrapped-proof-token-secret");
+    expect(serialized).not.toContain("proof-iv-secret");
+    expect(serialized).not.toContain("staffProofToken");
+    expect(serialized).not.toContain("verifier");
+    expect(serialized).not.toContain("syncSecret");
+  });
+
+  it("persists cashier presence through the IndexedDB cashier presence store", async () => {
+    const originalIndexedDb = globalThis.indexedDB;
+    const fakeIndexedDb = createControlledIndexedDb();
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: fakeIndexedDb.indexedDB,
+    });
+
+    try {
+      const store = createPosLocalStore({
+        adapter: createIndexedDbPosLocalStorageAdapter({
+          databaseName: "athena-pos-local-cashier-presence-test",
+        }),
+        clock: () => 2_000,
+      });
+
+      const write = store.writeCashierPresence(buildCashierPresenceRecord());
+      await fakeIndexedDb.waitForTransaction();
+      fakeIndexedDb.completeLastTransaction();
+      await expect(write).resolves.toMatchObject({
+        ok: true,
+        value: {
+          staffProfileId: "staff-1",
+          username: "frontdesk",
+        },
+      });
+
+      const read = store.readCashierPresence({
+        organizationId: "org-1",
+        operatingDate: "2026-06-04",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      });
+      await fakeIndexedDb.waitForTransaction();
+      fakeIndexedDb.completeLastTransaction();
+      await expect(read).resolves.toMatchObject({
+        ok: true,
+        value: expect.objectContaining({
+          staffProfileId: "staff-1",
+        }),
+      });
+
+      expect(fakeIndexedDb.database.createObjectStore).toHaveBeenCalledWith(
+        "cashierPresence",
+      );
+      expect(fakeIndexedDb.database.transaction).toHaveBeenCalledWith(
+        ["meta", "cashierPresence"],
+        "readwrite",
+      );
+    } finally {
+      Object.defineProperty(globalThis, "indexedDB", {
+        configurable: true,
+        value: originalIndexedDb,
+      });
+    }
   });
 
   it("reads local-to-cloud mappings for later events on the same local entity", async () => {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
@@ -8,7 +8,7 @@ import type {
   PosServiceCatalogRowDto,
 } from "@/lib/pos/application/dto";
 
-export const POS_LOCAL_STORE_SCHEMA_VERSION = 7;
+export const POS_LOCAL_STORE_SCHEMA_VERSION = 8;
 
 export type PosLocalEntityKind =
   | "registerSession"
@@ -174,6 +174,41 @@ export type PosLocalStaffAuthorityReadiness =
   | "expired"
   | "ready";
 
+export type PosLocalActiveCashierPresenceRecord = {
+  activeRoles: Array<"cashier" | "manager">;
+  credentialId: string;
+  credentialVersion: number;
+  displayName?: string | null;
+  expiresAt: number;
+  lastValidatedAt: number;
+  offlineFreshUntil: number;
+  operatingDate: string;
+  organizationId: string;
+  signedInAt: number;
+  staffProfileId: string;
+  storeId: string;
+  terminalId: string;
+  username: string;
+  wrappedPosLocalStaffProof: WrappedLocalStaffProof;
+};
+
+export type PosLocalCashierPresenceScope = {
+  operatingDate: string;
+  organizationId: string;
+  storeId: string;
+  terminalId: string;
+};
+
+export type PosLocalCashierPresenceDiagnostic = Omit<
+  PosLocalActiveCashierPresenceRecord,
+  "wrappedPosLocalStaffProof"
+> & {
+  proof: {
+    expiresAt: number;
+    status: "present";
+  };
+};
+
 export interface PosLocalRegisterCatalogSnapshot {
   refreshedAt: number;
   rows: PosRegisterCatalogRowDto[];
@@ -217,6 +252,7 @@ export type PosLocalObjectStoreName =
   | "mappings"
   | "readiness"
   | "staffAuthority"
+  | "cashierPresence"
   | "registerCatalog"
   | "registerServiceCatalog"
   | "registerAvailability";
@@ -709,6 +745,127 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
                 readinessKey(input.storeId, input.operatingDate),
               )) ?? null
             );
+          },
+        );
+
+        return { ok: true, value };
+      } catch (error) {
+        return toFailure(error);
+      }
+    },
+
+    async writeCashierPresence(
+      presence: PosLocalActiveCashierPresenceRecord,
+    ): Promise<PosLocalStoreResult<PosLocalActiveCashierPresenceRecord>> {
+      try {
+        const value = await options.adapter.transaction(
+          "readwrite",
+          ["meta", "cashierPresence"],
+          async (transaction) => {
+            await ensureSupportedSchema(transaction, "readwrite");
+            const normalized = normalizeCashierPresenceRecord(presence);
+            await transaction.put(
+              "cashierPresence",
+              cashierPresenceKey(normalized),
+              normalized,
+            );
+            return normalized;
+          },
+        );
+
+        return { ok: true, value };
+      } catch (error) {
+        return toFailure(error);
+      }
+    },
+
+    async readCashierPresence(
+      input: PosLocalCashierPresenceScope & { now?: number },
+    ): Promise<PosLocalStoreResult<PosLocalActiveCashierPresenceRecord | null>> {
+      try {
+        const value = await options.adapter.transaction(
+          "readwrite",
+          ["meta", "cashierPresence"],
+          async (transaction) => {
+            await ensureSupportedSchema(transaction, "readwrite");
+            const key = cashierPresenceKey(input);
+            const record =
+              (await transaction.get<unknown>("cashierPresence", key)) ?? null;
+
+            if (
+              !isCashierPresenceRecord(record) ||
+              !matchesCashierPresenceScope(record, input)
+            ) {
+              return null;
+            }
+
+            if (isExpiredCashierPresence(record, input.now ?? clock())) {
+              await transaction.delete("cashierPresence", key);
+              return null;
+            }
+
+            return record;
+          },
+        );
+
+        return { ok: true, value };
+      } catch (error) {
+        return toFailure(error);
+      }
+    },
+
+    async clearCashierPresence(
+      input: PosLocalCashierPresenceScope,
+    ): Promise<PosLocalStoreResult<null>> {
+      try {
+        await options.adapter.transaction(
+          "readwrite",
+          ["meta", "cashierPresence"],
+          async (transaction) => {
+            await ensureSupportedSchema(transaction, "readwrite");
+            await transaction.delete(
+              "cashierPresence",
+              cashierPresenceKey(input),
+            );
+          },
+        );
+
+        return { ok: true, value: null };
+      } catch (error) {
+        return toFailure(error);
+      }
+    },
+
+    async invalidateCashierPresenceForTerminal(input: {
+      organizationId?: string;
+      storeId?: string;
+      terminalId: string;
+    }): Promise<PosLocalStoreResult<number>> {
+      try {
+        const value = await options.adapter.transaction(
+          "readwrite",
+          ["meta", "cashierPresence"],
+          async (transaction) => {
+            await ensureSupportedSchema(transaction, "readwrite");
+            const records =
+              await transaction.getAll<unknown>("cashierPresence");
+            let cleared = 0;
+            for (const record of records) {
+              if (
+                isCashierPresenceRecord(record) &&
+                record.terminalId === input.terminalId &&
+                (!input.storeId || record.storeId === input.storeId) &&
+                (!input.organizationId ||
+                  record.organizationId === input.organizationId)
+              ) {
+                await transaction.delete(
+                  "cashierPresence",
+                  cashierPresenceKey(record),
+                );
+                cleared += 1;
+              }
+            }
+            return cleared;
           },
         );
 
@@ -1299,6 +1456,15 @@ function readinessKey(storeId: string, operatingDate: string) {
   return `${storeId}:${operatingDate}`;
 }
 
+function cashierPresenceKey(input: PosLocalCashierPresenceScope) {
+  return [
+    input.organizationId,
+    input.storeId,
+    input.terminalId,
+    input.operatingDate,
+  ].join(":");
+}
+
 function uploadSequenceKey(localRegisterSessionId: string) {
   return `${META_UPLOAD_SEQUENCE_PREFIX}${localRegisterSessionId}`;
 }
@@ -1322,6 +1488,38 @@ function normalizeStaffAuthorityRecord(
     ...record,
     username: normalizeUsername(record.username),
   };
+}
+
+function normalizeCashierPresenceRecord(
+  record: PosLocalActiveCashierPresenceRecord,
+): PosLocalActiveCashierPresenceRecord {
+  return {
+    ...record,
+    username: normalizeUsername(record.username),
+  };
+}
+
+function matchesCashierPresenceScope(
+  record: PosLocalActiveCashierPresenceRecord,
+  scope: PosLocalCashierPresenceScope,
+) {
+  return (
+    record.operatingDate === scope.operatingDate &&
+    record.organizationId === scope.organizationId &&
+    record.storeId === scope.storeId &&
+    record.terminalId === scope.terminalId
+  );
+}
+
+function isExpiredCashierPresence(
+  record: PosLocalActiveCashierPresenceRecord,
+  now: number,
+) {
+  return (
+    record.expiresAt <= now ||
+    record.offlineFreshUntil <= now ||
+    record.wrappedPosLocalStaffProof.expiresAt <= now
+  );
 }
 
 function preserveWrappedStaffProof(
@@ -1465,6 +1663,58 @@ function isStaffAuthorityRecord(
   );
 }
 
+function isCashierPresenceRecord(
+  value: unknown,
+): value is PosLocalActiveCashierPresenceRecord {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Record<string, unknown>;
+  const wrappedProof = record.wrappedPosLocalStaffProof as
+    | Record<string, unknown>
+    | undefined;
+
+  return (
+    Array.isArray(record.activeRoles) &&
+    record.activeRoles.some(
+      (role) => role === "cashier" || role === "manager",
+    ) &&
+    record.activeRoles.every(
+      (role) => role === "cashier" || role === "manager",
+    ) &&
+    typeof record.credentialId === "string" &&
+    typeof record.credentialVersion === "number" &&
+    Number.isSafeInteger(record.credentialVersion) &&
+    typeof record.expiresAt === "number" &&
+    typeof record.lastValidatedAt === "number" &&
+    typeof record.offlineFreshUntil === "number" &&
+    typeof record.operatingDate === "string" &&
+    typeof record.organizationId === "string" &&
+    typeof record.signedInAt === "number" &&
+    typeof record.staffProfileId === "string" &&
+    typeof record.storeId === "string" &&
+    typeof record.terminalId === "string" &&
+    typeof record.username === "string" &&
+    typeof wrappedProof?.ciphertext === "string" &&
+    typeof wrappedProof.expiresAt === "number" &&
+    typeof wrappedProof.iv === "string"
+  );
+}
+
+export function toSafePosLocalCashierPresenceDiagnostic(
+  presence: PosLocalActiveCashierPresenceRecord | null,
+): PosLocalCashierPresenceDiagnostic | null {
+  if (!presence) return null;
+  const { wrappedPosLocalStaffProof: proof, ...safePresence } =
+    normalizeCashierPresenceRecord(presence);
+
+  return {
+    ...safePresence,
+    proof: {
+      expiresAt: proof.expiresAt,
+      status: "present",
+    },
+  };
+}
+
 export function createIndexedDbPosLocalStorageAdapter(options?: {
   databaseName?: string;
 }): PosLocalStorageAdapter {
@@ -1484,6 +1734,7 @@ export function createIndexedDbPosLocalStorageAdapter(options?: {
           "mappings",
           "readiness",
           "staffAuthority",
+          "cashierPresence",
           "registerCatalog",
           "registerServiceCatalog",
           "registerAvailability",
@@ -1652,6 +1903,7 @@ function createEmptyMemoryStore(): MemoryStore {
     mappings: new Map(),
     readiness: new Map(),
     staffAuthority: new Map(),
+    cashierPresence: new Map(),
     registerCatalog: new Map(),
     registerServiceCatalog: new Map(),
     registerAvailability: new Map(),
@@ -1667,6 +1919,7 @@ function cloneMemoryStore(store: MemoryStore): MemoryStore {
     mappings: new Map(store.mappings),
     readiness: new Map(store.readiness),
     staffAuthority: new Map(store.staffAuthority),
+    cashierPresence: new Map(store.cashierPresence),
     registerCatalog: new Map(store.registerCatalog),
     registerServiceCatalog: new Map(store.registerServiceCatalog),
     registerAvailability: new Map(store.registerAvailability),

--- a/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/expense/useExpenseRegisterViewModel.ts
@@ -647,6 +647,7 @@ export function useExpenseRegisterViewModel(): RegisterViewModel {
       cashierName: getCashierDisplayName(staffProfile ?? undefined),
       onSignOut: handleCashierSignOut,
     },
+    cashierPresenceRestore: { status: "missing" },
     drawerGate: null,
     closeoutControl: null,
     authDialog:

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -309,12 +309,28 @@ export interface RegisterOnboardingState {
   nextStep: "terminal" | "cashierSetup" | "ready";
 }
 
+export type CashierPresenceRestoreStatus =
+  | "pending"
+  | "restored"
+  | "validation_pending"
+  | "missing"
+  | "expired"
+  | "offline_freshness_expired"
+  | "invalidated"
+  | "failed";
+
+export interface RegisterCashierPresenceRestoreState {
+  status: CashierPresenceRestoreStatus;
+  message?: string;
+}
+
 export interface RegisterViewModel {
   workflowMode?: RegisterWorkflowMode;
   hasActiveStore: boolean;
   debug?: {
     activeStoreSource: "live" | "local" | "missing";
     authDialogOpen: boolean;
+    cashierPresence: CashierPresenceRestoreStatus;
     hasLiveActiveStore: boolean;
     localStaffAuthorityStatus: string;
     localEntryStatus: string;
@@ -370,6 +386,7 @@ export interface RegisterViewModel {
   checkout: RegisterCheckoutState;
   sessionPanel: RegisterSessionPanelState | null;
   cashierCard: RegisterCashierCardState | null;
+  cashierPresenceRestore: RegisterCashierPresenceRestoreState;
   drawerGate: RegisterDrawerGateState | null;
   closeoutControl: RegisterCloseoutControlState | null;
   syncStatus?: (PosSyncStatusPresentation & {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -8,6 +8,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Id } from "~/convex/_generated/dataModel";
 import { ok, userError } from "~/shared/commandResult";
+import type { StaffAuthenticationResult } from "@/components/staff-auth/StaffAuthenticationDialog";
 
 const mockUseQuery = vi.fn();
 const mockUseMutation = vi.fn();
@@ -39,6 +40,11 @@ const mockReadProvisionedTerminalSeed = vi.fn();
 const mockWriteProvisionedTerminalSeed = vi.fn();
 const mockWriteProvisionedTerminalSeedAndClearTerminalIntegrity = vi.fn();
 const mockGetStaffAuthorityReadiness = vi.fn();
+const mockReadStoreDayReadiness = vi.fn();
+const mockReadCashierPresence = vi.fn();
+const mockClearCashierPresence = vi.fn();
+const mockInvalidateCashierPresenceForTerminal = vi.fn();
+const mockWriteCashierPresence = vi.fn();
 const mockMarkLocalEventsSynced = vi.fn();
 const mockWriteLocalCloudMapping = vi.fn();
 const mockListLocalCloudMappings = vi.fn();
@@ -47,7 +53,13 @@ const mockReadTerminalIntegrityState = vi.fn();
 const mockWriteDrawerAuthorityState = vi.fn();
 const mockUsePosTerminalAppSessionRecoveryRuntimeInput = vi.fn();
 
-let mockActiveStore: { _id: Id<"store">; currency: string } | null;
+let mockActiveStore:
+  | {
+      _id: Id<"store">;
+      currency: string;
+      organizationId: Id<"organization">;
+    }
+  | null;
 let mockTerminal:
   | {
       _id: Id<"posTerminal">;
@@ -325,9 +337,17 @@ vi.mock("@/lib/pos/infrastructure/local/posLocalStore", () => ({
     listEvents: mockListLocalEvents,
     listEventsForUpload: mockListLocalEvents,
     listLocalCloudMappings: mockListLocalCloudMappings,
+    readActiveCashierPresence: mockReadCashierPresence,
+    readCashierPresence: mockReadCashierPresence,
     readDrawerAuthorityState: mockReadDrawerAuthorityState,
     readProvisionedTerminalSeed: mockReadProvisionedTerminalSeed,
+    readStoreDayReadiness: mockReadStoreDayReadiness,
     readTerminalIntegrityState: mockReadTerminalIntegrityState,
+    clearActiveCashierPresence: mockClearCashierPresence,
+    clearCashierPresence: mockClearCashierPresence,
+    invalidateCashierPresenceForTerminal:
+      mockInvalidateCashierPresenceForTerminal,
+    writeCashierPresence: mockWriteCashierPresence,
     markEventsSynced: mockMarkLocalEventsSynced,
     writeProvisionedTerminalSeed: mockWriteProvisionedTerminalSeed,
     writeProvisionedTerminalSeedAndClearTerminalIntegrity:
@@ -406,17 +426,79 @@ function buildLocalEvent(
 
 function buildStaffAuthenticationResult(
   overrides: Partial<Record<string, unknown>> = {},
-) {
+): StaffAuthenticationResult {
+  const expiresAt = Date.now() + 60_000;
   return {
     activeRoles: ["manager"],
+    localStaffAuthority: {
+      activeRoles: ["manager"],
+      credentialId: "credential-1",
+      credentialVersion: 2,
+      displayName: "Ama Kusi",
+      expiresAt,
+      issuedAt: Date.now() - 1_000,
+      organizationId: "org-1",
+      refreshedAt: Date.now(),
+      staffProfileId: "staff-1",
+      status: "active",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      username: "ama",
+      verifier: {
+        algorithm: "PBKDF2-SHA256",
+        hash: "hash",
+        iterations: 100_000,
+        salt: "salt",
+        version: 1,
+      },
+      wrappedPosLocalStaffProof: {
+        ciphertext: "ciphertext",
+        expiresAt,
+        iv: "iv",
+      },
+    },
     staffProfileId: "staff-1" as Id<"staffProfile">,
     staffProfile: {
       firstName: "Ama",
       lastName: "Kusi",
     },
     posLocalStaffProof: {
-      expiresAt: Date.now() + 60_000,
+      expiresAt,
       token: "staff-proof-token",
+    },
+    ...overrides,
+  };
+}
+
+function getTestOperatingDate(date = new Date()) {
+  return [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, "0"),
+    String(date.getDate()).padStart(2, "0"),
+  ].join("-");
+}
+
+function buildCashierPresence(overrides: Partial<Record<string, unknown>> = {}) {
+  const expiresAt = Date.now() + 60_000;
+  return {
+    activeRoles: ["cashier"],
+    credentialId: "credential-1",
+    credentialVersion: 2,
+    displayName: "Ama Kusi",
+    expiresAt,
+    lastValidatedAt: Date.now(),
+    offlineFreshUntil: expiresAt,
+    operatingDate: getTestOperatingDate(),
+    organizationId: "org-1",
+    signedInAt: Date.now(),
+    staffProfileId: "staff-1",
+    storeId: "store-1",
+    terminalId: "terminal-1",
+    username: "ama",
+    wrappedPosLocalStaffProof: {
+      ciphertext: "ciphertext",
+      expiresAt,
+      iv: "iv",
     },
     ...overrides,
   };
@@ -451,6 +533,7 @@ describe("useRegisterViewModel", () => {
     mockActiveStore = {
       _id: "store-1" as Id<"store">,
       currency: "GHS",
+      organizationId: "org-1" as Id<"organization">,
     };
     mockTerminal = {
       _id: "terminal-1" as Id<"posTerminal">,
@@ -533,6 +616,10 @@ describe("useRegisterViewModel", () => {
     mockUsePosTerminalAppSessionRecoveryRuntimeInput.mockReturnValue(null);
     mockUsePosLocalSyncRuntimeStatus.mockReset();
     mockUsePosLocalSyncRuntimeStatus.mockReturnValue(null);
+    Object.defineProperty(globalThis.navigator, "onLine", {
+      configurable: true,
+      value: true,
+    });
     mockAppendLocalEvent.mockReset();
     mockAppendLocalEvent.mockResolvedValue({
       ok: true,
@@ -573,6 +660,28 @@ describe("useRegisterViewModel", () => {
       ok: true,
       value: "ready",
     });
+    mockReadStoreDayReadiness.mockReset();
+    mockReadStoreDayReadiness.mockResolvedValue({
+      ok: true,
+      value: {
+        operatingDate: getTestOperatingDate(),
+        source: "local",
+        status: "started",
+        storeId: "store-1",
+        updatedAt: Date.now(),
+      },
+    });
+    mockReadCashierPresence.mockReset();
+    mockReadCashierPresence.mockResolvedValue({
+      ok: true,
+      value: null,
+    });
+    mockClearCashierPresence.mockReset();
+    mockClearCashierPresence.mockResolvedValue({ ok: true });
+    mockInvalidateCashierPresenceForTerminal.mockReset();
+    mockInvalidateCashierPresenceForTerminal.mockResolvedValue({ ok: true });
+    mockWriteCashierPresence.mockReset();
+    mockWriteCashierPresence.mockResolvedValue({ ok: true, value: {} });
     mockMarkLocalEventsSynced.mockReset();
     mockMarkLocalEventsSynced.mockResolvedValue({ ok: true, value: [] });
     mockWriteLocalCloudMapping.mockReset();
@@ -771,6 +880,230 @@ describe("useRegisterViewModel", () => {
     expect(result.current.productEntry.canQuickAddProduct).toBe(true);
     expect(result.current.authDialog?.open).toBe(false);
     expect(result.current.syncStatus).toBeNull();
+  });
+
+  it("persists terminal-scoped cashier presence after successful cashier sign-in", async () => {
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
+
+    await waitFor(() =>
+      expect(mockWriteCashierPresence).toHaveBeenCalledWith(
+        expect.objectContaining({
+          credentialId: "credential-1",
+          credentialVersion: 2,
+          operatingDate: getTestOperatingDate(),
+          organizationId: "org-1",
+          staffProfileId: "staff-1",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          username: "ama",
+          wrappedPosLocalStaffProof: expect.objectContaining({
+            ciphertext: "ciphertext",
+          }),
+        }),
+      ),
+    );
+  });
+
+  it("keeps cashier sign-in closed while cashier presence restore is pending", async () => {
+    const pendingPresence = deferred<{ ok: true; value: null }>();
+    mockReadCashierPresence.mockReturnValueOnce(pendingPresence.promise);
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    expect(result.current.cashierPresenceRestore.status).toBe("pending");
+    expect(result.current.authDialog?.open).toBe(false);
+
+    await act(async () => {
+      pendingPresence.resolve({ ok: true, value: null });
+    });
+
+    await waitFor(() =>
+      expect(result.current.cashierPresenceRestore.status).toBe("missing"),
+    );
+    expect(result.current.authDialog?.open).toBe(true);
+  });
+
+  it("does not let a delayed presence restore clear a fresh cashier sign-in", async () => {
+    const pendingPresence = deferred<{
+      ok: true;
+      value: ReturnType<typeof buildCashierPresence>;
+    }>();
+    mockReadCashierPresence.mockReturnValueOnce(pendingPresence.promise);
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
+    expect(result.current.cashierPresenceRestore.status).toBe("restored");
+
+    await act(async () => {
+      pendingPresence.resolve({
+        ok: true,
+        value: buildCashierPresence({ staffProofToken: "stale-token" }),
+      });
+      await pendingPresence.promise;
+    });
+
+    expect(result.current.cashierPresenceRestore.status).toBe("restored");
+    expect(result.current.cashierCard?.cashierName).toBe("Ama K.");
+    expect(result.current.authDialog?.open).toBe(false);
+  });
+
+  it("does not trust plaintext staff proof fields from restored cashier presence", async () => {
+    mockReadCashierPresence.mockResolvedValue({
+      ok: true,
+      value: buildCashierPresence({
+        activeRoles: ["manager"],
+        freshnessExpiresAt: Date.now() + 60_000,
+        proofExpiresAt: Date.now() + 60_000,
+        staffProofToken: "forged-proof-token",
+      }),
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await waitFor(() =>
+      expect(result.current.cashierPresenceRestore.status).toBe(
+        "validation_pending",
+      ),
+    );
+
+    expect(result.current.cashierCard).toBeNull();
+    expect(result.current.authDialog?.open).toBe(true);
+    expect(result.current.debug?.cashierPresence).toBe("validation_pending");
+    expect(mockStartSession).not.toHaveBeenCalled();
+  });
+
+  it("requires sign-in for persisted cashier presence that still needs proof validation", async () => {
+    mockReadCashierPresence.mockResolvedValue({
+      ok: true,
+      value: buildCashierPresence(),
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await waitFor(() =>
+      expect(result.current.cashierPresenceRestore.status).toBe(
+        "validation_pending",
+      ),
+    );
+
+    expect(result.current.cashierPresenceRestore.message).toBe(
+      "Checking cashier access before new sales.",
+    );
+    expect(result.current.cashierCard).toBeNull();
+    expect(result.current.authDialog?.open).toBe(true);
+    expect(result.current.productEntry.disabled).toBe(true);
+    expect(result.current.sessionPanel).toBeNull();
+  });
+
+  it("invalidates cashier presence for mismatched scope and clears the record", async () => {
+    mockReadCashierPresence.mockResolvedValue({
+      ok: true,
+      value: buildCashierPresence({
+        terminalId: "terminal-2",
+      }),
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await waitFor(() =>
+      expect(result.current.cashierPresenceRestore.status).toBe("invalidated"),
+    );
+
+    expect(result.current.cashierPresenceRestore.message).toBe(
+      "Cashier sign-in no longer matches this register. Sign in to continue.",
+    );
+    expect(result.current.cashierCard).toBeNull();
+    expect(result.current.authDialog?.open).toBe(true);
+    expect(mockClearCashierPresence).toHaveBeenCalledWith({
+      operatingDate: getTestOperatingDate(),
+      organizationId: "org-1",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    });
+  });
+
+  it("requires an online refresh when offline cashier presence freshness expires", async () => {
+    Object.defineProperty(globalThis.navigator, "onLine", {
+      configurable: true,
+      value: false,
+    });
+    mockReadCashierPresence.mockResolvedValue({
+      ok: true,
+      value: buildCashierPresence({
+        offlineFreshUntil: Date.now() - 1_000,
+      }),
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await waitFor(() =>
+      expect(result.current.cashierPresenceRestore.status).toBe(
+        "offline_freshness_expired",
+      ),
+    );
+
+    expect(result.current.cashierPresenceRestore.message).toBe(
+      "This terminal needs an online staff refresh before offline sign-in. Reconnect, then sign in once.",
+    );
+    expect(result.current.authDialog?.open).toBe(true);
+    expect(mockClearCashierPresence).toHaveBeenCalledWith({
+      operatingDate: getTestOperatingDate(),
+      organizationId: "org-1",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    });
+  });
+
+  it("clears expired cashier presence and opens deterministic sign-in guidance", async () => {
+    mockReadCashierPresence.mockResolvedValue({
+      ok: true,
+      value: buildCashierPresence({
+        expiresAt: Date.now() - 1_000,
+        offlineFreshUntil: Date.now() - 1_000,
+        wrappedPosLocalStaffProof: {
+          ciphertext: "ciphertext",
+          expiresAt: Date.now() - 1_000,
+          iv: "iv",
+        },
+      }),
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await waitFor(() =>
+      expect(result.current.cashierPresenceRestore.status).toBe("expired"),
+    );
+
+    expect(result.current.cashierPresenceRestore.message).toBe(
+      "Cashier sign-in expired. Sign in to continue.",
+    );
+    expect(result.current.cashierCard).toBeNull();
+    expect(result.current.authDialog?.open).toBe(true);
+    expect(mockClearCashierPresence).toHaveBeenCalledWith({
+      operatingDate: getTestOperatingDate(),
+      organizationId: "org-1",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    });
   });
 
   it("maps local pending-sync status into POS presentation state", async () => {
@@ -2149,7 +2482,77 @@ describe("useRegisterViewModel", () => {
       staffProfileId: "staff-1",
       reason: "Signing out",
     });
+    expect(mockClearCashierPresence).toHaveBeenCalledWith({
+      operatingDate: getTestOperatingDate(),
+      organizationId: "org-1",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    });
     expect(result.current.authDialog?.open).toBe(true);
+  });
+
+  it("invalidates terminal cashier presence on sign-out when live store organization metadata is unavailable", async () => {
+    mockActiveStore = null;
+    mockRegisterState = undefined;
+    mockActiveSession = null;
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await waitFor(() =>
+      expect(result.current.debug?.activeStoreSource).toBe("local"),
+    );
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
+
+    await act(async () => {
+      await result.current.cashierCard?.onSignOut();
+    });
+
+    expect(mockClearCashierPresence).not.toHaveBeenCalled();
+    expect(mockInvalidateCashierPresenceForTerminal).toHaveBeenCalledWith({
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    });
+    expect(result.current.authDialog?.open).toBe(true);
+  });
+
+  it("keeps cashier signed in when cashier presence cannot be cleared on sign-out", async () => {
+    mockActiveSession = null;
+    mockRegisterState = {
+      ...mockRegisterState!,
+      activeSession: null,
+    };
+    mockClearCashierPresence.mockResolvedValueOnce({ ok: false });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
+
+    await act(async () => {
+      await result.current.cashierCard?.onSignOut();
+    });
+
+    expect(mockClearCashierPresence).toHaveBeenCalledWith({
+      operatingDate: getTestOperatingDate(),
+      organizationId: "org-1",
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    });
+    expect(toast.error).toHaveBeenCalledWith(
+      "Cashier sign-out could not finish. Try again.",
+    );
+    expect(result.current.cashierCard?.cashierName).toBe("Ama K.");
+    expect(result.current.authDialog?.open).toBe(false);
   });
 
   it("opens the cashier auth dialog when a terminal exists but no cashier is signed in", async () => {
@@ -2201,6 +2604,9 @@ describe("useRegisterViewModel", () => {
     const { result } = renderHook(() => useRegisterViewModel());
     const expiresAt = Date.now() + 60_000;
 
+    await waitFor(() =>
+      expect(result.current.cashierPresenceRestore.status).toBe("missing"),
+    );
     expect(result.current.authDialog?.open).toBe(true);
     expect(result.current.authDialog?.onAuthenticated).toBeTypeOf("function");
 
@@ -2265,6 +2671,9 @@ describe("useRegisterViewModel", () => {
     const { useRegisterViewModel } = await import("./useRegisterViewModel");
     const { result } = renderHook(() => useRegisterViewModel());
 
+    await waitFor(() =>
+      expect(result.current.cashierPresenceRestore.status).toBe("missing"),
+    );
     expect(result.current.authDialog?.open).toBe(true);
     expect(result.current.cashierCard).toBeNull();
 

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -36,6 +36,7 @@ import { useConvexCommandGateway } from "@/lib/pos/infrastructure/convex/command
 import {
   createIndexedDbPosLocalStorageAdapter,
   createPosLocalStore,
+  type PosLocalActiveCashierPresenceRecord,
   type PosLocalEventRecord,
 } from "@/lib/pos/infrastructure/local/posLocalStore";
 import { createLocalCommandGateway } from "@/lib/pos/infrastructure/local/localCommandGateway";
@@ -70,6 +71,7 @@ import {
 
 import type {
   RegisterCommandApprovalDialogState,
+  CashierPresenceRestoreStatus,
   RegisterServiceLineState,
   RegisterServiceSearchResult,
   RegisterViewModel,
@@ -121,6 +123,75 @@ type LocalAuthenticatedStaff = {
   activeRoles: string[];
   displayName: string;
 } | null;
+
+type RestoredCashierPresence = {
+  activeRoles?: string[];
+  displayName?: string | null;
+  expiresAt?: number | null;
+  freshnessExpiresAt?: number | null;
+  offlineFreshUntil?: number | null;
+  operatingDate?: string;
+  organizationId?: string;
+  proofExpiresAt?: number | null;
+  staffProfileId?: string;
+  staffProofToken?: string | null;
+  storeId?: string;
+  terminalId?: string;
+};
+
+type CashierPresenceRestoreState = {
+  message?: string;
+  status: CashierPresenceRestoreStatus;
+};
+
+const POS_CASHIER_PRESENCE_OFFLINE_FRESHNESS_MS = 15 * 60 * 1000;
+
+type CashierPresenceStore = {
+  clearActiveCashierPresence?: (input: {
+    operatingDate: string;
+    organizationId?: string;
+    storeId: string;
+    terminalId: string;
+  }) => Promise<{ ok: boolean }>;
+  clearCashierPresence?: (input: {
+    operatingDate: string;
+    organizationId: string;
+    storeId: string;
+    terminalId: string;
+  }) => Promise<{ ok: boolean }>;
+  invalidateCashierPresenceForTerminal?: (input: {
+    organizationId?: string;
+    storeId?: string;
+    terminalId: string;
+  }) => Promise<{ ok: boolean }>;
+  readActiveCashierPresence?: (input: {
+    now?: number;
+    operatingDate: string;
+    organizationId?: string;
+    storeId: string;
+    terminalId: string;
+  }) => Promise<{
+    ok: boolean;
+    value?: RestoredCashierPresence | null;
+  }>;
+  readCashierPresence?: (input: {
+    now?: number;
+    operatingDate: string;
+    organizationId: string;
+    storeId: string;
+    terminalId: string;
+  }) => Promise<{
+    ok: boolean;
+    value?: RestoredCashierPresence | null;
+  }>;
+  writeCashierPresence?: (
+    presence: PosLocalActiveCashierPresenceRecord,
+  ) => Promise<{
+    ok: boolean;
+    value?: PosLocalActiveCashierPresenceRecord;
+    error?: { code: string };
+  }>;
+};
 
 type ServiceCatalogRow = {
   basePrice?: number;
@@ -264,6 +335,80 @@ function getStaffDisplayNameFromAuthResult(result: StaffAuthenticationResult) {
       .filter(Boolean)
       .join(" ")
   );
+}
+
+function getLocalOperatingDate(date = new Date()) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function validateRestoredCashierPresence(input: {
+  isOnline: boolean;
+  now: number;
+  operatingDate: string;
+  organizationId?: string;
+  presence: RestoredCashierPresence;
+  storeId: string;
+  terminalId: string;
+}): CashierPresenceRestoreState {
+  const {
+    isOnline,
+    now,
+    operatingDate,
+    organizationId,
+    presence,
+    storeId,
+    terminalId,
+  } = input;
+  const proofExpiresAt = presence.proofExpiresAt ?? presence.expiresAt;
+  const freshnessExpiresAt =
+    presence.freshnessExpiresAt ?? presence.offlineFreshUntil;
+
+  if (
+    (presence.organizationId &&
+      organizationId &&
+      presence.organizationId !== organizationId) ||
+    presence.storeId !== storeId ||
+    presence.terminalId !== terminalId ||
+    presence.operatingDate !== operatingDate ||
+    !presence.staffProfileId ||
+    !hasRegisterOperatorRole(presence.activeRoles)
+  ) {
+    return {
+      message: "Cashier sign-in no longer matches this register. Sign in to continue.",
+      status: "invalidated",
+    };
+  }
+
+  if (typeof proofExpiresAt === "number" && proofExpiresAt <= now) {
+    return {
+      message: "Cashier sign-in expired. Sign in to continue.",
+      status: "expired",
+    };
+  }
+
+  if (
+    !isOnline &&
+    typeof freshnessExpiresAt === "number" &&
+    freshnessExpiresAt <= now
+  ) {
+    return {
+      message:
+        "This terminal needs an online staff refresh before offline sign-in. Reconnect, then sign in once.",
+      status: "offline_freshness_expired",
+    };
+  }
+
+  return {
+    message: "Checking cashier access before new sales.",
+    status: "validation_pending",
+  };
+}
+
+function isCashierPresenceBlockingSale(status: CashierPresenceRestoreStatus) {
+  return status === "pending" || status === "validation_pending";
 }
 
 function hasCustomerDetails(
@@ -1165,6 +1310,10 @@ export function useRegisterViewModel(): RegisterViewModel {
     (localEntryContext.status === "ready"
       ? localEntryContext.storeId
       : undefined)) as Id<"store"> | undefined;
+  const activeStoreOrganizationId = (activeStore as
+    | { organizationId?: string }
+    | null
+    | undefined)?.organizationId;
   const activeStoreCurrency = activeStore?.currency ?? "GHS";
   const navigateBack = useNavigateBack();
   const [staffProfileId, setStaffProfileId] =
@@ -1176,6 +1325,8 @@ export function useRegisterViewModel(): RegisterViewModel {
   staffProofTokenRef.current = staffProofToken;
   const [localAuthenticatedStaff, setLocalAuthenticatedStaff] =
     useState<LocalAuthenticatedStaff>(null);
+  const [cashierPresenceRestore, setCashierPresenceRestore] =
+    useState<CashierPresenceRestoreState>({ status: "pending" });
   const [autoStartRequestedStaffProfileId, setAutoStartRequestedStaffProfileId] =
     useState<Id<"staffProfile"> | null>(null);
   const terminalRegisterNumber = terminal?.registerNumber
@@ -1183,6 +1334,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     : undefined;
   const [localStaffAuthorityStatus, setLocalStaffAuthorityStatus] =
     useState("unknown");
+  const activeOperatingDate = useMemo(() => getLocalOperatingDate(), []);
   const [showCustomerPanel, setShowCustomerPanel] = useState(false);
   const [showProductEntry, setShowProductEntry] = useState(true);
   const [productSearchQuery, setProductSearchQuery] = useState("");
@@ -1703,6 +1855,148 @@ export function useRegisterViewModel(): RegisterViewModel {
       }),
     [localStore, terminal?._id],
   );
+  useEffect(() => {
+    let cancelled = false;
+
+    async function restoreCashierPresence() {
+      if (!activeStoreId || !terminal?._id) {
+        setCashierPresenceRestore({ status: "pending" });
+        return;
+      }
+
+      if (staffProfileIdRef.current) {
+        setCashierPresenceRestore({ status: "restored" });
+        return;
+      }
+
+      if (typeof indexedDB === "undefined") {
+        setCashierPresenceRestore({
+          message: "Cashier sign-in could not be restored. Sign in to continue.",
+          status: "failed",
+        });
+        return;
+      }
+
+      setCashierPresenceRestore({ status: "pending" });
+
+      const storeDayReadiness = await localStore.readStoreDayReadiness({
+        operatingDate: activeOperatingDate,
+        storeId: activeStoreId,
+      });
+      if (cancelled) return;
+
+      if (!storeDayReadiness.ok) {
+        setCashierPresenceRestore({
+          message: "Cashier sign-in could not be restored. Sign in to continue.",
+          status: "failed",
+        });
+        return;
+      }
+
+      if (
+        storeDayReadiness.value?.status !== "started" &&
+        storeDayReadiness.value?.status !== "reopened"
+      ) {
+        setCashierPresenceRestore({
+          message: "Store day not ready. Complete opening before cashier sign-in.",
+          status: "failed",
+        });
+        return;
+      }
+
+      const presenceStore = localStore as CashierPresenceStore;
+      if (!activeStoreOrganizationId || !presenceStore.readCashierPresence) {
+        setCashierPresenceRestore({ status: "missing" });
+        return;
+      }
+
+      const now = Date.now();
+      const presenceResult = await presenceStore.readCashierPresence({
+        now,
+        operatingDate: activeOperatingDate,
+        organizationId: activeStoreOrganizationId,
+        storeId: activeStoreId,
+        terminalId: terminal._id,
+      });
+      if (cancelled) return;
+
+      if (staffProfileIdRef.current) {
+        setCashierPresenceRestore({ status: "restored" });
+        return;
+      }
+
+      if (!presenceResult.ok) {
+        setCashierPresenceRestore({
+          message: "Cashier sign-in could not be restored. Sign in to continue.",
+          status: "failed",
+        });
+        return;
+      }
+
+      const presence = presenceResult.value;
+      if (!presence) {
+        setCashierPresenceRestore({ status: "missing" });
+        return;
+      }
+
+      const nextRestoreState = validateRestoredCashierPresence({
+        isOnline: globalThis.navigator?.onLine ?? true,
+        now,
+        operatingDate: activeOperatingDate,
+        organizationId: activeStoreOrganizationId,
+        presence,
+        storeId: activeStoreId,
+        terminalId: terminal._id,
+      });
+
+      if (nextRestoreState.status === "restored") {
+        staffProfileIdRef.current = presence.staffProfileId as Id<"staffProfile">;
+        staffProofTokenRef.current = presence.staffProofToken ?? null;
+        setStaffProfileId(presence.staffProfileId as Id<"staffProfile">);
+        setStaffProofToken(presence.staffProofToken ?? null);
+        setLocalAuthenticatedStaff({
+          activeRoles: presence.activeRoles ?? [],
+          displayName: presence.displayName ?? "Signed-in cashier",
+        });
+      } else if (nextRestoreState.status === "validation_pending") {
+        staffProfileIdRef.current = null;
+        staffProofTokenRef.current = null;
+        setStaffProfileId(null);
+        setStaffProofToken(null);
+        setLocalAuthenticatedStaff(null);
+      } else {
+        staffProfileIdRef.current = null;
+        staffProofTokenRef.current = null;
+        setStaffProfileId(null);
+        setStaffProofToken(null);
+        setLocalAuthenticatedStaff(null);
+        if (presenceStore.clearCashierPresence) {
+          await presenceStore.clearCashierPresence({
+            operatingDate: activeOperatingDate,
+            organizationId: activeStoreOrganizationId,
+            storeId: activeStoreId,
+            terminalId: terminal._id,
+          });
+        }
+      }
+
+      if (!cancelled) {
+        setCashierPresenceRestore(nextRestoreState);
+      }
+    }
+
+    void restoreCashierPresence();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    activeOperatingDate,
+    activeStoreId,
+    activeStoreOrganizationId,
+    localStore,
+    terminal?._id,
+  ]);
   const localRuntimeStoreFactory = useCallback(() => localStore, [localStore]);
   useEffect(() => {
     if (!staffProfileId || !staffProofToken) {
@@ -2506,6 +2800,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         setStaffProofToken(null);
         setLocalAuthenticatedStaff(null);
         setLocalOperableRegisterSession(null);
+        setCashierPresenceRestore({ status: "missing" });
       }
     },
     [setPaymentState],
@@ -4743,10 +5038,69 @@ export function useRegisterViewModel(): RegisterViewModel {
           displayName: getStaffDisplayNameFromAuthResult(result),
         });
         setAutoStartRequestedStaffProfileId(authenticatedStaffProfileId);
+
+        const localAuthority = result.localStaffAuthority;
+        if (
+          activeStoreId &&
+          activeStoreOrganizationId &&
+          activeOperatingDate &&
+          terminal?._id &&
+          localAuthority?.wrappedPosLocalStaffProof
+        ) {
+          const now = Date.now();
+          const expiresAt = Math.min(
+            localAuthority.expiresAt,
+            result.posLocalStaffProof?.expiresAt ??
+              localAuthority.wrappedPosLocalStaffProof.expiresAt,
+            localAuthority.wrappedPosLocalStaffProof.expiresAt,
+          );
+          const offlineFreshUntil = Math.min(
+            expiresAt,
+            now + POS_CASHIER_PRESENCE_OFFLINE_FRESHNESS_MS,
+          );
+
+          void (localStore as CashierPresenceStore)
+            .writeCashierPresence?.({
+              activeRoles: localAuthority.activeRoles,
+              credentialId: localAuthority.credentialId,
+              credentialVersion: localAuthority.credentialVersion,
+              displayName: localAuthority.displayName,
+              expiresAt,
+              lastValidatedAt: now,
+              offlineFreshUntil,
+              operatingDate: activeOperatingDate,
+              organizationId: activeStoreOrganizationId,
+              signedInAt: now,
+              staffProfileId: authenticatedStaffProfileId,
+              storeId: activeStoreId,
+              terminalId: terminal._id,
+              username: localAuthority.username,
+              wrappedPosLocalStaffProof:
+                localAuthority.wrappedPosLocalStaffProof,
+            })
+            .then((writeResult) => {
+              if (writeResult && !writeResult.ok) {
+                logger.warn("[POS] Cashier presence could not be stored", {
+                  code: writeResult.error?.code,
+                  staffProfileId: authenticatedStaffProfileId,
+                  storeId: activeStoreId,
+                  terminalId: terminal._id,
+                });
+              }
+            });
+        }
       }
+      setCashierPresenceRestore({ status: "restored" });
       requestBootstrap();
     },
-    [requestBootstrap],
+    [
+      activeOperatingDate,
+      activeStoreId,
+      activeStoreOrganizationId,
+      localStore,
+      requestBootstrap,
+      terminal?._id,
+    ],
   );
 
   useEffect(() => {
@@ -4831,6 +5185,35 @@ export function useRegisterViewModel(): RegisterViewModel {
   ]);
 
   const handleCashierSignOut = useCallback(async () => {
+    const clearStoredCashierPresence = async () => {
+      if (!activeStoreId || !terminal?._id) {
+        return true;
+      }
+
+      const presenceStore = localStore as CashierPresenceStore;
+      const clearResult = activeStoreOrganizationId
+        ? await presenceStore.clearCashierPresence?.({
+            operatingDate: activeOperatingDate,
+            organizationId: activeStoreOrganizationId,
+            storeId: activeStoreId,
+            terminalId: terminal._id,
+          })
+        : await presenceStore.invalidateCashierPresenceForTerminal?.({
+            storeId: activeStoreId,
+            terminalId: terminal._id,
+          });
+      if (clearResult && !clearResult.ok) {
+        logger.warn("[POS] Cashier presence could not be cleared on sign-out", {
+          storeId: activeStoreId,
+          terminalId: terminal._id,
+        });
+        toast.error("Cashier sign-out could not finish. Try again.");
+        return false;
+      }
+
+      return true;
+    };
+
     const isRecoveringLocalSale = Boolean(
       drawerGateMode === "recovery" &&
         operableActiveSession &&
@@ -4840,6 +5223,9 @@ export function useRegisterViewModel(): RegisterViewModel {
     );
 
     if (isRecoveringLocalSale) {
+      if (!(await clearStoredCashierPresence())) {
+        return;
+      }
       staffProfileIdRef.current = null;
       staffProofTokenRef.current = null;
       resetDraftState();
@@ -4872,16 +5258,24 @@ export function useRegisterViewModel(): RegisterViewModel {
       }
     }
 
+    if (!(await clearStoredCashierPresence())) {
+      return;
+    }
     resetDraftState();
   }, [
+    activeOperatingDate,
+    activeStoreId,
+    activeStoreOrganizationId,
     drawerGateMode,
     operableActiveSession,
     activeCartItems.length,
     holdCurrentSession,
+    localStore,
     localRegisterReadModel?.activeSale?.localPosSessionId,
     requestBootstrap,
     resetDraftState,
     serviceLineDrafts.length,
+    terminal?._id,
     voidCurrentSession,
   ]);
 
@@ -4893,6 +5287,11 @@ export function useRegisterViewModel(): RegisterViewModel {
 
     if (!operableActiveSession || !staffProfileId) {
       toast.error("No sale in progress. Start a sale before taking payment.");
+      return false;
+    }
+
+    if (isCashierPresenceBlockingSale(cashierPresenceRestore.status)) {
+      toast.error("Cashier sign-in required. Sign in to continue this sale.");
       return false;
     }
 
@@ -5036,6 +5435,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     localEventRegisterSessionId,
     activeStoreId,
     activeTotals,
+    cashierPresenceRestore.status,
     serviceSubtotal,
     serviceLineDrafts,
     serviceCheckoutBlockMessage,
@@ -5245,6 +5645,9 @@ export function useRegisterViewModel(): RegisterViewModel {
     staffProfileId,
     terminal,
   ]);
+  const cashierPresenceBlocksSale = isCashierPresenceBlockingSale(
+    cashierPresenceRestore.status,
+  );
 
   const sessionPanel =
     activeStoreId && terminal?._id && staffProfileId
@@ -5255,7 +5658,7 @@ export function useRegisterViewModel(): RegisterViewModel {
           canHoldSession: Boolean(operableActiveSession) && hasActiveCartDraft,
           canClearSale: hasClearableSaleState,
           disableNewSession: Boolean(
-            operableActiveSession?.status === "active",
+            cashierPresenceBlocksSale || operableActiveSession?.status === "active",
           ),
           heldSessions:
             heldSessions?.map((session) => ({
@@ -5581,11 +5984,14 @@ export function useRegisterViewModel(): RegisterViewModel {
           },
         }
       : null;
+  const shouldOpenCashierAuth =
+    !staffProfileId &&
+    cashierPresenceRestore.status !== "pending";
 
   const authDialog =
     activeStoreId && terminal?._id
       ? {
-          open: !staffProfileId,
+          open: shouldOpenCashierAuth,
           storeId: activeStoreId!,
           terminalId: terminal._id,
 	          onAuthenticated: (
@@ -5609,6 +6015,7 @@ export function useRegisterViewModel(): RegisterViewModel {
           ? "local"
           : "missing",
       authDialogOpen: Boolean(authDialog?.open),
+      cashierPresence: cashierPresenceRestore.status,
       hasLiveActiveStore: Boolean(activeStore),
       localStaffAuthorityStatus,
       localEntryStatus: localEntryContext.status,
@@ -5694,6 +6101,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       disabled:
         !terminal ||
         !staffProfileId ||
+        cashierPresenceBlocksSale ||
         isProjectedLocalActiveSaleBlockingCurrentStaff ||
         shouldShowDrawerGate ||
         cloudRegisterSessionBlocksLocalProjection ||
@@ -5714,6 +6122,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       disabled:
         !terminal ||
         !staffProfileId ||
+        cashierPresenceBlocksSale ||
         isProjectedLocalActiveSaleBlockingCurrentStaff ||
         shouldShowDrawerGate ||
         cloudRegisterSessionBlocksLocalProjection ||
@@ -5782,6 +6191,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     },
     sessionPanel,
     cashierCard,
+    cashierPresenceRestore,
     drawerGate,
     closeoutControl,
     syncStatus,


### PR DESCRIPTION
## Summary
- Add terminal/store-day scoped cashier presence persistence for POS register continuity.
- Keep restored presence fail-closed: persisted IndexedDB state is continuity evidence only, not cashier authority; sign-in is required before sale-affecting commands.
- Add server-side restored proof validation, duplicate proof-hash fail-closed handling, and sign-out cleanup that blocks when durable presence cannot be cleared.
- Move the approved plan artifacts into the delivery worktree and add the architecture solution note.

## Linear
- V26-666
- V26-667
- V26-668
- V26-669
- V26-670
- V26-671
- V26-672

## Validation
- `bun run --filter '@athena/webapp' test -- src/lib/pos/presentation/register/useRegisterViewModel.test.ts convex/operations/staffCredentials.test.ts`
- `bun run --filter '@athena/webapp' typecheck`
- `bun run graphify:rebuild`
- `bun run plan-html:check`
- `bun run pr:athena`

Reviewer subagents reached approval across correctness, security, data integrity, frontend race, and testing passes after fixes.
