### PR TITLE
Harden POS register offline readiness

### DIFF
--- a/docs/solutions/logic-errors/athena-quick-add-scanner-nested-dialog-2026-06-04.md
+++ b/docs/solutions/logic-errors/athena-quick-add-scanner-nested-dialog-2026-06-04.md
@@ -50,16 +50,19 @@ modal relationship explicit:
   scanned barcode before writing it into `quickAddLookupCode`.
 - Give the scanner overlay explicit pointer-event access because it is portaled
   above a modalized Radix dialog.
-- While the scanner is open, prevent the parent quick-add `DialogContent` from
-  handling pointer, interact-outside, or escape events as parent-dismiss events.
+- Treat the quick-add modal as a deliberate-dismiss surface: prevent parent
+  pointer/interact-outside events from dismissing the dialog, and continue to
+  block Escape only while the scanner is open so the child overlay can close
+  without taking down the parent.
 
 ## Why This Works
 
 The quick-add dialog owns the barcode field state, validation, submit payload,
 and existing-SKU barcode recovery path. Keeping scanner state in the same
 component avoids caller-specific plumbing and makes the affordance available
-wherever quick add is used. Blocking parent outside-dismiss only while the
-scanner is open preserves normal quick-add close behavior the rest of the time.
+wherever quick add is used. Blocking parent outside-dismiss keeps in-progress
+product entry from disappearing on accidental backdrop taps, while explicit
+close, cancel, submit, and scanner-close paths remain available.
 
 ## Prevention
 
@@ -69,3 +72,5 @@ scanner is open preserves normal quick-add close behavior the rest of the time.
   path and the parent remaining open.
 - Add focused tests that assert scanner decode fills the field and scanner close
   does not call the parent `onOpenChange(false)`.
+- Add focused tests that assert backdrop pointer events do not close the parent
+  quick-add dialog.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1825 files · ~0 words
+- 1826 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6126 nodes · 6586 edges · 1753 communities detected
+- 6130 nodes · 6590 edges · 1754 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1763,6 +1763,7 @@
 - [[_COMMUNITY_Community 1750|Community 1750]]
 - [[_COMMUNITY_Community 1751|Community 1751]]
 - [[_COMMUNITY_Community 1752|Community 1752]]
