### PR TITLE
Improve offline sale operations timeline links

### DIFF
--- a/docs/solutions/logic-errors/athena-offline-pos-sale-operations-timeline-links-2026-06-05.md
+++ b/docs/solutions/logic-errors/athena-offline-pos-sale-operations-timeline-links-2026-06-05.md
@@ -1,0 +1,91 @@
+---
+title: Athena Offline POS Sale Operations Timeline Links
+date: 2026-06-05
+category: logic-errors
+module: athena-webapp
+problem_type: offline_pos_sale_timeline_attribution
+component: operations-timeline
+symptoms:
+  - "Offline POS sale sync events show generic messages without receipt, total, or tender context"
+  - "Daily operations timeline entries do not link directly to the projected POS transaction"
+  - "Product SKU timeline links can lose useful labels when sync metadata is partial"
+root_cause: sale_projection_and_timeline_linking_did_not_share_operator_audit_metadata
+resolution_type: server_owned_timeline_metadata_and_inline_links
+severity: medium
+tags:
+  - pos
+  - local-sync
+  - operations
+  - timeline
+  - auditability
+---
+
+# Athena Offline POS Sale Operations Timeline Links
+
+## Problem
+
+Offline POS sale sync events reached the operations timeline as generic
+`Offline POS sale synced.` messages. That made the event auditable in a narrow
+sense, but operators could not quickly answer which receipt synced, how many
+lines were included, how it was paid, or where to inspect the resulting POS
+transaction.
+
+The same timeline code already handled product links, so adding richer sale
+copy only on the client would have split the audit source of truth across
+projection and rendering layers.
+
+## Solution
+
+Build the operator-facing sale summary when the local event is projected. Store
+receipt number, line count, payment methods, and total in the timeline event
+metadata, and use a calm sentence such as:
+
+`Offline POS sale #R-100 synced: 2 sale lines, GHS 120.00, cash and card.`
+
+Expose a transaction link from the daily operations read model when the event
+subject is a POS transaction. Keep product links server-derived as well, and
+resolve SKU metadata from `productSkuId` when local sync recorded the SKU but
+did not include every product label field.
+
+On the React side, render one inline timeline link chosen from the transaction
+link first, then the product link. This keeps the message readable while giving
+operators a direct route into the relevant transaction or catalog record.
+
+## Implementation Notes
+
+- Keep message construction in
+  `convex/pos/application/sync/projectLocalEvents.ts` so replayed projections
+  and timeline reads share one wording source.
+- Format money through the existing currency helpers and fall back to GHS when
+  a store currency value is malformed.
+- Deduplicate payment method labels before writing metadata so split payments
+  do not repeat the same tender type.
+- In `convex/operations/dailyOperations.ts`, enrich timeline events with
+  transaction links for POS transaction subjects and product links for SKU
+  subjects or SKU metadata.
+- In `DailyOperationsView`, splice the inline link into the message by matching
+  the link label. Fall back to the full linked label when the message does not
+  contain it.
+
+## Verification
+
+- Add projection tests that assert sale timeline messages include receipt,
+  line-count, total, and payment labels.
+- Add operations read-model tests for transaction links and product SKU links.
+- Add React tests that prove the timeline renders transaction links inline and
+  still handles product links.
+- Run focused Convex and React tests first, then `bun run pr:athena` before
+  merge-ready handoff.
+
+## Prevention
+
+- Do not make the operations timeline infer offline sale totals or payment
+  labels from client-only state. Record those details when the sale projection
+  creates the timeline event.
+- Do not rely on `subjectLabel` alone for product SKU events. Prefer explicit
+  metadata and resolve the SKU document when the event has `productSkuId`.
+- Do not render multiple competing inline links in one timeline sentence.
+  Prefer transaction links for transaction events and product links for product
+  events.
+- Do not surface raw payment method enum values directly to operators. Normalize
+  labels such as `mobile_money` into restrained operational copy.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6134 nodes · 6594 edges · 1754 communities detected
+- 6143 nodes · 6613 edges · 1754 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1804,24 +1804,24 @@ Cohesion: 0.05
 Nodes (31): addLocalAvailabilityConsumption(), addLocalAvailabilityDeltaConsumption(), asCloudOperableSession(), buildCompletedSalePayload(), buildLocalAvailabilityEventIndex(), cartItemsFromLocalRegisterModel(), completedCustomerInfo(), countPendingSyncableLocalEventsForStaff() (+23 more)
 
 ### Community 3 - "Community 3"
+Cohesion: 0.11
+Nodes (47): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(), canMapExistingCloudRegisterSession(), collectExistingSaleMappings(), collectSaleSkuQuantities(), conflictResult(), createConflict() (+39 more)
+
+### Community 4 - "Community 4"
 Cohesion: 0.1
 Nodes (45): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectHarnessSafetySignalFindings(), collectHarnessScriptTestUpdateFindings(), createOutput() (+37 more)
 
