### PR TITLE
fix(pos): restore cashier reload unlock flow

### DIFF
--- a/docs/solutions/architecture/athena-terminal-scoped-cashier-presence-2026-06-04.md
+++ b/docs/solutions/architecture/athena-terminal-scoped-cashier-presence-2026-06-04.md
@@ -48,12 +48,15 @@ terminal integrity, staff-authority roster data, or manager approval.
 
 ## Solution
 
-Register boot should start in a restore-pending state. The PIN form should open
+Register boot should start in a restore-pending state. Sign-in UI should open
 only after the local read reaches a deterministic missing, expired, invalidated,
 failed, or validation-needed state. A valid same-terminal record should preserve
-operator context and move to validation-pending sign-in guidance; it must not
-restore active cashier authority from local serialized proof or role material.
-Background checks and non-destructive repair success should stay quiet.
+operator context and move to a returning-cashier unlock flow: show the restored
+cashier identity, hide the username field, ask only for the PIN needed to unwrap
+the local staff proof, and keep a footer action to sign in as a different
+cashier. It must not restore active cashier authority from local serialized role
+material alone. Background checks and non-destructive repair success should stay
+quiet.
 
 Persist cashier presence as a separate local record keyed by organization,
 store, terminal, and operating date. Keep the POS local staff proof wrapped at
@@ -62,8 +65,18 @@ token. When proof or freshness is stale or only local continuity evidence is
 available, preserve cashier context only for operator guidance and block
 sale-affecting commands until sign-in supplies a valid proof.
 
+Do not render generic username/PIN sign-in as the first reload state for a valid
+presence record. Generic sign-in erases the operator's mental model that the
+same cashier is still associated with the terminal. Prefer a PIN-only unlock
+that uses the persisted username internally. The alternate-cashier path should
+be explicit and placed with the submit action, not inside the cashier identity
+field.
+
 Operator copy stays calm and action-oriented:
 
+- `Unlock cashier session`
+- `Enter the cashier PIN to continue on this register`
+- `Sign in as a different cashier`
 - `Checking cashier access before new sales.`
 - `Cashier sign-in expired. Sign in to continue.`
 - `This terminal needs an online staff refresh before offline sign-in. Reconnect, then sign in once.`
@@ -85,17 +98,20 @@ boundary owns the state:
 
 Tests should prove no PIN-dialog flicker while restore is pending, no
 cross-terminal or cross-store authorization, no plaintext proof serialization,
-no stale local proof trust, and no sale-affecting command while presence is
-validation-pending.
+no stale local proof trust, no sale-affecting command while presence is
+validation-pending, PIN-only unlock for the restored cashier, and the ability to
+switch to a different cashier sign-in.
 
 ## Validation
 
 Warm offline reload validation should use a production build after the app shell
 and chunks are already loaded: open `/pos/register`, sign in, verify presence is
 written, block network, hard reload, and confirm the register reaches a stable
-validation-pending sign-in state without granting cashier authority from local
-storage. This does not promise cold offline startup when the app shell or chunks
-are not already available.
+PIN-only unlock state for the restored cashier without granting cashier
+authority until the PIN unwraps proof. This does not promise cold offline
+startup when the app shell or chunks are not already available.
 
 Run targeted register view-model and register UI tests after restore/copy
-changes, then `bun run typecheck` and `bun run graphify:rebuild`.
+changes. Include `CashierAuthDialog` coverage for PIN-only unlock and switching
+to a different cashier, then run `bun run typecheck` and `bun run
+graphify:rebuild`.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6130 nodes · 6590 edges · 1754 communities detected
+- 6134 nodes · 6594 edges · 1754 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2528,16 +2528,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 184 - "Community 184"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
-
-### Community 185 - "Community 185"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 186 - "Community 186"
+### Community 185 - "Community 185"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 186 - "Community 186"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 187 - "Community 187"
 Cohesion: 0.43
@@ -2884,12 +2884,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 273 - "Community 273"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
-
-### Community 274 - "Community 274"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 274 - "Community 274"
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 275 - "Community 275"
 Cohesion: 0.4
@@ -2897,11 +2897,11 @@ Nodes (0):
 
 ### Community 276 - "Community 276"
 Cohesion: 0.4
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 277 - "Community 277"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 278 - "Community 278"
 Cohesion: 0.4
@@ -2912,52 +2912,52 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 280 - "Community 280"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 281 - "Community 281"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 281 - "Community 281"
+### Community 282 - "Community 282"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 282 - "Community 282"
+### Community 283 - "Community 283"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 283 - "Community 283"
+### Community 284 - "Community 284"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 284 - "Community 284"
+### Community 285 - "Community 285"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 285 - "Community 285"
-Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 286 - "Community 286"
 Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 287 - "Community 287"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 288 - "Community 288"
 Cohesion: 0.6
-Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 289 - "Community 289"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
 ### Community 290 - "Community 290"