+- [[_COMMUNITY_Community 1753|Community 1753]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1811,12 +1812,12 @@ Cohesion: 0.06
 Nodes (27): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatCompactTextList(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary() (+19 more)
 
 ### Community 5 - "Community 5"
-Cohesion: 0.09
-Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
+Cohesion: 0.06
+Nodes (23): assertPosLocalStoreOk(), clearAcceptedTerminalIntegrityState(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds() (+15 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.06
-Nodes (22): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus() (+14 more)
+Cohesion: 0.09
+Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.13
@@ -1843,7 +1844,7 @@ Cohesion: 0.08
 Nodes (20): formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels(), getSkuDetailEntries() (+12 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.08
+Cohesion: 0.07
 Nodes (12): createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), normalizeCashierPresenceRecord(), normalizeDrawerAuthorityState(), normalizeStaffAuthorityRecord(), normalizeTerminalIntegrityState(), normalizeUsername(), PosLocalStoreSchemaError (+4 more)
 
 ### Community 14 - "Community 14"
@@ -1867,12 +1868,12 @@ Cohesion: 0.14
 Nodes (24): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+16 more)
 
 ### Community 19 - "Community 19"
-Cohesion: 0.2
-Nodes (28): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftCreatedMessage(), buildCycleCountDraftSavedMessage(), buildCycleCountDraftSubmissionKey(), buildCycleCountDraftSubmittedMessage(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx() (+20 more)
-
-### Community 20 - "Community 20"
 Cohesion: 0.15
 Nodes (24): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+16 more)
+
+### Community 20 - "Community 20"
+Cohesion: 0.2
+Nodes (28): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftCreatedMessage(), buildCycleCountDraftSavedMessage(), buildCycleCountDraftSubmissionKey(), buildCycleCountDraftSubmittedMessage(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx() (+20 more)
 
 ### Community 21 - "Community 21"
 Cohesion: 0.16
@@ -2123,36 +2124,36 @@ Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
 ### Community 83 - "Community 83"
+Cohesion: 0.18
+Nodes (3): handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
+
+### Community 84 - "Community 84"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 85 - "Community 85"
+### Community 86 - "Community 86"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.31
 Nodes (12): collectFilesUnder(), collectProofSnapshot(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof(), hashValidationWiring(), normalizeRepoPath(), readPrAthenaScript(), recordPrePushValidationProof() (+4 more)
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.24
 Nodes (7): classifyTerminalHealth(), formatAge(), formatStatusLabel(), getPrimaryTerminalAttentionReason(), getReviewEvidenceCount(), getSnapshotAgeSummary(), getTerminalAttentionReasons()
-
-### Community 90 - "Community 90"
-Cohesion: 0.2
-Nodes (3): handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
 
 ### Community 91 - "Community 91"
 Cohesion: 0.21
@@ -2171,24 +2172,24 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 95 - "Community 95"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 96 - "Community 96"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 97 - "Community 97"
+### Community 96 - "Community 96"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 98 - "Community 98"
+### Community 97 - "Community 97"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 99 - "Community 99"
+### Community 98 - "Community 98"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
+
+### Community 99 - "Community 99"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 100 - "Community 100"
 Cohesion: 0.2
@@ -2571,16 +2572,16 @@ Cohesion: 0.47
 Nodes (4): buildOperationalEvent(), matchesExistingEvent(), metadataDedupeKeysMatch(), recordOperationalEventWithCtx()
 
 ### Community 195 - "Community 195"
-Cohesion: 0.4
-Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
-
-### Community 196 - "Community 196"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 197 - "Community 197"
+### Community 196 - "Community 196"
 Cohesion: 0.4
 Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
+
+### Community 197 - "Community 197"
+Cohesion: 0.4
+Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
 
 ### Community 198 - "Community 198"
 Cohesion: 0.33
@@ -2679,8 +2680,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 222 - "Community 222"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 223 - "Community 223"
 Cohesion: 0.33
@@ -2699,60 +2700,60 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 227 - "Community 227"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 228 - "Community 228"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
+
+### Community 228 - "Community 228"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 229 - "Community 229"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 230 - "Community 230"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 231 - "Community 231"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 232 - "Community 232"
+### Community 231 - "Community 231"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 232 - "Community 232"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 233 - "Community 233"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 234 - "Community 234"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 235 - "Community 235"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 236 - "Community 236"
+### Community 235 - "Community 235"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 237 - "Community 237"
+### Community 236 - "Community 236"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 238 - "Community 238"
+### Community 237 - "Community 237"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 239 - "Community 239"
+### Community 238 - "Community 238"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 240 - "Community 240"
+### Community 239 - "Community 239"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 240 - "Community 240"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 241 - "Community 241"
 Cohesion: 0.53
@@ -8802,6 +8803,10 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1753 - "Community 1753"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -10113,1055 +10118,1057 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1227`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1228`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1229`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1230`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1231`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1232`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `constants.ts`
+- **Thin community `Community 1233`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1234`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1235`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1236`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `types.ts`
+- **Thin community `Community 1237`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1238`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1239`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1240`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1241`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1242`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1243`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1244`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1245`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1246`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1247`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1248`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1249`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1250`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1251`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1252`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1253`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1254`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1255`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1256`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1257`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `constants.ts`
+- **Thin community `Community 1258`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1259`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1260`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1261`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `data.ts`
+- **Thin community `Community 1262`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1263`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1264`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1265`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1266`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1267`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1268`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1269`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1270`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1271`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `constants.ts`
+- **Thin community `Community 1272`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1273`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1274`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1275`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `data.ts`
+- **Thin community `Community 1276`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1277`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1278`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1279`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1280`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1281`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1282`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1283`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1284`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1285`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1286`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1287`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1288`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `constants.ts`
+- **Thin community `Community 1289`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1290`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1291`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1292`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1293`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1294`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1295`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1296`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1297`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1298`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1299`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1300`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1301`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1302`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1303`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1304`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1305`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1306`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1307`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1308`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1309`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1310`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1311`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1312`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1313`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1314`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1315`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1316`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1317`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1318`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1319`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1320`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `constants.ts`
+- **Thin community `Community 1321`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1322`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1323`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1324`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `data.ts`
+- **Thin community `Community 1325`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1326`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1327`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `constants.ts`
+- **Thin community `Community 1328`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1329`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1330`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1331`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1332`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `data.ts`
+- **Thin community `Community 1333`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1334`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `constants.ts`
+- **Thin community `Community 1335`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1336`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1337`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1338`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1339`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `data.ts`
+- **Thin community `Community 1340`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1341`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1342`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1343`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1344`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1345`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1346`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1347`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1348`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1349`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1350`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1351`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1352`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1353`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1354`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1355`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1356`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1357`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1358`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1359`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1360`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1361`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1362`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1363`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1364`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1365`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `POSSettingsView.test.tsx`
+- **Thin community `Community 1366`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1367`** (1 nodes): `POSSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `POSTerminalHealthView.test.tsx`
+- **Thin community `Community 1368`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1369`** (1 nodes): `POSTerminalHealthView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1370`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1371`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `types.ts`
+- **Thin community `Community 1372`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1373`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1374`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1375`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1376`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1377`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1378`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1379`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1380`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1381`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1382`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1383`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1384`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1385`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1386`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1387`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `data.ts`
+- **Thin community `Community 1388`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1389`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1390`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1391`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1392`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1393`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1394`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1395`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1396`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1397`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1398`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1399`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1400`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `constants.ts`
+- **Thin community `Community 1401`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1402`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1403`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1404`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `data.ts`
+- **Thin community `Community 1405`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `types.ts`
+- **Thin community `Community 1406`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1407`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1408`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1409`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1410`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1411`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `index.tsx`
+- **Thin community `Community 1412`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1413`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1414`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1415`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1416`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1417`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1418`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1419`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1420`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `index.tsx`
+- **Thin community `Community 1421`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1422`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1423`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1424`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `button.tsx`
+- **Thin community `Community 1425`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1426`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `card.tsx`
+- **Thin community `Community 1427`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1428`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1429`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `command.tsx`
+- **Thin community `Community 1430`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1431`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1432`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1433`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `form.tsx`
+- **Thin community `Community 1434`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1435`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1436`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `input.tsx`
+- **Thin community `Community 1437`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1438`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1439`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1440`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1441`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1442`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1443`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `select.tsx`
+- **Thin community `Community 1444`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1445`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1446`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1447`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `table.tsx`
+- **Thin community `Community 1448`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1449`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1450`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1451`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1452`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1453`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1454`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1455`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1456`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `constants.ts`
+- **Thin community `Community 1457`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1458`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1459`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1460`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `data.ts`
+- **Thin community `Community 1461`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1462`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1463`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1464`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1465`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1466`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1467`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1468`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1469`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1470`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1471`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1472`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `index.ts`
+- **Thin community `Community 1473`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1474`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1475`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1476`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1477`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1478`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1479`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1480`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1481`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1482`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1483`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1484`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `aws.ts`
+- **Thin community `Community 1485`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `constants.ts`
+- **Thin community `Community 1486`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `countries.ts`
+- **Thin community `Community 1487`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1488`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1489`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1490`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1491`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1492`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1493`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `dto.ts`
+- **Thin community `Community 1494`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `ports.ts`
+- **Thin community `Community 1495`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `constants.ts`
+- **Thin community `Community 1496`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1497`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1498`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `index.ts`
+- **Thin community `Community 1499`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1500`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `types.ts`
+- **Thin community `Community 1501`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1502`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1503`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1504`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1505`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1506`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1507`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1508`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1509`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1510`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1511`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `category.ts`
+- **Thin community `Community 1512`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `product.ts`
+- **Thin community `Community 1513`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `store.ts`
+- **Thin community `Community 1514`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1515`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `user.ts`
+- **Thin community `Community 1516`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1517`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1518`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1519`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1520`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1521`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1522`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1523`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1524`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1525`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1526`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `index.tsx`
+- **Thin community `Community 1527`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1528`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1529`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1530`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1531`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1532`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1533`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1534`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `index.tsx`
+- **Thin community `Community 1535`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1536`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1537`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1538`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `home.tsx`
+- **Thin community `Community 1539`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1540`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1541`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1542`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `index.tsx`
+- **Thin community `Community 1543`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1544`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `index.tsx`
+- **Thin community `Community 1545`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1546`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1547`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1548`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `index.tsx`
+- **Thin community `Community 1549`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1550`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1551`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1552`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1553`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1554`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1555`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `index.tsx`
+- **Thin community `Community 1556`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1557`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1558`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1559`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1560`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1561`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1562`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1563`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1564`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1565`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `index.tsx`
+- **Thin community `Community 1566`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1567`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `index.tsx`
+- **Thin community `Community 1568`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `new.tsx`
+- **Thin community `Community 1569`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `index.tsx`
+- **Thin community `Community 1570`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `new.tsx`
+- **Thin community `Community 1571`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1572`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1573`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `index.tsx`
+- **Thin community `Community 1574`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `new.tsx`
+- **Thin community `Community 1575`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `index.tsx`
+- **Thin community `Community 1576`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1577`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1578`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1579`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1580`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `index.tsx`
+- **Thin community `Community 1581`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1582`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1583`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1584`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `index.tsx`
+- **Thin community `Community 1585`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1586`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1587`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1588`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1589`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1590`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1591`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1592`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1593`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1594`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1595`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1596`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1597`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1598`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1599`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1600`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1601`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1602`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1603`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1604`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1605`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1606`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1607`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1608`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1609`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `setup.ts`
+- **Thin community `Community 1610`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1611`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `types.ts`
+- **Thin community `Community 1612`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1613`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1614`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1615`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1616`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1617`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `types.ts`
+- **Thin community `Community 1618`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1619`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1620`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1621`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1622`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1623`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1624`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1625`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1626`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1627`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `schema.ts`
+- **Thin community `Community 1628`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1629`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1630`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1631`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1632`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1633`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1634`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1635`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1636`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1637`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `types.ts`
+- **Thin community `Community 1638`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1639`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1640`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1641`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1642`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1643`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1644`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1645`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `constants.ts`
+- **Thin community `Community 1646`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1647`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `About.tsx`
+- **Thin community `Community 1648`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1649`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1650`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1651`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1652`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1653`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1654`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1655`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1656`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1657`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1658`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `types.ts`
+- **Thin community `Community 1659`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1660`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1661`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1662`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1663`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1664`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1665`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1666`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1667`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1668`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1669`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1670`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `button.tsx`
+- **Thin community `Community 1671`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `card.tsx`
+- **Thin community `Community 1672`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1673`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `command.tsx`
+- **Thin community `Community 1674`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1675`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1676`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1677`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `form.tsx`
+- **Thin community `Community 1678`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1679`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1680`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1681`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1682`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `input.tsx`
+- **Thin community `Community 1683`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `label.tsx`
+- **Thin community `Community 1684`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1685`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1686`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1687`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `index.ts`
+- **Thin community `Community 1688`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `types.ts`
+- **Thin community `Community 1689`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1690`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1691`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1692`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1693`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `select.tsx`
+- **Thin community `Community 1694`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1695`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1696`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `table.tsx`
+- **Thin community `Community 1697`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1698`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1699`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1700`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1701`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1702`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `config.ts`
+- **Thin community `Community 1703`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1704`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1705`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1706`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1707`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `constants.ts`
+- **Thin community `Community 1708`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `countries.ts`
+- **Thin community `Community 1709`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1710`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1711`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1712`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1713`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `index.ts`
+- **Thin community `Community 1714`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `store.ts`
+- **Thin community `Community 1715`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `bag.ts`
+- **Thin community `Community 1716`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1717`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `category.ts`
+- **Thin community `Community 1718`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `organization.ts`
+- **Thin community `Community 1719`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `product.ts`
+- **Thin community `Community 1720`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `store.ts`
+- **Thin community `Community 1721`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1722`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `user.ts`
+- **Thin community `Community 1723`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `states.ts`
+- **Thin community `Community 1724`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1725`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1726`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1727`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1728`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1729`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1730`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1731`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `index.tsx`
+- **Thin community `Community 1732`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1733`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `index.tsx`
+- **Thin community `Community 1734`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1735`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1736`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1737`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1738`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1739`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `index.tsx`
+- **Thin community `Community 1740`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1741`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1742`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1743`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1744`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1745`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `index.js`
+- **Thin community `Community 1746`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1747`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1748`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1749`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1750`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1751`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1752`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1753`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -11180,4 +11187,4 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 4` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 5` be split into smaller, more focused modules?**
-  _Cohesion score 0.09 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.06 - nodes in this community are weakly interconnected._

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1825
-- Graph nodes: 6126
-- Graph edges: 6586
-- Communities: 1753
+- Code files discovered: 1826
+- Graph nodes: 6130
+- Graph edges: 6590
+- Communities: 1754
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (84 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
@@ -18,8 +18,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - `useRegisterViewModel.ts` (58 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `harness-inferential-review.ts` (46 edges, Community 3) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `RegisterSessionView.tsx` (45 edges, Community 4) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
-- `storefrontJourneyEvents.ts` (45 edges, Community 5) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `usePosLocalSyncRuntime.ts` (44 edges, Community 6) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
+- `storefrontJourneyEvents.ts` (45 edges, Community 6) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `usePosLocalSyncRuntime.ts` (45 edges, Community 5) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
 - `ProcurementView.tsx` (41 edges, Community 8) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
 
 ## Registered Packages

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -21,7 +21,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `useRegisterViewModel.ts` (58 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `RegisterSessionView.tsx` (45 edges, Community 4) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
-- `usePosLocalSyncRuntime.ts` (44 edges, Community 6) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
+- `usePosLocalSyncRuntime.ts` (45 edges, Community 5) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -17,8 +17,8 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - [validation-map.json](../../../packages/storefront-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `storefrontJourneyEvents.ts` (45 edges, Community 5) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `createJourneyEvent()` (40 edges, Community 5) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `storefrontJourneyEvents.ts` (45 edges, Community 6) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `createJourneyEvent()` (40 edges, Community 6) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 38) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `checkoutSession.ts` (14 edges, Community 60) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 - `storeConfig.ts` (14 edges, Community 38) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)

--- a/packages/athena-webapp/convex/operations/staffCredentials.ts
+++ b/packages/athena-webapp/convex/operations/staffCredentials.ts
@@ -72,6 +72,28 @@ type StaffCredentialAuthenticationData = {
   activeRoles: OperationalRole[];
   credentialId: Id<"staffCredential">;
   credentialVersion?: number;
+  posLocalStaffAuthority?: {
+    activeRoles: Array<"cashier" | "manager">;
+    credentialId: Id<"staffCredential">;
+    credentialVersion: number;
+    displayName?: string | null;
+    expiresAt: number;
+    issuedAt: number;
+    organizationId: Id<"organization">;
+    refreshedAt: number;
+    staffProfileId: Id<"staffProfile">;
+    status: "active";
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+    username: string;
+    verifier: {
+      algorithm: string;
+      hash: string;
+      iterations: number;
+      salt: string;
+      version: number;
+    };
+  };
   posLocalStaffProof?: {
     expiresAt: number;
     token: string;
@@ -819,9 +841,44 @@ async function withPosLocalStaffProof(
     storeId: args.storeId,
     terminalId: args.terminalId,
   });
+  const activePosRoles = authentication.data.activeRoles.filter(
+    (role): role is "cashier" | "manager" =>
+      role === "cashier" || role === "manager",
+  );
+  const issuedAt = Date.now();
+  const posLocalStaffAuthority =
+    credential?.localPinVerifier &&
+    credential.localVerifierVersion &&
+    activePosRoles.length > 0
+      ? {
+          activeRoles: activePosRoles,
+          credentialId: credential._id,
+          credentialVersion: credential.localVerifierVersion,
+          displayName:
+            authentication.data.staffProfile.fullName ??
+            [
+              authentication.data.staffProfile.firstName,
+              authentication.data.staffProfile.lastName,
+            ]
+              .filter(Boolean)
+              .join(" ") ??
+            null,
+          expiresAt: proof.expiresAt,
+          issuedAt,
+          organizationId: credential.organizationId,
+          refreshedAt: issuedAt,
+          staffProfileId: authentication.data.staffProfileId,
+          status: "active" as const,
+          storeId: args.storeId,
+          terminalId: args.terminalId,
+          username: credential.username,
+          verifier: credential.localPinVerifier,
+        }
+      : undefined;
 
   return ok({
     ...authentication.data,
+    ...(posLocalStaffAuthority ? { posLocalStaffAuthority } : {}),
     posLocalStaffProof: proof,
   });
 }

--- a/packages/athena-webapp/convex/pos/public/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.test.ts
@@ -101,7 +101,7 @@ describe("POS terminal public mutations", () => {
     });
   });
 
-  it("derives terminal ownership from the signed-in user and verifies store membership", async () => {
+  it("derives terminal ownership from the signed-in user and allows POS store membership", async () => {
     const ctx = buildCtx();
 
     await getHandler(registerTerminal)(ctx as never, {
@@ -116,7 +116,7 @@ describe("POS terminal public mutations", () => {
     expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(
       ctx,
       expect.objectContaining({
-        allowedRoles: ["full_admin"],
+        allowedRoles: ["full_admin", "pos_only"],
         organizationId: "org-1",
         userId: "athena-user-1",
       }),

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -495,7 +495,7 @@ export const registerTerminal = mutation({
     try {
       const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
       await requireTerminalStoreAccess(ctx, {
-        allowedRoles: ["full_admin"],
+        allowedRoles: ["full_admin", "pos_only"],
         failureMessage: "You do not have access to register this POS terminal.",
         storeId: args.storeId,
         userId: athenaUser._id,

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -7,7 +7,7 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Core app surfaces
 
 - [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 86 file(s); key children: __root.tsx, _authed, _authed.test.tsx, _authed.tsx, index.test.tsx.
-- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 592 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
+- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 593 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
 - [`src/components/traces`](../../src/components/traces) — Shared workflow trace screens, ordered timelines, and trace detail primitives. Currently 3 file(s); key children: WorkflowTraceRouteLink.tsx, WorkflowTraceView.test.tsx, WorkflowTraceView.tsx.
 - [`src/components/operations`](../../src/components/operations) — Manager-queue and stock-adjustment workflows that share approval rails with other operational surfaces. Currently 24 file(s); key children: CommandApprovalDialog.test.tsx, CommandApprovalDialog.tsx, DailyCloseHistoryView.test.tsx, DailyCloseHistoryView.tsx, DailyCloseView.test.tsx.
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -155,6 +155,7 @@ This index enumerates the current automated test files and ties them back to the
 
 ## Section `src`
 
+- [`src/components/View.test.tsx`](../../src/components/View.test.tsx)
 - [`src/components/add-product/ProductStock.test.ts`](../../src/components/add-product/ProductStock.test.ts)
 - [`src/components/add-product/ProductView.test.tsx`](../../src/components/add-product/ProductView.test.tsx)
 - [`src/components/analytics/analyticsWorkspaceEfficiency.test.ts`](../../src/components/analytics/analyticsWorkspaceEfficiency.test.ts)

--- a/packages/athena-webapp/src/components/View.test.tsx
+++ b/packages/athena-webapp/src/components/View.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import View from "./View";
+
+describe("View", () => {
+  beforeEach(() => {
+    vi.spyOn(window, "scrollTo").mockImplementation(() => undefined);
+  });
+
+  it("keeps full-width and full-height layouts inside their parent box", () => {
+    render(
+      <View width="full">
+        <div>Content</div>
+      </View>,
+    );
+
+    const section = screen.getByText("Content").closest("section");
+    expect(section).toHaveClass("box-border");
+    expect(section?.firstElementChild).toHaveClass("box-border");
+  });
+});

--- a/packages/athena-webapp/src/components/View.tsx
+++ b/packages/athena-webapp/src/components/View.tsx
@@ -58,15 +58,15 @@ export default function View({
     <section
       className={cn(
         width === "full"
-          ? "w-full max-w-none px-4 sm:px-6 lg:px-8"
+          ? "box-border w-full max-w-none px-4 sm:px-6 lg:px-8"
           : "container mx-auto",
-        fullHeight && "h-full max-h-full min-h-0",
+        fullHeight && "box-border h-full max-h-full min-h-0",
         className,
       )}
     >
       <div
         className={cn(
-          "min-h-0 flex flex-col rounded-lg",
+          "box-border min-h-0 flex flex-col rounded-lg",
           fullHeight && scrollMode === "content" && "h-full overflow-hidden",
           fullHeight &&
             scrollMode === "page" &&

--- a/packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx
+++ b/packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx
@@ -109,7 +109,7 @@ const storeId = "store-1" as Id<"store">;
 const terminalId = "terminal-1" as Id<"posTerminal">;
 const staffProfileId = "staff-1" as Id<"staffProfile">;
 
-function buildLocalAuthorityRecord() {
+function buildLocalAuthorityRecord(overrides = {}) {
   return {
     activeRoles: ["cashier"],
     credentialId: "credential-1",
@@ -136,6 +136,7 @@ function buildLocalAuthorityRecord() {
       expiresAt: Date.now() + 10_000,
       iv: "proof-iv",
     },
+    ...overrides,
   };
 }
 
@@ -209,6 +210,10 @@ describe("CashierAuthDialog", () => {
       replaceStaffAuthoritySnapshot: vi.fn(async () => ({
         ok: true,
         value: [],
+      })),
+      upsertStaffAuthorityRecord: vi.fn(async ({ record }) => ({
+        ok: true,
+        value: record,
       })),
     });
     mocks.verifyLocalPin.mockResolvedValue({ ok: true });
@@ -344,6 +349,63 @@ describe("CashierAuthDialog", () => {
     ).toBeInTheDocument();
   });
 
+  it("stores the current cashier offline proof immediately after online sign-in", async () => {
+    const upsertStaffAuthorityRecord = vi.fn(async ({ record }) => ({
+      ok: true,
+      value: record,
+    }));
+    mocks.createPosLocalStore.mockReturnValue({
+      readStaffAuthorityForUsername: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
+      replaceStaffAuthoritySnapshot: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      upsertStaffAuthorityRecord,
+    });
+    const authenticateMutation = vi.fn(async () =>
+      ok({
+        activeRoles: ["cashier"],
+        posLocalStaffAuthority: buildLocalAuthorityRecord({
+          wrappedPosLocalStaffProof: undefined,
+        }),
+        posLocalStaffProof: {
+          expiresAt: Date.now() + 10_000,
+          token: "proof-token-1",
+        },
+        staffProfile: { fullName: "Ama Mensah" },
+        staffProfileId,
+      }),
+    );
+
+    const { user, onAuthenticated } = renderDialog({ authenticateMutation });
+
+    await submitCredentials(user);
+
+    await waitFor(() =>
+      expect(upsertStaffAuthorityRecord).toHaveBeenCalledWith({
+        record: expect.objectContaining({
+          staffProfileId,
+          wrappedPosLocalStaffProof: {
+            ciphertext: "wrapped-proof-token",
+            expiresAt: expect.any(Number),
+            iv: "proof-iv",
+          },
+        }),
+        storeId,
+        terminalId,
+      }),
+    );
+    expect(mocks.wrapLocalStaffProofToken).toHaveBeenCalledWith(
+      expect.objectContaining({ algorithm: "PBKDF2-SHA256" }),
+      "1234",
+      expect.objectContaining({ token: "proof-token-1" }),
+    );
+    expect(onAuthenticated).toHaveBeenCalled();
+  });
+
   it("authenticates a locally authorized cashier while offline", async () => {
     Object.defineProperty(window.navigator, "onLine", {
       configurable: true,
@@ -358,6 +420,10 @@ describe("CashierAuthDialog", () => {
       replaceStaffAuthoritySnapshot: vi.fn(async () => ({
         ok: true,
         value: [],
+      })),
+      upsertStaffAuthorityRecord: vi.fn(async ({ record }) => ({
+        ok: true,
+        value: record,
       })),
     });
     const authenticateMutation = vi.fn();
@@ -405,6 +471,10 @@ describe("CashierAuthDialog", () => {
         ok: true,
         value: [],
       })),
+      upsertStaffAuthorityRecord: vi.fn(async ({ record }) => ({
+        ok: true,
+        value: record,
+      })),
     });
     const authenticateMutation = vi.fn();
 
@@ -440,6 +510,10 @@ describe("CashierAuthDialog", () => {
         ok: true,
         value: [],
       })),
+      upsertStaffAuthorityRecord: vi.fn(async ({ record }) => ({
+        ok: true,
+        value: record,
+      })),
     });
     const authenticateMutation = vi.fn();
 
@@ -471,6 +545,10 @@ describe("CashierAuthDialog", () => {
       replaceStaffAuthoritySnapshot: vi.fn(async () => ({
         ok: true,
         value: [],
+      })),
+      upsertStaffAuthorityRecord: vi.fn(async ({ record }) => ({
+        ok: true,
+        value: record,
       })),
     });
     const authenticateMutation = vi.fn();

--- a/packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx
+++ b/packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx
@@ -33,6 +33,11 @@ interface CashierAuthDialogProps {
   workflowMode?: RegisterWorkflowMode;
 }
 
+type StaffAuthenticationResultWithLocalAuthority = StaffAuthenticationResult & {
+  localStaffAuthority?: PosLocalStaffAuthorityRecord;
+  posLocalStaffAuthority?: PosLocalStaffAuthorityRecord;
+};
+
 function getStaffDisplayName(result: StaffAuthenticationResult) {
   return (
     result.staffProfile.fullName ||
@@ -72,6 +77,57 @@ export function CashierAuthDialog({
     [],
   );
   const isExpenseWorkflow = workflowMode === "expense";
+
+  const persistAuthenticatedStaffAuthority = useCallback(
+    async (result: StaffAuthenticationResult, pin: string) => {
+      const localAuthority = (
+        result as StaffAuthenticationResultWithLocalAuthority
+      ).localStaffAuthority ?? (
+        result as StaffAuthenticationResultWithLocalAuthority
+      ).posLocalStaffAuthority;
+      const proof = result.posLocalStaffProof;
+      if (
+        !localAuthority ||
+        !proof ||
+        localAuthority.storeId !== storeId ||
+        localAuthority.terminalId !== terminalId
+      ) {
+        return;
+      }
+
+      const wrappedProof = await wrapLocalStaffProofToken(
+        localAuthority.verifier,
+        pin,
+        proof,
+      );
+      if (!wrappedProof) {
+        logger.warn("[POS] Authenticated staff proof could not be wrapped", {
+          staffProfileId: localAuthority.staffProfileId,
+          storeId,
+          terminalId,
+        });
+        return;
+      }
+
+      const writeResult = await localStore.upsertStaffAuthorityRecord({
+        record: {
+          ...localAuthority,
+          wrappedPosLocalStaffProof: wrappedProof,
+        },
+        storeId,
+        terminalId,
+      });
+      if (!writeResult.ok) {
+        logger.warn("[POS] Authenticated staff authority could not be stored", {
+          code: writeResult.error.code,
+          staffProfileId: localAuthority.staffProfileId,
+          storeId,
+          terminalId,
+        });
+      }
+    },
+    [localStore, storeId, terminalId],
+  );
 
   const refreshLocalAuthority = useCallback(async (unlock?: {
     pin: string;
@@ -291,6 +347,7 @@ export function CashierAuthDialog({
       return authenticationResult;
     }
 
+    void persistAuthenticatedStaffAuthority(authenticationResult.data, args.pin);
     const localStaffAuthority = await refreshLocalAuthority({
       pin: args.pin,
       posLocalStaffProof: authenticationResult.data.posLocalStaffProof,
@@ -331,6 +388,7 @@ export function CashierAuthDialog({
       }),
     );
     if (recoveryResult.kind === "ok") {
+      void persistAuthenticatedStaffAuthority(recoveryResult.data, args.pin);
       const recoveryLocalStaffAuthority = await refreshLocalAuthority({
         pin: args.pin,
         posLocalStaffProof: recoveryResult.data.posLocalStaffProof,

--- a/packages/athena-webapp/src/components/pos/OrderSummary.test.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.test.tsx
@@ -89,7 +89,7 @@ describe("OrderSummary completed transaction summary", () => {
     mockStoreState.printReceipt.mockClear();
   });
 
-  it("opens the print window when a POS sale completes", async () => {
+  it("does not open the print window when a POS sale completes", async () => {
     render(
       <OrderSummary
         cartItems={[]}
@@ -112,12 +112,12 @@ describe("OrderSummary completed transaction summary", () => {
     );
 
     await waitFor(() => {
-      expect(renderEmail).toHaveBeenCalledTimes(1);
-      expect(mockStoreState.printReceipt).toHaveBeenCalledWith("<receipt />");
+      expect(renderEmail).not.toHaveBeenCalled();
+      expect(mockStoreState.printReceipt).not.toHaveBeenCalled();
     });
   });
 
-  it("opens the print window after POS completion once store data is available", async () => {
+  it("does not open the print window after POS completion once store data is available", async () => {
     mockStoreState.activeStore = null;
     const completedTransactionData = {
       paymentMethod: "cash",
@@ -162,12 +162,12 @@ describe("OrderSummary completed transaction summary", () => {
     );
 
     await waitFor(() => {
-      expect(renderEmail).toHaveBeenCalledTimes(1);
-      expect(mockStoreState.printReceipt).toHaveBeenCalledWith("<receipt />");
+      expect(renderEmail).not.toHaveBeenCalled();
+      expect(mockStoreState.printReceipt).not.toHaveBeenCalled();
     });
   });
 
-  it("does not auto-open the print window again after the completed POS sale remounts", async () => {
+  it("does not auto-open the print window after the completed POS sale remounts", async () => {
     const completedTransactionData = {
       paymentMethod: "cash",
       transactionId: "txn-remount",
@@ -192,7 +192,7 @@ describe("OrderSummary completed transaction summary", () => {
     );
 
     await waitFor(() => {
-      expect(mockStoreState.printReceipt).toHaveBeenCalledTimes(1);
+      expect(mockStoreState.printReceipt).not.toHaveBeenCalled();
     });
 
     unmount();
@@ -206,7 +206,7 @@ describe("OrderSummary completed transaction summary", () => {
     );
 
     await waitFor(() => {
-      expect(mockStoreState.printReceipt).toHaveBeenCalledTimes(1);
+      expect(mockStoreState.printReceipt).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/athena-webapp/src/components/pos/OrderSummary.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.tsx
@@ -158,6 +158,7 @@ interface OrderSummaryProps {
 }
 
 const attemptedAutoPrintReceiptKeys = new Set<string>();
+const AUTO_PRINT_COMPLETED_SALE_RECEIPTS = false;
 
 export function clearAttemptedOrderSummaryAutoPrintReceiptKeysForTest() {
   attemptedAutoPrintReceiptKeys.clear();
@@ -679,6 +680,7 @@ export function OrderSummary({
 
   useEffect(() => {
     if (
+      !AUTO_PRINT_COMPLETED_SALE_RECEIPTS ||
       readOnly ||
       !isTransactionCompleted ||
       !completedTransactionData ||

--- a/packages/athena-webapp/src/components/pos/PointOfSaleView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/PointOfSaleView.test.tsx
@@ -192,6 +192,20 @@ describe("PointOfSaleView", () => {
     ).toBeInTheDocument();
   });
 
+  it("links POS-only users to POS settings from the POS landing page", () => {
+    usePermissionsMock.mockReturnValue({
+      canAccessPOS: () => true,
+      hasFullAdminAccess: false,
+    });
+
+    render(<PointOfSaleView />);
+
+    const link = screen.getByRole("link", { name: /POS Settings/i });
+
+    expect(link).toHaveAttribute("href", "/acme/store/downtown/pos/settings");
+    expect(screen.queryByRole("link", { name: /Active Sessions/i })).toBeNull();
+  });
+
   it("renders the POS launcher from local entry context when live summary and store context are unavailable", () => {
     useGetActiveStoreMock.mockReturnValue({
       activeStore: null,

--- a/packages/athena-webapp/src/components/pos/PointOfSaleView.tsx
+++ b/packages/athena-webapp/src/components/pos/PointOfSaleView.tsx
@@ -205,7 +205,7 @@ export default function PointOfSaleView() {
       href: "/$orgUrlSlug/store/$storeUrlSlug/pos/settings" as const,
       params: liveLinkParams,
       color: "bg-gray-500",
-      available: hasFullAdminAccess && Boolean(liveLinkParams),
+      available: canAccessPOS() && Boolean(liveLinkParams),
     },
   ];
 

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -32,8 +32,12 @@ vi.mock("@/lib/pos/presentation/register/useRegisterViewModel", () => ({
 }));
 
 vi.mock("@/components/ui/sidebar", () => ({
+  SidebarProvider: ({ children }: { children: ReactNode }) => (
+    <div data-testid="sidebar-provider">{children}</div>
+  ),
   useSidebar: () => ({
     isMobile: false,
+    open: true,
     setOpen: vi.fn(),
   }),
 }));
@@ -86,7 +90,13 @@ vi.mock("@/components/View", () => ({
 }));
 
 vi.mock("@/components/common/FadeIn", () => ({
-  FadeIn: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  FadeIn: ({
+    children,
+    className,
+  }: {
+    children: ReactNode;
+    className?: string;
+  }) => <div className={className}>{children}</div>,
 }));
 
 vi.mock("@/components/common/PageHeader", () => ({
@@ -388,6 +398,9 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("cart-items")).toBeInTheDocument();
     expect(screen.getByText("register-checkout-panel")).toBeInTheDocument();
     expect(screen.getByText("hide-active-summary-cards")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("register-main-workspace").closest(".box-border"),
+    ).toBeInTheDocument();
     expect(screen.queryByText("cashier-auth-dialog")).not.toBeInTheDocument();
   });
 
@@ -1092,9 +1105,7 @@ describe("POSRegisterView", () => {
     const { POSRegisterView } = await import("./POSRegisterView");
     render(<POSRegisterView />);
 
-    await userEvent.click(
-      screen.getByRole("button", { name: /Ready for product lookup/i }),
-    );
+    await userEvent.click(screen.getByTestId("product-lookup-empty-state"));
 
     expect(setShowProductLookup).toHaveBeenCalledWith(true);
     expect(screen.getByLabelText("product search input")).toHaveFocus();
@@ -1154,9 +1165,7 @@ describe("POSRegisterView", () => {
     const { POSRegisterView } = await import("./POSRegisterView");
     const { rerender } = render(<POSRegisterView />);
 
-    await userEvent.click(
-      screen.getByRole("button", { name: /Ready for product lookup/i }),
-    );
+    await userEvent.click(screen.getByTestId("product-lookup-empty-state"));
     expect(onStartNewSession).toHaveBeenCalledTimes(1);
 
     rerender(<POSRegisterView />);

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -10,7 +10,7 @@ import {
   ProductSearchInput,
 } from "@/components/pos/ProductEntry";
 import type { Product } from "@/components/pos/types";
-import { useSidebar } from "@/components/ui/sidebar";
+import { SidebarProvider, useSidebar } from "@/components/ui/sidebar";
 import { Button } from "@/components/ui/button";
 import View from "@/components/View";
 import {
@@ -32,7 +32,15 @@ import {
   Users,
 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import {
   type RegisterServiceSearchResult,
@@ -94,15 +102,49 @@ function ProductLookupEmptyState({
   workflowMode: RegisterWorkflowMode;
 }) {
   const isExpenseWorkflow = workflowMode === "expense";
+  const isInteractive = Boolean(onActivate);
+  const handleActivate = useCallback(() => {
+    void onActivate?.();
+  }, [onActivate]);
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (!onActivate || (event.key !== "Enter" && event.key !== " ")) {
+        return;
+      }
+
+      event.preventDefault();
+      void onActivate();
+    },
+    [onActivate],
+  );
+  const handleQuickAddClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      onQuickAddProduct?.();
+    },
+    [onQuickAddProduct],
+  );
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-col items-center justify-center rounded-lg border border-border bg-surface-raised p-8 text-center transition hover:border-ring hover:bg-muted/30">
-      <button
-        type="button"
-        onClick={onActivate}
-        className="flex flex-col items-center text-center focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-4 disabled:cursor-default"
-        disabled={!onActivate}
-      >
+    <div
+      aria-label={
+        isExpenseWorkflow
+          ? "Ready for expense entry"
+          : "Ready for product lookup"
+      }
+      className={cn(
+        "flex h-full min-h-0 w-full flex-col items-center justify-center rounded-lg border border-border bg-surface-raised p-8 text-center transition focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-4",
+        isInteractive
+          ? "cursor-pointer hover:border-ring hover:bg-muted/30"
+          : "cursor-default",
+      )}
+      data-testid="product-lookup-empty-state"
+      role={isInteractive ? "button" : undefined}
+      tabIndex={isInteractive ? 0 : undefined}
+      onClick={isInteractive ? handleActivate : undefined}
+      onKeyDown={isInteractive ? handleKeyDown : undefined}
+    >
+      <div className="flex flex-col items-center text-center">
         <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-surface text-muted-foreground shadow-surface">
           <Search className="h-7 w-7" />
         </div>
@@ -118,7 +160,7 @@ function ProductLookupEmptyState({
               : "Scan a barcode or search products to add items to this sale"}
           </p>
         </div>
-      </button>
+      </div>
       <div className="mt-5 flex flex-wrap items-center justify-center gap-2 text-xs text-muted-foreground">
         <span className="inline-flex items-center gap-1 rounded-full border border-border bg-surface px-3 py-1">
           <ScanBarcode className="h-3.5 w-3.5" />
@@ -137,7 +179,7 @@ function ProductLookupEmptyState({
             variant="outline"
             size="sm"
             className="h-7 gap-1.5 rounded-full bg-surface px-3 text-xs"
-            onClick={onQuickAddProduct}
+            onClick={handleQuickAddClick}
           >
             <PackagePlus className="h-3.5 w-3.5" />
             Quick add product
@@ -983,7 +1025,15 @@ interface POSRegisterViewProps {
   viewModel?: RegisterViewModel;
 }
 
-export function POSRegisterView({
+export function POSRegisterView(props: POSRegisterViewProps) {
+  return (
+    <SidebarProvider className="contents" defaultOpen={false}>
+      <POSRegisterViewContent {...props} />
+    </SidebarProvider>
+  );
+}
+
+function POSRegisterViewContent({
   workflowMode,
   viewModel: injectedViewModel,
 }: POSRegisterViewProps) {
@@ -1009,7 +1059,7 @@ export function POSRegisterView({
   const isSessionActive = viewModel.header.isSessionActive;
   const registerViewWidth = "full";
   const registerContentClassName = cn(
-    "w-full px-6 py-5",
+    "box-border w-full px-6 py-5",
     "h-full min-h-0",
     "overflow-hidden",
   );

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx
@@ -160,6 +160,27 @@ describe("RegisterDrawerGate", () => {
     expect(onSignOut).toHaveBeenCalledTimes(1);
   });
 
+  it("shows terminal repair errors when repair cannot continue", async () => {
+    const user = userEvent.setup();
+    const onRepairTerminalSetup = vi.fn();
+    renderGate({
+      errorMessage:
+        "Terminal setup repair needs the current local setup record. Open POS Settings to repair setup.",
+      mode: "terminalRepair",
+      onRepairTerminalSetup,
+    });
+
+    expect(
+      screen.getByText(
+        "Terminal setup repair needs the current local setup record. Open POS Settings to repair setup.",
+      ),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Repair setup" }));
+
+    expect(onRepairTerminalSetup).toHaveBeenCalledTimes(1);
+  });
+
   it("shows drawer authority repair copy and sign-out action", async () => {
     const user = userEvent.setup();
     const onSignOut = vi.fn();

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
@@ -124,6 +124,11 @@ export function RegisterDrawerGate({
                 ? `${drawerGate.registerLabel} cannot record new sales until terminal setup is repaired. Existing local activity is preserved for support.`
                 : `${drawerGate.registerLabel} needs a current drawer before sales can continue. Existing local activity is preserved for support.`}
             </p>
+            {drawerGate.errorMessage ? (
+              <p className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm leading-6 text-destructive">
+                {drawerGate.errorMessage}
+              </p>
+            ) : null}
           </div>
           <div className="flex flex-wrap gap-2 pt-2">
             {isTerminalRepair && drawerGate.onRepairTerminalSetup ? (

--- a/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
@@ -59,7 +59,12 @@ vi.mock("@tanstack/react-router", () => ({
 
 vi.mock("~/convex/_generated/api", () => ({
   api: {
-    inventory: { posTerminal: {} },
+    inventory: {
+      posTerminal: {
+        getTerminalByFingerprint: "getTerminalByFingerprint",
+        registerTerminal: "registerTerminal",
+      },
+    },
     pos: {
       public: {
         posRecoveryCodes: {
@@ -172,6 +177,10 @@ describe("registerAndProvisionPosTerminal", () => {
     mocks.generateBrowserFingerprint.mockResolvedValue({
       browserInfo: { userAgent: "test" },
       fingerprintHash: "fingerprint-1",
+    });
+    Object.defineProperty(globalThis, "caches", {
+      configurable: true,
+      value: undefined,
     });
     Object.defineProperty(globalThis, "crypto", {
       configurable: true,
@@ -425,11 +434,13 @@ describe("registerAndProvisionPosTerminal", () => {
     expect(screen.getByText("Offline diagnostics need attention")).toBeInTheDocument();
     expect(
       screen.getByText((_content, element) =>
-        Boolean(element?.textContent?.trim() === "0 of 6 ready"),
+        Boolean(element?.textContent?.trim() === "0 of 6 reporting"),
       ),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("App shell readiness has not reported from this checkout station."),
+      screen.getByText(
+        "App shell recovery needs attention before offline route access is reliable.",
+      ),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
@@ -439,6 +450,93 @@ describe("registerAndProvisionPosTerminal", () => {
     expect(
       screen.getByRole("link", { name: "Open terminal health" }),
     ).toHaveAttribute("href", "/acme/store/downtown/pos/terminals");
+  });
+
+  it("shows when the current register is ready for offline checkout", async () => {
+    const existingTerminal = {
+      _id: "terminal-existing",
+      _creationTime: 1,
+      browserInfo: { userAgent: "test" },
+      displayName: "Front counter",
+      fingerprintHash: "fingerprint-1",
+      registeredAt: 1,
+      registeredByUserId: "user-1",
+      registerNumber: "3",
+      status: "active",
+      storeId: "store-1",
+    };
+    mocks.useQuery.mockImplementation((ref) => {
+      if (ref === "getRecoveryCodeStatus") {
+        return {
+          failedAttemptCount: 0,
+          lastUsedAt: undefined,
+          lockedUntil: undefined,
+          plaintextCode: "mintlamp42",
+          rotatedAt: 1,
+          status: "active",
+        };
+      }
+      if (ref === "getTerminalByFingerprint") {
+        return existingTerminal;
+      }
+      return null;
+    });
+    Object.defineProperty(globalThis, "caches", {
+      configurable: true,
+      value: {
+        keys: vi.fn(async () => ["athena-pos-app-shell-v6"]),
+        open: vi.fn(async () => ({
+          match: vi.fn(async () => ({ ok: true })),
+        })),
+      },
+    });
+
+    render(
+      <POSSettingsView
+        storeFactory={() =>
+          ({
+            getStaffAuthorityReadiness: vi.fn(async () => ({
+              ok: true,
+              value: "ready",
+            })),
+            readProvisionedTerminalSeed: vi.fn(async () => ({
+              ok: true,
+              value: {
+                cloudTerminalId: "terminal-existing",
+                storeId: "store-1",
+                terminalId: "fingerprint-1",
+              },
+            })),
+            readRegisterAvailabilitySnapshot: vi.fn(async () => ({
+              ok: true,
+              value: { refreshedAt: Date.now() },
+            })),
+            readRegisterCatalogSnapshot: vi.fn(async () => ({
+              ok: true,
+              value: { refreshedAt: Date.now() },
+            })),
+            readRegisterServiceCatalogSnapshot: vi.fn(async () => ({
+              ok: true,
+              value: { refreshedAt: Date.now() },
+            })),
+          }) as never
+        }
+      />,
+    );
+
+    expect(
+      await screen.findByText("Register ready for offline checkout"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This checkout station has the app shell, terminal setup, staff authority, catalog, and availability data needed for offline POS.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText((_content, element) =>
+        Boolean(element?.textContent?.trim() === "6 of 6 reporting"),
+      ),
+    ).toBeInTheDocument();
   });
 
   it("sends an independent sync secret and writes it into the local terminal seed", async () => {

--- a/packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx
+++ b/packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx
@@ -23,8 +23,13 @@ import {
 import { usePermissions } from "@/hooks/usePermissions";
 import {
   buildPosOfflineReadinessSummary,
+  type PosOfflineReadinessInput,
   type PosOfflineReadinessSummary,
 } from "@/offline/posOfflineReadiness";
+import {
+  createIndexedDbPosLocalStorageAdapter,
+  createPosLocalStore,
+} from "@/lib/pos/infrastructure/local/posLocalStore";
 
 type HealthLinkProps = {
   children: ReactNode;
@@ -37,6 +42,7 @@ type HealthLinkProps = {
 };
 
 const HealthLink = Link as unknown as ComponentType<HealthLinkProps>;
+const POS_APP_SHELL_CACHE_PREFIX = "athena-pos-app-shell-";
 
 type FingerprintRegistrationCardProps = {
   displayName: string;
@@ -191,7 +197,7 @@ function FingerprintRegistrationCard({
             </div>
             <span className="inline-flex rounded-full border border-border bg-background px-layout-sm py-layout-2xs text-sm text-muted-foreground">
               {offlineReadiness.readyCount} of{" "}
-              {offlineReadiness.signals.length} ready
+              {offlineReadiness.signals.length} reporting
             </span>
           </div>
 
@@ -411,6 +417,193 @@ function POSRecoveryCodeAdminPanel({
   );
 }
 
+type PosSettingsLocalReadinessStore = ReturnType<typeof createPosLocalStore>;
+
+function createDefaultLocalReadinessStore() {
+  if (typeof indexedDB === "undefined") {
+    return null;
+  }
+
+  return createPosLocalStore({
+    adapter: createIndexedDbPosLocalStorageAdapter(),
+  });
+}
+
+async function readPosAppShellReadiness(input: {
+  orgUrlSlug?: string;
+  storeUrlSlug?: string;
+}): Promise<PosOfflineReadinessInput["appShell"]> {
+  if (typeof caches === "undefined") {
+    return { ready: false };
+  }
+
+  try {
+    const cacheNames = await caches.keys();
+    const shellCacheName = cacheNames.find((name) =>
+      name.startsWith(POS_APP_SHELL_CACHE_PREFIX),
+    );
+    if (!shellCacheName) {
+      return { ready: false };
+    }
+
+    const cache = await caches.open(shellCacheName);
+    const registerPath =
+      input.orgUrlSlug && input.storeUrlSlug
+        ? `/${input.orgUrlSlug}/store/${input.storeUrlSlug}/pos/register`
+        : null;
+    const cachedRegister =
+      registerPath && typeof window !== "undefined"
+        ? await cache.match(
+            new URL(registerPath, window.location.origin).toString(),
+            {
+              ignoreVary: true,
+            },
+          )
+        : null;
+    const cachedRoot = await cache.match("/", { ignoreVary: true });
+
+    return { ready: Boolean(cachedRegister || cachedRoot) };
+  } catch {
+    return { ready: false };
+  }
+}
+
+function signalFromSnapshot(
+  snapshot:
+    | { ok: true; value: { refreshedAt?: number } | null }
+    | { ok: false }
+    | null
+    | undefined,
+): PosOfflineReadinessInput["registerCatalog"] {
+  if (!snapshot?.ok) {
+    return { ready: false };
+  }
+  if (!snapshot.value) {
+    return { ready: false };
+  }
+
+  return {
+    ageMs:
+      typeof snapshot.value.refreshedAt === "number"
+        ? Date.now() - snapshot.value.refreshedAt
+        : undefined,
+    ready: true,
+  };
+}
+
+function usePosSettingsOfflineReadiness(input: {
+  existingTerminal: ProvisionedTerminalRecord | null;
+  storeFactory?: Parameters<typeof registerAndProvisionPosTerminal>[0]["storeFactory"];
+  storeId?: string;
+  orgUrlSlug?: string;
+  storeUrlSlug?: string;
+}) {
+  const [signals, setSignals] = useState<PosOfflineReadinessInput>({
+    appShell: null,
+    availabilitySnapshot: null,
+    registerCatalog: null,
+    serviceCatalog: null,
+    staffAuthority: null,
+    terminalSeed: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadReadiness() {
+      const appShell = await readPosAppShellReadiness({
+        orgUrlSlug: input.orgUrlSlug,
+        storeUrlSlug: input.storeUrlSlug,
+      });
+
+      if (!input.storeId || !input.existingTerminal) {
+        if (!cancelled) {
+          setSignals({
+            appShell,
+            availabilitySnapshot: { ready: false },
+            registerCatalog: { ready: false },
+            serviceCatalog: { ready: false },
+            staffAuthority: { ready: false },
+            terminalSeed: { ready: false },
+          });
+        }
+        return;
+      }
+
+      const store =
+        (input.storeFactory?.() as PosSettingsLocalReadinessStore | undefined) ??
+        createDefaultLocalReadinessStore();
+      if (!store) {
+        if (!cancelled) {
+          setSignals({
+            appShell,
+            availabilitySnapshot: { ready: false },
+            registerCatalog: { ready: false },
+            serviceCatalog: { ready: false },
+            staffAuthority: { ready: false },
+            terminalSeed: { ready: false },
+          });
+        }
+        return;
+      }
+
+      const [
+        terminalSeed,
+        staffAuthority,
+        registerCatalog,
+        serviceCatalog,
+        availabilitySnapshot,
+      ] = await Promise.all([
+        store.readProvisionedTerminalSeed?.() ??
+          Promise.resolve({ ok: true as const, value: null }),
+        store.getStaffAuthorityReadiness?.({
+          storeId: input.storeId,
+          terminalId: input.existingTerminal._id,
+        }) ?? Promise.resolve({ ok: true as const, value: "missing" as const }),
+        store.readRegisterCatalogSnapshot?.({ storeId: input.storeId }) ??
+          Promise.resolve({ ok: true as const, value: null }),
+        store.readRegisterServiceCatalogSnapshot?.({ storeId: input.storeId }) ??
+          Promise.resolve({ ok: true as const, value: null }),
+        store.readRegisterAvailabilitySnapshot?.({ storeId: input.storeId }) ??
+          Promise.resolve({ ok: true as const, value: null }),
+      ]);
+
+      if (cancelled) return;
+
+      const localTerminalSeed = terminalSeed.ok ? terminalSeed.value : null;
+      setSignals({
+        appShell,
+        availabilitySnapshot: signalFromSnapshot(availabilitySnapshot),
+        registerCatalog: signalFromSnapshot(registerCatalog),
+        serviceCatalog: signalFromSnapshot(serviceCatalog),
+        staffAuthority: {
+          ready: staffAuthority.ok && staffAuthority.value === "ready",
+        },
+        terminalSeed: {
+          ready:
+            Boolean(localTerminalSeed) &&
+            localTerminalSeed?.storeId === input.storeId &&
+            localTerminalSeed?.cloudTerminalId === input.existingTerminal._id,
+        },
+      });
+    }
+
+    void loadReadiness();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    input.existingTerminal,
+    input.orgUrlSlug,
+    input.storeFactory,
+    input.storeId,
+    input.storeUrlSlug,
+  ]);
+
+  return signals;
+}
+
 export function POSSettingsView({
   storeFactory,
 }: {
@@ -569,21 +762,16 @@ export function POSSettingsView({
     registerNumber,
   ]);
 
+  const offlineReadinessSignals = usePosSettingsOfflineReadiness({
+    existingTerminal,
+    orgUrlSlug: routeParams?.orgUrlSlug,
+    storeFactory,
+    storeId: activeStore?._id,
+    storeUrlSlug: routeParams?.storeUrlSlug,
+  });
   const offlineReadiness = useMemo(
-    () =>
-      buildPosOfflineReadinessSummary({
-        appShell: null,
-        terminalSeed: existingTerminal
-          ? { ready: true }
-          : fingerprintError
-            ? { ready: false }
-            : { ready: false },
-        staffAuthority: null,
-        registerCatalog: null,
-        serviceCatalog: null,
-        availabilitySnapshot: null,
-      }),
-    [existingTerminal, fingerprintError],
+    () => buildPosOfflineReadinessSummary(offlineReadinessSignals),
+    [offlineReadinessSignals],
   );
 
   const handleRegisterTerminal = async () => {

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx
@@ -255,7 +255,7 @@ describe("POSTerminalHealthViewContent", () => {
     expect(
       screen.getAllByText("Register session evidence is shown in cash controls").length,
     ).toBeGreaterThan(0);
-    expect(screen.getAllByText("Offline diagnostics incomplete").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Offline diagnostics need attention").length).toBeGreaterThan(0);
     expect(
       screen.getAllByText(
         "Service catalog data is available locally. Last refreshed 3 minutes ago.",
@@ -263,7 +263,7 @@ describe("POSTerminalHealthViewContent", () => {
     ).toBeGreaterThan(0);
     expect(
       screen.getAllByText(
-        "App shell readiness has not reported from this checkout station.",
+        "App shell status has not reported to this page yet.",
       ).length,
     ).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: /Front counter/i })).toHaveAttribute(

--- a/packages/athena-webapp/src/components/product/QuickAddProductDialog.test.tsx
+++ b/packages/athena-webapp/src/components/product/QuickAddProductDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -129,6 +129,18 @@ describe("QuickAddProductDialog", () => {
       }),
     );
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("does not dismiss quick add when tapping outside the dialog", async () => {
+    const onOpenChange = vi.fn();
+    renderQuickAddDialog({ onOpenChange });
+
+    fireEvent.pointerDown(document.body);
+
+    expect(
+      screen.getByRole("heading", { name: /quick add product/i }),
+    ).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
   });
 
   it("fills the barcode field from the shared scanner trigger", async () => {

--- a/packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx
+++ b/packages/athena-webapp/src/components/product/QuickAddProductDialog.tsx
@@ -415,6 +415,10 @@ export function QuickAddProductDialog({
     onOpenChange(false);
   };
 
+  const preventOutsideDismiss = (event: Event) => {
+    event.preventDefault();
+  };
+
   const handleBarcodeDetected = useCallback((barcode: string) => {
     setQuickAddLookupCode(normalizeQuickAddLookupCode(barcode));
     setQuickAddError(null);
@@ -650,16 +654,8 @@ export function QuickAddProductDialog({
             event.preventDefault();
           }
         }}
-        onInteractOutside={(event) => {
-          if (isBarcodeScannerOpen) {
-            event.preventDefault();
-          }
-        }}
-        onPointerDownOutside={(event) => {
-          if (isBarcodeScannerOpen) {
-            event.preventDefault();
-          }
-        }}
+        onInteractOutside={preventOutsideDismiss}
+        onPointerDownOutside={preventOutsideDismiss}
       >
         <form
           onSubmit={handleQuickAddSubmit}

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
@@ -1302,7 +1302,17 @@ describe("posLocalStore", () => {
       clock: () => 6_000,
     });
 
-    await store.writeCashierPresence(buildCashierPresenceRecord());
+    await store.writeCashierPresence(
+      buildCashierPresenceRecord({
+        expiresAt: 10_000,
+        offlineFreshUntil: 5_000,
+        wrappedPosLocalStaffProof: {
+          ciphertext: "wrapped-proof-token",
+          expiresAt: 10_000,
+          iv: "proof-iv",
+        },
+      }),
+    );
 
     await expect(
       store.readCashierPresence({
@@ -1490,6 +1500,103 @@ describe("posLocalStore", () => {
         value: originalIndexedDb,
       });
     }
+  });
+
+  it("requires an unexpired wrapped proof before staff authority is offline ready", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 1_500,
+    });
+
+    await store.replaceStaffAuthoritySnapshot({
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      records: [
+        buildAuthorityRecord({
+          expiresAt: 3_000,
+          wrappedPosLocalStaffProof: undefined,
+        }),
+      ],
+    });
+
+    await expect(
+      store.getStaffAuthorityReadiness({
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).resolves.toEqual({ ok: true, value: "expired" });
+
+    await store.upsertStaffAuthorityRecord({
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      record: buildAuthorityRecord({
+        expiresAt: 3_000,
+        wrappedPosLocalStaffProof: {
+          ciphertext: "wrapped-proof-token",
+          expiresAt: 3_000,
+          iv: "proof-iv",
+        },
+      }),
+    });
+
+    await expect(
+      store.getStaffAuthorityReadiness({
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).resolves.toEqual({ ok: true, value: "ready" });
+  });
+
+  it("upserts one staff authority record without clearing the terminal snapshot", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 1_500,
+    });
+
+    await store.replaceStaffAuthoritySnapshot({
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      records: [
+        buildAuthorityRecord({ username: "frontdesk" }),
+        buildAuthorityRecord({
+          credentialId: "credential-2",
+          staffProfileId: "staff-2",
+          username: "manager",
+        }),
+      ],
+    });
+
+    await expect(
+      store.upsertStaffAuthorityRecord({
+        storeId: "store-1",
+        terminalId: "terminal-1",
+        record: buildAuthorityRecord({
+          displayName: "Ama Updated",
+          expiresAt: 4_000,
+          username: "frontdesk",
+        }),
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      value: expect.objectContaining({
+        displayName: "Ama Updated",
+        username: "frontdesk",
+      }),
+    });
+
+    await expect(
+      store.readStaffAuthorityForUsername({
+        storeId: "store-1",
+        terminalId: "terminal-1",
+        username: "manager",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      value: expect.objectContaining({
+        credentialId: "credential-2",
+        username: "manager",
+      }),
+    });
   });
 
   it("reads local-to-cloud mappings for later events on the same local entity", async () => {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
@@ -251,8 +251,8 @@ export type PosLocalObjectStoreName =
   | "events"
   | "mappings"
   | "readiness"
-  | "staffAuthority"
   | "cashierPresence"
+  | "staffAuthority"
   | "registerCatalog"
   | "registerServiceCatalog"
   | "registerAvailability";
@@ -937,6 +937,50 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
       }
     },
 
+    async upsertStaffAuthorityRecord(input: {
+      record: PosLocalStaffAuthorityRecord;
+      storeId: string;
+      terminalId: string;
+    }): Promise<PosLocalStoreResult<PosLocalStaffAuthorityRecord>> {
+      try {
+        const value = await options.adapter.transaction(
+          "readwrite",
+          ["meta", "staffAuthority"],
+          async (transaction) => {
+            await ensureSupportedSchema(transaction, "readwrite");
+            if (
+              input.record.storeId !== input.storeId ||
+              input.record.terminalId !== input.terminalId
+            ) {
+              return normalizeStaffAuthorityRecord(input.record);
+            }
+
+            const existing =
+              (await transaction.get<unknown>(
+                "staffAuthority",
+                staffAuthorityKey(input.record),
+              )) ?? null;
+            const existingByKey = isStaffAuthorityRecord(existing)
+              ? new Map([[staffAuthorityKey(existing), existing]])
+              : new Map<string, PosLocalStaffAuthorityRecord>();
+            const record = normalizeStaffAuthorityRecord(
+              preserveWrappedStaffProof(input.record, existingByKey),
+            );
+            await transaction.put(
+              "staffAuthority",
+              staffAuthorityKey(record),
+              record,
+            );
+            return record;
+          },
+        );
+
+        return { ok: true, value };
+      } catch (error) {
+        return toFailure(error);
+      }
+    },
+
     async readStaffAuthorityForUsername(input: {
       now?: number;
       storeId: string;
@@ -963,7 +1007,7 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
               record.storeId !== input.storeId ||
               record.terminalId !== input.terminalId ||
               record.status !== "active" ||
-              record.expiresAt <= (input.now ?? clock())
+              record.expiresAt < (input.now ?? clock())
             ) {
               return null;
             }
@@ -1002,10 +1046,9 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
               return "missing" as const;
             }
 
-            return scopedRecords.some(
-              (record) =>
-                record.status === "active" &&
-                record.expiresAt > (input.now ?? clock()),
+            const now = input.now ?? clock();
+            return scopedRecords.some((record) =>
+              isOfflineStaffAuthorityReady(record, now),
             )
               ? ("ready" as const)
               : ("expired" as const);
@@ -1456,15 +1499,6 @@ function readinessKey(storeId: string, operatingDate: string) {
   return `${storeId}:${operatingDate}`;
 }
 
-function cashierPresenceKey(input: PosLocalCashierPresenceScope) {
-  return [
-    input.organizationId,
-    input.storeId,
-    input.terminalId,
-    input.operatingDate,
-  ].join(":");
-}
-
 function uploadSequenceKey(localRegisterSessionId: string) {
   return `${META_UPLOAD_SEQUENCE_PREFIX}${localRegisterSessionId}`;
 }
@@ -1481,6 +1515,10 @@ function staffAuthorityKey(input: {
   return `${input.storeId}:${input.terminalId}:${normalizeUsername(input.username)}`;
 }
 
+function cashierPresenceKey(input: PosLocalCashierPresenceScope) {
+  return `${input.organizationId}:${input.storeId}:${input.terminalId}:${input.operatingDate}`;
+}
+
 function normalizeStaffAuthorityRecord(
   record: PosLocalStaffAuthorityRecord,
 ): PosLocalStaffAuthorityRecord {
@@ -1495,6 +1533,10 @@ function normalizeCashierPresenceRecord(
 ): PosLocalActiveCashierPresenceRecord {
   return {
     ...record,
+    activeRoles: Array.from(new Set(record.activeRoles)).filter(
+      (role): role is "cashier" | "manager" =>
+        role === "cashier" || role === "manager",
+    ),
     username: normalizeUsername(record.username),
   };
 }
@@ -1543,6 +1585,18 @@ function preserveWrappedStaffProof(
     ...record,
     wrappedPosLocalStaffProof: existing.wrappedPosLocalStaffProof,
   };
+}
+
+function isOfflineStaffAuthorityReady(
+  record: PosLocalStaffAuthorityRecord,
+  now: number,
+) {
+  return (
+    record.status === "active" &&
+    record.expiresAt > now &&
+    Boolean(record.wrappedPosLocalStaffProof) &&
+    (record.wrappedPosLocalStaffProof?.expiresAt ?? 0) > now
+  );
 }
 
 function normalizeTerminalIntegrityState(
@@ -1714,7 +1768,6 @@ export function toSafePosLocalCashierPresenceDiagnostic(
     },
   };
 }
-
 export function createIndexedDbPosLocalStorageAdapter(options?: {
   databaseName?: string;
 }): PosLocalStorageAdapter {
@@ -1733,6 +1786,7 @@ export function createIndexedDbPosLocalStorageAdapter(options?: {
           "events",
           "mappings",
           "readiness",
+          "cashierPresence",
           "staffAuthority",
           "cashierPresence",
           "registerCatalog",
@@ -1902,8 +1956,8 @@ function createEmptyMemoryStore(): MemoryStore {
     events: new Map(),
     mappings: new Map(),
     readiness: new Map(),
-    staffAuthority: new Map(),
     cashierPresence: new Map(),
+    staffAuthority: new Map(),
     registerCatalog: new Map(),
     registerServiceCatalog: new Map(),
     registerAvailability: new Map(),
@@ -1918,8 +1972,8 @@ function cloneMemoryStore(store: MemoryStore): MemoryStore {
     events: new Map(store.events),
     mappings: new Map(store.mappings),
     readiness: new Map(store.readiness),
-    staffAuthority: new Map(store.staffAuthority),
     cashierPresence: new Map(store.cashierPresence),
+    staffAuthority: new Map(store.staffAuthority),
     registerCatalog: new Map(store.registerCatalog),
     registerServiceCatalog: new Map(store.registerServiceCatalog),
     registerAvailability: new Map(store.registerAvailability),

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -37,7 +37,10 @@ import {
   usePosLocalSyncRuntimeStatus,
   writeReturnedLocalCloudMappings,
 } from "./usePosLocalSyncRuntime";
-import type { PosLocalEventRecord } from "./posLocalStore";
+import type {
+  PosLocalEventRecord,
+  PosTerminalIntegrityState,
+} from "./posLocalStore";
 import { buildPosLocalSyncUploadEvents } from "./syncContract";
 
 function deferred<T>() {
@@ -2214,6 +2217,78 @@ describe("usePosLocalSyncRuntimeStatus", () => {
         storeId: "store-1",
         terminalId: "local-terminal-1",
       }),
+    );
+  });
+
+  it("clears stale terminal integrity after an accepted runtime check-in", async () => {
+    let terminalIntegrity: PosTerminalIntegrityState | null = {
+      cloudTerminalId: "terminal-cloud-1",
+      observedAt: 1,
+      reason: "authorization_failed" as const,
+      status: "requires_reprovision" as const,
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+    };
+    const onLocalEventsChanged = vi.fn();
+    const store = {
+      clearTerminalIntegrityState: vi.fn(async () => {
+        terminalIntegrity = null;
+        return {
+          ok: true,
+          value: null,
+        };
+      }),
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+      readTerminalIntegrityState: vi.fn(async () => ({
+        ok: true,
+        value: terminalIntegrity,
+      })),
+    };
+
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        mode: "status-only",
+        onLocalEventsChanged,
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(store.clearTerminalIntegrityState).toHaveBeenCalledWith({
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+    expect(store.clearTerminalIntegrityState).toHaveBeenCalledWith({
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+    });
+    expect(onLocalEventsChanged).toHaveBeenCalled();
+    await waitFor(() =>
+      expect(mocks.reportTerminalRuntimeStatus).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          status: expect.not.objectContaining({
+            terminalIntegrity: expect.anything(),
+          }),
+        }),
+      ),
     );
   });
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -786,6 +786,35 @@ export function usePosLocalSyncRuntimeStatus(input: {
         if (!isCurrentPublishScope()) return;
 
         if (result.kind === "ok") {
+          if (runtimeReadiness.terminalSeed) {
+            const authorityStore =
+              storeFactory?.() ??
+              (typeof indexedDB === "undefined"
+                ? null
+                : createPosLocalStore({
+                    adapter: createIndexedDbPosLocalStorageAdapter(),
+                  }));
+
+            if (authorityStore) {
+              const cleared = await clearAcceptedTerminalIntegrityState({
+                checkInTerminalId,
+                store: authorityStore,
+                storeId: checkInStoreId,
+                terminalSeed: runtimeReadiness.terminalSeed,
+              });
+              if (!isCurrentPublishScope()) return;
+
+              if (cleared) {
+                setRuntimeReadiness((current) => ({
+                  ...current,
+                  terminalIntegrity: null,
+                }));
+                setRuntimeStatusObservationToken((current) => current + 1);
+                onLocalEventsChanged?.();
+              }
+            }
+          }
+
           setDebug((current) =>
             withCheckInPublishDebug(current, {
               checkInPublishCompletedAt: Date.now(),
@@ -886,6 +915,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
     runtimeStatusInput,
     runtimeStatusSyncSecretHash,
     runtimeStatusTerminalId,
+    onLocalEventsChanged,
     storeFactory,
     storeId,
   ]);
@@ -1046,6 +1076,56 @@ async function refreshTerminalRuntimeReadiness(input: {
     terminalIntegrity: terminalIntegrity.ok ? terminalIntegrity.value : null,
     terminalSeed: input.terminalSeed,
   };
+}
+
+async function clearAcceptedTerminalIntegrityState(input: {
+  checkInTerminalId: string;
+  store: PosLocalRuntimeStore;
+  storeId: string;
+  terminalSeed: PosProvisionedTerminalSeed;
+}): Promise<boolean> {
+  if (
+    typeof input.store.readTerminalIntegrityState !== "function" ||
+    typeof input.store.clearTerminalIntegrityState !== "function"
+  ) {
+    return false;
+  }
+
+  const terminalIds = Array.from(
+    new Set(
+      [
+        input.checkInTerminalId,
+        input.terminalSeed.cloudTerminalId,
+        input.terminalSeed.terminalId,
+      ].filter((value): value is string => Boolean(value)),
+    ),
+  );
+  let hasIntegrityBlock = false;
+  for (const terminalId of terminalIds) {
+    const state = await input.store.readTerminalIntegrityState({
+      storeId: input.storeId,
+      terminalId,
+    });
+    assertPosLocalStoreOk(state);
+    if (state.value && state.value.status !== "healthy") {
+      hasIntegrityBlock = true;
+      break;
+    }
+  }
+
+  if (!hasIntegrityBlock) {
+    return false;
+  }
+
+  for (const terminalId of terminalIds) {
+    const clearResult = await input.store.clearTerminalIntegrityState({
+      storeId: input.storeId,
+      terminalId,
+    });
+    assertPosLocalStoreOk(clearResult);
+  }
+
+  return true;
 }
 
 async function persistTerminalAuthorizationFailure(input: {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -1144,7 +1144,7 @@ describe("useRegisterViewModel", () => {
     expect(onRetrySync).toHaveBeenCalled();
   });
 
-  it("starts a new sale after cashier sign-in when the drawer is already open", async () => {
+  it("does not start a sale immediately after cashier sign-in when the drawer is already open", async () => {
     mockRegisterState = {
       phase: "readyToStart",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -1173,21 +1173,17 @@ describe("useRegisterViewModel", () => {
       );
     });
 
-    await waitFor(() =>
-      expect(mockAppendLocalEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: "session.started",
-          localRegisterSessionId: "drawer-1",
-          staffProfileId: "staff-1",
-        }),
+    expect(
+      mockAppendLocalEvent.mock.calls.filter(
+        ([event]) => event.type === "session.started",
       ),
-    );
+    ).toHaveLength(0);
     expect(result.current.checkout.isTransactionCompleted).toBe(false);
     expect(result.current.productEntry.disabled).toBe(false);
     expect(toast.success).not.toHaveBeenCalledWith("Sale started");
   });
 
-  it("starts a new sale when cashier sign-in beats the local drawer bootstrap", async () => {
+  it("does not start a sale after cashier sign-in when local drawer bootstrap finishes", async () => {
     mockRegisterState = {
       phase: "readyToStart",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -1239,19 +1235,15 @@ describe("useRegisterViewModel", () => {
       await pendingLocalEvents.promise;
     });
 
-    await waitFor(() =>
-      expect(mockAppendLocalEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: "session.started",
-          localRegisterSessionId: "drawer-1",
-          staffProfileId: "staff-1",
-        }),
+    expect(
+      mockAppendLocalEvent.mock.calls.filter(
+        ([event]) => event.type === "session.started",
       ),
-    );
+    ).toHaveLength(0);
     expect(result.current.productEntry.disabled).toBe(false);
   });
 
-  it("keeps cashier autostart pending until the local drawer is sellable", async () => {
+  it("does not keep a cashier sign-in start pending until the local drawer is sellable", async () => {
     mockRegisterState = {
       phase: "readyToStart",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -1293,18 +1285,10 @@ describe("useRegisterViewModel", () => {
       );
     });
 
-    await waitFor(() =>
-      expect(mockAppendLocalEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: "register.opened",
-          localRegisterSessionId: "drawer-1",
-          staffProfileId: "staff-1",
-        }),
-      ),
-    );
     expect(
       mockAppendLocalEvent.mock.calls.filter(
-        ([event]) => event.type === "session.started",
+        ([event]) =>
+          event.type === "register.opened" || event.type === "session.started",
       ),
     ).toHaveLength(0);
 
@@ -1336,19 +1320,15 @@ describe("useRegisterViewModel", () => {
       runtimeInput?.onLocalEventsChanged?.();
     });
 
-    await waitFor(() =>
-      expect(mockAppendLocalEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: "session.started",
-          localRegisterSessionId: "drawer-1",
-          staffProfileId: "staff-1",
-        }),
+    expect(
+      mockAppendLocalEvent.mock.calls.filter(
+        ([event]) => event.type === "session.started",
       ),
-    );
+    ).toHaveLength(0);
     expect(result.current.productEntry.disabled).toBe(false);
   });
 
-  it("starts a new sale when the active-session summary is stale but no sale is operable", async () => {
+  it("does not start a new sale after sign-in when the active-session summary is stale but no sale is operable", async () => {
     mockRegisterState = {
       phase: "readyToStart",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -1377,19 +1357,15 @@ describe("useRegisterViewModel", () => {
       );
     });
 
-    await waitFor(() =>
-      expect(mockAppendLocalEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: "session.started",
-          localRegisterSessionId: "drawer-1",
-          staffProfileId: "staff-1",
-        }),
+    expect(
+      mockAppendLocalEvent.mock.calls.filter(
+        ([event]) => event.type === "session.started",
       ),
-    );
+    ).toHaveLength(0);
     expect(result.current.sessionPanel?.disableNewSession).toBe(false);
   });
 
-  it("does not start duplicate local sales when cashier sign-in completes twice", async () => {
+  it("does not start local sales when cashier sign-in completes twice", async () => {
     mockRegisterState = {
       phase: "readyToStart",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -1429,13 +1405,11 @@ describe("useRegisterViewModel", () => {
       result.current.authDialog?.onAuthenticated(buildStaffAuthenticationResult());
     });
 
-    await waitFor(() =>
-      expect(
-        mockAppendLocalEvent.mock.calls.filter(
-          ([event]) => event.type === "session.started",
-        ),
-      ).toHaveLength(1),
-    );
+    expect(
+      mockAppendLocalEvent.mock.calls.filter(
+        ([event]) => event.type === "session.started",
+      ),
+    ).toHaveLength(0);
 
     pendingStart.resolve({
       ok: true,
@@ -7141,7 +7115,7 @@ describe("useRegisterViewModel", () => {
         terminalId: "local-terminal-1",
       },
     });
-    expect(toast.success).toHaveBeenCalledWith("Terminal setup repaired");
+    expect(toast.success).not.toHaveBeenCalledWith("Terminal setup repaired");
   });
 
   it("routes lifecycle drawer authority blocks to the open-drawer gate", async () => {
@@ -10597,6 +10571,76 @@ describe("useRegisterViewModel", () => {
     await waitFor(() => expect(result.current.checkout.cartItems).toEqual([]));
     expect(result.current.checkout.total).toBe(0);
     expect(result.current.checkout.isTransactionCompleted).toBe(false);
+  });
+
+  it("does not keep retrying a new sale when terminal setup blocks post-completion start", async () => {
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: [
+        buildLocalEvent({
+          sequence: 1,
+          terminalId: "terminal-1",
+          type: "register.opened",
+          payload: {
+            expectedCash: 5_000,
+            localRegisterSessionId: "drawer-1",
+            openingFloat: 5_000,
+            status: "open",
+          },
+        }),
+      ],
+    });
+    mockCompleteTransaction.mockResolvedValueOnce(
+      userError({
+        code: "unavailable",
+        message: "Connection unavailable.",
+      }),
+    );
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+    });
+
+    await act(async () => {
+      await result.current.checkout.onAddPayment("cash", 120);
+    });
+
+    await act(async () => {
+      await result.current.checkout.onCompleteTransaction();
+    });
+
+    mockAppendLocalEvent.mockClear();
+    vi.mocked(toast.error).mockClear();
+    mockReadTerminalIntegrityState.mockResolvedValue({
+      ok: true,
+      value: {
+        observedAt: 110,
+        reason: "authorization_failed",
+        status: "requires_reprovision",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      },
+    });
+
+    await act(async () => {
+      await result.current.checkout.onStartNewTransaction();
+    });
+
+    await waitFor(() =>
+      expect(result.current.drawerGate?.mode).toBe("terminalRepair"),
+    );
+    expect(mockAppendLocalEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "session.started" }),
+    );
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    expect(toast.error).toHaveBeenCalledWith(
+      "Terminal setup needs repair before selling can continue.",
+    );
   });
 
   it("does not resurrect a cloud-backed sale after a reload replays local completion", async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -1327,8 +1327,6 @@ export function useRegisterViewModel(): RegisterViewModel {
     useState<LocalAuthenticatedStaff>(null);
   const [cashierPresenceRestore, setCashierPresenceRestore] =
     useState<CashierPresenceRestoreState>({ status: "pending" });
-  const [autoStartRequestedStaffProfileId, setAutoStartRequestedStaffProfileId] =
-    useState<Id<"staffProfile"> | null>(null);
   const terminalRegisterNumber = terminal?.registerNumber
     ? trimOptional(terminal.registerNumber)
     : undefined;
@@ -2708,7 +2706,6 @@ export function useRegisterViewModel(): RegisterViewModel {
       setLocalRegisterReadModelVersion((current) => current + 1);
       setLocalSyncEventAppendToken((current) => current + 1);
       await refreshLocalRegisterReadModel();
-      toast.success("Terminal setup repaired");
     } catch (error) {
       logger.warn("[POS] Terminal setup auto repair failed", {
         error,
@@ -2795,7 +2792,6 @@ export function useRegisterViewModel(): RegisterViewModel {
       }
 
       if (!options?.keepCashier) {
-        setAutoStartRequestedStaffProfileId(null);
         setStaffProfileId(null);
         setStaffProofToken(null);
         setLocalAuthenticatedStaff(null);
@@ -3616,14 +3612,14 @@ export function useRegisterViewModel(): RegisterViewModel {
       });
 
       if (result.kind !== "ok") {
-        presentOperatorError("Unable to start this sale. Try again.");
+        await refreshLocalRegisterReadModel();
+        presentOperatorError(result.error.message);
         return;
       }
 
       const localPosSessionId = result.data.localPosSessionId;
       keepSessionStartGuard = true;
       noteLocalRegisterEventChanged();
-      setAutoStartRequestedStaffProfileId(null);
       resetDraftState({
         keepCashier: true,
       });
@@ -3658,6 +3654,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     locallyOperableRegisterSession?.localRegisterSessionId,
     noteLocalRegisterEventChanged,
     projectedLocalActiveSale,
+    refreshLocalRegisterReadModel,
     registerNumber,
     resetDraftState,
     serviceLineDrafts.length,
@@ -3726,7 +3723,6 @@ export function useRegisterViewModel(): RegisterViewModel {
 
     const localRegisterSessionId = result.data.localRegisterSessionId;
     noteLocalRegisterEventChanged();
-    setAutoStartRequestedStaffProfileId(null);
     setLocalOperableRegisterSession({
       expectedCash: parsedOpeningFloat,
       localRegisterSessionId,
@@ -3927,7 +3923,6 @@ export function useRegisterViewModel(): RegisterViewModel {
     noteLocalRegisterEventChanged();
     setCloseoutCountedCash("");
     setCloseoutNotes("");
-    setAutoStartRequestedStaffProfileId(null);
     setLocalOperableRegisterSession({
       expectedCash: closeoutBlockedRegisterSession.expectedCash,
       localRegisterSessionId: registerSessionId,
@@ -5025,7 +5020,6 @@ export function useRegisterViewModel(): RegisterViewModel {
         setStaffProfileId(authenticatedStaffProfileId);
         setStaffProofToken(null);
         setLocalAuthenticatedStaff(null);
-        setAutoStartRequestedStaffProfileId(null);
       } else {
         authenticatedStaffProfileId = result.staffProfileId;
         const authenticatedStaffProofToken = readStaffProofFromAuthResult(result);
@@ -5037,7 +5031,6 @@ export function useRegisterViewModel(): RegisterViewModel {
           activeRoles: result.activeRoles ?? [],
           displayName: getStaffDisplayNameFromAuthResult(result),
         });
-        setAutoStartRequestedStaffProfileId(authenticatedStaffProfileId);
 
         const localAuthority = result.localStaffAuthority;
         if (
@@ -5102,37 +5095,6 @@ export function useRegisterViewModel(): RegisterViewModel {
       terminal?._id,
     ],
   );
-
-  useEffect(() => {
-    const autoStartStaffProfileId = autoStartRequestedStaffProfileId;
-    if (
-      !autoStartStaffProfileId ||
-      !activeStoreId ||
-      !terminal?._id ||
-      !localEventRegisterSessionId ||
-      projectedLocalActiveSale ||
-      operableActiveSession ||
-      activeSessionConflict ||
-      isTransactionCompleted
-    ) {
-      return;
-    }
-
-    void handleStartNewSession({
-      staffProfileId: autoStartStaffProfileId,
-    });
-  }, [
-    activeSessionConflict,
-    activeStoreId,
-    autoStartRequestedStaffProfileId,
-    handleStartNewSession,
-    isTransactionCompleted,
-    localRegisterReadModel?.syncStatus.lastLocalSequence,
-    localEventRegisterSessionId,
-    operableActiveSession,
-    projectedLocalActiveSale,
-    terminal?._id,
-  ]);
 
   const handleNavigateBack = useCallback(async () => {
     if (

--- a/packages/athena-webapp/src/offline/posOfflineReadiness.test.ts
+++ b/packages/athena-webapp/src/offline/posOfflineReadiness.test.ts
@@ -14,6 +14,7 @@ describe("buildPosOfflineReadinessSummary", () => {
     });
 
     expect(summary.status).toBe("ready");
+    expect(summary.title).toBe("Register ready for offline checkout");
     expect(summary.readyCount).toBe(6);
     expect(summary.signals.map((signal) => signal.domain)).toEqual([
       "app_shell",
@@ -23,7 +24,7 @@ describe("buildPosOfflineReadinessSummary", () => {
       "service_catalog",
       "availability_snapshot",
     ]);
-    expect(summary.description).toContain("diagnostic view");
+    expect(summary.description).toContain("needed for offline POS");
   });
 
   it("reports stale snapshots as diagnostic attention without authorizing sales", () => {
@@ -38,7 +39,7 @@ describe("buildPosOfflineReadinessSummary", () => {
 
     expect(summary.status).toBe("needs_attention");
     expect(summary.description).toBe(
-      "One or more offline readiness signals need attention. This view is diagnostic only.",
+      "One or more offline diagnostic signals need attention. This view is diagnostic only.",
     );
     expect(
       summary.signals.find(
@@ -58,6 +59,7 @@ describe("buildPosOfflineReadinessSummary", () => {
     expect(summary.status).toBe("unknown");
     expect(summary.readyCount).toBe(1);
     expect(summary.signals[0]).toMatchObject({
+      description: "App shell status has not reported to this page yet.",
       domain: "app_shell",
       status: "unknown",
     });

--- a/packages/athena-webapp/src/offline/posOfflineReadiness.ts
+++ b/packages/athena-webapp/src/offline/posOfflineReadiness.ts
@@ -64,7 +64,7 @@ const DOMAIN_DEFINITIONS: Array<{
       domain: "app_shell",
       label: "App shell",
       missingDescription:
-        "App shell readiness has not reported from this checkout station.",
+        "App shell status has not reported to this page yet.",
       needsAttentionDescription:
         "App shell recovery needs attention before offline route access is reliable.",
       readyDescription: "App shell recovery is ready.",
@@ -76,7 +76,7 @@ const DOMAIN_DEFINITIONS: Array<{
       domain: "terminal_seed",
       label: "Terminal setup",
       missingDescription:
-        "Terminal setup has not reported from this checkout station.",
+        "Terminal setup has not reported to this page yet.",
       needsAttentionDescription:
         "Terminal setup data is missing on this checkout station.",
       readyDescription: "Terminal setup data is stored locally.",
@@ -87,7 +87,7 @@ const DOMAIN_DEFINITIONS: Array<{
     definition: {
       domain: "staff_authority",
       label: "Staff authority",
-      missingDescription: "Staff authority readiness has not reported yet.",
+      missingDescription: "Staff authority has not reported to this page yet.",
       needsAttentionDescription:
         "Local staff authority is missing or expired on this checkout station.",
       readyDescription: "Local staff authority is ready.",
@@ -99,7 +99,7 @@ const DOMAIN_DEFINITIONS: Array<{
     definition: {
       domain: "register_catalog",
       label: "Register catalog",
-      missingDescription: "Register catalog freshness has not reported yet.",
+      missingDescription: "Register catalog has not reported to this page yet.",
       needsAttentionDescription:
         "Register catalog data needs a fresh local snapshot.",
       readyDescription: "Register catalog data is available locally.",
@@ -111,7 +111,7 @@ const DOMAIN_DEFINITIONS: Array<{
     definition: {
       domain: "service_catalog",
       label: "Service catalog",
-      missingDescription: "Service catalog freshness has not reported yet.",
+      missingDescription: "Service catalog has not reported to this page yet.",
       needsAttentionDescription:
         "Service catalog data needs a fresh local snapshot.",
       readyDescription: "Service catalog data is available locally.",
@@ -124,7 +124,7 @@ const DOMAIN_DEFINITIONS: Array<{
       domain: "availability_snapshot",
       label: "Availability snapshot",
       missingDescription:
-        "Availability snapshot freshness has not reported yet.",
+        "Availability snapshot has not reported to this page yet.",
       needsAttentionDescription:
         "Availability data needs a fresh local snapshot.",
       readyDescription: "Availability data is available locally.",
@@ -232,9 +232,9 @@ function getSignalDescription(
 }
 
 function getSummaryTitle(status: PosOfflineReadinessSignalStatus) {
-  if (status === "ready") return "Offline diagnostics ready";
+  if (status === "ready") return "Register ready for offline checkout";
   if (status === "needs_attention") return "Offline diagnostics need attention";
-  return "Offline diagnostics incomplete";
+  return "Offline diagnostics partially reported";
 }
 
 function getSummaryDescription(
@@ -243,14 +243,14 @@ function getSummaryDescription(
   totalCount: number,
 ) {
   if (status === "ready") {
-    return "This diagnostic view has all offline readiness signals. Sale authorization still comes from the register workflow.";
+    return "This checkout station has the app shell, terminal setup, staff authority, catalog, and availability data needed for offline POS.";
   }
 
   if (status === "needs_attention") {
-    return "One or more offline readiness signals need attention. This view is diagnostic only.";
+    return "One or more offline diagnostic signals need attention. This view is diagnostic only.";
   }
 
-  return `${readyCount} of ${totalCount} offline readiness signals have reported. This view is diagnostic only.`;
+  return `${readyCount} of ${totalCount} offline diagnostic signals are reporting here. Missing signals do not block checkout by themselves.`;
 }
 
 function formatAge(ageMs: number) {

--- a/packages/athena-webapp/src/routes/_authed.test.tsx
+++ b/packages/athena-webapp/src/routes/_authed.test.tsx
@@ -22,6 +22,7 @@ const mocked = vi.hoisted(() => ({
   usePermissions: vi.fn(),
   usePosTerminalAppSessionRecovery: vi.fn(),
   readStoredPosAppAccountId: vi.fn(),
+  SidebarProvider: vi.fn(),
   useRouterState: vi.fn(),
 }));
 
@@ -76,7 +77,17 @@ vi.mock("../contexts/ManagerElevationContext", () => ({
 }));
 
 vi.mock("../components/ui/sidebar", () => ({
-  SidebarProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SidebarProvider: ({
+    children,
+    ...props
+  }: {
+    children: ReactNode;
+    className?: string;
+    defaultOpen?: boolean;
+  }) => {
+    mocked.SidebarProvider(props);
+    return <div data-testid="sidebar-provider">{children}</div>;
+  },
   SidebarInset: ({ children }: { children: ReactNode }) => <>{children}</>,
   SidebarTrigger: () => null,
   useSidebar: () => ({ state: "expanded" }),
@@ -182,6 +193,7 @@ describe("Authed layout", () => {
     );
     mocked.readStoredPosAppAccountId.mockReset();
     mocked.readStoredPosAppAccountId.mockReturnValue("stored-app-user-1");
+    mocked.SidebarProvider.mockReset();
     mocked.useManagerElevation.mockReturnValue({
       activeElevation: null,
       endManagerElevation: mocked.endManagerElevation,
@@ -227,6 +239,18 @@ describe("Authed layout", () => {
     render(<Layout />);
 
     expect(screen.getByTestId("authed-outlet")).toBeInTheDocument();
+    expect(screen.getByTestId("authed-outlet").closest("main")).toHaveClass(
+      "h-[calc(100svh-4rem)]",
+      "p-0",
+      "overflow-hidden",
+    );
+    expect(screen.getByTestId("sidebar-provider")).toBeInTheDocument();
+    expect(mocked.SidebarProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        className: "contents",
+        defaultOpen: false,
+      }),
+    );
     expect(screen.queryByTestId("app-sidebar")).not.toBeInTheDocument();
     expect(screen.queryByTestId("app-header")).not.toBeInTheDocument();
     expect(screen.queryByTestId("store-modal")).not.toBeInTheDocument();
@@ -894,6 +918,11 @@ describe("Authed layout", () => {
 
     expect(screen.queryByTestId("app-header")).not.toBeInTheDocument();
     expect(screen.getByTestId("app-sidebar")).toBeInTheDocument();
+    expect(screen.getByTestId("authed-outlet").closest("main")).toHaveClass(
+      "box-border",
+      "h-full",
+      "overflow-hidden",
+    );
   });
 
   it("starts fullscreen from the browser pathname on first register render", () => {

--- a/packages/athena-webapp/src/routes/_authed.tsx
+++ b/packages/athena-webapp/src/routes/_authed.tsx
@@ -281,14 +281,18 @@ function PosTerminalShell({
           <PosTerminalAppSessionRecoveryProvider
             value={appSessionRecovery ?? null}
           >
-            <main
-              className={cn(
-                "flex min-h-0 flex-1 flex-col overflow-hidden bg-background",
-                isFullscreenActive ? "h-svh p-0" : "h-svh p-8",
-              )}
-            >
-              {children}
-            </main>
+            <SidebarProvider className="contents" defaultOpen={false}>
+              <main
+                className={cn(
+                  "flex min-h-0 flex-1 flex-col overflow-hidden bg-background",
+                  isFullscreenActive
+                    ? "h-[calc(100svh-4rem)] p-0"
+                    : "h-[calc(100svh-4rem)] p-8",
+                )}
+              >
+                {children}
+              </main>
+            </SidebarProvider>
           </PosTerminalAppSessionRecoveryProvider>
         </AppShellFullscreenContext.Provider>
       </ManagerElevationProvider>
@@ -602,7 +606,7 @@ export default function Layout() {
             >
               <AppSidebar />
               <SidebarInset className="h-full !min-h-0 overflow-hidden">
-                <main className="flex min-h-0 flex-1 flex-col overflow-hidden bg-transparent p-8">
+                <main className="box-border flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-transparent p-8">
                   <AuthedComponent />
                 </main>
               </SidebarInset>


### PR DESCRIPTION
## Summary
- make the POS register route self-contained with a sidebar provider so direct/prod register loads do not crash outside the app shell provider
- carry the moved dirty-set POS offline readiness work forward, including cashier presence persistence, local proof handling, and terminal readiness copy/tests
- refresh Graphify and harness docs for the changed POS surfaces

## Validation
- bun run --filter '@athena/webapp' test -- src/lib/pos/presentation/register/useRegisterViewModel.test.ts src/components/pos/register/POSRegisterView.test.tsx src/components/pos/CashierAuthDialog.test.tsx
- bun run pr:athena

## Deploy
- Prod deploy will be run from local main after merge using local builds.