-### Community 4 - "Community 4"
+### Community 5 - "Community 5"
 Cohesion: 0.06
 Nodes (27): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatCompactTextList(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary() (+19 more)
 
-### Community 5 - "Community 5"
+### Community 6 - "Community 6"
 Cohesion: 0.06
 Nodes (23): assertPosLocalStoreOk(), clearAcceptedTerminalIntegrityState(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds() (+15 more)
 
-### Community 6 - "Community 6"
+### Community 7 - "Community 7"
 Cohesion: 0.09
 Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
-
-### Community 7 - "Community 7"
-Cohesion: 0.13
-Nodes (40): assertNever(), calculateSalePayments(), canMapExistingCloudRegisterSession(), collectExistingSaleMappings(), collectSaleSkuQuantities(), conflictResult(), createConflict(), createMapping() (+32 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.07
@@ -2152,48 +2152,48 @@ Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
 ### Community 90 - "Community 90"
+Cohesion: 0.2
+Nodes (4): formatProductLineMeta(), formatServiceLabel(), formatServiceLineMeta(), formatStoredAmount()
+
+### Community 91 - "Community 91"
 Cohesion: 0.24
 Nodes (7): classifyTerminalHealth(), formatAge(), formatStatusLabel(), getPrimaryTerminalAttentionReason(), getReviewEvidenceCount(), getSnapshotAgeSummary(), getTerminalAttentionReasons()
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.21
 Nodes (5): formatDeposit(), formatMoney(), handleCancelEdit(), handleSaveEdit(), summarizeService()
 
-### Community 92 - "Community 92"
+### Community 93 - "Community 93"
 Cohesion: 0.24
 Nodes (7): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), useConvexRegisterServiceCatalog(), usePrewarmRegisterCatalogOfflineSnapshots()
 
-### Community 93 - "Community 93"
+### Community 94 - "Community 94"
 Cohesion: 0.29
 Nodes (10): bestFuzzyTokenScore(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreFuzzySearchEntry(), scoreFuzzyTokenMatch(), scoreQueryTokenForEntry() (+2 more)
 
-### Community 94 - "Community 94"
+### Community 95 - "Community 95"
 Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.29
 Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 100 - "Community 100"
-Cohesion: 0.2
-Nodes (2): formatServiceLabel(), formatServiceLineMeta()
 
 ### Community 101 - "Community 101"
 Cohesion: 0.31
@@ -2273,15 +2273,15 @@ Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalize
 
 ### Community 120 - "Community 120"
 Cohesion: 0.39
-Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 121 - "Community 121"
-Cohesion: 0.42
-Nodes (7): getRegisterCatalogPrice(), listRegisterCatalog(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
+Cohesion: 0.39
+Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
 ### Community 122 - "Community 122"
-Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Cohesion: 0.42
+Nodes (7): getRegisterCatalogPrice(), listRegisterCatalog(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
 
 ### Community 123 - "Community 123"
 Cohesion: 0.5
@@ -2528,16 +2528,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 184 - "Community 184"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 185 - "Community 185"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 186 - "Community 186"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
 
 ### Community 187 - "Community 187"
 Cohesion: 0.43
@@ -2680,8 +2680,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 222 - "Community 222"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 223 - "Community 223"
 Cohesion: 0.33
@@ -2700,60 +2700,60 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 227 - "Community 227"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
-
-### Community 228 - "Community 228"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 228 - "Community 228"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 229 - "Community 229"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 230 - "Community 230"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 231 - "Community 231"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 231 - "Community 231"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
 ### Community 232 - "Community 232"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 233 - "Community 233"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 234 - "Community 234"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 235 - "Community 235"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 236 - "Community 236"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 237 - "Community 237"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 238 - "Community 238"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 240 - "Community 240"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 241 - "Community 241"
 Cohesion: 0.53
@@ -11179,8 +11179,8 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 2` be split into smaller, more focused modules?**
   _Cohesion score 0.05 - nodes in this community are weakly interconnected._
 - **Should `Community 3` be split into smaller, more focused modules?**
-  _Cohesion score 0.1 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.11 - nodes in this community are weakly interconnected._
 - **Should `Community 4` be split into smaller, more focused modules?**
-  _Cohesion score 0.06 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.1 - nodes in this community are weakly interconnected._
 - **Should `Community 5` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,19 +8,19 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1826
-- Graph nodes: 6134
-- Graph edges: 6594
+- Graph nodes: 6143
+- Graph edges: 6613
 - Communities: 1754
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (84 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `useRegisterViewModel.ts` (58 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
-- `harness-inferential-review.ts` (46 edges, Community 3) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
-- `RegisterSessionView.tsx` (45 edges, Community 4) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
-- `storefrontJourneyEvents.ts` (45 edges, Community 6) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `usePosLocalSyncRuntime.ts` (45 edges, Community 5) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
-- `ProcurementView.tsx` (41 edges, Community 8) - [`packages/athena-webapp/src/components/procurement/ProcurementView.tsx`](../../packages/athena-webapp/src/components/procurement/ProcurementView.tsx)
+- `projectLocalEvents.ts` (49 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `harness-inferential-review.ts` (46 edges, Community 4) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
+- `RegisterSessionView.tsx` (45 edges, Community 5) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
+- `storefrontJourneyEvents.ts` (45 edges, Community 7) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `usePosLocalSyncRuntime.ts` (45 edges, Community 6) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
 
 ## Registered Packages
 - [Athena Webapp](packages/athena-webapp.md)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -20,8 +20,8 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - `DailyCloseView.tsx` (84 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `useRegisterViewModel.ts` (58 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
-- `RegisterSessionView.tsx` (45 edges, Community 4) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
-- `usePosLocalSyncRuntime.ts` (45 edges, Community 5) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
+- `projectLocalEvents.ts` (49 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `RegisterSessionView.tsx` (45 edges, Community 5) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -17,8 +17,8 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - [validation-map.json](../../../packages/storefront-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `storefrontJourneyEvents.ts` (45 edges, Community 6) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `createJourneyEvent()` (40 edges, Community 6) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `storefrontJourneyEvents.ts` (45 edges, Community 7) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `createJourneyEvent()` (40 edges, Community 7) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 38) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `checkoutSession.ts` (14 edges, Community 60) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 - `storeConfig.ts` (14 edges, Community 38) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)

--- a/packages/athena-webapp/convex/operations/dailyOperations.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.test.ts
@@ -15,6 +15,7 @@ type TableName =
   | "posTerminal"
   | "posTransactionAdjustment"
   | "posTransaction"
+  | "productSku"
   | "registerSession"
   | "staffProfile"
   | "store";
@@ -856,6 +857,20 @@ describe("daily operations overview read model", () => {
             subjectType: "product_sku",
           },
           {
+            _id: "event-pos-sale-synced",
+            createdAt: Date.UTC(2026, 4, 8, 18),
+            eventType: "pos_local_sync.sale_projected",
+            message:
+              "Offline POS sale #946956 synced: 3 sale lines, GH₵1,039, cash.",
+            metadata: {
+              receiptNumber: "946956",
+              transactionNumber: "946956",
+            },
+            storeId: "store-1",
+            subjectId: "txn-946956",
+            subjectType: "posTransaction",
+          },
+          {
             _id: "event-other-day",
             createdAt: Date.UTC(2026, 4, 9, 8),
             eventType: "daily_opening.started",
@@ -877,9 +892,20 @@ describe("daily operations overview read model", () => {
     });
     expect(snapshot.timeline.map((event) => event.id)).toEqual([
       "event-2",
+      "event-pos-sale-synced",
       "event-quick-add",
       "event-1",
     ]);
+    expect(
+      snapshot.timeline.find((event) => event.id === "event-pos-sale-synced")
+        ?.transactionLink,
+    ).toEqual({
+      label: "#946956",
+      params: {
+        transactionId: "txn-946956",
+      },
+      to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId",
+    });
     expect(
       snapshot.timeline.find((event) => event.id === "event-quick-add")
         ?.productLink,
@@ -965,9 +991,22 @@ describe("daily operations overview read model", () => {
             createdAt: Date.UTC(2026, 4, 8, 20, 41, 20),
             eventType: "cycle_count_draft_updated",
             message: "Operator counted agya (6N2Y-RFF-1J1) as 950.",
+            metadata: {
+              productSkuId: "sku-1",
+              productSkuLabel: "agya (6N2Y-RFF-1J1)",
+            },
             storeId: "store-1",
             subjectId: "draft-1",
             subjectType: "cycle_count_draft",
+          },
+        ],
+        productSku: [
+          {
+            _id: "sku-1",
+            productId: "product-1",
+            productName: "agya",
+            sku: "6N2Y-RFF-1J1",
+            storeId: "store-1",
           },
         ],
         store: [store],
@@ -981,5 +1020,18 @@ describe("daily operations overview read model", () => {
       "event-draft-updated",
       "event-draft-started",
     ]);
+    expect(
+      snapshot.timeline.find((event) => event.id === "event-draft-updated")
+        ?.productLink,
+    ).toEqual({
+      label: "agya (6N2Y-RFF-1J1)",
+      params: {
+        productSlug: "product-1",
+      },
+      search: {
+        variant: "6N2Y-RFF-1J1",
+      },
+      to: "/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug",
+    });
   });
 });

--- a/packages/athena-webapp/convex/operations/dailyOperations.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.ts
@@ -86,6 +86,7 @@ type DailyOperationsTimelineEvent = {
   message: string;
   productLink?: LinkTarget;
   subject: SourceSubject;
+  transactionLink?: LinkTarget;
   type: string;
 };
 
@@ -473,21 +474,61 @@ async function listTimelineEvents(
     .order("desc")
     .take(MAX_OPERATIONS_QUERY_LIMIT);
 
-  return events.sort(compareTimelineEvents).map((event) => {
+  return Promise.all(events.sort(compareTimelineEvents).map(async (event) => {
     const metadata = event.metadata ?? {};
     const productId =
       typeof metadata.productId === "string" ? metadata.productId : undefined;
+    const productSkuId =
+      typeof metadata.productSkuId === "string"
+        ? (metadata.productSkuId as Id<"productSku">)
+        : undefined;
+    const productSku = productSkuId
+      ? await ctx.db.get("productSku", productSkuId)
+      : null;
     const productName =
       typeof metadata.productName === "string"
         ? metadata.productName
         : event.subjectLabel;
-    const sku = typeof metadata.sku === "string" ? metadata.sku : undefined;
-    const productLink =
-      event.subjectType === "product_sku" && productId && productName
+    const productSkuLabel =
+      typeof metadata.productSkuLabel === "string"
+        ? metadata.productSkuLabel
+        : undefined;
+    const sku =
+      typeof metadata.sku === "string"
+        ? metadata.sku
+        : productSku?.sku ?? undefined;
+    const productLinkProductId = productId ?? productSku?.productId;
+    const productLinkLabel =
+      event.subjectType === "product_sku"
+        ? productName
+        : productSkuLabel ||
+          (productSku?.productName && sku
+            ? `${productSku.productName} (${sku})`
+            : productSku?.productName || productName);
+    const canLinkProduct =
+      event.subjectType === "product_sku" || productSkuId !== undefined;
+    const transactionNumber =
+      typeof metadata.transactionNumber === "string"
+        ? metadata.transactionNumber
+        : typeof metadata.receiptNumber === "string"
+          ? metadata.receiptNumber
+          : undefined;
+    const transactionLink =
+      event.subjectType === "posTransaction" && transactionNumber
         ? {
-            label: productName,
+            label: `#${transactionNumber}`,
             params: {
-              productSlug: productId,
+              transactionId: event.subjectId,
+            },
+            to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId",
+          }
+        : undefined;
+    const productLink =
+      canLinkProduct && productLinkProductId && productLinkLabel
+        ? {
+            label: productLinkLabel,
+            params: {
+              productSlug: productLinkProductId,
             },
             search: {
               ...(sku ? { variant: sku } : {}),
@@ -506,9 +547,10 @@ async function listTimelineEvents(
         label: event.subjectLabel,
         type: event.subjectType,
       },
+      transactionLink,
       type: event.eventType,
     };
-  });
+  }));
 }
 
 function getTimelineMinuteBucket(createdAt: number) {

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
@@ -100,7 +100,16 @@ describe("projectLocalSyncEvent", () => {
     expect(repository.createdOperationalEvents).toEqual([
       expect.objectContaining({
         eventType: "pos_local_sync.sale_projected",
-        message: "Offline POS sale synced.",
+        message:
+          "Offline POS sale #LR-001 synced: 1 sale line, GH₵0.25, cash.",
+        metadata: expect.objectContaining({
+          lineCount: 1,
+          localReceiptNumber: "LR-001",
+          paymentMethods: ["cash"],
+          receiptNumber: "LR-001",
+          total: 25,
+          transactionNumber: "LR-001",
+        }),
         posTransactionId: "transaction-1",
       }),
     ]);
@@ -225,6 +234,18 @@ describe("projectLocalSyncEvent", () => {
         }),
       ]),
     );