-Cohesion: 0.6
-Nodes (3): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier()
-
-### Community 291 - "Community 291"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 291 - "Community 291"
+Cohesion: 0.6
+Nodes (3): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier()
 
 ### Community 292 - "Community 292"
 Cohesion: 0.4
@@ -2968,88 +2968,88 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 294 - "Community 294"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 295 - "Community 295"
 Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 295 - "Community 295"
+### Community 296 - "Community 296"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 296 - "Community 296"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 297 - "Community 297"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 298 - "Community 298"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 299 - "Community 299"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 300 - "Community 300"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 301 - "Community 301"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
-
-### Community 302 - "Community 302"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 302 - "Community 302"
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 303 - "Community 303"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 304 - "Community 304"
-Cohesion: 0.6
-Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 305 - "Community 305"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 305 - "Community 305"
+Cohesion: 0.6
+Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+
 ### Community 306 - "Community 306"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 307 - "Community 307"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 307 - "Community 307"
+### Community 308 - "Community 308"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 308 - "Community 308"
+### Community 309 - "Community 309"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 309 - "Community 309"
+### Community 310 - "Community 310"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 310 - "Community 310"
+### Community 311 - "Community 311"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 311 - "Community 311"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 312 - "Community 312"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 313 - "Community 313"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
-
-### Community 314 - "Community 314"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 314 - "Community 314"
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 315 - "Community 315"
 Cohesion: 0.5
@@ -3060,72 +3060,72 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 317 - "Community 317"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 318 - "Community 318"
 Cohesion: 0.67
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 318 - "Community 318"
+### Community 319 - "Community 319"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 319 - "Community 319"
+### Community 320 - "Community 320"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 320 - "Community 320"
+### Community 321 - "Community 321"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 321 - "Community 321"
+### Community 322 - "Community 322"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 322 - "Community 322"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 323 - "Community 323"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 324 - "Community 324"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 325 - "Community 325"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 325 - "Community 325"
+### Community 326 - "Community 326"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 326 - "Community 326"
+### Community 327 - "Community 327"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 327 - "Community 327"
+### Community 328 - "Community 328"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 328 - "Community 328"
+### Community 329 - "Community 329"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 329 - "Community 329"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 330 - "Community 330"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 331 - "Community 331"
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+
+### Community 332 - "Community 332"
 Cohesion: 0.67
 Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
-### Community 332 - "Community 332"
+### Community 333 - "Community 333"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
-
-### Community 333 - "Community 333"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 334 - "Community 334"
 Cohesion: 0.5
@@ -3140,24 +3140,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 337 - "Community 337"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 338 - "Community 338"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 338 - "Community 338"
+### Community 339 - "Community 339"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 339 - "Community 339"
+### Community 340 - "Community 340"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 340 - "Community 340"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 341 - "Community 341"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 342 - "Community 342"
 Cohesion: 0.5
@@ -3172,20 +3172,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 345 - "Community 345"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 346 - "Community 346"
 Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 347 - "Community 347"
 Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 348 - "Community 348"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 349 - "Community 349"
 Cohesion: 0.5
@@ -3208,20 +3208,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 354 - "Community 354"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 355 - "Community 355"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 355 - "Community 355"
+### Community 356 - "Community 356"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 356 - "Community 356"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 357 - "Community 357"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 358 - "Community 358"
 Cohesion: 0.5
@@ -3232,12 +3232,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 360 - "Community 360"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 361 - "Community 361"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 361 - "Community 361"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 362 - "Community 362"
 Cohesion: 0.5
@@ -3248,112 +3248,112 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 364 - "Community 364"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 365 - "Community 365"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 365 - "Community 365"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 366 - "Community 366"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 367 - "Community 367"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 368 - "Community 368"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
 
-### Community 368 - "Community 368"
+### Community 369 - "Community 369"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 369 - "Community 369"
-Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 370 - "Community 370"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 371 - "Community 371"
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+
+### Community 372 - "Community 372"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 372 - "Community 372"
+### Community 373 - "Community 373"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 373 - "Community 373"
+### Community 374 - "Community 374"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 374 - "Community 374"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 375 - "Community 375"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 376 - "Community 376"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 377 - "Community 377"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 378 - "Community 378"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 379 - "Community 379"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 379 - "Community 379"
+### Community 380 - "Community 380"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 380 - "Community 380"
+### Community 381 - "Community 381"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 381 - "Community 381"
+### Community 382 - "Community 382"
 Cohesion: 0.83
 Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 382 - "Community 382"
+### Community 383 - "Community 383"
 Cohesion: 0.83
 Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
-### Community 383 - "Community 383"
+### Community 384 - "Community 384"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 384 - "Community 384"
+### Community 385 - "Community 385"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 385 - "Community 385"
+### Community 386 - "Community 386"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 386 - "Community 386"
+### Community 387 - "Community 387"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 387 - "Community 387"
+### Community 388 - "Community 388"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 388 - "Community 388"
+### Community 389 - "Community 389"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 389 - "Community 389"
+### Community 390 - "Community 390"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 390 - "Community 390"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 391 - "Community 391"
 Cohesion: 0.5