+    expect(repository.createdOperationalEvents).toEqual([
+      expect.objectContaining({
+        eventType: "pos_local_sync.sale_projected",
+        message:
+          "Offline POS sale #LR-001 synced: 2 sale lines, GH₵1, cash and card.",
+        metadata: expect.objectContaining({
+          lineCount: 2,
+          paymentMethods: ["cash", "card"],
+          total: 100,
+        }),
+      }),
+    ]);
     expect(repository.registerSessionPatches).toEqual(
       expect.arrayContaining([
         {
@@ -251,6 +272,54 @@ describe("projectLocalSyncEvent", () => {
         }),
       ]),
     );
+  });
+
+  it("names every payment method on the projected sale timeline event", async () => {
+    const repository = createProjectionRepository();
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: buildSaleCompletedEvent({
+        payload: {
+          ...buildSaleCompletedEvent().payload,
+          payments: [
+            {
+              localPaymentId: "local-payment-cash",
+              method: "cash",
+              amount: 10,
+              timestamp: 21,
+            },
+            {
+              localPaymentId: "local-payment-card",
+              method: "card",
+              amount: 5,
+              timestamp: 22,
+            },
+            {
+              localPaymentId: "local-payment-mobile-money",
+              method: "mobile_money",
+              amount: 10,
+              timestamp: 23,
+            },
+          ],
+        },
+      }),
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("projected");
+    expect(repository.createdOperationalEvents).toEqual([
+      expect.objectContaining({
+        eventType: "pos_local_sync.sale_projected",
+        message:
+          "Offline POS sale #LR-001 synced: 1 sale line, GH₵0.25, cash, card, and mobile money.",
+        metadata: expect.objectContaining({
+          paymentMethods: ["cash", "card", "mobile money"],
+        }),
+      }),
+    ]);
   });
 
   it("projects service-only sales without product inventory movement or retail allocations", async () => {

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -1,5 +1,7 @@
 import type { Id } from "../../../_generated/dataModel";
 import { normalizeInStorePayments } from "../../../cashControls/paymentAllocationAttribution";
+import { toDisplayAmount } from "../../../lib/currency";
+import { currencyFormatter } from "../../../utils";
 import type {
   LocalSyncConflictRecord,
   LocalSyncMappingRecord,
@@ -559,6 +561,7 @@ async function projectSaleCompleted(
   });
 
   await recordSaleProjectedEvent(repository, args, {
+    payments,
     payload: validation.payload,
     sale,
     session: sessionResolution,
@@ -1510,6 +1513,7 @@ function recordSaleProjectedEvent(
   repository: SyncProjectionRepository,
   args: SaleCompletedArgs,
   input: {
+    payments: SalePaymentCalculation;
     payload: PosLocalSalePayload;
     sale: PersistedSale;
     session: SaleSessionResolution;
@@ -1522,17 +1526,113 @@ function recordSaleProjectedEvent(
     eventType: "pos_local_sync.sale_projected",
     subjectType: "posTransaction",
     subjectId: input.sale.transactionId,
-    message: "Offline POS sale synced.",
+    message: buildSaleProjectedMessage({
+      currency: input.store?.currency,
+      payments: input.payments,
+      payload: input.payload,
+    }),
     metadata: {
+      lineCount: getSaleLineCount(input.payload),
       localEventId: args.event.localEventId,
       localReceiptNumber: input.payload.localReceiptNumber,
+      paymentMethods: getPaymentMethodLabels(input.payments.validPayments),
       receiptNumber: input.payload.receiptNumber,
+      total: input.payload.totals.total,
+      transactionNumber: input.payload.receiptNumber,
     },
     createdAt: args.event.occurredAt,
     actorStaffProfileId: args.event.staffProfileId,
     registerSessionId: input.session.registerSession._id,
     posTransactionId: input.sale.transactionId,
   });
+}
+
+function buildSaleProjectedMessage(args: {
+  currency?: string;
+  payments: SalePaymentCalculation;
+  payload: PosLocalSalePayload;
+}) {
+  const receiptNumber =
+    args.payload.receiptNumber?.trim() ||
+    args.payload.localReceiptNumber?.trim();
+  const transactionLabel = receiptNumber ? ` #${receiptNumber}` : "";
+  const lineCount = getSaleLineCount(args.payload);
+  const paymentLabel = getPaymentSummaryLabel(args.payments.validPayments);
+
+  return [
+    `Offline POS sale${transactionLabel} synced: ${formatSaleLineCount(lineCount)}`,
+    formatSaleTotal(args.currency, args.payload.totals.total),
+    paymentLabel,
+  ].join(", ") + ".";
+}
+
+function getSaleLineCount(payload: PosLocalSalePayload) {
+  return payload.items.length + (payload.serviceLines?.length ?? 0);
+}
+
+function formatSaleLineCount(lineCount: number) {
+  return lineCount === 1 ? "1 sale line" : `${lineCount} sale lines`;
+}
+
+function formatSaleTotal(currency: string | undefined, amount: number) {
+  const displayAmount = toDisplayAmount(amount);
+  const storeCurrency = currency?.trim() || "GHS";
+
+  try {
+    return currencyFormatter(storeCurrency).format(displayAmount);
+  } catch (error) {
+    console.error("[pos-sync] sale.projected.currency-format", {
+      currency: storeCurrency,
+      error,
+    });
+
+    return currencyFormatter("GHS").format(displayAmount);
+  }
+}
+
+function getPaymentMethodLabels(payments: PosLocalSalePayload["payments"]) {
+  return Array.from(
+    new Set(
+      payments
+        .map((payment) => formatPaymentMethod(payment.method))
+        .filter(Boolean),
+    ),
+  );
+}
+
+function getPaymentSummaryLabel(payments: PosLocalSalePayload["payments"]) {
+  const labels = getPaymentMethodLabels(payments);
+
+  if (labels.length === 0) {
+    return "payment needs review";
+  }
+
+  if (labels.length === 1) {
+    return labels[0];
+  }
+
+  return formatPaymentMethodList(labels);
+}
+
+function formatPaymentMethodList(labels: string[]) {
+  if (labels.length === 2) {
+    return `${labels[0]} and ${labels[1]}`;
+  }
+
+  const lastLabel = labels[labels.length - 1];
+  const leadingLabels = labels.slice(0, -1).join(", ");
+
+  return `${leadingLabels}, and ${lastLabel}`;
+}
+
+function formatPaymentMethod(method: string) {
+  const normalized = method.trim().toLowerCase();
+
+  if (normalized === "mobile_money") return "mobile money";
+  if (normalized === "card") return "card";
+  if (normalized === "cash") return "cash";
+
+  return normalized.replaceAll("_", " ");
 }
 
 async function recordSaleWorkflowEvidence(

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -347,6 +347,58 @@ const quickAddTimelineSnapshot: DailyOperationsSnapshot = {
   ],
 };
 
+const posSyncedSaleTimelineSnapshot: DailyOperationsSnapshot = {
+  ...operatingSnapshot,
+  timeline: [
+    {
+      createdAt: Date.UTC(2026, 4, 8, 18),
+      id: "event-pos-sale-synced",
+      message:
+        "Offline POS sale 946956 synced: 3 sale lines, GH₵1,039, cash.",
+      subject: {
+        id: "txn-946956",
+        type: "posTransaction",
+      },
+      transactionLink: {
+        label: "#946956",
+        params: {
+          transactionId: "txn-946956",
+        },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId",
+      },
+      type: "pos_local_sync.sale_projected",
+    },
+  ],
+};
+
+const cycleCountSkuTimelineSnapshot: DailyOperationsSnapshot = {
+  ...operatingSnapshot,
+  timeline: [
+    {
+      createdAt: Date.UTC(2026, 4, 8, 18),
+      id: "event-cycle-count-sku",
+      message:
+        "pos@wigclub.store counted AI Engineering (6N2Y-8T-6RM) as 24. Draft has 1 change",
+      productLink: {
+        label: "AI Engineering (6N2Y-8T-6RM)",
+        params: {
+          productSlug: "product-1",
+        },
+        search: {
+          variant: "6N2Y-8T-6RM",
+        },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug",
+      },
+      subject: {
+        id: "draft-1",
+        label: "Cycle count draft",
+        type: "cycle_count_draft",
+      },
+      type: "cycle_count_draft_updated",
+    },
+  ],
+};
+
 function getCurrentLocalOperatingDate() {
   const date = new Date();
   const localDate = new Date(
@@ -898,6 +950,56 @@ describe("DailyOperationsViewContent", () => {
         );
       }),
     ).toBeInTheDocument();
+  });
+
+  it("links synced offline POS sale transaction numbers with link-out affordance", () => {
+    renderContent(posSyncedSaleTimelineSnapshot);
+
+    const transactionLink = screen.getByRole("link", { name: "#946956" });
+
+    expect(transactionLink).toHaveAttribute(
+      "href",
+      expect.stringContaining(
+        "/wigclub/store/osu/pos/transactions/txn-946956?o=",
+      ),
+    );
+    expect(
+      screen.getByText((content, node) => {
+        return (
+          node?.textContent ===
+          "Offline POS sale #946956 synced: 3 sale lines, GH₵1,039, cash."
+        );
+      }),
+    ).toBeInTheDocument();
+    expect(transactionLink.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("links cycle-count product labels and SKU tokens with link-out affordance", () => {
+    renderContent(cycleCountSkuTimelineSnapshot);
+
+    const skuLink = screen.getByRole("link", {
+      name: "AI Engineering (6N2Y-8T-6RM)",
+    });
+
+    expect(skuLink).toHaveAttribute(
+      "href",
+      expect.stringContaining(
+        "/wigclub/store/osu/products/product-1?o=",
+      ),
+    );
+    expect(skuLink).toHaveAttribute(
+      "href",
+      expect.stringContaining("variant=6N2Y-8T-6RM"),
+    );
+    expect(
+      screen.getByText((content, node) => {
+        return (
+          node?.textContent ===
+          "pos@wigclub.store counted AI Engineering (6N2Y-8T-6RM) as 24. Draft has 1 change"
+        );
+      }),
+    ).toBeInTheDocument();
+    expect(skuLink.querySelector("svg")).toBeInTheDocument();
   });
 
   it("leaves content empty while the store-day snapshot loads", () => {

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -165,6 +165,12 @@ export type DailyOperationsSnapshot = {
       search?: Record<string, string>;
       to?: string;
     };
+    transactionLink?: {
+      label?: string;
+      params?: Record<string, string>;
+      search?: Record<string, string>;
+      to?: string;
+    };
     subject: {
       id: string;
       label?: string;
@@ -456,16 +462,21 @@ function TimelineMessage({
   orgUrlSlug: string;
   storeUrlSlug: string;
 }) {
-  const productLink = event.productLink;
-  const linkLabel = productLink?.label?.trim();
-  const linkIndex = linkLabel ? event.message.indexOf(linkLabel) : -1;
+  const inlineLink = event.transactionLink ?? event.productLink;
+  const linkLabel = inlineLink?.label?.trim();
+  const linkMatch = findTimelineLinkMatch(event.message, linkLabel);
 
-  if (!productLink?.to || !productLink.params || !linkLabel || linkIndex < 0) {
+  if (
+    !inlineLink?.to ||
+    !inlineLink.params ||
+    !linkLabel ||
+    !linkMatch
+  ) {
     return <>{formatTimelineMessage(event.message)}</>;
   }
 
-  const before = event.message.slice(0, linkIndex);
-  const after = event.message.slice(linkIndex + linkLabel.length);
+  const before = event.message.slice(0, linkMatch.index);
+  const after = event.message.slice(linkMatch.index + linkMatch.length);
 
   return (
     <>
@@ -473,12 +484,12 @@ function TimelineMessage({
       <Link
         className="inline-flex items-center gap-0.5 font-medium text-link underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         params={{
-          ...productLink.params,
+          ...inlineLink.params,
           orgUrlSlug,
           storeUrlSlug,
         }}
-        search={{ o: getOrigin(), ...(productLink.search ?? {}) }}
-        to={productLink.to}
+        search={{ o: getOrigin(), ...(inlineLink.search ?? {}) }}
+        to={inlineLink.to}
       >
         <span>{linkLabel}</span>
         <ArrowUpRight aria-hidden="true" className="h-3 w-3" />
@@ -486,6 +497,24 @@ function TimelineMessage({
       {formatTimelineMessage(after)}
     </>
   );
+}
+
+function findTimelineLinkMatch(message: string, label: string | undefined) {
+  if (!label) return null;
+
+  const exactIndex = message.indexOf(label);
+  if (exactIndex >= 0) {
+    return { index: exactIndex, length: label.length };
+  }
+
+  if (!label.startsWith("#")) return null;
+
+  const plainLabel = label.slice(1);
+  const plainIndex = plainLabel ? message.indexOf(plainLabel) : -1;
+
+  if (plainIndex < 0) return null;
+
+  return { index: plainIndex, length: plainLabel.length };
 }
 
 function formatWeekdayLabel(operatingDate: string) {

--- a/packages/athena-webapp/src/components/pos/OrderSummary.test.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.test.tsx
@@ -492,7 +492,7 @@ describe("OrderSummary completed transaction summary", () => {
     ]);
   });
 
-  it("includes service lines in completed summaries and printed receipts", async () => {
+  it("includes product and service lines in completed summaries and printed receipts", async () => {
     const user = userEvent.setup();
 
     render(
@@ -510,6 +510,7 @@ describe("OrderSummary completed transaction summary", () => {
               price: 7000,
               quantity: 1,
               productId: "product-1",
+              sku: "CAP-1",
               skuId: "sku-1",
             },
           ] as never,
@@ -540,6 +541,10 @@ describe("OrderSummary completed transaction summary", () => {
       />,
     );
 
+    expect(screen.getByText("Product lines")).toBeInTheDocument();
+    expect(screen.getByText("Edge Brush")).toBeInTheDocument();
+    expect(screen.getByText("1 x GH₵70 • CAP-1")).toBeInTheDocument();
+    expect(screen.getByText("GH₵70")).toBeInTheDocument();
     expect(screen.getByText("Service lines")).toBeInTheDocument();
     expect(screen.getByText("Tokin")).toBeInTheDocument();
     expect(
@@ -568,8 +573,66 @@ describe("OrderSummary completed transaction summary", () => {
           name: "Tokin",
           totalPrice: "GH₵150",
         }),
+        expect.objectContaining({
+          name: "Edge Brush",
+          totalPrice: "GH₵70",
+        }),
       ]),
     );
+  });
+
+  it("hides product and service line sections in read-only rail summaries", () => {
+    render(
+      <OrderSummary
+        cartItems={[]}
+        completedOrderNumber="956338"
+        completedTransactionData={{
+          paymentMethod: "cash",
+          completedAt: new Date("2026-06-04T17:53:00.000Z"),
+          cartItems: [
+            {
+              id: "item-1",
+              name: "nicca",
+              barcode: "4739394883944",
+              price: 6500,
+              quantity: 4,
+              productId: "product-1",
+              sku: "6N2Y-WMA-EAW",
+              skuId: "sku-1",
+            },
+          ] as never,
+          serviceLines: [
+            {
+              id: "service-line-1",
+              name: "chieftin",
+              quantity: 1,
+              serviceCaseId: "case-1",
+              serviceCaseTitle: "chieftin",
+              servicePaymentStatus: "paid",
+              serviceStatus: "intake",
+              totalPrice: 40000,
+              unitPrice: 40000,
+            },
+          ],
+          customerInfo: undefined,
+          subtotal: 66000,
+          tax: 0,
+          total: 66000,
+          payments: [
+            { id: "payment-1", method: "cash", amount: 66000, timestamp: 1 },
+          ],
+        }}
+        readOnly
+        presentation="rail"
+      />,
+    );
+
+    expect(screen.getByText("Subtotal")).toBeInTheDocument();
+    expect(screen.getByText("Amount paid")).toBeInTheDocument();
+    expect(screen.queryByText("Product lines")).not.toBeInTheDocument();
+    expect(screen.queryByText("Service lines")).not.toBeInTheDocument();
+    expect(screen.queryByText("Nicca")).not.toBeInTheDocument();
+    expect(screen.queryByText("Chieftin")).not.toBeInTheDocument();
   });
 
   it("prints receipt header contact fields from grouped store configuration", async () => {

--- a/packages/athena-webapp/src/components/pos/OrderSummary.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.tsx
@@ -87,6 +87,20 @@ function formatServiceLineMeta(line: PosServiceReceiptLine) {
     .join(" • ");
 }
 
+function formatProductLineMeta(
+  item: CartItem,
+  formatter: Intl.NumberFormat,
+) {
+  const skuOrBarcode = item.sku || item.barcode;
+
+  return [
+    `${item.quantity} x ${formatStoredAmount(formatter, item.price)}`,
+    skuOrBarcode,
+  ]
+    .filter(Boolean)
+    .join(" • ");
+}
+
 interface OrderSummaryProps {
   cartItems: CartItem[];
   customerInfo?: {
@@ -222,6 +236,10 @@ export function OrderSummary({
       ? completedTransactionData.serviceLines
       : serviceLines;
   const completedServiceLines = completedTransactionData?.serviceLines ?? [];
+  const completedProductLines = completedTransactionData
+    ? effectiveCartItems.filter((item) => item.lineKind !== "service")
+    : [];
+  const showCompletedLineSections = Boolean(completedTransactionData) && !readOnly;
   const serviceLinesCount = effectiveServiceLines.reduce(
     (sum, line) => sum + (line.quantity ?? 1),
     0,
@@ -757,7 +775,34 @@ export function OrderSummary({
               {formatStoredAmount(formatter, summarySubtotal)}
             </span>
           </div>
-          {completedServiceLines.length > 0 ? (
+          {showCompletedLineSections && completedProductLines.length > 0 ? (
+            <div className="space-y-4 border-y border-border/70 py-4 text-sm">
+              <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                Product lines
+              </p>
+              <div className="space-y-4">
+                {completedProductLines.map((item) => (
+                  <div className="grid gap-1" key={item.id}>
+                    <div className="flex items-start justify-between gap-3">
+                      <span className="min-w-0 text-foreground">
+                        {capitalizeWords(item.name)}
+                      </span>
+                      <span className="font-medium text-foreground">
+                        {formatStoredAmount(
+                          formatter,
+                          item.price * item.quantity,
+                        )}
+                      </span>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      {formatProductLineMeta(item, formatter)}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
+          {showCompletedLineSections && completedServiceLines.length > 0 ? (
             <div className="space-y-4 border-y border-border/70 py-4 text-sm">
               <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
                 Service lines
@@ -1086,7 +1131,34 @@ export function OrderSummary({
                   </span>
                 </div>
               )}
-              {completedServiceLines.length > 0 ? (
+              {showCompletedLineSections && completedProductLines.length > 0 ? (
+                <div className="space-y-3 border-y border-border/70 py-4 text-sm">
+                  <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                    Product lines
+                  </p>
+                  <div className="space-y-3">
+                    {completedProductLines.map((item) => (
+                      <div className="grid gap-1" key={item.id}>
+                        <div className="flex items-start justify-between gap-3">
+                          <span className="min-w-0 text-foreground">
+                            {capitalizeWords(item.name)}
+                          </span>
+                          <span className="font-medium text-foreground">
+                            {formatStoredAmount(
+                              formatter,
+                              item.price * item.quantity,
+                            )}
+                          </span>
+                        </div>
+                        <p className="text-xs text-muted-foreground">
+                          {formatProductLineMeta(item, formatter)}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+              {showCompletedLineSections && completedServiceLines.length > 0 ? (
                 <div className="space-y-3 border-y border-border/70 py-4 text-sm">
                   <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
                     Service lines


### PR DESCRIPTION
## Summary
- Enrich offline POS sale projected timeline events with receipt, line count, total, and payment metadata
- Add daily operations transaction/product timeline links and inline link rendering
- Add regression coverage plus a reusable docs/solutions note and refreshed graphify artifacts

## Validation
- bunx vitest run packages/athena-webapp/convex/operations/dailyOperations.test.ts packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts --maxWorkers=4
- (packages/athena-webapp) bunx vitest run src/components/operations/DailyOperationsView.test.tsx src/components/pos/OrderSummary.test.tsx --maxWorkers=4
- bun run graphify:rebuild
- bun run pr:athena