@@ -3384,59 +3384,59 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 398 - "Community 398"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 399 - "Community 399"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 400 - "Community 400"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 401 - "Community 401"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 401 - "Community 401"
+### Community 402 - "Community 402"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 402 - "Community 402"
-Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 403 - "Community 403"
 Cohesion: 0.83
-Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 404 - "Community 404"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
 ### Community 405 - "Community 405"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 406 - "Community 406"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 407 - "Community 407"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 408 - "Community 408"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 408 - "Community 408"
+### Community 409 - "Community 409"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 409 - "Community 409"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 410 - "Community 410"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 411 - "Community 411"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 412 - "Community 412"
@@ -3444,12 +3444,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 413 - "Community 413"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 414 - "Community 414"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 414 - "Community 414"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 415 - "Community 415"
 Cohesion: 0.67
@@ -3484,12 +3484,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 423 - "Community 423"
-Cohesion: 1.0
-Nodes (2): buildCtx(), createDb()
-
-### Community 424 - "Community 424"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 424 - "Community 424"
+Cohesion: 1.0
+Nodes (2): buildCtx(), createDb()
 
 ### Community 425 - "Community 425"
 Cohesion: 0.67
@@ -3504,20 +3504,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 428 - "Community 428"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 429 - "Community 429"
 Cohesion: 1.0
 Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
-### Community 429 - "Community 429"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 430 - "Community 430"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 431 - "Community 431"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 432 - "Community 432"
 Cohesion: 0.67
@@ -3532,24 +3532,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 435 - "Community 435"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 436 - "Community 436"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 436 - "Community 436"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 437 - "Community 437"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 438 - "Community 438"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 439 - "Community 439"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 439 - "Community 439"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 440 - "Community 440"
 Cohesion: 0.67
@@ -3564,36 +3564,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 443 - "Community 443"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 444 - "Community 444"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 445 - "Community 445"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 446 - "Community 446"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 447 - "Community 447"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 448 - "Community 448"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 449 - "Community 449"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 449 - "Community 449"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 450 - "Community 450"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 451 - "Community 451"
 Cohesion: 0.67
@@ -3608,12 +3608,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 454 - "Community 454"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 455 - "Community 455"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 455 - "Community 455"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 456 - "Community 456"
 Cohesion: 0.67
@@ -3624,16 +3624,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 458 - "Community 458"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 459 - "Community 459"
 Cohesion: 1.0
 Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
-### Community 459 - "Community 459"
-Cohesion: 0.67
-Nodes (1): FadeIn()
-
 ### Community 460 - "Community 460"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 461 - "Community 461"
 Cohesion: 0.67
@@ -3641,15 +3641,15 @@ Nodes (0):
 
 ### Community 462 - "Community 462"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 463 - "Community 463"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (1): VideoPlayer()
 
 ### Community 464 - "Community 464"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 465 - "Community 465"
 Cohesion: 0.67
@@ -3725,83 +3725,83 @@ Nodes (0):
 
 ### Community 483 - "Community 483"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 484 - "Community 484"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (0):
 
 ### Community 485 - "Community 485"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 486 - "Community 486"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 487 - "Community 487"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 488 - "Community 488"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 489 - "Community 489"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TableSkeleton()
 
 ### Community 490 - "Community 490"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
+Cohesion: 0.67
+Nodes (1): TransactionsSkeleton()
 
 ### Community 491 - "Community 491"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (1): NotFound()
 
 ### Community 492 - "Community 492"
-Cohesion: 0.67
-Nodes (1): Badge()
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
 ### Community 493 - "Community 493"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): AppContextMenu()
 
 ### Community 494 - "Community 494"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): Badge()
 
 ### Community 495 - "Community 495"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (0):
 
 ### Community 496 - "Community 496"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): LoadingButton()
 
 ### Community 497 - "Community 497"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): onChange()
 
 ### Community 498 - "Community 498"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): AlertModal()
 
 ### Community 499 - "Community 499"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): OverlayModal()
 
 ### Community 500 - "Community 500"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Skeleton()
 
 ### Community 501 - "Community 501"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 502 - "Community 502"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 503 - "Community 503"
 Cohesion: 0.67
@@ -3829,7 +3829,7 @@ Nodes (0):
 
 ### Community 509 - "Community 509"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 510 - "Community 510"
 Cohesion: 0.67
@@ -3837,27 +3837,27 @@ Nodes (0):
 
 ### Community 511 - "Community 511"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 512 - "Community 512"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 513 - "Community 513"
-Cohesion: 1.0
-Nodes (2): getApprovalGuidance(), presentCommandToast()
-
-### Community 514 - "Community 514"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
-### Community 515 - "Community 515"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 516 - "Community 516"
+### Community 514 - "Community 514"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 515 - "Community 515"
 Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
+Nodes (2): getApprovalGuidance(), presentCommandToast()
+
+### Community 516 - "Community 516"
+Cohesion: 0.67
+Nodes (1): isInMaintenanceMode()
 
 ### Community 517 - "Community 517"
 Cohesion: 0.67
@@ -3865,15 +3865,15 @@ Nodes (0):
 
 ### Community 518 - "Community 518"
 Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 519 - "Community 519"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 520 - "Community 520"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 521 - "Community 521"
 Cohesion: 0.67
@@ -3881,55 +3881,55 @@ Nodes (0):
 
 ### Community 522 - "Community 522"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 523 - "Community 523"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 524 - "Community 524"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 525 - "Community 525"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 526 - "Community 526"
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+
+### Community 527 - "Community 527"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 527 - "Community 527"
+### Community 528 - "Community 528"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 529 - "Community 529"
 Cohesion: 1.0
 Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
-### Community 528 - "Community 528"
+### Community 530 - "Community 530"
 Cohesion: 1.0
 Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
-### Community 529 - "Community 529"
+### Community 531 - "Community 531"
 Cohesion: 0.67
 Nodes (1): hashPassword()
 
-### Community 530 - "Community 530"
+### Community 532 - "Community 532"
 Cohesion: 0.67
 Nodes (1): createVersionChecker()
 
-### Community 531 - "Community 531"
+### Community 533 - "Community 533"
 Cohesion: 0.67
 Nodes (1): manualChunks()
 
-### Community 532 - "Community 532"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 533 - "Community 533"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 534 - "Community 534"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 535 - "Community 535"
 Cohesion: 0.67
@@ -3937,19 +3937,19 @@ Nodes (0):
 
 ### Community 536 - "Community 536"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 537 - "Community 537"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 538 - "Community 538"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 539 - "Community 539"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 540 - "Community 540"
 Cohesion: 0.67
@@ -3960,32 +3960,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 542 - "Community 542"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 543 - "Community 543"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 544 - "Community 544"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 545 - "Community 545"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 546 - "Community 546"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 547 - "Community 547"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 548 - "Community 548"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 549 - "Community 549"
 Cohesion: 0.67
@@ -4048,8 +4048,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 564 - "Community 564"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 565 - "Community 565"
 Cohesion: 0.67
@@ -4057,11 +4057,11 @@ Nodes (0):
 
 ### Community 566 - "Community 566"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
 
 ### Community 567 - "Community 567"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 568 - "Community 568"
 Cohesion: 1.0
@@ -4076,24 +4076,24 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 571 - "Community 571"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 572 - "Community 572"
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
+
+### Community 573 - "Community 573"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 573 - "Community 573"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
-
 ### Community 574 - "Community 574"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 575 - "Community 575"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 576 - "Community 576"
 Cohesion: 1.0
@@ -8810,379 +8810,375 @@ Nodes (0):
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 574`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 576`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 575`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 577`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 576`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 578`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 579`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 580`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 581`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 582`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 583`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 584`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 585`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 586`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 587`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 588`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 589`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 590`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 591`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 592`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 593`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 594`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 595`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 596`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 597`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 598`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 599`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 600`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 601`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 602`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 603`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 604`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 605`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 606`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 607`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 608`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 609`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 610`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 611`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 612`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 613`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 614`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 615`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 616`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 617`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 618`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 619`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 620`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 621`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 622`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 623`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 624`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 625`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
+- **Thin community `Community 626`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
+- **Thin community `Community 627`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 628`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 629`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 630`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 631`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 632`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
+- **Thin community `Community 633`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 634`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 635`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 636`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 637`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 638`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 639`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 640`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 641`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 642`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 643`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 644`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 645`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 646`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 647`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 648`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 649`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 650`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 651`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 652`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 653`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 654`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 655`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 656`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 657`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 658`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 659`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 660`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 661`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 662`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 663`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 664`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 665`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 666`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 667`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 668`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 669`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 670`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 671`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 672`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 673`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 674`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 675`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 676`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 677`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 678`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 679`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 680`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 681`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 682`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 683`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 684`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 685`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 686`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 687`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 688`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 689`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 690`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 691`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 692`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 693`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 694`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 695`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 696`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 697`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 698`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 699`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 700`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 701`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 702`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 703`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 704`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 705`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 706`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 707`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 708`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 709`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 710`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 711`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 712`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 713`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 714`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 715`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 716`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 717`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `buildLocalAuthorityRecord()`, `CashierAuthDialog.test.tsx`
+- **Thin community `Community 718`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 719`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 720`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 721`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 722`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 723`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 724`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 725`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 726`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 727`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 728`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 729`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 730`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 731`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 732`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 733`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 734`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 735`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 736`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 737`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 738`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 739`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 740`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 741`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 742`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 743`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 744`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 745`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 746`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 747`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 748`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 749`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 750`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 751`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 752`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 753`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 754`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 755`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 756`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 757`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 758`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 759`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `StaffAuthenticationDialog.tsx`, `handleKeyDown()`
+- **Thin community `Community 760`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 761`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1826
-- Graph nodes: 6130
-- Graph edges: 6590
+- Graph nodes: 6134
+- Graph edges: 6594
 - Communities: 1754
 
 ## Graph Hotspots

--- a/packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx
+++ b/packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx
@@ -144,11 +144,16 @@ function renderDialog({
   authenticateMutation = vi.fn(),
   expireMutation = vi.fn(),
   refreshAuthorityMutation = vi.fn().mockResolvedValue(ok([])),
+  restoredCashier,
   workflowMode,
 }: {
   authenticateMutation?: ReturnType<typeof vi.fn>;
   expireMutation?: ReturnType<typeof vi.fn>;
   refreshAuthorityMutation?: ReturnType<typeof vi.fn>;
+  restoredCashier?: {
+    displayName?: string | null;
+    username: string;
+  } | null;
   workflowMode?: "pos" | "expense";
 } = {}) {
   mocks.useMutation.mockReset();
@@ -169,6 +174,7 @@ function renderDialog({
       open
       onAuthenticated={onAuthenticated}
       onDismiss={onDismiss}
+      restoredCashier={restoredCashier}
       storeId={storeId}
       terminalId={terminalId}
       workflowMode={workflowMode}
@@ -182,6 +188,14 @@ function renderDialog({
     onDismiss,
     user: userEvent.setup(),
   };
+}
+
+async function submitLockedCashierPin(
+  user: ReturnType<typeof userEvent.setup>,
+  pin = "1234",
+) {
+  await waitFor(() => expect(screen.getByLabelText(/pin/i)).toHaveFocus());
+  await user.type(screen.getByLabelText(/pin/i), pin);
 }
 
 async function submitCredentials(
@@ -455,6 +469,116 @@ describe("CashierAuthDialog", () => {
       expect.objectContaining({ ciphertext: "wrapped-proof-token" }),
     );
     expect(mocks.toastSuccess).toHaveBeenCalledWith("Signed in as Ama Mensah");
+  });
+
+  it("unlocks a restored cashier session with PIN only", async () => {
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: false,
+    });
+    const readStaffAuthorityForUsername = vi.fn(async () => ({
+      ok: true,
+      value: buildLocalAuthorityRecord(),
+    }));
+    mocks.createPosLocalStore.mockReturnValue({
+      readStaffAuthorityForUsername,
+      replaceStaffAuthoritySnapshot: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      upsertStaffAuthorityRecord: vi.fn(async ({ record }) => ({
+        ok: true,
+        value: record,
+      })),
+    });
+    const { user, onAuthenticated } = renderDialog({
+      restoredCashier: {
+        displayName: "Ama Mensah",
+        username: "frontdesk",
+      },
+    });
+
+    await submitLockedCashierPin(user);
+
+    await waitFor(() =>
+      expect(onAuthenticated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          staffProfileId,
+        }),
+      ),
+    );
+    expect(readStaffAuthorityForUsername).toHaveBeenCalledWith({
+      storeId,
+      terminalId,
+      username: "frontdesk",
+    });
+  });
+
+  it("lets a restored cashier session switch to a different cashier sign-in", async () => {
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: false,
+    });
+    const readStaffAuthorityForUsername = vi.fn(async () => ({
+      ok: true,
+      value: buildLocalAuthorityRecord(),
+    }));
+    mocks.createPosLocalStore.mockReturnValue({
+      readStaffAuthorityForUsername,
+      replaceStaffAuthoritySnapshot: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      upsertStaffAuthorityRecord: vi.fn(async ({ record }) => ({
+        ok: true,
+        value: record,
+      })),
+    });
+    const { user, onAuthenticated } = renderDialog({
+      restoredCashier: {
+        displayName: "Ama Mensah",
+        username: "frontdesk",
+      },
+    });
+
+    expect(
+      screen.getByRole("heading", { name: "Unlock cashier session" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Ama Mensah")).toBeInTheDocument();
+    expect(screen.queryByLabelText(/username/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Sign out from other registers" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Sign in as a different cashier" }),
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Sign in required" }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Sign out from other registers" }),
+    ).toBeInTheDocument();
+
+    const usernameInput = screen.getByLabelText(/username/i);
+    await user.type(usernameInput, "frontdesk");
+    await waitFor(() => expect(usernameInput).toHaveValue("frontdesk"));
+    await user.type(screen.getByLabelText(/pin/i), "1234");
+
+    await waitFor(() =>
+      expect(onAuthenticated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          staffProfileId,
+        }),
+      ),
+    );
+    expect(readStaffAuthorityForUsername).toHaveBeenCalledWith({
+      storeId,
+      terminalId,
+      username: "frontdesk",
+    });
   });
 
   it("clears the PIN when local offline authority cannot be read", async () => {

--- a/packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx
+++ b/packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx
@@ -28,6 +28,10 @@ interface CashierAuthDialogProps {
   onDismiss: () => void;
   open: boolean;
   presentation?: "dialog" | "inline";
+  restoredCashier?: {
+    displayName?: string | null;
+    username: string;
+  } | null;
   storeId: Id<"store">;
   terminalId: Id<"posTerminal">;
   workflowMode?: RegisterWorkflowMode;
@@ -56,6 +60,7 @@ export function CashierAuthDialog({
   onDismiss,
   open,
   presentation = "dialog",
+  restoredCashier,
   storeId,
   terminalId,
   workflowMode = "pos",
@@ -427,6 +432,12 @@ export function CashierAuthDialog({
         title: primaryCopy.title,
         description: primaryCopy.description,
         submitLabel: "Sign in",
+      }}
+      lockedUsername={restoredCashier}
+      lockedUsernameCopy={{
+        title: "Unlock cashier session",
+        description: "Enter the cashier PIN to continue on this register",
+        submitLabel: "Unlock",
       }}
       alternateCopy={{
         title: recoveryLabel,

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -795,8 +795,8 @@ describe("POSRegisterView", () => {
     render(<POSRegisterView />);
 
     expect(
-      screen.getByText("Checking cashier access before new sales."),
-    ).toBeInTheDocument();
+      screen.queryByText("Checking cashier access before new sales."),
+    ).not.toBeInTheDocument();
     expect(screen.getByText("cashier-auth-dialog")).toBeInTheDocument();
     expect(screen.queryByText(/Cashier Ama K\./)).not.toBeInTheDocument();
   });

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -235,6 +235,7 @@ function CashierAuthWorkspace({
     <CashierAuthDialog
       open={authDialog.open}
       presentation="inline"
+      restoredCashier={authDialog.restoredCashier}
       storeId={authDialog.storeId}
       terminalId={authDialog.terminalId}
       workflowMode={authDialog.workflowMode}
@@ -1572,9 +1573,11 @@ function POSRegisterViewContent({
                   <DrawerGateWorkspace drawerGate={viewModel.drawerGate} />
                 ) : isAwaitingCashierAuth && viewModel.authDialog ? (
                   <div className="flex min-h-0 flex-1 flex-col gap-4">
-                    <CashierPresenceRestoreWorkspace
-                      restore={cashierPresenceRestore}
-                    />
+                    {cashierPresenceRestore.status === "validation_pending" ? null : (
+                      <CashierPresenceRestoreWorkspace
+                        restore={cashierPresenceRestore}
+                      />
+                    )}
                     <CashierAuthWorkspace authDialog={viewModel.authDialog} />
                   </div>
                 ) : cashierPresenceRestore.status === "validation_pending" &&

--- a/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx
+++ b/packages/athena-webapp/src/components/staff-auth/StaffAuthenticationDialog.tsx
@@ -57,6 +57,12 @@ export type StaffAuthenticationDialogProps = {
     result: StaffAuthenticationResult,
     mode: StaffAuthMode,
   ) => string | null;
+  hideAlternateAction?: boolean;
+  lockedUsername?: {
+    displayName?: string | null;
+    username: string;
+  } | null;
+  lockedUsernameCopy?: StaffAuthenticationDialogCopy;
   onAuthenticate: (args: {
     mode: StaffAuthMode;
     pin: string;
@@ -79,6 +85,9 @@ export function StaffAuthenticationDialog({
   alternateTriggerLabel,
   copy,
   getSuccessMessage,
+  hideAlternateAction = false,
+  lockedUsername,
+  lockedUsernameCopy,
   onAuthenticate,
   onAuthenticated,
   onDismiss,
@@ -90,33 +99,65 @@ export function StaffAuthenticationDialog({
   const [username, setUsername] = useState("");
   const [pin, setPin] = useState("");
   const [isAuthenticating, setIsAuthenticating] = useState(false);
+  const [useLockedUsername, setUseLockedUsername] = useState(true);
   const usernameInputRef = useRef<HTMLInputElement>(null);
+  const pinInputWrapperRef = useRef<HTMLDivElement>(null);
 
-  const activeCopy = mode === "recover" && alternateCopy ? alternateCopy : copy;
+  const isUsernameLocked = Boolean(lockedUsername?.username && useLockedUsername);
+  const activeCopy =
+    isUsernameLocked && lockedUsernameCopy
+      ? lockedUsernameCopy
+      : mode === "recover" && alternateCopy
+        ? alternateCopy
+        : copy;
+  const effectiveUsername = isUsernameLocked
+    ? lockedUsername!.username
+    : username;
   const canSubmit =
-    username.trim().length > 0 && pin.length === STAFF_PIN_LENGTH;
+    effectiveUsername.trim().length > 0 && pin.length === STAFF_PIN_LENGTH;
 
   useEffect(() => {
     if (!open) {
       setMode("authenticate");
       setUsername("");
       setPin("");
+      setUseLockedUsername(true);
+      return;
+    }
+
+    if (lockedUsername?.username) {
+      setMode("authenticate");
+      setUsername(lockedUsername.username);
+      setUseLockedUsername(true);
+    }
+
+  }, [lockedUsername?.username, open]);
+
+  useEffect(() => {
+    if (!open) {
       return;
     }
 
     const focusTimer = window.setTimeout(() => {
+      if (lockedUsername?.username && useLockedUsername) {
+        const pinInput =
+          pinInputWrapperRef.current?.querySelector<HTMLInputElement>("input");
+        pinInput?.focus();
+        return;
+      }
+
       usernameInputRef.current?.focus();
     }, 100);
 
     return () => window.clearTimeout(focusTimer);
-  }, [open]);
+  }, [lockedUsername?.username, open, useLockedUsername]);
 
   const handleSubmit = useCallback(async () => {
     if (isAuthenticating) {
       return;
     }
 
-    if (!username.trim()) {
+    if (!effectiveUsername.trim()) {
       toast.error("Username required. Enter a username to continue.");
       return;
     }
@@ -130,7 +171,7 @@ export function StaffAuthenticationDialog({
 
     let result: NormalizedCommandResult<StaffAuthenticationResult>;
     let submittedPinHash = "";
-    const submittedUsername = username.trim();
+    const submittedUsername = effectiveUsername.trim();
 
     try {
       submittedPinHash = await hashPin(pin);
@@ -174,12 +215,12 @@ export function StaffAuthenticationDialog({
     setMode("authenticate");
   }, [
     getSuccessMessage,
+    effectiveUsername,
     isAuthenticating,
     mode,
     onAuthenticate,
     onAuthenticated,
     pin,
-    username,
   ]);
 
   useEffect(() => {
@@ -192,6 +233,13 @@ export function StaffAuthenticationDialog({
     if (event.key === "Enter" && canSubmit) {
       void handleSubmit();
     }
+  }
+
+  function switchToDifferentCashier() {
+    setUseLockedUsername(false);
+    setUsername("");
+    setPin("");
+    window.setTimeout(() => usernameInputRef.current?.focus(), 0);
   }
 
   if (!open) {
@@ -222,20 +270,29 @@ export function StaffAuthenticationDialog({
       </div>
 
       <div className="min-w-0 space-y-layout-lg">
-        <div className="max-w-72 min-w-0 space-y-layout-xs">
-          <Label htmlFor="staff-auth-username">Username</Label>
-          <Input
-            ref={usernameInputRef}
-            id="staff-auth-username"
-            placeholder="Enter username"
-            value={username}
-            onChange={(event) => setUsername(event.target.value)}
-            onKeyDown={handleKeyDown}
-            disabled={isAuthenticating}
-          />
-        </div>
+        {isUsernameLocked ? (
+          <div className="max-w-72 min-w-0 space-y-layout-xs">
+            <Label>Cashier</Label>
+            <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-sm font-medium text-foreground">
+              {lockedUsername?.displayName || lockedUsername?.username}
+            </div>
+          </div>
+        ) : (
+          <div className="max-w-72 min-w-0 space-y-layout-xs">
+            <Label htmlFor="staff-auth-username">Username</Label>
+            <Input
+              ref={usernameInputRef}
+              id="staff-auth-username"
+              placeholder="Enter username"
+              value={username}
+              onChange={(event) => setUsername(event.target.value)}
+              onKeyDown={handleKeyDown}
+              disabled={isAuthenticating}
+            />
+          </div>
+        )}
 
-        <div className="space-y-layout-xs">
+        <div ref={pinInputWrapperRef} className="space-y-layout-xs">
           <Label htmlFor="staff-auth-pin">PIN</Label>
           <StaffPinInput
             value={pin}
@@ -247,7 +304,19 @@ export function StaffAuthenticationDialog({
       </div>
 
       <div className="flex flex-col gap-layout-sm border-t pt-layout-lg sm:flex-row sm:items-center sm:justify-between">
-        {alternateCopy && alternateTriggerLabel ? (
+        {isUsernameLocked ? (
+          <button
+            type="button"
+            className="text-left text-sm font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            onClick={switchToDifferentCashier}
+            disabled={isAuthenticating}
+          >
+            Sign in as a different cashier
+          </button>
+        ) : alternateCopy &&
+        alternateTriggerLabel &&
+        !hideAlternateAction &&
+        !isUsernameLocked ? (
           <button
             type="button"
             className="text-left text-sm font-medium text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -279,6 +279,10 @@ export interface RegisterCloseoutControlState {
 
 export interface RegisterAuthDialogState {
   open: boolean;
+  restoredCashier?: {
+    displayName?: string | null;
+    username: string;
+  } | null;
   storeId: Id<"store">;
   terminalId: Id<"posTerminal">;
   workflowMode?: RegisterWorkflowMode;
@@ -321,7 +325,9 @@ export type CashierPresenceRestoreStatus =
 
 export interface RegisterCashierPresenceRestoreState {
   status: CashierPresenceRestoreStatus;
+  displayName?: string | null;
   message?: string;
+  username?: string | null;
 }
 
 export interface RegisterViewModel {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -981,9 +981,14 @@ describe("useRegisterViewModel", () => {
       ),
     );
 
-    expect(result.current.cashierCard).toBeNull();
+    expect(result.current.cashierCard?.cashierName).toBe("Ama K.");
     expect(result.current.authDialog?.open).toBe(true);
+    expect(result.current.authDialog?.restoredCashier).toEqual({
+      displayName: "Ama Kusi",
+      username: "ama",
+    });
     expect(result.current.debug?.cashierPresence).toBe("validation_pending");
+    expect(result.current.debug?.syncFlow.staffProof).toBe("missing");
     expect(mockStartSession).not.toHaveBeenCalled();
   });
 
@@ -1005,10 +1010,10 @@ describe("useRegisterViewModel", () => {
     expect(result.current.cashierPresenceRestore.message).toBe(
       "Checking cashier access before new sales.",
     );
-    expect(result.current.cashierCard).toBeNull();
+    expect(result.current.cashierCard?.cashierName).toBe("Ama K.");
     expect(result.current.authDialog?.open).toBe(true);
     expect(result.current.productEntry.disabled).toBe(true);
-    expect(result.current.sessionPanel).toBeNull();
+    expect(result.current.sessionPanel?.disableNewSession).toBe(true);
   });
 
   it("invalidates cashier presence for mismatched scope and clears the record", async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -137,11 +137,14 @@ type RestoredCashierPresence = {
   staffProofToken?: string | null;
   storeId?: string;
   terminalId?: string;
+  username?: string | null;
 };
 
 type CashierPresenceRestoreState = {
+  displayName?: string | null;
   message?: string;
   status: CashierPresenceRestoreStatus;
+  username?: string | null;
 };
 
 const POS_CASHIER_PRESENCE_OFFLINE_FRESHNESS_MS = 15 * 60 * 1000;
@@ -1957,11 +1960,14 @@ export function useRegisterViewModel(): RegisterViewModel {
           displayName: presence.displayName ?? "Signed-in cashier",
         });
       } else if (nextRestoreState.status === "validation_pending") {
-        staffProfileIdRef.current = null;
+        staffProfileIdRef.current = presence.staffProfileId as Id<"staffProfile">;
         staffProofTokenRef.current = null;
-        setStaffProfileId(null);
+        setStaffProfileId(presence.staffProfileId as Id<"staffProfile">);
         setStaffProofToken(null);
-        setLocalAuthenticatedStaff(null);
+        setLocalAuthenticatedStaff({
+          activeRoles: presence.activeRoles ?? [],
+          displayName: presence.displayName ?? "Signed-in cashier",
+        });
       } else {
         staffProfileIdRef.current = null;
         staffProofTokenRef.current = null;
@@ -1979,7 +1985,11 @@ export function useRegisterViewModel(): RegisterViewModel {
       }
 
       if (!cancelled) {
-        setCashierPresenceRestore(nextRestoreState);
+        setCashierPresenceRestore({
+          ...nextRestoreState,
+          displayName: presence.displayName ?? null,
+          username: presence.username ?? null,
+        });
       }
     }
 
@@ -5947,13 +5957,21 @@ export function useRegisterViewModel(): RegisterViewModel {
         }
       : null;
   const shouldOpenCashierAuth =
-    !staffProfileId &&
-    cashierPresenceRestore.status !== "pending";
+    cashierPresenceRestore.status === "validation_pending" ||
+    (!staffProfileId && cashierPresenceRestore.status !== "pending");
 
   const authDialog =
     activeStoreId && terminal?._id
       ? {
           open: shouldOpenCashierAuth,
+          restoredCashier:
+            cashierPresenceRestore.status === "validation_pending" &&
+            cashierPresenceRestore.username
+              ? {
+                  displayName: cashierPresenceRestore.displayName ?? null,
+                  username: cashierPresenceRestore.username,
+                }
+              : null,
           storeId: activeStoreId!,
           terminalId: terminal._id,
 	          onAuthenticated: (


### PR DESCRIPTION
## Summary

Reloading the POS after cashier sign-in no longer drops operators back into the generic username/PIN gate. The register now restores the returning cashier identity from terminal-scoped presence, keeps the sale proof locked, and asks only for that cashier's PIN before sales resume.

The locked session card now includes a footer action for signing in as a different cashier, placed opposite the unlock CTA, so switching operators is explicit without making the returning-cashier path ambiguous. The register also suppresses the redundant “checking cashier access” banner while the restored-session unlock gate is already visible.

## Validation

- `bun run --filter '@athena/webapp' test src/components/pos/CashierAuthDialog.test.tsx src/components/pos/register/POSRegisterView.test.tsx src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
- `bun run --filter '@athena/webapp' typecheck`
- `bun run graphify:check`
- `bun run pr:athena`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
