### PR TITLE
Continue POS offline sales through recovery

### DIFF
--- a/docs/brainstorms/2026-06-04-pos-offline-app-session-sales-continuity-requirements.md
+++ b/docs/brainstorms/2026-06-04-pos-offline-app-session-sales-continuity-requirements.md
@@ -1,0 +1,168 @@
+---
+date: 2026-06-04
+topic: pos-offline-app-session-sales-continuity
+---
+
+# POS Offline App-Session Sales Continuity
+
+## Summary
+
+Athena should let returning provisioned POS terminals keep starting and completing sales during total network loss even when the app-level session is missing or stale. App-session uncertainty and other cloud-dependent sale blockers should become internal reconciliation conditions, while the cashier's normal local checkout flow continues from trusted local POS authority.
+
+---
+
+## Problem Frame
+
+Field POS terminals cannot assume stable internet. A terminal can be provisioned, locally ready, and staffed for checkout, then lose the app-level Athena session while the network is unavailable. If the register responds by requiring app sign-in before a cashier can finish or start a sale, checkout stops for a reason the operator cannot fix in the field.
+
+Athena already treats POS as a local-first workflow in several areas: terminal setup, local staff authority, drawer/register state, catalog/readiness snapshots, and local event recording. The remaining product gap is not whether a brand-new user can authenticate offline. The gap is whether a known POS terminal keeps operating when cloud session validation is temporarily unreachable.
+
+---
+
+## Actors
+
+- A1. Cashier: Uses the provisioned register to start and complete sales during the selling day.
+- A2. Store manager or support operator: Reviews reconciliation items after connectivity returns when cloud validation cannot accept local history cleanly.
+- A3. Athena POS terminal: The provisioned browser/device that holds local POS authority, records local events, and syncs when online.
+- A4. Athena cloud: The online authority for app sessions, terminal status, staff proof validation, sync acceptance, reporting, and review workflows.
+
+---
+
+## Key Flows
+
+- F1. Continue selling after app-session loss while offline
+  - **Trigger:** A returning provisioned terminal opens or reloads POS with no network, and the app-level session is missing, stale, or cannot be validated.
+  - **Actors:** A1, A3
+  - **Steps:** POS boots from local terminal state, restores local register context, allows local cashier sign-in when needed, and lets the cashier start or continue checkout without requiring app sign-in.
+  - **Outcome:** Checkout continues locally, and app-session uncertainty is preserved for later reconciliation instead of blocking the cashier.
+  - **Covered by:** R1, R2, R3, R4, R5, R6, R7, R8
+
+- F2. Complete active checkout during network loss
+  - **Trigger:** A cashier is in the middle of a cart, payment, or sale completion flow when app-session validation is unavailable.
+  - **Actors:** A1, A3
+  - **Steps:** POS keeps the active sale usable, records cart/payment/completion activity locally, and returns the cashier to the normal register workflow after completion.
+  - **Outcome:** The customer interaction completes without waiting for network restoration.
+  - **Covered by:** R3, R4, R7, R8, R9, R10
+
+- F3. Audit and convert field-unsafe sale blockers
+  - **Trigger:** Planning or implementation reviews the known states that currently prevent POS sales.
+  - **Actors:** A2, A3, A4
+  - **Steps:** Each blocker is classified as a local impossibility, locally known safety failure, or cloud-validation uncertainty. Field-unsafe blockers caused by unavailable cloud validation are converted into internal review or reconciliation items.
+  - **Outcome:** The register blocks only when local sale recording cannot be trusted or cannot be performed.
+  - **Covered by:** R11, R12, R13, R14, R15, R16
+
+- F4. Reconcile after connectivity returns
+  - **Trigger:** The terminal regains usable network access after app-session-unverified offline selling.
+  - **Actors:** A2, A3, A4
+  - **Steps:** Athena validates app-session, terminal, drawer, staff, and sync evidence, accepts clean local events, and routes unresolved mismatches to manager or support review without hiding completed local sales.
+  - **Outcome:** Clean local sales become cloud-visible, and unresolved issues have enough context for reconciliation.
+  - **Covered by:** R17, R18, R19, R20, R21
+
+---
+
+## Requirements
+
+**Offline Sales Continuity**
+- R1. A returning provisioned POS terminal must not require fresh app sign-in to enter POS when the network is unavailable.
+- R2. A missing, stale, or unvalidated app-level session during total network loss must not block POS route entry for a returning provisioned terminal.
+- R3. A missing, stale, or unvalidated app-level session during total network loss must not block starting a new local sale when local POS authority is otherwise sufficient.
+- R4. A missing, stale, or unvalidated app-level session during total network loss must not block completing an active local cart, payment, or sale when local POS authority is otherwise sufficient.
+- R5. POS continuity must apply only to POS surfaces needed for register operation, not to generic Athena app access.
+- R6. POS continuity must use the terminal's existing local authority rather than treating app-session recovery as sale authority.
+
+**Local Sale Authority**
+- R7. Local sale continuation must require enough local state to identify the provisioned terminal, store, register context, cashier authority, and durable local event destination.
+- R8. Cashier-facing checkout should proceed through the normal POS workflow when local sale authority is sufficient, without presenting review or reconciliation as a normal-flow task.
+- R9. Local sale actions must be durably recorded before being presented as completed to the cashier.
+- R10. Locally recorded sales must preserve enough staff, terminal, register, sale, payment, and timing context for later sync and review.
+
+**Blocker Audit**
+- R11. The implementation plan must audit every known POS state that can prevent sale-affecting local actions in the field.
+- R12. The blocker audit must include app-session state, terminal state, drawer/register state, cashier/staff authority, catalog/readiness state, sync state, pending review state, stale cloud state, and command preconditions.
+- R13. Each blocker must be classified as one of: local recording impossible, locally known unsafe, or cloud-validation uncertainty.
+- R14. Cloud-validation uncertainty must default to local sale continuation plus internal reconciliation when local recording and local sale authority are available.
+- R15. Hard sale blockers must be retained only when local sale recording is impossible or locally known to be unsafe.
+- R16. Every retained hard blocker must have an explicit product justification and an operator-safe recovery path.
+
+**Reconciliation**
+- R17. App-session uncertainty during offline POS use must be captured as internal audit or reconciliation context on local history, not as a cashier workflow interruption.
+- R18. When connectivity returns, Athena must validate locally recorded sale history against current app-session, terminal, drawer, staff, and sync authority rules.
+- R19. Cleanly accepted local sale history must sync into normal cloud POS, transaction, payment, inventory, cash-control, and trace surfaces.
+- R20. Local sale history that cannot be accepted cleanly must become manager or support review work with enough context to reconcile.
+- R21. Reconciliation must preserve completed local sales and their evidence rather than silently deleting or rewriting cashier-recorded history.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R2, R5.** Given a provisioned terminal previously loaded POS and later loses network, when the app-level session is missing on reload, POS opens the register surface instead of sending the cashier to a sign-in dead end.
+- AE2. **Covers R3, R6, R7, R8.** Given the terminal has local terminal setup, local cashier authority, register context, and a writable local event store, when the cashier starts a new sale offline with no app session, POS allows the sale to proceed through the normal register workflow.
+- AE3. **Covers R4, R9, R10.** Given a cart is already active when app-session validation becomes unavailable, when the cashier records payment and completes the sale offline, POS durably records the completion and preserves enough context for later sync.
+- AE4. **Covers R11, R12, R13, R14, R15, R16.** Given a current sale blocker depends on live cloud validation, when the blocker audit classifies it as cloud-validation uncertainty and local authority is otherwise available, the blocker is converted into review/reconciliation behavior instead of stopping sales.
+- AE5. **Covers R15, R16.** Given the terminal has no local event destination or cannot identify the provisioned terminal, when the cashier tries to sell offline, POS may hard block because the sale cannot be durably or safely recorded locally.
+- AE6. **Covers R17, R18, R19.** Given sales were completed offline while the app session was missing, when the terminal reconnects and cloud validation accepts the terminal, staff, drawer, and event evidence, the sales sync into normal Athena records.
+- AE7. **Covers R20, R21.** Given offline sales were completed and later cloud validation finds a terminal, drawer, staff, or sync mismatch, when reconciliation runs, Athena preserves the completed local history and creates review work with enough context for managers or support to resolve it.
+
+---
+
+## Success Criteria
+
+- Returning provisioned POS terminals can continue starting and completing sales locally during total network loss.
+- Cashiers do not need to understand app-session recovery, sync review, or reconciliation housekeeping to keep serving customers.
+- Product and engineering can point to an explicit audit of every known sale blocker and why each one continues, becomes review, or remains a hard stop.
+- Manager or support review receives enough context to reconcile app-session, terminal, drawer, staff, payment, inventory, and sync mismatches after connectivity returns.
+- Downstream planning can proceed without inventing the product stance on app-session absence, new-sale behavior, active-sale completion, or blocker conversion.
+
+---
+
+## Scope Boundaries
+
+- Fresh app login while offline is out of scope.
+- Fresh POS recovery-code verification while offline is out of scope.
+- First-time terminal provisioning while offline is out of scope.
+- Terminal repair while offline is out of scope unless the repair can be completed entirely from already trusted local state.
+- Broad offline access to non-POS Athena routes is out of scope.
+- Offline manager approval for protected manager-only commands is out of scope unless planned separately.
+- Exact local storage structures, sync event formats, route-gate implementation, and review-surface design belong to planning.
+
+---
+
+## Key Decisions
+
+- Continue sales by default: Field checkout should not stop because cloud validation is temporarily unreachable.
+- App-session absence is not sale authority: POS sale authority remains grounded in local terminal, staff, drawer/register, readiness, and command evidence.
+- Reconciliation over interruption: Cloud uncertainty should create internal review work after the fact, not normal-flow cashier friction.
+- Audit blockers explicitly: The implementation must not fix only the known app-session symptom while leaving other field-unsafe blockers in place.
+- Hard blockers need justification: Blocking checkout is acceptable only when local recording cannot happen or local evidence already proves the sale would be unsafe.
+- POS-only scope: The continuity promise is for register operation, not a general offline Athena app session.
+
+---
+
+## Dependencies / Assumptions
+
+- The terminal was previously provisioned online for the same store before offline operation begins.
+- The terminal has previously loaded enough POS app shell and local business state to mount the register without network.
+- Local staff authority exists for at least one eligible cashier or manager if cashier sign-in is required.
+- Local command recording is durable enough to preserve sale history until sync or review.
+- Existing POS review and reconciliation surfaces can be extended or adapted during planning.
+
+---
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+- None.
+
+### Deferred to Planning
+
+- [Affects R11, R12, R13][Technical] Inventory all current sale-affecting blockers and classify each into local recording impossible, locally known unsafe, or cloud-validation uncertainty.
+- [Affects R14, R17, R20][Technical] Decide how app-session-unverified local history is represented in sync/reconciliation without surfacing normal-flow warnings to cashiers.
+- [Affects R15, R16][Technical] Define the exact retained hard-block list and the operator-safe recovery path for each retained blocker.
+- [Affects R18, R19, R20, R21][Technical] Define the reconciliation behavior for terminal, drawer, staff, payment, inventory, and sync mismatches after network returns.
+
+---
+
+## Next Steps
+
+-> /ce-plan for structured implementation planning

--- a/docs/plans/2026-06-04-002-feat-pos-offline-sales-continuity-plan.html
+++ b/docs/plans/2026-06-04-002-feat-pos-offline-sales-continuity-plan.html
@@ -1,0 +1,472 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>feat: Keep provisioned POS terminals selling offline</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f7f7f4;
+      --surface: #ffffff;
+      --text: #1f2933;
+      --muted: #596774;
+      --line: #d9ded8;
+      --accent: #1f6f5b;
+      --accent-soft: #e7f2ed;
+      --warn-soft: #fff4df;
+      --warn: #8a5a00;
+      --code: #f1f3f1;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.55;
+    }
+    main {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 40px 24px 64px;
+    }
+    header {
+      border-bottom: 1px solid var(--line);
+      margin-bottom: 28px;
+      padding-bottom: 22px;
+    }
+    h1 {
+      font-size: 2rem;
+      line-height: 1.15;
+      margin: 0 0 12px;
+      letter-spacing: 0;
+    }
+    h2 {
+      border-bottom: 1px solid var(--line);
+      font-size: 1.2rem;
+      margin: 34px 0 14px;
+      padding-bottom: 6px;
+    }
+    h3 {
+      font-size: 1rem;
+      margin: 22px 0 8px;
+    }
+    p { margin: 0 0 12px; }
+    a { color: var(--accent); }
+    code {
+      background: var(--code);
+      border-radius: 4px;
+      padding: 0.1rem 0.25rem;
+      font-size: 0.92em;
+    }
+    .meta {
+      color: var(--muted);
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px 18px;
+      font-size: 0.95rem;
+    }
+    .summary {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-left: 4px solid var(--accent);
+      border-radius: 8px;
+      padding: 18px;
+    }
+    .toc {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 16px 18px;
+    }
+    .toc ul {
+      columns: 2;
+      list-style: none;
+      margin: 0;
+      padding: 0;
+    }
+    .toc li { break-inside: avoid; margin: 5px 0; }
+    .grid {
+      display: grid;
+      gap: 14px;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    }
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 16px;
+    }
+    .card h3 { margin-top: 0; }
+    .badge {
+      background: var(--accent-soft);
+      border-radius: 999px;
+      color: var(--accent);
+      display: inline-block;
+      font-size: 0.82rem;
+      font-weight: 650;
+      margin-bottom: 8px;
+      padding: 2px 9px;
+    }
+    table {
+      border-collapse: collapse;
+      margin: 12px 0;
+      width: 100%;
+    }
+    th, td {
+      border: 1px solid var(--line);
+      padding: 9px 10px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: #eef1ed; }
+    ul { padding-left: 1.25rem; }
+    li { margin: 6px 0; }
+    .callout {
+      background: var(--warn-soft);
+      border: 1px solid #ead3a3;
+      border-radius: 8px;
+      color: var(--warn);
+      padding: 14px 16px;
+    }
+    .unit {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      margin: 14px 0;
+      padding: 16px;
+    }
+    .unit h3 {
+      margin-top: 0;
+    }
+    .small {
+      color: var(--muted);
+      font-size: 0.92rem;
+    }
+    pre {
+      background: #eef1ed;
+      border-radius: 8px;
+      overflow-x: auto;
+      padding: 14px;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>feat: Keep provisioned POS terminals selling offline</h1>
+      <div class="meta">
+        <span>Type: feat</span>
+        <span>Status: active</span>
+        <span>Date: 2026-06-04</span>
+        <span>Markdown: <a href="2026-06-04-002-feat-pos-offline-sales-continuity-plan.md">2026-06-04-002-feat-pos-offline-sales-continuity-plan.md</a></span>
+      </div>
+    </header>
+
+    <section class="summary" id="summary">
+      <h2>Summary</h2>
+      <p>This plan extends Athena's route-scoped POS continuity into local sales continuity: a returning provisioned terminal with local sale authority can keep starting and completing sales when app-session validation is unavailable, including when Convex is totally unreachable. The implementation updates the POS route shell, audits sale blockers, converts cloud-validation uncertainty into reconciliation metadata, and verifies the full no-network register path.</p>
+    </section>
+
+    <nav class="toc" aria-label="Plan sections">
+      <h2>Contents</h2>
+      <ul>
+        <li><a href="#requirements">Requirements</a></li>
+        <li><a href="#scope">Scope Boundaries</a></li>
+        <li><a href="#research">Context &amp; Research</a></li>
+        <li><a href="#decisions">Key Technical Decisions</a></li>
+        <li><a href="#design">Design Shape</a></li>
+        <li><a href="#units">Implementation Units</a></li>
+        <li><a href="#impact">System-Wide Impact</a></li>
+        <li><a href="#risks">Risks</a></li>
+        <li><a href="#sources">Sources</a></li>
+      </ul>
+    </nav>
+
+    <section id="requirements">
+      <h2>Requirements Digest</h2>
+      <div class="grid">
+        <article class="card">
+          <span class="badge">Route continuity</span>
+          <p>Returning provisioned terminals should enter POS without fresh app sign-in when network, Convex, and app-session validation are unavailable.</p>
+        </article>
+        <article class="card">
+          <span class="badge">Sales continuity</span>
+          <p>New sale start and active cart/payment completion continue locally when local POS authority is sufficient.</p>
+        </article>
+        <article class="card">
+          <span class="badge">Blocker audit</span>
+          <p>Every sale-affecting blocker is classified as local recording impossible, locally known unsafe, or cloud-validation uncertainty.</p>
+        </article>
+        <article class="card">
+          <span class="badge">Reconciliation</span>
+          <p>Cloud-validation uncertainty becomes internal audit/reconciliation context; clean history syncs normally and mismatches route to review.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="scope">
+      <h2>Scope Boundaries</h2>
+      <ul>
+        <li>Fresh app login, fresh POS recovery-code verification, first-time terminal provisioning, and broad non-POS offline access remain out of scope.</li>
+        <li>Offline manager approval for protected manager-only commands remains out of scope unless planned separately.</li>
+        <li>Terminal repair offline is out of scope unless it can be completed entirely from already trusted local state.</li>
+        <li>Payment-provider-specific offline authorization behavior is unchanged; the plan preserves current POS payment recording.</li>
+        <li>Follow-up work may broaden offline continuity to non-register POS subroutes or add fleet-level reporting.</li>
+      </ul>
+    </section>
+
+    <section id="research">
+      <h2>Context &amp; Research</h2>
+      <p>The plan reuses existing POS local-first boundaries rather than adding a new offline auth model.</p>
+      <ul>
+        <li><code>src/routes/_authed.tsx</code> owns route-scoped POS shell and app-session recovery behavior.</li>
+        <li><code>usePosTerminalAppSessionRecovery.ts</code> publishes recovery states including <code>waiting_for_network</code>.</li>
+        <li><code>registerReadModel.ts</code> and <code>localCommandGateway.ts</code> compute and enforce sale authority.</li>
+        <li><code>usePosLocalSyncRuntime.ts</code>, <code>syncScheduler.ts</code>, and <code>terminalRuntimeStatus.ts</code> own sync/review diagnostics.</li>
+        <li>The offline route access Playwright spec provides the no-network browser regression pattern.</li>
+      </ul>
+    </section>
+
+    <section id="decisions">
+      <h2>Key Technical Decisions</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Decision</th>
+            <th>Rationale</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Keep app-session continuity POS-scoped</td>
+            <td>Prevents register reliability work from becoming generic offline Athena access.</td>
+          </tr>
+          <tr>
+            <td>Turn <code>waiting_for_network</code> into local sale continuation</td>
+            <td>Network absence, including total Convex unreachability, should delay cloud validation and sync, not local sale recording.</td>
+          </tr>
+          <tr>
+            <td>Add a sale-blocker policy boundary</td>
+            <td>Stops product decisions from staying scattered across route, read-model, command, and UI code.</td>
+          </tr>
+          <tr>
+            <td>Keep cashier UI normal</td>
+            <td>Operators need confidence that sales proceed; review housekeeping belongs behind the scenes.</td>
+          </tr>
+          <tr>
+            <td>Do not bypass authenticated cloud sync boundaries</td>
+            <td>Offline recording can proceed, but upload waits for supported recovery, POS-scoped validation, or existing authenticated sync context.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="design">
+      <h2>Design Shape</h2>
+      <div class="callout">
+        POS sale authority remains grounded in local terminal, staff, drawer/register, readiness, and command evidence. App-session uncertainty is metadata for reconciliation, not the sale gate.
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Blocker class</th>
+            <th>Meaning</th>
+            <th>Cashier behavior</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Local recording impossible</td>
+            <td>The terminal cannot create durable local sale evidence.</td>
+            <td>Hard block.</td>
+          </tr>
+          <tr>
+            <td>Locally known unsafe</td>
+            <td>Local evidence says the terminal or drawer cannot safely append sale-affecting work.</td>
+            <td>Hard block with recovery path.</td>
+          </tr>
+          <tr>
+            <td>Cloud-validation uncertainty</td>
+            <td>The cloud cannot validate now, but local recording remains possible.</td>
+            <td>Continue sale locally and reconcile later.</td>
+          </tr>
+        </tbody>
+      </table>
+      <h3>Preliminary Sale-Blocker Audit Results</h3>
+      <p>This table moves the blocker audit into the plan for product sign-off. Implementation should verify these classifications with tests, and any newly discovered sale stop must be added here before it remains a hard block.</p>
+      <table>
+        <thead>
+          <tr>
+            <th>Current blocker</th>
+            <th>Intended classification</th>
+            <th>Sign-off disposition</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>App-session recovery is <code>waiting_for_network</code>, the app user is missing on a POS route, or Convex is totally unreachable while local POS prerequisites exist.</td>
+            <td>Cloud-validation uncertainty.</td>
+            <td>Continue route entry, new sale start, active cart/payment updates, and completion locally. Tag local history and defer upload.</td>
+          </tr>
+          <tr>
+            <td>Missing POS app shell, local POS entry context, terminal seed, stored app account id, or supported POS route scope.</td>
+            <td>Local recording impossible.</td>
+            <td>Hard block with setup/reload guidance because the app cannot prove the terminal/store scope for local sale evidence.</td>
+          </tr>
+          <tr>
+            <td>Missing store, terminal, register-session, sync-secret, or writable local event-store evidence; unreadable IndexedDB or unsupported local schema.</td>
+            <td>Local recording impossible.</td>
+            <td>Hard block until local storage/setup is repaired.</td>
+          </tr>
+          <tr>
+            <td>No open or active local drawer/register session.</td>
+            <td>Local recording impossible until a local drawer event exists.</td>
+            <td>Block sale commands, but keep drawer open/recovery local-first when local setup is sufficient.</td>
+          </tr>
+          <tr>
+            <td>Register is locally closing or closed after closeout started.</td>
+            <td>Locally known unsafe.</td>
+            <td>Block new sales for that drawer until a permitted local reopen is recorded.</td>
+          </tr>
+          <tr>
+            <td>Terminal integrity is not healthy, including terminal authorization failure.</td>
+            <td>Locally known unsafe.</td>
+            <td>Hard block future sale-affecting writes until terminal repair/reprovision clears integrity state; preserve completed local history.</td>
+          </tr>
+          <tr>
+            <td>Drawer authority says the mapped cloud drawer is closed or a drawer lifecycle command was rejected for the current drawer.</td>
+            <td>Locally known unsafe for the affected drawer.</td>
+            <td>Stop appending to that drawer. Allow a new/recovered local drawer session when distinct drawer evidence can be recorded.</td>
+          </tr>
+          <tr>
+            <td>Drawer authority is unknown, mapping write failed, live cloud drawer/store state is stale, or review lacks explicit local-unsafe evidence.</td>
+            <td>Cloud-validation uncertainty.</td>
+            <td>Continue locally when terminal/drawer/staff/local-store evidence is otherwise sufficient; reconcile after the fact.</td>
+          </tr>
+          <tr>
+            <td>Uploaded <code>needs_review</code> exists for register lifecycle or completed sale.</td>
+            <td>Split by review reason.</td>
+            <td>Hard block only when review proves the current drawer/session is locally unsafe. Ordinary sync review must not block future local sales.</td>
+          </tr>
+          <tr>
+            <td>Pending sync, failed sync retry, held batch, retryable sync authorization failure, browser offline, or Convex unavailable.</td>
+            <td>Cloud-validation uncertainty.</td>
+            <td>Keep appending local sale evidence; retry/defer upload and surface manager/support reconciliation later.</td>
+          </tr>
+          <tr>
+            <td>No signed-in cashier, missing staff profile/proof, expired or revoked local authority, or staff presence scoped to the wrong store/terminal/date.</td>
+            <td>Local recording impossible or locally known unsafe.</td>
+            <td>Require local cashier sign-in or online staff refresh. If fresh local proof exists and only cloud validation is pending, continue.</td>
+          </tr>
+          <tr>
+            <td>Product/service local identity or required payload fields are missing, including SKU, product, service, price, customer/amount, or payment details required to complete.</td>
+            <td>Local recording impossible.</td>
+            <td>Hard block only until the cashier supplies the missing local sale data.</td>
+          </tr>
+          <tr>
+            <td>Catalog availability is unknown, stale, or reports no trusted quantity remaining, but local SKU identity and price exist.</td>
+            <td>Inventory validation uncertainty.</td>
+            <td>Target behavior: allow the sale locally and create inventory reconciliation if cloud stock later disagrees. Hard block only when item/price cannot be identified locally.</td>
+          </tr>
+          <tr>
+            <td>Payment-provider-specific online authorization is unavailable.</td>
+            <td>Outside this plan's authority.</td>
+            <td>Preserve current POS payment recording behavior without implying Athena can override an external provider refusal.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="units">
+      <h2>Implementation Units</h2>
+      <article class="unit">
+        <h3>U1. Allow POS route continuity while recovery waits for network</h3>
+        <p>Change the route shell so trusted POS terminals mount the register while app-session recovery is waiting for network. Keep blocked recovery and non-POS redirects unchanged.</p>
+        <p class="small">Primary tests: <code>src/routes/_authed.test.tsx</code>, <code>usePosTerminalAppSessionRecovery.test.ts</code>.</p>
+      </article>
+      <article class="unit">
+        <h3>U2. Create the POS sale-blocker audit policy</h3>
+        <p>Encode the preliminary audit table as a shared decision boundary for the read model and command gateway. Any newly discovered sale stop must be classified before it remains a hard block.</p>
+        <p class="small">Primary tests: <code>saleBlockerPolicy.test.ts</code>, <code>registerReadModel.test.ts</code>, <code>localCommandGateway.test.ts</code>.</p>
+      </article>
+      <article class="unit">
+        <h3>U3. Let local read model and command gateway continue sales under cloud uncertainty</h3>
+        <p>Apply the blocker policy to sale-affecting local commands so new sales and active sale completion proceed locally when only cloud validation is missing.</p>
+        <p class="small">Primary tests: local read-model, command-gateway, and register view-model tests.</p>
+      </article>
+      <article class="unit">
+        <h3>U4. Carry app-session uncertainty into sync and reconciliation metadata</h3>
+        <p>Preserve support-safe evidence for events recorded while app-session validation was unavailable, then accept clean history or route mismatches to review on reconnect.</p>
+        <p class="small">Primary tests: local store, sync contract, sync scheduler, runtime status, and Convex sync tests.</p>
+      </article>
+      <article class="unit">
+        <h3>U5. Keep cashier presentation normal while preserving support visibility</h3>
+        <p>Remove normal-flow app-session/review interruption from the cashier path while preserving hard-block recovery copy and terminal-health diagnostics.</p>
+        <p class="small">Primary tests: POS register, opening guard, drawer gate, terminal health, and readiness tests.</p>
+      </article>
+      <article class="unit">
+        <h3>U6. Add no-network sales-continuity regression coverage</h3>
+        <p>Prove the browser case end to end: no network and no reachable Convex backend, missing app session, local cashier sign-in, new sale start, active payment/completion, and local evidence persistence without Convex reads, mutations, or sync.</p>
+        <p class="small">Primary tests: <code>src/tests/pos/offlineSalesContinuity.spec.ts</code>.</p>
+      </article>
+      <article class="unit">
+        <h3>U7. Document the final blocker policy and validation map</h3>
+        <p>Add solution guidance and harness mapping so future POS changes do not reintroduce cloud-validation sale stops.</p>
+      </article>
+    </section>
+
+    <section id="impact">
+      <h2>System-Wide Impact</h2>
+      <ul>
+        <li><strong>Interaction graph:</strong> route classification feeds recovery context, register view-model, sync runtime, terminal health, and browser no-network behavior.</li>
+        <li><strong>Error propagation:</strong> cloud failures become support-safe reconciliation categories; local impossibility and unsafe evidence remain hard blockers.</li>
+        <li><strong>State lifecycle:</strong> app-session-unverified local events must survive reload and sync retry without storing reusable credentials.</li>
+        <li><strong>Unchanged invariants:</strong> non-POS routes still require app auth; local staff authority remains separate from app-session recovery.</li>
+      </ul>
+    </section>
+
+    <section id="risks">
+      <h2>Risks</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Risk</th>
+            <th>Mitigation</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Converting too many blockers could allow sales under locally unsafe state.</td>
+            <td>Use the explicit taxonomy and retain locally unsafe or impossible states as hard-block candidates.</td>
+          </tr>
+          <tr>
+            <td>Quiet cashier UI could hide support work.</td>
+            <td>Keep reconciliation in terminal health, sync diagnostics, and manager/support surfaces.</td>
+          </tr>
+          <tr>
+            <td>No-network browser tests may be brittle in CI.</td>
+            <td>Reuse existing offline route access patterns and assert DOM/local evidence rather than network idle.</td>
+          </tr>
+          <tr>
+            <td>Sync may still be blocked after reconnect if the app session is missing.</td>
+            <td>Keep local sales durable and defer upload until supported recovery or POS-scoped validation succeeds.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section id="sources">
+      <h2>Sources</h2>
+      <ul>
+        <li><a href="../brainstorms/2026-06-04-pos-offline-app-session-sales-continuity-requirements.md">Origin requirements</a></li>
+        <li><a href="2026-06-02-001-feat-pos-register-terminal-app-session-plan.md">POS app-session continuity plan</a></li>
+        <li><a href="2026-06-03-002-feat-pos-offline-route-access-plan.md">POS offline route access plan</a></li>
+        <li><a href="../solutions/architecture/athena-pos-local-first-sync-2026-05-13.md">POS local-first sync solution</a></li>
+        <li><a href="../solutions/architecture/athena-pos-hub-app-session-continuity-2026-06-02.md">POS app-session continuity solution</a></li>
+        <li><a href="../solutions/logic-errors/athena-pos-stale-terminal-sale-block-2026-05-29.md">POS stale-terminal sale block solution</a></li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/plans/2026-06-04-002-feat-pos-offline-sales-continuity-plan.md
+++ b/docs/plans/2026-06-04-002-feat-pos-offline-sales-continuity-plan.md
@@ -1,0 +1,538 @@
+---
+title: "feat: Keep provisioned POS terminals selling offline"
+type: feat
+status: active
+date: 2026-06-04
+origin: docs/brainstorms/2026-06-04-pos-offline-app-session-sales-continuity-requirements.md
+---
+
+# feat: Keep provisioned POS terminals selling offline
+
+## Summary
+
+This plan extends Athena's route-scoped POS continuity into local sales continuity: a returning provisioned terminal with local sale authority can keep starting and completing sales when app-session validation is unavailable, including when Convex is totally unreachable. The implementation updates the POS route shell, audits sale blockers, converts cloud-validation uncertainty into reconciliation metadata, and verifies the full no-network register path.
+
+---
+
+## Problem Frame
+
+The current POS route/app-session recovery work keeps the POS shell available during drift, but it can still pause the register while recovery is waiting for network. For field terminals, that leaves cashiers unable to fix a cloud-session problem during an outage even though the local POS state may be sufficient to record sales.
+
+---
+
+## Requirements
+
+- R1. A returning provisioned POS terminal must not require fresh app sign-in to enter POS when the network is unavailable or Convex is totally unreachable. Origin: R1, F1, AE1.
+- R2. Missing, stale, or unvalidated app-level session state during total network loss must not block POS route entry for a returning provisioned terminal. Origin: R2, F1, AE1.
+- R3. Missing, stale, or unvalidated app-level session state during total network loss must not block starting a new local sale when local POS authority is otherwise sufficient. Origin: R3, F1, F3, AE2, AE4.
+- R4. Missing, stale, or unvalidated app-level session state during total network loss must not block completing an active local cart, payment, or sale when local POS authority is otherwise sufficient. Origin: R4, F2, AE3.
+- R5. POS continuity must stay scoped to POS register operation and must not become generic Athena app access. Origin: R5, AE1.
+- R6. POS sale authority must continue to come from local terminal, staff, drawer/register, readiness, and command evidence, not app-session recovery alone. Origin: R6, R7, F1, AE2.
+- R7. Cashier-facing checkout must proceed through the normal POS workflow when local sale authority is sufficient, without presenting review or reconciliation as a normal-flow task. Origin: R8, F1, F2.
+- R8. Local sale actions must be durably recorded with enough terminal, staff, register, sale, payment, and timing context for later sync and review. Origin: R9, R10, AE3.
+- R9. The implementation must audit all known sale-affecting blockers and classify each as local recording impossible, locally known unsafe, or cloud-validation uncertainty. Origin: R11, R12, R13, F3, AE4.
+- R10. Cloud-validation uncertainty must default to local sale continuation plus internal reconciliation when local recording and local sale authority are available. Origin: R14, F3, AE4.
+- R11. Retained hard blockers must be limited to local recording impossible or locally known unsafe states, with explicit product justification and operator-safe recovery paths. Origin: R15, R16, AE5.
+- R12. App-session uncertainty must be captured as internal audit/reconciliation context on local history, not as a cashier workflow interruption. Origin: R17, AE6.
+- R13. Reconnection must validate locally recorded sale history against app-session, terminal, drawer, staff, and sync authority rules. Origin: R18, F4, AE6, AE7.
+- R14. Clean local sale history must sync into normal POS cloud records; unresolved mismatches must become manager/support review while preserving completed local history. Origin: R19, R20, R21, F4, AE6, AE7.
+
+**Origin actors:** A1 Cashier, A2 Store manager or support operator, A3 Athena POS terminal, A4 Athena cloud.
+**Origin flows:** F1 Continue selling after app-session loss while offline, F2 Complete active checkout during network loss, F3 Audit and convert field-unsafe sale blockers, F4 Reconcile after connectivity returns.
+**Origin acceptance examples:** AE1, AE2, AE3, AE4, AE5, AE6, AE7.
+
+---
+
+## Scope Boundaries
+
+- Fresh app login while offline remains out of scope.
+- Fresh POS recovery-code verification while offline remains out of scope.
+- First-time terminal provisioning while offline remains out of scope.
+- Terminal repair while offline remains out of scope unless repair can be completed entirely from already trusted local state.
+- Non-POS Athena routes must not inherit POS offline continuity.
+- Offline manager approval for protected manager-only commands remains out of scope unless planned separately.
+- Payment-provider-specific offline authorization behavior is unchanged; this plan preserves the current POS payment recording model.
+- Exact local storage field shapes, sync payload fields, and review-surface UI details are implementation-time choices within the boundaries of this plan.
+
+### Deferred to Follow-Up Work
+
+- Broaden offline continuity to POS subroutes that are not required for register operation, such as expense reports, terminal detail management, or transaction history browsing.
+- Add fleet-level reporting for stores that repeatedly produce app-session-unverified reconciliation items.
+- Revisit any retained hard blocker after production evidence shows it still interrupts field sales unnecessarily.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/src/routes/_authed.tsx` owns the current signed-out redirect, POS-only shell, app-session recovery pending shell, and non-POS route protection.
+- `packages/athena-webapp/src/routes/_authed.test.tsx` already proves POS shell recovery and contains a current expectation that POS mutations pause while recovery is `waiting_for_network`; that expectation should become a regression target for the new product stance.
+- `packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts` waits for network before validating app-session recovery and publishes `waiting_for_network`, `recoverable`, and `blocked` states.
+- `packages/athena-webapp/src/lib/pos/infrastructure/terminal/posTerminalAppSessionRecoveryContext.tsx` projects recovery state into POS runtime diagnostics.
+- `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts` consumes app-session recovery runtime input, local sync runtime, local read model, cashier presence, drawer gates, and command handlers that drive product/service entry and transaction completion.
+- `packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx` already supports offline staff authentication using terminal-scoped local staff authority.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts` computes `canSell` and current sale block reasons from active register state, terminal integrity, drawer authority, and uploaded lifecycle review events.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts` gates sale-affecting local appends and currently hard-stops several authority/review states.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`, `syncScheduler.ts`, `syncContract.ts`, and `terminalRuntimeStatus.ts` own local event upload, review event marking, support-safe runtime diagnostics, and terminal check-ins.
+- `packages/athena-webapp/src/offline/posAppShellRoutes.ts`, `registerPosAppShellServiceWorker.ts`, `posOfflineReadiness.ts`, and `src/tests/pos/offlineRouteAccess.spec.ts` provide the existing no-network route-access foundation and browser regression pattern.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md`: POS local events are the first durable cashier record; preserve completed local sales and route conflicts to review.
+- `docs/solutions/architecture/athena-pos-always-local-first-register-2026-05-14.md`: cashier commands must append local register events before returning success, regardless of browser online state.
+- `docs/solutions/architecture/athena-pos-local-staff-authority-2026-05-14.md`: offline staff sign-in uses terminal-scoped local verifiers and wrapped proof tokens, not online PIN hashes.
+- `docs/solutions/architecture/athena-pos-offline-route-access-2026-06-03.md`: app-shell route continuity is POS-scoped and must not imply terminal integrity, drawer authority, staff authority, or command permission.
+- `docs/solutions/architecture/athena-pos-hub-app-session-continuity-2026-06-02.md`: app-session recovery keeps POS mounted but must not become sale authority or generic app access.
+- `docs/solutions/logic-errors/athena-pos-stale-terminal-sale-block-2026-05-29.md`: terminal integrity and drawer authority are separate persisted sale-authority inputs and cannot be inferred only from the event log.
+- `docs/product-copy-tone.md`: any operator-facing copy should stay calm, restrained, operational, and normalized away from raw backend wording.
+
+### External References
+
+- No external references are needed for planning. The change is constrained by Athena's existing POS local-first architecture and route-scoped app-session recovery; implementation should consult official Convex Auth documentation only if it changes supported auth-session mechanics.
+
+---
+
+## Key Technical Decisions
+
+| Decision | Rationale |
+|---|---|
+| Keep the app-session layer route scoped | The origin explicitly rejects broad offline app access; `_authed` should continue to distinguish POS register operation from generic Athena authentication. |
+| Treat `waiting_for_network` as POS-local continuation when local sale authority is sufficient | The current pause is the field failure. Network absence, including total Convex unreachability, should delay cloud validation and sync, not local sale recording. |
+| Add a sale-blocker policy/audit boundary | The implementation needs one place to classify blockers as local impossibility, local unsafe evidence, or cloud uncertainty instead of scattering product decisions through route, view-model, read-model, and gateway code. |
+| Preserve local terminal/drawer integrity as hard-block candidates | These states are locally known evidence that sale authority may be invalid. They can remain blockers only when the audit justifies them as locally unsafe rather than merely cloud-unverified. |
+| Convert uploaded review and sync uncertainty into reconciliation where possible | A server-acknowledged review item should not automatically freeze unrelated future field sales if the local drawer/session can keep recording evidence for later review. |
+| Keep cashier UI normal for expected offline selling | The user explicitly rejected normal-flow review warnings. Support and manager review surfaces should carry reconciliation details after the fact. |
+| Do not bypass authenticated cloud sync boundaries | Local recording can proceed offline, but upload still needs a supported app-session recovery, POS-scoped validation path, or existing authenticated sync context before cloud mutation. |
+| Verify with browser no-network and unit-level blocker coverage | This failure spans route shell, local register state, command appends, and sync diagnostics; unit tests alone will miss hard-reload and auth-rehydration failures. |
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should new sales be blocked while app-session recovery is waiting for network? No. They should proceed locally when local sale authority is sufficient.
+- Should active cart/payment completion be supported in the same state? Yes. Both new-sale start and active-sale completion are in scope.
+- Should operators see normal-flow review warnings for this state? No. Housekeeping should happen behind the scenes unless a locally known unsafe state exists.
+- Should all current sale blockers be accepted as-is? No. The plan must audit them and justify any retained hard blocker.
+
+### Deferred to Implementation
+
+- Exact blocker-policy representation: implementation should choose the smallest helper/type shape that clarifies classification without over-abstracting the command gateway.
+- Exact reconciliation metadata fields: implementation should extend local event/sync metadata only as much as needed to identify app-session-unverified or cloud-validation-uncertain local history.
+- Exact retained hard-block list: the implementation audit must produce it from current code behavior and tests, then document it in code comments/tests or a solution note.
+- Exact review target for unresolved mismatches: use existing terminal health, cash-control review, and POS sync review surfaces where possible before creating new review UI.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+stateDiagram-v2
+  [*] --> SignedIn
+  SignedIn --> AppSessionMissing: auth/user becomes null
+  AppSessionMissing --> GenericLogin: non-POS route
+  AppSessionMissing --> PosLocalContinuity: POS route + provisioned terminal + local prerequisites
+  AppSessionMissing --> PosBlocked: missing local terminal/event/staff prerequisites
+  PosLocalContinuity --> LocalSaleRecorded: cashier starts or completes sale
+  LocalSaleRecorded --> PendingSync: event persisted locally
+  PendingSync --> CloudAccepted: connectivity returns and validation accepts
+  PendingSync --> Reconciliation: validation finds mismatch
+  PosLocalContinuity --> PosBlocked: local integrity evidence becomes unsafe
+```
+
+The sale-blocker audit should classify each relevant state before it reaches the cashier path:
+
+| Blocker class | Meaning | Cashier behavior | Examples to evaluate |
+|---|---|---|---|
+| Local recording impossible | The terminal cannot create durable local sale evidence | Hard block | No local event store, no terminal/store identity, unreadable local DB |
+| Locally known unsafe | Local evidence says this terminal/drawer/session cannot safely append sale-affecting work | Hard block with recovery path | Terminal integrity repair, drawer authority block, closed local register without reopen |
+| Cloud-validation uncertainty | The cloud cannot currently validate, or a prior upload needs review, but local recording remains possible | Continue sale locally and reconcile later | App-session waiting for network, sync review, stale live store/drawer state |
+
+### Preliminary Sale-Blocker Audit Results
+
+This is the planning-time audit of current sale-affecting blockers in the POS route shell, register read model, local command gateway, sync runtime, cashier/staff authority, catalog/availability path, and related solution notes. Implementation should verify the table with tests, but product sign-off should happen here so engineers are not making blocker policy ad hoc.
+
+| Current blocker or stop condition | Current source | Intended classification | Sign-off disposition |
+|---|---|---|---|
+| App-session recovery is `waiting_for_network`, app user is missing on a POS route, or Convex is totally unreachable while a returning terminal has local POS prerequisites | `packages/athena-webapp/src/routes/_authed.tsx`, `packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts` | Cloud-validation uncertainty | Continue route entry, new sale start, active cart/payment updates, and completion locally. Tag local history for app-session-unverified reconciliation and defer cloud upload. |
+| Missing POS app shell, missing local POS entry context, missing terminal seed, missing stored app account id, or unsupported local route scope after hard reload | `packages/athena-webapp/src/routes/_authed.tsx`, `packages/athena-webapp/src/offline/posOfflineReadiness.ts`, `docs/solutions/architecture/athena-pos-offline-route-access-2026-06-03.md` | Local recording impossible | Hard block with setup/reload guidance. The app cannot prove the terminal/store scope needed for local sale evidence. |
+| Missing store id, terminal id, register session id for a sale event, sync secret, or writable local POS event store; unreadable IndexedDB or unsupported local schema | `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`, `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts`, `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts` | Local recording impossible | Hard block until local storage/setup is repaired. Do not create sales that cannot be durably scoped and replayed. |
+| No open/active local drawer/register session for the sale | `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts`, `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts`, `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts` | Local recording impossible until a local drawer event exists | Block sale commands, but keep drawer open/recovery local-first. Opening or recovering the drawer must not depend on Convex when local setup is sufficient. |
+| Register is locally closing/closed after closeout started | `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts`, `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts`, `docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md` | Locally known unsafe | Hard block new sales for that drawer until a permitted local reopen is recorded. Closeout/reopen evidence syncs later. |
+| Terminal integrity state is not healthy, including sync/check-in `authorization_failed` with terminal authorization failure metadata | `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`, `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts`, `docs/solutions/logic-errors/athena-pos-stale-terminal-sale-block-2026-05-29.md` | Locally known unsafe | Hard block future sale-affecting writes until terminal repair/reprovision clears integrity state. Preserve already completed local history. |
+| Drawer authority is blocked because the mapped cloud drawer is closed or a drawer lifecycle command was rejected for the current drawer | `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`, `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`, `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts` | Locally known unsafe for the affected drawer | Do not keep appending to that drawer. Allow a new/recovered local drawer session when the app can record distinct drawer evidence; otherwise hard block with drawer recovery. |
+| Drawer authority is `authority_unknown`, mapping write failed, live cloud drawer/store state is stale, or prior upload review lacks explicit local-unsafe evidence | `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`, `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts` | Cloud-validation uncertainty | Continue locally when terminal/drawer/staff/local store evidence is otherwise sufficient. Route the uncertainty to reconciliation instead of freezing unrelated future sales. |
+| Uploaded `needs_review` event exists for register lifecycle or completed sale | `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts`, `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`, `docs/solutions/logic-errors/athena-pos-register-sync-closeout-review-recovery-2026-05-23.md` | Split by review reason | Hard block only when review proves the current drawer/session is locally unsafe. Ordinary sync/reconciliation review must not block future local sales. |
+| Pending sync, failed sync retry, held batch, retryable sync authorization failure, browser offline, or Convex unavailable | `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`, `packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts` | Cloud-validation uncertainty | Keep appending local sale evidence. Retry/defer upload and expose manager/support reconciliation after the fact. |
+| No signed-in cashier, missing staff profile id, missing event-scoped staff proof for uploadable events, expired/revoked local authority, or staff presence scoped to the wrong store/terminal/date | `packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx`, `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`, `docs/solutions/architecture/athena-pos-local-staff-authority-2026-05-14.md` | Local recording impossible or locally known unsafe, depending on the missing evidence | Require local cashier sign-in or online staff refresh. If fresh local proof exists and only cloud validation is pending, treat that pending validation as cloud uncertainty and continue. |
+| Product/service local identity or required payload fields are missing: SKU id, product id, service catalog id, local price, customer/amount required by service checkout, or payment details required to complete | `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`, `packages/athena-webapp/src/components/pos/OrderSummary.tsx` | Local recording impossible | Hard block only until the cashier supplies the missing local sale data. This is not a cloud/network blocker. |
+| Catalog availability is unknown, stale, or reports no trusted quantity remaining, but the app has local SKU identity and price needed to record the sale | `packages/athena-webapp/src/lib/pos/presentation/register/catalogSearchPresentation.ts`, `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`, `docs/solutions/architecture/athena-pos-offline-inventory-snapshot-2026-05-15.md` | Inventory validation uncertainty | Target behavior: allow the sale locally and create inventory reconciliation if cloud stock later disagrees. Retain a hard block only when the app cannot identify the item/price locally. |
+| Payment-provider-specific online authorization is unavailable | Current POS payment recording model and scope boundary | Outside this plan's authority | Preserve current POS payment recording behavior. Do not imply Athena can override an external payment terminal/provider that refuses offline authorization. |
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1["U1 POS route continuity"]
+  U2["U2 Sale-blocker audit policy"]
+  U3["U3 Read model and command gateway"]
+  U4["U4 Reconciliation metadata and runtime status"]
+  U5["U5 Register presentation"]
+  U6["U6 Browser and integration regression"]
+  U7["U7 Docs and validation map"]
+
+  U1 --> U3
+  U2 --> U3
+  U2 --> U4
+  U3 --> U5
+  U4 --> U5
+  U5 --> U6
+  U6 --> U7
+```
+
+- U1. **Allow POS route continuity while recovery waits for network**
+
+**Goal:** Change the POS route shell so a returning provisioned terminal can mount the POS register while app-session recovery is waiting for network, without granting generic app access.
+
+**Requirements:** R1, R2, R5, R6, R12.
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/routes/_authed.tsx`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/terminal/posTerminalAppSessionRecoveryContext.tsx`
+- Test: `packages/athena-webapp/src/routes/_authed.test.tsx`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.test.ts`
+
+**Approach:**
+- Replace the current "pending recovery shell pauses POS mutations" behavior for `waiting_for_network` with POS-local continuity when the local entry context is ready and the terminal has a stored app account id.
+- Preserve pending/blocked behavior for recovery states that do not have enough local POS context or where the server has already rejected the terminal/app account.
+- Keep non-POS route redirect parity exactly as-is.
+- Keep recovery runtime context available so the register/sync layers can tag local work and report support-safe diagnostics without using app-session recovery as sale authority.
+
+**Execution note:** Add failing route-shell characterization for the current `waiting_for_network` pause before changing behavior.
+
+**Patterns to follow:**
+- Existing POS-only shell handling in `packages/athena-webapp/src/routes/_authed.tsx`.
+- Route-scoped recovery boundary in `docs/solutions/architecture/athena-pos-hub-app-session-continuity-2026-06-02.md`.
+- POS offline route access tests in `packages/athena-webapp/src/routes/_authed.test.tsx`.
+
+**Test scenarios:**
+- Covers AE1. Happy path: POS register route with ready local entry context and recovery `waiting_for_network` renders the POS outlet instead of the recovery waiting shell.
+- Covers AE1. Happy path: POS hub route with app user missing and local terminal context does not navigate to `/login` while offline.
+- Edge case: recovery `validating` or `retrying` while online can still show pending recovery if the implementation keeps cloud validation in-flight before local continuity is selected.
+- Error path: recovery `blocked` still renders the POS blocked shell.
+- Error path: missing seed, store mismatch, or unsupported local schema still blocks POS continuity.
+- Integration: non-POS routes still redirect to `/login` when app user is null even if a POS terminal seed exists.
+
+**Verification:**
+- Route tests prove `waiting_for_network` no longer blocks POS register mounting for a trusted returning terminal and non-POS route behavior is unchanged.
+
+---
+
+- U2. **Create the POS sale-blocker audit policy**
+
+**Goal:** Make sale-blocker classification explicit so implementation can convert cloud-validation uncertainty into reconciliation and retain only justified hard blockers.
+
+**Requirements:** R3, R4, R6, R9, R10, R11.
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `packages/athena-webapp/src/lib/pos/infrastructure/local/saleBlockerPolicy.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/saleBlockerPolicy.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts`
+
+**Approach:**
+- Introduce a small decision boundary that classifies sale-affecting stop conditions as local recording impossible, locally known unsafe, or cloud-validation uncertainty.
+- Encode the preliminary audit results above, then verify them against the implementation. If code discovery finds another sale-affecting stop condition, classify it in the same table before adding or retaining a hard block.
+- Use the policy from the read model and command gateway so UI and command acceptance agree on whether the cashier can proceed.
+- Retain hard blockers only when they are locally unsafe or prevent durable local recording. Treat app-session waiting, sync review, stale cloud state, and unresolved live validation as reconciliation candidates when local recording remains possible.
+- Make the retained hard-block list visible in tests so future additions cannot silently stop field sales.
+
+**Patterns to follow:**
+- Existing `canSell` and `saleBlockReason` logic in `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts`.
+- Existing command preconditions in `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts`.
+- Stale-terminal prevention guidance in `docs/solutions/logic-errors/athena-pos-stale-terminal-sale-block-2026-05-29.md`.
+
+**Test scenarios:**
+- Covers AE4. Happy path: app-session `waiting_for_network` is classified as cloud-validation uncertainty, not a hard blocker.
+- Covers AE4. Happy path: uploaded review, mapping uncertainty, pending sync, failed sync retry, and stale cloud validation that do not make local recording unsafe are classified as reconciliation, not sale stops.
+- Covers AE5. Error path: missing local event destination is classified as local recording impossible.
+- Covers AE5. Error path: terminal integrity requiring reprovision remains locally known unsafe unless the audit proves a narrower safe continuation case.
+- Error path: drawer authority block remains locally known unsafe for the affected drawer, while a new/recovered drawer can proceed when distinct local evidence can be recorded.
+- Edge case: unknown store-day live state, unknown catalog availability, or stale cloud inventory is not a hard blocker when the local sale payload can be recorded and reconciled.
+- Integration: read-model classification and command-gateway classification return compatible decisions for the same event history.
+
+**Verification:**
+- A focused blocker policy test suite enumerates current sale blockers and the intended product classification for each one.
+
+---
+
+- U3. **Let local read model and command gateway continue sales under cloud uncertainty**
+
+**Goal:** Apply the blocker policy to sale-affecting local commands so new sales and active sale completion proceed locally when only cloud validation is missing.
+
+**Requirements:** R3, R4, R6, R7, R8, R10, R11.
+
+**Dependencies:** U1, U2.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+
+**Approach:**
+- Replace unconditional hard stops for cloud-validation uncertainty with a sellable local read-model state that still carries reconciliation metadata.
+- Ensure `startSession`, cart item append, service line append, payment state append, transaction completion, closeout start, and permitted reopen use the same policy.
+- Keep local command append as the first durable write before returning cashier success.
+- Preserve current hard blockers for no local register/session identity, no staff authority, terminal integrity repair, unreadable local store, and any other policy-classified local impossibility or unsafe state.
+- Make active cart/payment completion explicitly covered so it does not regress while new-sale start is being fixed.
+
+**Execution note:** Implement command-gateway behavior test-first because these methods define the cashier-path write boundary.
+
+**Patterns to follow:**
+- Local-first command rule in `docs/solutions/architecture/athena-pos-always-local-first-register-2026-05-14.md`.
+- Existing local append APIs in `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts`.
+- Register view-model command handlers in `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`.
+
+**Test scenarios:**
+- Covers AE2. Happy path: starting a new local sale succeeds while app-session recovery is waiting for network and local terminal/staff/drawer state is sufficient.
+- Covers AE3. Happy path: appending payment and completing an active sale succeeds under the same app-session-unverified offline state.
+- Happy path: normal pending offline sync remains sellable.
+- Edge case: an uploaded review item on a completed prior sale creates reconciliation metadata without disabling product/service entry for a new sale when the drawer remains locally usable.
+- Error path: command appends still fail when local event storage returns an error.
+- Error path: command appends still fail when terminal identity, store identity, staff profile, or local register session id is missing.
+- Error path: local closeout remains a hard stop until a permitted reopen event is recorded.
+- Integration: view-model `productEntry.disabled` and `serviceEntry.disabled` align with the command gateway's sale-continuation decision.
+
+**Verification:**
+- Local read-model, command-gateway, and view-model tests prove both new-sale start and active-sale completion continue under cloud uncertainty while retained hard blockers still stop unsafe local appends.
+
+---
+
+- U4. **Carry app-session uncertainty into sync and reconciliation metadata**
+
+**Goal:** Preserve enough internal evidence for cloud validation and review after connectivity returns without surfacing reconciliation as a cashier task.
+
+**Requirements:** R8, R10, R12, R13, R14.
+
+**Dependencies:** U2, U3.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/sync.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/terminals.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts`
+- Test: `packages/athena-webapp/convex/pos/public/sync.test.ts`
+- Test: `packages/athena-webapp/convex/pos/public/terminals.test.ts`
+
+**Approach:**
+- Add internal metadata to local events or sync batches that says the event was recorded while app-session validation was unavailable, without storing reusable credentials or exposing raw auth data.
+- Keep metadata support-safe in terminal runtime diagnostics. Diagnostics can show that app-session validation was unavailable or recovered, but must not expose tokens, proof material, payment payloads, or customer data.
+- On sync, allow the server to accept clean events once terminal, drawer, staff proof, and app-session conditions validate.
+- When network returns but app-session recovery is still unresolved, keep local history durable and defer upload until a supported authenticated or POS-scoped validation path is available; do not introduce unauthenticated sync mutation access.
+- When validation cannot accept cleanly, route the local history into existing review/reconciliation paths with enough local event identifiers, terminal/store/staff context, and sanitized reason categories.
+- Keep idempotency and sequence ordering intact for events recorded in this state.
+
+**Patterns to follow:**
+- Sync review behavior in `packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts`.
+- Support-safe runtime diagnostics in `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts`.
+- Local review event sampling tests that redact payments and customer data.
+
+**Test scenarios:**
+- Covers AE6. Happy path: events recorded while app-session validation is unavailable sync cleanly after connectivity returns and validation succeeds.
+- Covers AE7. Error path: server rejection for terminal, drawer, staff, or app-session mismatch marks events for review without deleting local history.
+- Edge case: retrying the same app-session-unverified events remains idempotent and does not duplicate cloud records.
+- Edge case: network returns before app-session recovery completes; sync remains deferred without losing local history or exposing unauthenticated upload access.
+- Error path: runtime diagnostics redact raw recovery reasons, tokens, staff proof material, payment payloads, and customer data.
+- Integration: terminal runtime check-in includes support-safe app-session/reconciliation posture alongside existing sync, terminal integrity, and drawer authority diagnostics.
+
+**Verification:**
+- Sync/runtime tests prove app-session-unverified local history is internally traceable, safely reportable, accepted when clean, and reviewable when mismatched.
+
+---
+
+- U5. **Keep cashier presentation normal while preserving support visibility**
+
+**Goal:** Ensure the register UI does not present expected offline/app-session-unverified operation as a cashier-facing review problem, while support/manager surfaces still expose real reconciliation work.
+
+**Requirements:** R7, R10, R11, R12, R14.
+
+**Dependencies:** U3, U4.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`
+- Modify: `packages/athena-webapp/src/offline/posOfflineReadiness.ts`
+- Test: `packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts`
+- Test: `packages/athena-webapp/src/offline/posOfflineReadiness.test.ts`
+
+**Approach:**
+- Remove or narrow normal-flow "recovery waiting for network" and "review pending" copy from the cashier path when local sale authority is sufficient.
+- Keep actual hard blockers visible with specific operator-safe recovery paths, such as reconnecting terminal setup, signing in a locally authorized cashier, reopening a locally closed drawer, or repairing terminal integrity.
+- Keep terminal health and support diagnostics as the place to explain app-session recovery, local review records, and cloud reconciliation mismatches.
+- Ensure manager/support review copy distinguishes pending sync, local-only review evidence, uploaded review events, and accepted reconciliation.
+
+**Patterns to follow:**
+- Existing POS sync review presentation in `packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx`.
+- Terminal health visibility guidance in `docs/solutions/architecture/athena-pos-terminal-health-visibility-2026-05-20.md`.
+- Product copy guidance in `docs/product-copy-tone.md`.
+
+**Test scenarios:**
+- Covers AE2. Happy path: cashier can see and use product/service entry while app-session validation is unavailable and local authority is sufficient.
+- Covers AE3. Happy path: active checkout completion does not display app-session recovery as a blocking warning.
+- Edge case: support diagnostics still include app-session recovery/reconciliation status in redacted terms.
+- Error path: retained hard blockers show operator-safe recovery copy.
+- Error path: raw backend errors, tokens, staff proof, payment payloads, and customer data do not appear in cashier or support diagnostics.
+- Integration: POS readiness remains diagnostic only and does not become a sale blocker by itself.
+
+**Verification:**
+- Component tests prove normal cashier flow remains quiet during expected offline continuation while retained hard blockers and support diagnostics remain visible where appropriate.
+
+---
+
+- U6. **Add no-network sales-continuity regression coverage**
+
+**Goal:** Prove the whole browser path: provisioned terminal, no network and no reachable Convex backend, missing app session, local cashier sign-in, new sale start, active payment/completion, and later reconciliation visibility.
+
+**Requirements:** R1, R2, R3, R4, R7, R8, R12, R14.
+
+**Dependencies:** U1, U3, U4, U5.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts`
+- Create: `packages/athena-webapp/src/tests/pos/offlineSalesContinuity.spec.ts`
+- Modify: `packages/athena-webapp/playwright.config.ts` if scenario setup needs deterministic POS local fixtures
+- Modify: `scripts/harness-app-registry.ts`
+- Test: `packages/athena-webapp/src/tests/pos/offlineSalesContinuity.spec.ts`
+
+**Approach:**
+- Extend the existing Playwright no-network setup rather than inventing a new browser harness.
+- Seed or prepare a provisioned terminal with local app shell, terminal seed, local staff authority, catalog/readiness snapshots, and a local register context.
+- Simulate app-session loss or missing app user, block network so Convex queries/mutations are unreachable, hard reload into `/pos/register`, authenticate locally if needed, start a sale, add an item/service, record payment, and complete the sale.
+- Include an active-cart variant where the outage/session-loss happens mid-flow before payment/completion.
+- Verify local evidence exists after completion without depending on Convex reads, Convex mutations, or cloud sync.
+- Re-enable network in a separate scenario only if the existing harness can do so deterministically; otherwise leave cloud reconciliation acceptance to unit/integration tests in U4.
+
+**Patterns to follow:**
+- Browser no-network regression in `packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts`.
+- CI Convex env fallback note from recent offline-route work.
+- Harness registry pattern in `scripts/harness-app-registry.ts`.
+
+**Test scenarios:**
+- Covers AE1. Browser hard reload with network blocked and Convex unreachable reaches the POS register rather than login or blank shell.
+- Covers AE2. Browser no-network scenario starts a new sale and appends local sale evidence when app session is missing.
+- Covers AE3. Browser no-network scenario completes an already active cart/payment flow after app-session loss.
+- Error path: browser no-network scenario with missing terminal seed does not allow sale and shows the retained hard-block path.
+- Integration: local sale evidence persists across reload after completion.
+
+**Verification:**
+- Browser regression proves the field case end to end, and harness registry maps changed POS offline/sales-continuity files to the focused scenario.
+
+---
+
+- U7. **Document the final blocker policy and validation map**
+
+**Goal:** Preserve the new field-sales posture so future POS changes do not reintroduce cloud-validation sale stops.
+
+**Requirements:** R9, R10, R11, R14.
+
+**Dependencies:** U2, U3, U4, U6.
+
+**Files:**
+- Create: `docs/solutions/architecture/athena-pos-offline-sales-continuity-2026-06-04.md`
+- Modify: `docs/solutions/architecture/athena-pos-hub-app-session-continuity-2026-06-02.md`
+- Modify: `docs/solutions/logic-errors/athena-pos-stale-terminal-sale-block-2026-05-29.md`
+- Modify: `scripts/harness-app-registry.ts`
+- Test: `scripts/harness-app-registry.test.ts` if present, or the nearest harness registry test file discovered during implementation
+
+**Approach:**
+- Add a solution note that states the blocker taxonomy, retained hard-block policy, and reconciliation-over-interruption stance.
+- Update existing app-session and stale-terminal notes so future work understands that app-session uncertainty is not sale authority and not a sale stop by itself.
+- Update harness mapping so changes to the route shell, recovery runtime, blocker policy, local command gateway, read model, sync runtime, terminal diagnostics, or offline browser specs trigger the right focused tests.
+
+**Patterns to follow:**
+- Existing solution note shape in `docs/solutions/architecture/athena-pos-offline-route-access-2026-06-03.md`.
+- Harness registry coverage mentioned in POS local-first and offline-route solution docs.
+
+**Test scenarios:**
+- Test expectation: focused harness registry coverage only if the repo has a test for `scripts/harness-app-registry.ts`; otherwise validate by static review and existing harness generation checks.
+
+**Verification:**
+- The final docs explain which blockers remain hard stops, which become reconciliation, and which tests protect the policy.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `_authed` route classification feeds POS recovery context, which feeds register view-model, local sync runtime, terminal health diagnostics, and browser no-network behavior.
+- **Error propagation:** App-session/network failures should become support-safe reconciliation categories, while local impossibility/unsafe states continue to produce operator-safe hard-block copy.
+- **State lifecycle risks:** App-session-unverified local events must remain durable across reload, sync retry, and review without storing reusable auth credentials or proof material in unsafe places.
+- **API surface parity:** Local register read model, command gateway, view-model disabled states, and runtime diagnostics must agree on the same blocker classification.
+- **Integration coverage:** Route unit tests, local command tests, sync/runtime tests, component tests, and Playwright no-network coverage are all needed; none alone proves the field case.
+- **Unchanged invariants:** Non-POS routes still require normal app auth; fresh app login and POS recovery-code verification still require network; local staff authority remains separate from app-session recovery; terminal/drawer integrity remains separate from app login.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Converting too many blockers could allow sales when local evidence already proves the terminal or drawer is unsafe. | Use the explicit blocker taxonomy and keep terminal integrity, missing local recording, and locally closed drawer states as retained hard-block candidates unless tests justify a narrower continuation path. |
+| Keeping cashier UI quiet could hide real support work. | Keep reconciliation details in terminal health, sync diagnostics, and manager/support review surfaces while avoiding normal-flow cashier interruption. |
+| App-session-unverified metadata could leak auth or staff proof material. | Store only safe categories and local event identifiers; test runtime diagnostics for redaction. |
+| Browser no-network coverage could be brittle in CI. | Reuse the existing offline route access Playwright pattern and deterministic Convex env fallback; assert DOM/local evidence rather than `networkidle`. |
+| Existing tests encode the old pause behavior. | Treat those tests as characterization and update them alongside new route/register tests rather than deleting coverage. |
+| Sync may be blocked after reconnect if the app session is still missing. | Keep local sales durable and defer upload until supported app-session recovery or POS-scoped validation succeeds; do not add an unauthenticated sync bypass. |
+
+---
+
+## Documentation / Operational Notes
+
+- Add a solution note after implementation because the blocker taxonomy is a reusable POS architecture decision.
+- Update existing app-session continuity and stale-terminal notes to prevent future confusion between app login, sale authority, and reconciliation.
+- Run graphify rebuild after code changes during implementation, per repo instructions.
+- Keep operator-facing copy aligned with `docs/product-copy-tone.md`.
+
+---
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-06-04-pos-offline-app-session-sales-continuity-requirements.md](../brainstorms/2026-06-04-pos-offline-app-session-sales-continuity-requirements.md)
+- Related plan: [docs/plans/2026-06-02-001-feat-pos-register-terminal-app-session-plan.md](2026-06-02-001-feat-pos-register-terminal-app-session-plan.md)
+- Related plan: [docs/plans/2026-06-03-002-feat-pos-offline-route-access-plan.md](2026-06-03-002-feat-pos-offline-route-access-plan.md)
+- Related solution: [docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md](../solutions/architecture/athena-pos-local-first-sync-2026-05-13.md)
+- Related solution: [docs/solutions/architecture/athena-pos-always-local-first-register-2026-05-14.md](../solutions/architecture/athena-pos-always-local-first-register-2026-05-14.md)
+- Related solution: [docs/solutions/architecture/athena-pos-local-staff-authority-2026-05-14.md](../solutions/architecture/athena-pos-local-staff-authority-2026-05-14.md)
+- Related solution: [docs/solutions/architecture/athena-pos-offline-route-access-2026-06-03.md](../solutions/architecture/athena-pos-offline-route-access-2026-06-03.md)
+- Related solution: [docs/solutions/architecture/athena-pos-hub-app-session-continuity-2026-06-02.md](../solutions/architecture/athena-pos-hub-app-session-continuity-2026-06-02.md)
+- Related solution: [docs/solutions/logic-errors/athena-pos-stale-terminal-sale-block-2026-05-29.md](../solutions/logic-errors/athena-pos-stale-terminal-sale-block-2026-05-29.md)

--- a/docs/solutions/architecture/athena-pos-offline-route-access-2026-06-03.md
+++ b/docs/solutions/architecture/athena-pos-offline-route-access-2026-06-03.md
@@ -51,8 +51,9 @@ Keep offline POS route access as a static shell plus local POS state:
 - POS route entry remains local-first through `_authed.tsx`,
   `useGetActiveStore.ts`, local terminal seed, and existing register guards.
 - Offline readiness copy is diagnostic only. It distinguishes app shell,
-  terminal setup, staff authority, register catalog, service catalog, and
-  availability snapshot readiness without becoming sale authority.
+  app-session continuity, terminal setup, staff authority, register catalog,
+  service catalog, and availability snapshot readiness without becoming sale
+  authority.
 
 ## Storage Boundary
 
@@ -89,6 +90,8 @@ route entry, readiness diagnostics, or register hard-reload behavior changes:
 - `src/tests/pos/offlineRouteAccess.spec.ts` proves a production-built app can
   load POS online, install/cache the app shell, block network, hard reload, and
   still mount the POS register shell.
+- `src/tests/pos/offlineSalesContinuity.spec.ts` keeps the no-network register
+  shell redacted while app-session validation is unavailable.
 
 The Athena harness registry now includes "POS offline route access and app-shell
 edits" so future changed-file validation points to these commands and the
@@ -102,6 +105,9 @@ production-build Playwright regression.
   business payloads in Cache Storage.
 - Do not treat app-shell readiness as terminal integrity, drawer authority,
   local staff authority, or command permission.
+- Do not derive app-shell readiness from app-session recovery status. Keep
+  app-session-unverified continuation as redacted support posture, not
+  cashier-facing review.
 - Run browser validation against production build/preview rather than Vite dev
   HMR modules; dev-only clients can create false offline failures.
 - Rebuild graphify after code changes and regenerate harness docs after

--- a/docs/solutions/architecture/athena-pos-offline-sales-continuity-2026-06-04.md
+++ b/docs/solutions/architecture/athena-pos-offline-sales-continuity-2026-06-04.md
@@ -1,0 +1,107 @@
+---
+title: Athena POS Offline Sales Continuity Separates Local Authority From Cloud Validation
+date: 2026-06-04
+category: architecture
+module: athena-webapp
+problem_type: pos_offline_sales_continuity
+component: pos
+symptoms:
+  - "A returning POS register can look like it needs manager review when only app-session cloud validation is waiting for network"
+  - "Support diagnostics can expose app-session recovery posture without needing raw assertions or credentials"
+  - "Offline route access coverage can miss whether the register shell stays redacted during no-network sale continuation"
+root_cause: app_session_cloud_validation_uncertainty_was_treated_like_sale_authority_failure
+resolution_type: local_sale_blocker_policy_with_reconciliation_metadata
+severity: high
+tags:
+  - pos
+  - offline
+  - app-session
+  - reconciliation
+  - local-first
+---
+
+# Athena POS Offline Sales Continuity Separates Local Authority From Cloud Validation
+
+## Problem
+
+When a provisioned POS register is locally able to sell but cloud app-session
+validation is waiting for the network, the cashier flow should remain normal.
+That state is not sale authority by itself, and it is not manager review by
+itself. It is reconciliation context: local sale history can continue on the
+register and upload once cloud validation and sync are available.
+
+## Solution
+
+Keep app-session recovery separate from app-shell readiness, terminal setup,
+staff authority, drawer authority, local command invariants, and sync review:
+
+- `saleBlockerPolicy` classifies sale blockers. Terminal integrity failures,
+  drawer-authority blocks, missing durable local destinations, missing staff or
+  terminal identity, and non-reopenable locally closed drawers stay hard
+  blockers.
+- Uploaded lifecycle review, pending sync, failed retry, app-session recovery
+  `waiting_for_network`, and stale cloud validation are cloud-validation
+  uncertainty when local recording remains possible.
+- Local sale commands and uploadable drawer lifecycle events carry redacted
+  `validationMetadata` flags such as `app-session-unverified` and
+  `cloud-validation-uncertain`; they do not store raw assertions, tokens, staff
+  proof material, customer details, or payment payloads in the metadata.
+- Sync defers app-session-unverified uploads until supported validation returns,
+  then uploads idempotently through the normal authenticated terminal sync
+  boundary.
+- Offline readiness includes an `app_session` signal. `waiting_for_network` is
+  presented as local sale continuation, not as cashier-facing review work.
+- Register support diagnostics expose only redacted posture copy such as
+  `App session unverified; local sales stay on this register until cloud
+  validation returns.`
+- Terminal health can show `Local continuation` for support while keeping
+  review counts tied to actual sync review evidence.
+- Browser coverage should hard reload `/pos/register` with no network and
+  confirm the shell remains mounted and does not expose assertions, tokens,
+  secrets, passwords, OTP material, or sync secrets.
+
+## Prevention
+
+- Do not use app-session recovery as sale authority. Sale commands still depend
+  on terminal integrity, drawer authority, local command invariants, staff
+  proof, and local recording.
+- Do not add a new hard sale blocker for cloud-validation uncertainty without
+  adding it to the blocker policy tests and documenting why local recording is
+  impossible or locally unsafe.
+- Do not turn app-session-unverified local continuation into manager review
+  unless sync projection or command validation creates a real review item.
+- Do not derive app-shell readiness from app-session recovery status. The app
+  shell is a static browser-shell concern; app-session recovery is route-scoped
+  continuity evidence.
+- Keep diagnostics redacted by construction. Show status labels, counts,
+  timestamps, and next steps, not raw assertions or reusable credentials.
+
+## Validation
+
+Use this focused slice when changing POS offline sales-continuity behavior:
+
+- `src/routes/_authed.test.tsx`
+- `src/lib/pos/infrastructure/local/saleBlockerPolicy.test.ts`
+- `src/lib/pos/infrastructure/local/localCommandGateway.test.ts`
+- `src/lib/pos/infrastructure/local/registerReadModel.test.ts`
+- `src/lib/pos/infrastructure/local/posLocalStore.test.ts`
+- `src/lib/pos/infrastructure/local/syncContract.test.ts`
+- `src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`
+- `src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts`
+- `src/offline/posOfflineReadiness.test.ts`
+- `src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- `src/components/pos/register/POSRegisterView.test.tsx`
+- `src/components/pos/terminals/terminalHealthPresentation.test.ts`
+- `src/components/pos/terminals/POSTerminalHealthView.test.tsx`
+- `src/tests/pos/offlineSalesContinuity.spec.ts`
+
+The browser specs prove the production app shell remains mounted and redacted
+under no-network hard reloads. Local sale evidence, metadata deferral, and
+idempotent upload are protected by the command, store, sync-contract, and
+runtime tests above.
+
+## Related
+
+- [Athena POS Offline Route Access Uses A Static App Shell](./athena-pos-offline-route-access-2026-06-03.md)
+- [Athena POS Hub App-Session Continuity Is Route Scoped](./athena-pos-hub-app-session-continuity-2026-06-02.md)
+- [Athena Terminal-Scoped Cashier Presence](./athena-terminal-scoped-cashier-presence-2026-06-04.md)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1826 files · ~0 words
+- 1829 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6143 nodes · 6613 edges · 1754 communities detected
+- 6157 nodes · 6631 edges · 1757 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1764,6 +1764,9 @@
 - [[_COMMUNITY_Community 1751|Community 1751]]
 - [[_COMMUNITY_Community 1752|Community 1752]]
 - [[_COMMUNITY_Community 1753|Community 1753]]
+- [[_COMMUNITY_Community 1754|Community 1754]]
+- [[_COMMUNITY_Community 1755|Community 1755]]
+- [[_COMMUNITY_Community 1756|Community 1756]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1808,16 +1811,16 @@ Cohesion: 0.11
 Nodes (47): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(), canMapExistingCloudRegisterSession(), collectExistingSaleMappings(), collectSaleSkuQuantities(), conflictResult(), createConflict() (+39 more)
 
 ### Community 4 - "Community 4"
+Cohesion: 0.06
+Nodes (25): assertPosLocalStoreOk(), clearAcceptedTerminalIntegrityState(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds() (+17 more)
+
+### Community 5 - "Community 5"
 Cohesion: 0.1
 Nodes (45): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectHarnessSafetySignalFindings(), collectHarnessScriptTestUpdateFindings(), createOutput() (+37 more)
 
-### Community 5 - "Community 5"
-Cohesion: 0.06
-Nodes (27): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatCompactTextList(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary() (+19 more)
-
 ### Community 6 - "Community 6"
 Cohesion: 0.06
-Nodes (23): assertPosLocalStoreOk(), clearAcceptedTerminalIntegrityState(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds() (+15 more)
+Nodes (27): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatCompactTextList(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary() (+19 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.09
@@ -1836,28 +1839,28 @@ Cohesion: 0.11
 Nodes (23): canonicalize(), canonicalJson(), createLocalSyncIngestionService(), ingestLocalEventsWithCtx(), isNonEmptyString(), isNonNegativeFiniteNumber(), isOptionalNonEmptyString(), isRecord() (+15 more)
 
 ### Community 11 - "Community 11"
+Cohesion: 0.07
+Nodes (12): createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), normalizeCashierPresenceRecord(), normalizeDrawerAuthorityState(), normalizeStaffAuthorityRecord(), normalizeTerminalIntegrityState(), normalizeUsername(), PosLocalStoreSchemaError (+4 more)
+
+### Community 12 - "Community 12"
 Cohesion: 0.12
 Nodes (31): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+23 more)
 
-### Community 12 - "Community 12"
+### Community 13 - "Community 13"
 Cohesion: 0.08
 Nodes (20): formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels(), getSkuDetailEntries() (+12 more)
-
-### Community 13 - "Community 13"
-Cohesion: 0.07
-Nodes (12): createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), normalizeCashierPresenceRecord(), normalizeDrawerAuthorityState(), normalizeStaffAuthorityRecord(), normalizeTerminalIntegrityState(), normalizeUsername(), PosLocalStoreSchemaError (+4 more)
 
 ### Community 14 - "Community 14"
 Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
 ### Community 15 - "Community 15"
-Cohesion: 0.17
-Nodes (31): asRecord(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale(), getPhase() (+23 more)
-
-### Community 16 - "Community 16"
 Cohesion: 0.12
 Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
+
+### Community 16 - "Community 16"
+Cohesion: 0.18
+Nodes (30): asRecord(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale(), getPhase() (+22 more)
 
 ### Community 17 - "Community 17"
 Cohesion: 0.15
@@ -2000,20 +2003,20 @@ Cohesion: 0.11
 Nodes (0):
 
 ### Community 52 - "Community 52"
+Cohesion: 0.28
+Nodes (17): asRecord(), buildPosLocalSyncUploadEvents(), customerInfoFromPayload(), getCompletedSaleItems(), getCompletedServiceLines(), hasLaterCompletedSale(), isSyncablePosLocalEvent(), isUploadDeferredByValidation() (+9 more)
+
+### Community 53 - "Community 53"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
-### Community 53 - "Community 53"
+### Community 54 - "Community 54"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 54 - "Community 54"
+### Community 55 - "Community 55"
 Cohesion: 0.13
 Nodes (4): DailyCloseHistoryView(), getDailyCloseHistoryApi(), getHistoryRecordSnapshot(), normalizeHistorySnapshot()
-
-### Community 55 - "Community 55"
-Cohesion: 0.29
-Nodes (15): asRecord(), buildPosLocalSyncUploadEvents(), customerInfoFromPayload(), getCompletedSaleItems(), getCompletedServiceLines(), hasLaterCompletedSale(), nullableStringToOptional(), numberOrZero() (+7 more)
 
 ### Community 56 - "Community 56"
 Cohesion: 0.19
@@ -2032,36 +2035,36 @@ Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
 ### Community 60 - "Community 60"
+Cohesion: 0.24
+Nodes (12): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), buildValidationMetadataMetrics(), getReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), mapSyncStatus(), normalizeStaffAuthorityStatus() (+4 more)
+
+### Community 61 - "Community 61"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 61 - "Community 61"
+### Community 62 - "Community 62"
 Cohesion: 0.26
 Nodes (13): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget() (+5 more)
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.33
 Nodes (14): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+6 more)
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.17
 Nodes (6): buildServerPricedCheckoutProducts(), calculateItemsSubtotal(), deriveDeliveryOptionFromAddress(), isDeliveryFeeWaived(), normalizeDeliveryOption(), resolveServerDeliveryFee()
 
-### Community 64 - "Community 64"
+### Community 65 - "Community 65"
 Cohesion: 0.27
 Nodes (14): cacheAssetRequest(), cacheFirstAsset(), cacheLinkedShellAssets(), cacheModuleDependencies(), isExcluded(), isHtmlResponse(), isJavaScriptLikeResponse(), isPosNavigation() (+6 more)
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.15
 Nodes (4): formatCurrency(), formatFinancialLabel(), formatTimelineRange(), formatTimelineTime()
 
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.24
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
-
-### Community 67 - "Community 67"
-Cohesion: 0.26
-Nodes (11): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), getReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), mapSyncStatus(), normalizeStaffAuthorityStatus(), snapshotAges() (+3 more)
 
 ### Community 68 - "Community 68"
 Cohesion: 0.22
@@ -2124,40 +2127,40 @@ Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
 ### Community 83 - "Community 83"
+Cohesion: 0.23
+Nodes (8): classifyTerminalHealth(), formatAge(), formatStatusLabel(), getPrimaryTerminalAttentionReason(), getReviewEvidenceCount(), getSnapshotAgeSummary(), getTerminalAttentionReasons(), isAppSessionLocalContinuation()
+
+### Community 84 - "Community 84"
 Cohesion: 0.18
 Nodes (3): handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 85 - "Community 85"
+### Community 86 - "Community 86"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.31
 Nodes (12): collectFilesUnder(), collectProofSnapshot(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof(), hashValidationWiring(), normalizeRepoPath(), readPrAthenaScript(), recordPrePushValidationProof() (+4 more)
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.2
 Nodes (4): formatProductLineMeta(), formatServiceLabel(), formatServiceLineMeta(), formatStoredAmount()
-
-### Community 91 - "Community 91"
-Cohesion: 0.24
-Nodes (7): classifyTerminalHealth(), formatAge(), formatStatusLabel(), getPrimaryTerminalAttentionReason(), getReviewEvidenceCount(), getSnapshotAgeSummary(), getTerminalAttentionReasons()
 
 ### Community 92 - "Community 92"
 Cohesion: 0.21
@@ -2312,92 +2315,92 @@ Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
 ### Community 130 - "Community 130"
-Cohesion: 0.22
-Nodes (0):
+Cohesion: 0.36
+Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
 ### Community 131 - "Community 131"
 Cohesion: 0.22
-Nodes (2): ClusterRedis, StandaloneRedis
+Nodes (0):
 
 ### Community 132 - "Community 132"
+Cohesion: 0.22
+Nodes (2): ClusterRedis, StandaloneRedis
+
+### Community 133 - "Community 133"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.43
 Nodes (6): assertActiveTerminal(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 141 - "Community 141"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 142 - "Community 142"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 143 - "Community 143"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 144 - "Community 144"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
-
-### Community 146 - "Community 146"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 147 - "Community 147"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 148 - "Community 148"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
-
-### Community 149 - "Community 149"
 Cohesion: 0.25
 Nodes (0):
+
+### Community 149 - "Community 149"
+Cohesion: 0.39
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 150 - "Community 150"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 151 - "Community 151"
-Cohesion: 0.43
-Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 152 - "Community 152"
 Cohesion: 0.46
@@ -2528,16 +2531,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 184 - "Community 184"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
-
-### Community 185 - "Community 185"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 186 - "Community 186"
+### Community 185 - "Community 185"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 186 - "Community 186"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 187 - "Community 187"
 Cohesion: 0.43
@@ -2572,16 +2575,16 @@ Cohesion: 0.47
 Nodes (4): buildOperationalEvent(), matchesExistingEvent(), metadataDedupeKeysMatch(), recordOperationalEventWithCtx()
 
 ### Community 195 - "Community 195"
+Cohesion: 0.4
+Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
+
+### Community 196 - "Community 196"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 196 - "Community 196"
-Cohesion: 0.4
-Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
-
 ### Community 197 - "Community 197"
 Cohesion: 0.4
-Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
+Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
 ### Community 198 - "Community 198"
 Cohesion: 0.33
@@ -2896,16 +2899,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 276 - "Community 276"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): buildTerminalOfflineReadiness(), getAppSessionReadinessInput()
 
 ### Community 277 - "Community 277"
 Cohesion: 0.4
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 278 - "Community 278"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 279 - "Community 279"
 Cohesion: 0.4
@@ -2916,52 +2919,52 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 281 - "Community 281"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 282 - "Community 282"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 282 - "Community 282"
+### Community 283 - "Community 283"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 283 - "Community 283"
+### Community 284 - "Community 284"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 284 - "Community 284"
+### Community 285 - "Community 285"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 285 - "Community 285"
+### Community 286 - "Community 286"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 286 - "Community 286"
-Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 287 - "Community 287"
 Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 288 - "Community 288"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 289 - "Community 289"
 Cohesion: 0.6
-Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 290 - "Community 290"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
 ### Community 291 - "Community 291"
-Cohesion: 0.6
-Nodes (3): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier()
-
-### Community 292 - "Community 292"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 292 - "Community 292"
+Cohesion: 0.6
+Nodes (3): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier()
 
 ### Community 293 - "Community 293"
 Cohesion: 0.4
@@ -2972,88 +2975,88 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 295 - "Community 295"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 296 - "Community 296"
 Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 296 - "Community 296"
+### Community 297 - "Community 297"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 297 - "Community 297"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 298 - "Community 298"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 299 - "Community 299"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 300 - "Community 300"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 301 - "Community 301"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 302 - "Community 302"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
-
-### Community 303 - "Community 303"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 303 - "Community 303"
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 304 - "Community 304"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 305 - "Community 305"
-Cohesion: 0.6
-Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 306 - "Community 306"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 306 - "Community 306"
+Cohesion: 0.6
+Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+
 ### Community 307 - "Community 307"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 308 - "Community 308"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 308 - "Community 308"
+### Community 309 - "Community 309"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 309 - "Community 309"
+### Community 310 - "Community 310"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 310 - "Community 310"
+### Community 311 - "Community 311"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 311 - "Community 311"
+### Community 312 - "Community 312"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 312 - "Community 312"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 313 - "Community 313"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 314 - "Community 314"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
-
-### Community 315 - "Community 315"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 315 - "Community 315"
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 316 - "Community 316"
 Cohesion: 0.5
@@ -3064,72 +3067,72 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 318 - "Community 318"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 319 - "Community 319"
 Cohesion: 0.67
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 319 - "Community 319"
+### Community 320 - "Community 320"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 320 - "Community 320"
+### Community 321 - "Community 321"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 321 - "Community 321"
+### Community 322 - "Community 322"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 322 - "Community 322"
+### Community 323 - "Community 323"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 323 - "Community 323"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 324 - "Community 324"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 325 - "Community 325"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 326 - "Community 326"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 326 - "Community 326"
+### Community 327 - "Community 327"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 327 - "Community 327"
+### Community 328 - "Community 328"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 328 - "Community 328"
+### Community 329 - "Community 329"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 329 - "Community 329"
+### Community 330 - "Community 330"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 330 - "Community 330"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 331 - "Community 331"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 332 - "Community 332"
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+
+### Community 333 - "Community 333"
 Cohesion: 0.67
 Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
-### Community 333 - "Community 333"
+### Community 334 - "Community 334"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
-
-### Community 334 - "Community 334"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 335 - "Community 335"
 Cohesion: 0.5
@@ -3144,24 +3147,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 338 - "Community 338"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 339 - "Community 339"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 339 - "Community 339"
+### Community 340 - "Community 340"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 340 - "Community 340"
+### Community 341 - "Community 341"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 341 - "Community 341"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 342 - "Community 342"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 343 - "Community 343"
 Cohesion: 0.5
@@ -3176,20 +3179,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 346 - "Community 346"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 347 - "Community 347"
 Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 348 - "Community 348"
 Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 349 - "Community 349"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 350 - "Community 350"
 Cohesion: 0.5
@@ -3212,20 +3215,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 355 - "Community 355"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 356 - "Community 356"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 356 - "Community 356"
+### Community 357 - "Community 357"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 357 - "Community 357"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 358 - "Community 358"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 359 - "Community 359"
 Cohesion: 0.5
@@ -3345,19 +3348,19 @@ Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
 ### Community 388 - "Community 388"
 Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
+Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
 ### Community 389 - "Community 389"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 390 - "Community 390"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 391 - "Community 391"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 392 - "Community 392"
 Cohesion: 0.5
@@ -3388,59 +3391,59 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 399 - "Community 399"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 400 - "Community 400"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 401 - "Community 401"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 402 - "Community 402"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 402 - "Community 402"
+### Community 403 - "Community 403"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 403 - "Community 403"
-Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 404 - "Community 404"
 Cohesion: 0.83
-Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 405 - "Community 405"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
 ### Community 406 - "Community 406"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 407 - "Community 407"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 408 - "Community 408"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 409 - "Community 409"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 409 - "Community 409"
+### Community 410 - "Community 410"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 410 - "Community 410"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 411 - "Community 411"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 412 - "Community 412"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 413 - "Community 413"
@@ -3448,12 +3451,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 414 - "Community 414"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 415 - "Community 415"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 415 - "Community 415"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 416 - "Community 416"
 Cohesion: 0.67
@@ -3488,12 +3491,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 424 - "Community 424"
-Cohesion: 1.0
-Nodes (2): buildCtx(), createDb()
-
-### Community 425 - "Community 425"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 425 - "Community 425"
+Cohesion: 1.0
+Nodes (2): buildCtx(), createDb()
 
 ### Community 426 - "Community 426"
 Cohesion: 0.67
@@ -3508,20 +3511,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 429 - "Community 429"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 430 - "Community 430"
 Cohesion: 1.0
 Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
-### Community 430 - "Community 430"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 431 - "Community 431"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 432 - "Community 432"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 433 - "Community 433"
 Cohesion: 0.67
@@ -3536,24 +3539,24 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 436 - "Community 436"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 437 - "Community 437"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 437 - "Community 437"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 438 - "Community 438"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 439 - "Community 439"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 440 - "Community 440"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 440 - "Community 440"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 441 - "Community 441"
 Cohesion: 0.67
@@ -3568,36 +3571,36 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 444 - "Community 444"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 445 - "Community 445"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 446 - "Community 446"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 447 - "Community 447"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 448 - "Community 448"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 449 - "Community 449"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 450 - "Community 450"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 450 - "Community 450"
-Cohesion: 0.67
-Nodes (1): View()
-
 ### Community 451 - "Community 451"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 452 - "Community 452"
 Cohesion: 0.67
@@ -3612,12 +3615,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 455 - "Community 455"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 456 - "Community 456"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 456 - "Community 456"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 457 - "Community 457"
 Cohesion: 0.67
@@ -3628,16 +3631,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 459 - "Community 459"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 460 - "Community 460"
 Cohesion: 1.0
 Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
-### Community 460 - "Community 460"
-Cohesion: 0.67
-Nodes (1): FadeIn()
-
 ### Community 461 - "Community 461"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 462 - "Community 462"
 Cohesion: 0.67
@@ -3645,15 +3648,15 @@ Nodes (0):
 
 ### Community 463 - "Community 463"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 464 - "Community 464"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (1): VideoPlayer()
 
 ### Community 465 - "Community 465"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 466 - "Community 466"
 Cohesion: 0.67
@@ -3733,79 +3736,79 @@ Nodes (0):
 
 ### Community 485 - "Community 485"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 486 - "Community 486"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 487 - "Community 487"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 488 - "Community 488"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 489 - "Community 489"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 490 - "Community 490"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 491 - "Community 491"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 492 - "Community 492"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 493 - "Community 493"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 493 - "Community 493"
+### Community 494 - "Community 494"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 494 - "Community 494"
+### Community 495 - "Community 495"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 495 - "Community 495"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 496 - "Community 496"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 497 - "Community 497"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 498 - "Community 498"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 499 - "Community 499"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 500 - "Community 500"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 501 - "Community 501"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 502 - "Community 502"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 503 - "Community 503"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 504 - "Community 504"
 Cohesion: 0.67
@@ -3837,11 +3840,11 @@ Nodes (0):
 
 ### Community 511 - "Community 511"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 512 - "Community 512"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 513 - "Community 513"
 Cohesion: 0.67
@@ -3852,32 +3855,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 515 - "Community 515"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 516 - "Community 516"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 516 - "Community 516"
+### Community 517 - "Community 517"
 Cohesion: 0.67
 Nodes (1): isInMaintenanceMode()
 
-### Community 517 - "Community 517"
+### Community 518 - "Community 518"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 518 - "Community 518"
+### Community 519 - "Community 519"
 Cohesion: 1.0
 Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
-### Community 519 - "Community 519"
+### Community 520 - "Community 520"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 520 - "Community 520"
-Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 521 - "Community 521"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 522 - "Community 522"
 Cohesion: 0.67
@@ -3889,71 +3892,71 @@ Nodes (0):
 
 ### Community 524 - "Community 524"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 525 - "Community 525"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): App()
 
 ### Community 526 - "Community 526"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
-
-### Community 527 - "Community 527"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 527 - "Community 527"
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 528 - "Community 528"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 529 - "Community 529"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 530 - "Community 530"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 531 - "Community 531"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 532 - "Community 532"
 Cohesion: 0.67
-Nodes (1): createVersionChecker()
+Nodes (1): hashPassword()
 
 ### Community 533 - "Community 533"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): createVersionChecker()
 
 ### Community 534 - "Community 534"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 535 - "Community 535"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 536 - "Community 536"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 537 - "Community 537"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 537 - "Community 537"
+### Community 538 - "Community 538"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 538 - "Community 538"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 539 - "Community 539"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 540 - "Community 540"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 541 - "Community 541"
 Cohesion: 0.67
@@ -3968,12 +3971,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 544 - "Community 544"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 545 - "Community 545"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 545 - "Community 545"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 546 - "Community 546"
 Cohesion: 0.67
@@ -3984,12 +3987,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 548 - "Community 548"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 549 - "Community 549"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 549 - "Community 549"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 550 - "Community 550"
 Cohesion: 0.67
@@ -4056,16 +4059,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 566 - "Community 566"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 567 - "Community 567"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 568 - "Community 568"
+### Community 567 - "Community 567"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 568 - "Community 568"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 569 - "Community 569"
 Cohesion: 1.0
@@ -4084,20 +4087,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 573 - "Community 573"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 574 - "Community 574"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 575 - "Community 575"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 576 - "Community 576"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 577 - "Community 577"
 Cohesion: 1.0
@@ -8807,2364 +8810,2380 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1754 - "Community 1754"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1755 - "Community 1755"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1756 - "Community 1756"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 576`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 577`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 577`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 578`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 579`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 580`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 581`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 582`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 583`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 584`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 585`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 586`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 587`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 588`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 589`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 590`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 591`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 592`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 593`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 594`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 595`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 596`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 597`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 598`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 599`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 600`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 601`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 602`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 603`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 604`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 605`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 606`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 607`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 608`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 609`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 610`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 611`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 612`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 613`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 614`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 615`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 616`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 617`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 618`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 619`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 620`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 621`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 622`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 623`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 624`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 625`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 626`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
+- **Thin community `Community 627`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
+- **Thin community `Community 628`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 629`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 630`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 631`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 632`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 633`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
+- **Thin community `Community 634`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 635`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 636`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 637`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 638`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 639`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 640`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 641`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 642`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 643`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 644`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 645`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 646`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 647`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 648`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 649`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 650`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 651`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 652`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 653`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 654`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 655`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 656`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 657`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 658`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 659`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 660`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 661`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 662`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 663`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 664`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 665`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 666`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 667`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 668`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 669`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 670`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 671`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 672`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 673`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 674`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 675`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 676`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 677`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 678`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 679`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 680`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 681`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 682`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 683`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 684`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 685`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 686`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 687`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 688`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 689`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 690`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 691`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 692`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 693`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 694`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 695`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 696`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 697`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 698`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 699`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 700`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 701`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 702`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 703`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 704`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 705`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 706`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 707`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 708`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 709`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 710`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 711`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 712`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 713`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 714`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 715`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 716`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 717`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 718`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 719`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 720`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 721`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 722`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 723`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 724`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 725`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 726`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 727`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 728`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 729`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 730`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 731`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 732`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 733`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 734`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 735`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 736`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 737`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 738`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 739`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 740`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 741`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 742`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 743`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 744`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 745`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 746`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 747`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 748`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 749`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 750`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 751`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 752`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 753`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 754`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 755`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 756`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 757`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 758`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 759`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 760`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 761`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 762`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 763`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 764`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 765`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 766`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 767`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 768`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 769`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 770`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 771`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 772`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 773`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 774`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 775`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 776`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 777`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 778`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 779`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 780`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 781`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 782`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 783`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 784`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 785`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 786`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 787`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 788`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 789`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 790`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 791`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 792`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 793`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 794`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 795`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 796`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 797`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 798`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 799`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 800`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 801`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 802`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 803`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 804`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 805`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 806`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 807`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 808`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 809`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 810`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 811`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 812`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 813`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 814`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 815`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 816`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 817`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 818`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 819`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 820`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 821`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 822`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 823`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 824`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 825`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 826`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 827`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 828`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 829`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 830`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 831`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 832`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 833`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 834`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 835`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 836`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 837`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 838`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 839`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 840`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 841`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 842`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 843`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 844`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 845`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 846`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 847`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 848`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 849`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 850`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 851`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 852`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 853`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 854`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 855`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 856`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 857`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 858`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 859`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 860`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 861`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 862`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 863`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 864`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 865`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 866`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 867`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 868`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 869`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 870`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 871`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 872`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 873`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 874`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 875`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 876`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 877`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 878`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 879`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 880`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 881`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 882`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 883`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 884`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 885`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 886`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 887`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 888`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 889`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 890`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 891`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 892`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 893`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 894`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 895`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 896`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 897`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 898`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 899`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 900`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 901`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 902`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 903`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 904`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 905`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 906`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 907`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 908`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 909`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 910`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 911`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 912`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 913`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 914`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 915`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 916`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 917`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 918`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 919`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 920`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 921`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 922`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 923`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 924`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 925`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 926`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 927`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 928`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 929`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 930`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 931`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 932`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 933`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 934`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 935`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 936`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 937`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 938`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 939`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 940`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 941`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 942`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 943`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 944`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 945`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 946`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 947`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 948`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 949`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 950`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 951`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 952`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 953`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 954`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 955`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 956`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 957`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 958`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 959`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 960`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 961`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 962`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 963`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 964`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 965`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 966`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 967`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 968`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 969`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 970`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 971`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 972`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 973`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 974`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 975`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 976`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 977`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 978`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 979`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 980`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 981`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 982`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 983`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 984`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 985`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 986`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 987`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 988`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 989`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 990`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 991`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 992`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (1 nodes): `api.d.ts`
+- **Thin community `Community 993`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (1 nodes): `api.js`
+- **Thin community `Community 994`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 995`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `server.d.ts`
+- **Thin community `Community 996`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `server.js`
+- **Thin community `Community 997`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `app.ts`
+- **Thin community `Community 998`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 999`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1000`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1001`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1002`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `auth.ts`
+- **Thin community `Community 1003`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1004`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1005`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1006`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `countries.ts`
+- **Thin community `Community 1007`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `email.ts`
+- **Thin community `Community 1008`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1009`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `payment.ts`
+- **Thin community `Community 1010`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `crons.ts`
+- **Thin community `Community 1011`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1012`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `internal.ts`
+- **Thin community `Community 1013`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1014`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1015`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1016`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1017`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1018`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1019`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1020`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1021`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1022`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1023`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1024`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `env.ts`
+- **Thin community `Community 1025`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1026`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `auth.ts`
+- **Thin community `Community 1027`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1028`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `colors.ts`
+- **Thin community `Community 1029`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `index.ts`
+- **Thin community `Community 1030`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1031`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `products.ts`
+- **Thin community `Community 1032`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1033`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `stores.ts`
+- **Thin community `Community 1034`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `bag.ts`
+- **Thin community `Community 1035`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `guest.ts`
+- **Thin community `Community 1036`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `index.ts`
+- **Thin community `Community 1037`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `me.ts`
+- **Thin community `Community 1038`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `offers.ts`
+- **Thin community `Community 1039`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1040`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1041`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1042`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1043`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1044`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1045`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1046`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1047`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1048`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `user.ts`
+- **Thin community `Community 1049`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1050`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `index.ts`
+- **Thin community `Community 1051`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1052`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `http.ts`
+- **Thin community `Community 1053`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1054`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1055`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1056`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `categories.ts`
+- **Thin community `Community 1057`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `colors.ts`
+- **Thin community `Community 1058`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1059`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 1060`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1061`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1062`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1063`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1064`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `pos.ts`
+- **Thin community `Community 1065`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1066`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1067`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1068`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1069`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1070`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1071`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1072`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1073`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1074`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1075`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1076`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1077`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1078`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1079`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1080`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1081`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `types.ts`
+- **Thin community `Community 1082`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1083`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1084`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1085`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1086`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1087`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1088`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `dto.ts`
+- **Thin community `Community 1089`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1090`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1091`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `types.ts`
+- **Thin community `Community 1092`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `types.ts`
+- **Thin community `Community 1093`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1094`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `customers.ts`
+- **Thin community `Community 1095`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `register.ts`
+- **Thin community `Community 1096`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `sync.ts`
+- **Thin community `Community 1097`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `schema.ts`
+- **Thin community `Community 1098`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1099`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `index.ts`
+- **Thin community `Community 1100`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1101`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1102`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1103`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1104`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1105`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `category.ts`
+- **Thin community `Community 1106`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `color.ts`
+- **Thin community `Community 1107`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1108`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1109`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `index.ts`
+- **Thin community `Community 1110`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1111`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1112`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `organization.ts`
+- **Thin community `Community 1113`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1114`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `product.ts`
+- **Thin community `Community 1115`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1116`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1117`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `store.ts`
+- **Thin community `Community 1118`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1119`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `index.ts`
+- **Thin community `Community 1120`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1121`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1122`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1123`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1124`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1125`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1126`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1127`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `index.ts`
+- **Thin community `Community 1128`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1129`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1130`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1131`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1132`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1133`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1134`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1135`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1136`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1137`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1138`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1139`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `customer.ts`
+- **Thin community `Community 1140`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1141`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1142`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1143`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1144`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `index.ts`
+- **Thin community `Community 1145`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1146`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1147`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1148`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1149`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1150`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1151`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1152`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1153`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1154`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1155`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1156`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1157`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1158`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1159`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1160`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1161`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1162`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `index.ts`
+- **Thin community `Community 1163`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1164`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1165`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1166`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1167`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1168`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1169`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `index.ts`
+- **Thin community `Community 1170`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1171`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1172`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1173`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1174`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1175`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1176`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `bag.ts`
+- **Thin community `Community 1177`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1178`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1179`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1180`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `guest.ts`
+- **Thin community `Community 1181`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `index.ts`
+- **Thin community `Community 1182`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `offer.ts`
+- **Thin community `Community 1183`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1184`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1185`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `review.ts`
+- **Thin community `Community 1186`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1187`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1188`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1189`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1190`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1191`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1192`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1193`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1194`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1195`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `bag.ts`
+- **Thin community `Community 1196`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1197`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `customer.ts`
+- **Thin community `Community 1198`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `guest.ts`
+- **Thin community `Community 1199`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1200`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1201`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1202`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1203`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `payment.ts`
+- **Thin community `Community 1204`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1205`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1206`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1207`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `users.ts`
+- **Thin community `Community 1208`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `payment.ts`
+- **Thin community `Community 1209`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1210`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1211`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1212`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1213`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1214`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `index.ts`
+- **Thin community `Community 1215`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1216`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1217`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1218`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `auth.ts`
+- **Thin community `Community 1219`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1220`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1221`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1222`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1223`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1224`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1225`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1226`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1227`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1228`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1229`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1230`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1231`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1232`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1233`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1234`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `constants.ts`
+- **Thin community `Community 1235`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1236`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1237`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1238`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `types.ts`
+- **Thin community `Community 1239`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1240`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1241`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1242`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1243`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1244`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1245`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1246`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1247`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1248`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1249`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1250`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1251`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1252`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1253`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1254`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1255`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1256`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1257`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1258`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1259`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `constants.ts`
+- **Thin community `Community 1260`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1261`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1262`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1263`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `data.ts`
+- **Thin community `Community 1264`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1265`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1266`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1267`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1268`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1269`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1270`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1271`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1272`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1273`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `constants.ts`
+- **Thin community `Community 1274`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1275`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1276`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1277`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `data.ts`
+- **Thin community `Community 1278`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1279`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1280`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1281`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1282`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1283`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1284`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1285`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1286`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1287`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1288`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1289`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1290`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `constants.ts`
+- **Thin community `Community 1291`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1292`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1293`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1294`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1295`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1296`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1297`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1298`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1299`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1300`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1301`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1302`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1303`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1304`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1305`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1306`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1307`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1308`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1309`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1310`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1311`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1312`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1313`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1314`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1315`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1316`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1317`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1318`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1319`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1320`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1321`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1322`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `constants.ts`
+- **Thin community `Community 1323`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1324`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1325`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1326`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `data.ts`
+- **Thin community `Community 1327`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1328`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1329`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `constants.ts`
+- **Thin community `Community 1330`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1331`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1332`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1333`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1334`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `data.ts`
+- **Thin community `Community 1335`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1336`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `constants.ts`
+- **Thin community `Community 1337`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1338`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1339`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1340`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1341`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `data.ts`
+- **Thin community `Community 1342`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1343`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1344`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1345`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1346`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1347`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1348`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1349`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1350`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1351`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1352`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1353`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1354`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1355`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1356`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1357`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1358`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1359`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1360`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1361`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1362`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1363`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1364`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1365`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1366`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1367`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `POSSettingsView.test.tsx`
+- **Thin community `Community 1368`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1369`** (1 nodes): `POSSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `POSTerminalHealthView.test.tsx`
+- **Thin community `Community 1370`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1371`** (1 nodes): `POSTerminalHealthView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1372`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1373`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `types.ts`
+- **Thin community `Community 1374`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1375`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1376`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1377`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1378`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1379`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1380`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1381`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1382`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1383`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1384`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1385`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1386`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1387`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1388`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1389`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `data.ts`
+- **Thin community `Community 1390`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1391`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1392`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1393`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1394`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1395`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1396`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1397`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1398`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1399`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1400`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1401`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1402`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `constants.ts`
+- **Thin community `Community 1403`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1404`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1405`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1406`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `data.ts`
+- **Thin community `Community 1407`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `types.ts`
+- **Thin community `Community 1408`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1409`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1410`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1411`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1412`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1413`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `index.tsx`
+- **Thin community `Community 1414`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1415`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1416`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1417`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1418`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1419`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1420`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1421`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1422`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `index.tsx`
+- **Thin community `Community 1423`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1424`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1425`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1426`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `button.tsx`
+- **Thin community `Community 1427`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1428`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `card.tsx`
+- **Thin community `Community 1429`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1430`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1431`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `command.tsx`
+- **Thin community `Community 1432`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1433`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1434`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1435`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `form.tsx`
+- **Thin community `Community 1436`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1437`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1438`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `input.tsx`
+- **Thin community `Community 1439`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1440`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1441`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1442`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1443`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1444`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1445`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `select.tsx`
+- **Thin community `Community 1446`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1447`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1448`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1449`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `table.tsx`
+- **Thin community `Community 1450`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1451`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1452`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1453`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1454`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1455`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1456`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1457`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1458`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `constants.ts`
+- **Thin community `Community 1459`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1460`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1461`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1462`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `data.ts`
+- **Thin community `Community 1463`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1464`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1465`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1466`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1467`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1468`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1469`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1470`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1471`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1472`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1473`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1474`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `index.ts`
+- **Thin community `Community 1475`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1476`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1477`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1478`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1479`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1480`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1481`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1482`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1483`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1484`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1485`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1486`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `aws.ts`
+- **Thin community `Community 1487`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `constants.ts`
+- **Thin community `Community 1488`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `countries.ts`
+- **Thin community `Community 1489`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1490`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1491`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1492`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1493`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1494`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1495`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `dto.ts`
+- **Thin community `Community 1496`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `ports.ts`
+- **Thin community `Community 1497`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `constants.ts`
+- **Thin community `Community 1498`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1499`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1500`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `index.ts`
+- **Thin community `Community 1501`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1502`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `types.ts`
+- **Thin community `Community 1503`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1504`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1505`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1506`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1507`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1508`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1509`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1510`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1511`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1512`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1513`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `category.ts`
+- **Thin community `Community 1514`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `product.ts`
+- **Thin community `Community 1515`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `store.ts`
+- **Thin community `Community 1516`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1517`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `user.ts`
+- **Thin community `Community 1518`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1519`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1520`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1521`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1522`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1523`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1524`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1525`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1526`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1527`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1528`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `index.tsx`
+- **Thin community `Community 1529`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `index.tsx`
+- **Thin community `Community 1530`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `index.tsx`
+- **Thin community `Community 1531`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1532`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1533`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1534`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1535`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1536`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `index.tsx`
+- **Thin community `Community 1537`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1538`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1539`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1540`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `home.tsx`
+- **Thin community `Community 1541`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1542`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1543`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1544`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `index.tsx`
+- **Thin community `Community 1545`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1546`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `index.tsx`
+- **Thin community `Community 1547`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1548`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1549`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1550`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `index.tsx`
+- **Thin community `Community 1551`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1552`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1553`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1554`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1555`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1556`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1557`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `index.tsx`
+- **Thin community `Community 1558`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1559`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1560`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1561`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1562`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1563`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1564`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1565`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1566`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1567`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `index.tsx`
+- **Thin community `Community 1568`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1569`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `index.tsx`
+- **Thin community `Community 1570`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `new.tsx`
+- **Thin community `Community 1571`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `index.tsx`
+- **Thin community `Community 1572`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `new.tsx`
+- **Thin community `Community 1573`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1574`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1575`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `index.tsx`
+- **Thin community `Community 1576`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `new.tsx`
+- **Thin community `Community 1577`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `index.tsx`
+- **Thin community `Community 1578`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1579`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1580`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1581`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1582`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `index.tsx`
+- **Thin community `Community 1583`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1584`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1585`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1586`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `index.tsx`
+- **Thin community `Community 1587`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1588`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1589`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1590`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1591`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1592`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1593`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1594`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1595`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1596`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1597`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1598`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1599`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1600`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1601`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1602`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1603`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1604`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1605`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1606`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1607`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1608`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1609`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1610`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1611`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `setup.ts`
+- **Thin community `Community 1612`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1613`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `types.ts`
+- **Thin community `Community 1614`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1615`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1616`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1617`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1618`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1619`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `types.ts`
+- **Thin community `Community 1620`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1621`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1622`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1623`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1624`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1625`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1626`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1627`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1628`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1629`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `schema.ts`
+- **Thin community `Community 1630`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1631`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1632`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1633`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1634`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1635`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1636`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1637`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1638`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1639`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `types.ts`
+- **Thin community `Community 1640`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1641`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1642`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1643`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1644`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1645`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1646`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1647`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `constants.ts`
+- **Thin community `Community 1648`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1649`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `About.tsx`
+- **Thin community `Community 1650`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1651`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1652`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1653`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1654`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1655`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1656`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1657`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1658`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1659`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1660`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `types.ts`
+- **Thin community `Community 1661`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1662`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1663`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1664`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1665`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1666`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1667`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1668`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1669`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1670`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1671`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1672`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `button.tsx`
+- **Thin community `Community 1673`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `card.tsx`
+- **Thin community `Community 1674`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1675`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `command.tsx`
+- **Thin community `Community 1676`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1677`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1678`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1679`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `form.tsx`
+- **Thin community `Community 1680`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1681`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1682`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1683`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1684`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `input.tsx`
+- **Thin community `Community 1685`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `label.tsx`
+- **Thin community `Community 1686`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1687`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1688`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1689`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `index.ts`
+- **Thin community `Community 1690`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `types.ts`
+- **Thin community `Community 1691`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1692`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1693`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1694`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1695`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `select.tsx`
+- **Thin community `Community 1696`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1697`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1698`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `table.tsx`
+- **Thin community `Community 1699`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1700`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1701`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1702`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1703`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1704`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `config.ts`
+- **Thin community `Community 1705`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1706`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1707`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1708`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1709`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `constants.ts`
+- **Thin community `Community 1710`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `countries.ts`
+- **Thin community `Community 1711`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1712`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1713`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1714`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1715`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `index.ts`
+- **Thin community `Community 1716`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `store.ts`
+- **Thin community `Community 1717`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `bag.ts`
+- **Thin community `Community 1718`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1719`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `category.ts`
+- **Thin community `Community 1720`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `organization.ts`
+- **Thin community `Community 1721`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `product.ts`
+- **Thin community `Community 1722`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `store.ts`
+- **Thin community `Community 1723`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1724`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `user.ts`
+- **Thin community `Community 1725`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `states.ts`
+- **Thin community `Community 1726`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1727`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1728`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1729`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1730`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1731`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1732`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1733`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `index.tsx`
+- **Thin community `Community 1734`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1735`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `index.tsx`
+- **Thin community `Community 1736`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1737`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1738`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1739`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1740`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1741`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `index.tsx`
+- **Thin community `Community 1742`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1743`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1744`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1745`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1746`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1747`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `index.js`
+- **Thin community `Community 1748`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1749`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1750`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1751`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1752`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1753`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1754`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1755`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1756`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -11181,6 +11200,6 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 3` be split into smaller, more focused modules?**
   _Cohesion score 0.11 - nodes in this community are weakly interconnected._
 - **Should `Community 4` be split into smaller, more focused modules?**
-  _Cohesion score 0.1 - nodes in this community are weakly interconnected._
-- **Should `Community 5` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
+- **Should `Community 5` be split into smaller, more focused modules?**
+  _Cohesion score 0.1 - nodes in this community are weakly interconnected._

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,20 +7,20 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1826
-- Graph nodes: 6143
-- Graph edges: 6613
-- Communities: 1754
+- Code files discovered: 1829
+- Graph nodes: 6157
+- Graph edges: 6631
+- Communities: 1757
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (84 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `useRegisterViewModel.ts` (58 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
+- `useRegisterViewModel.ts` (59 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `projectLocalEvents.ts` (49 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
-- `harness-inferential-review.ts` (46 edges, Community 4) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
-- `RegisterSessionView.tsx` (45 edges, Community 5) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
+- `harness-inferential-review.ts` (46 edges, Community 5) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
+- `usePosLocalSyncRuntime.ts` (46 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
+- `RegisterSessionView.tsx` (45 edges, Community 6) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
 - `storefrontJourneyEvents.ts` (45 edges, Community 7) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `usePosLocalSyncRuntime.ts` (45 edges, Community 6) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
 
 ## Registered Packages
 - [Athena Webapp](packages/athena-webapp.md)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -19,9 +19,9 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 ## Graph Hotspots
 - `DailyCloseView.tsx` (84 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `useRegisterViewModel.ts` (58 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
+- `useRegisterViewModel.ts` (59 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `projectLocalEvents.ts` (49 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
-- `RegisterSessionView.tsx` (45 edges, Community 5) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
+- `usePosLocalSyncRuntime.ts` (46 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -20,7 +20,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - `storefrontJourneyEvents.ts` (45 edges, Community 7) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 7) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 38) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `checkoutSession.ts` (14 edges, Community 60) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `checkoutSession.ts` (14 edges, Community 61) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 - `storeConfig.ts` (14 edges, Community 38) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (14 edges, Community 70) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 131) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 132) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 70) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `createRedisCluster()` (3 edges, Community 70) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `deleteKeysIndividually()` (3 edges, Community 70) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/pos/public/sync.test.ts
+++ b/packages/athena-webapp/convex/pos/public/sync.test.ts
@@ -211,25 +211,22 @@ describe("POS local sync public mutation", () => {
     });
   });
 
-  it("rejects sync when the signed-in user does not own the terminal seed", async () => {
+  it("accepts sync from an authorized store member even when they did not register the terminal", async () => {
     const ctx = buildCtx({ terminalRegisteredByUserId: "athena-admin-1" });
 
-    const result = await getHandler(ingestLocalEvents)(ctx as never, {
+    await getHandler(ingestLocalEvents)(ctx as never, {
       storeId: "store-1",
       terminalId: "terminal-1",
       syncSecretHash: "sync-secret-1",
       events: [buildEvent()],
     });
 
-    expect(result).toEqual({
-      kind: "user_error",
-      error: {
-        code: "authorization_failed",
-        message: "You do not have access to sync this POS terminal.",
-        metadata: { terminalAuthorizationFailure: true },
-      },
-    });
-    expect(mocks.ingestLocalEventsWithCtx).not.toHaveBeenCalled();
+    expect(mocks.ingestLocalEventsWithCtx).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        submittedByUserId: "athena-user-1",
+      }),
+    );
   });
 
   it("rejects sync without the provisioned terminal secret", async () => {

--- a/packages/athena-webapp/convex/pos/public/sync.ts
+++ b/packages/athena-webapp/convex/pos/public/sync.ts
@@ -230,7 +230,6 @@ export const ingestLocalEvents = mutation({
       !terminal ||
       terminal.storeId !== args.storeId ||
       terminal.status !== "active" ||
-      terminal.registeredByUserId !== athenaUser._id ||
       !terminal.syncSecretHash ||
       terminal.syncSecretHash !== submittedSyncSecretHash
     ) {

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -13,7 +13,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.
 - [`src/hooks`](../../src/hooks) — React hooks that fan out auth, shell, and feature state. Currently 43 file(s); key children: use-image-upload.ts, use-mobile.tsx, use-navigate-back.ts, use-navigation-keyboard-shortcuts.ts, use-pagination-persistence.ts.
 - [`src/contexts`](../../src/contexts) — Context providers for app-wide state and wiring. Currently 8 file(s); key children: AppShellFullscreenContext.tsx, ManagerElevationContext.test.tsx, ManagerElevationContext.tsx, OnlineOrderContext.tsx, PermissionsContext.tsx.
-- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 124 file(s); key children: access, aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts.
+- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 126 file(s); key children: access, aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts.
 - [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 14 file(s); key children: approvalPolicy.ts, auth.ts, commandResult.test.ts, commandResult.ts, currencyFormatter.test.ts.
 - [`src/utils`](../../src/utils) — Cross-cutting browser helpers and lower-level utilities. Currently 3 file(s); key children: formatNumber.ts, index.ts, versionChecker.ts.
 
@@ -23,6 +23,6 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 6 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCases.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 11 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
 - [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 476 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
-- [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 7 file(s); key children: README.md, SUMMARY.md, pos.
+- [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 8 file(s); key children: README.md, SUMMARY.md, pos.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -279,6 +279,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/lib/pos/infrastructure/local/registerAvailabilitySnapshot.test.ts`](../../src/lib/pos/infrastructure/local/registerAvailabilitySnapshot.test.ts)
 - [`src/lib/pos/infrastructure/local/registerReadModel.test.ts`](../../src/lib/pos/infrastructure/local/registerReadModel.test.ts)
 - [`src/lib/pos/infrastructure/local/registerServiceCatalogSnapshot.test.ts`](../../src/lib/pos/infrastructure/local/registerServiceCatalogSnapshot.test.ts)
+- [`src/lib/pos/infrastructure/local/saleBlockerPolicy.test.ts`](../../src/lib/pos/infrastructure/local/saleBlockerPolicy.test.ts)
 - [`src/lib/pos/infrastructure/local/syncContract.test.ts`](../../src/lib/pos/infrastructure/local/syncContract.test.ts)
 - [`src/lib/pos/infrastructure/local/syncScheduler.test.ts`](../../src/lib/pos/infrastructure/local/syncScheduler.test.ts)
 - [`src/lib/pos/infrastructure/local/syncStatus.test.ts`](../../src/lib/pos/infrastructure/local/syncStatus.test.ts)
@@ -317,6 +318,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/tests/pos/backend.test.ts`](../../src/tests/pos/backend.test.ts)
 - [`src/tests/pos/inventoryValidationLogic.test.ts`](../../src/tests/pos/inventoryValidationLogic.test.ts)
 - [`src/tests/pos/offlineRouteAccess.spec.ts`](../../src/tests/pos/offlineRouteAccess.spec.ts)
+- [`src/tests/pos/offlineSalesContinuity.spec.ts`](../../src/tests/pos/offlineSalesContinuity.spec.ts)
 - [`src/tests/pos/simple.test.ts`](../../src/tests/pos/simple.test.ts)
 - [`src/tests/pos/usePrint.test.ts`](../../src/tests/pos/usePrint.test.ts)
 

--- a/packages/athena-webapp/docs/agent/validation-guide.md
+++ b/packages/athena-webapp/docs/agent/validation-guide.md
@@ -214,12 +214,12 @@ Use this when POS hub app-session recovery, route-shell continuity, terminal rec
 
 ## POS offline route access and app-shell edits
 
-Touched surfaces: `public/pos-app-shell-sw.js`, `playwright.config.ts`, `src/main.tsx`, `src/offline`, `src/routes/_authed.tsx`, `src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos`, `src/components/pos/PointOfSaleView.tsx`, `src/components/pos/register`, `src/components/pos/settings/POSSettingsView.tsx`, `src/components/pos/terminals/POSTerminalHealthView.tsx`, `src/lib/pos/infrastructure/local`, `src/lib/pos/presentation/register`, `src/tests/pos/offlineRouteAccess.spec.ts`
+Touched surfaces: `public/pos-app-shell-sw.js`, `playwright.config.ts`, `src/main.tsx`, `src/offline`, `src/routes/_authed.tsx`, `src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos`, `src/components/pos/PointOfSaleView.tsx`, `src/components/pos/register`, `src/components/pos/settings/POSSettingsView.tsx`, `src/components/pos/terminals/POSTerminalHealthView.tsx`, `src/lib/pos/infrastructure/local`, `src/lib/pos/presentation/register`, `src/tests/pos/offlineRouteAccess.spec.ts`, `src/tests/pos/offlineSalesContinuity.spec.ts`
 
 Run:
 
 - `bun run --filter '@athena/webapp' test -- src/offline/posAppShellRoutes.test.ts src/offline/registerPosAppShellServiceWorker.test.ts src/offline/posOfflineReadiness.test.ts src/routes/_authed.test.tsx src/components/pos/PointOfSaleView.test.tsx src/components/pos/settings/POSSettingsView.test.tsx src/components/pos/terminals/POSTerminalHealthView.test.tsx src/components/pos/register/POSRegisterOpeningGuard.test.tsx src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
-- `bun run --filter '@athena/webapp' test:e2e -- src/tests/pos/offlineRouteAccess.spec.ts`
+- `bun run --filter '@athena/webapp' test:e2e -- src/tests/pos/offlineRouteAccess.spec.ts src/tests/pos/offlineSalesContinuity.spec.ts`
 - `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
 - `bun run --filter '@athena/webapp' build`
 

--- a/packages/athena-webapp/docs/agent/validation-map.json
+++ b/packages/athena-webapp/docs/agent/validation-map.json
@@ -517,7 +517,8 @@
         "packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx",
         "packages/athena-webapp/src/lib/pos/infrastructure/local",
         "packages/athena-webapp/src/lib/pos/presentation/register",
-        "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts"
+        "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
+        "packages/athena-webapp/src/tests/pos/offlineSalesContinuity.spec.ts"
       ],
       "commands": [
         {
@@ -526,7 +527,7 @@
         },
         {
           "kind": "raw",
-          "command": "bun run --filter '@athena/webapp' test:e2e -- src/tests/pos/offlineRouteAccess.spec.ts"
+          "command": "bun run --filter '@athena/webapp' test:e2e -- src/tests/pos/offlineRouteAccess.spec.ts src/tests/pos/offlineSalesContinuity.spec.ts"
         },
         {
           "kind": "raw",

--- a/packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx
+++ b/packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -565,7 +565,9 @@ describe("CashierAuthDialog", () => {
     const usernameInput = screen.getByLabelText(/username/i);
     await user.type(usernameInput, "frontdesk");
     await waitFor(() => expect(usernameInput).toHaveValue("frontdesk"));
-    await user.type(screen.getByLabelText(/pin/i), "1234");
+    fireEvent.change(screen.getByLabelText(/pin/i), {
+      target: { value: "1234" },
+    });
 
     await waitFor(() =>
       expect(onAuthenticated).toHaveBeenCalledWith(

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -867,6 +867,90 @@ describe("POSRegisterView", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("shows app-session-unverified local continuation only in support diagnostics", async () => {
+    mockUseRegisterViewModel.mockReturnValue({
+      hasActiveStore: true,
+      header: {
+        title: "POS",
+        isSessionActive: true,
+      },
+      registerInfo: {
+        registerLabel: "Front Counter",
+        hasTerminal: true,
+      },
+      customerPanel: {},
+      productEntry: {
+        disabled: false,
+        productSearchQuery: "",
+        setProductSearchQuery: vi.fn(),
+        onBarcodeSubmit: vi.fn(),
+      },
+      cart: {
+        items: [],
+      },
+      checkout: {
+        isTransactionCompleted: false,
+      },
+      sessionPanel: {},
+      cashierCard: {
+        cashierName: "Ama Serwa",
+        onSignOut: vi.fn(),
+      },
+      closeoutControl: null,
+      authDialog: {
+        open: false,
+      },
+      drawerGate: null,
+      debug: {
+        activeStoreSource: "local",
+        appSessionRecovery: "waiting_for_network",
+        authDialogOpen: false,
+        cashierPresence: "restored",
+        hasLiveActiveStore: false,
+        localStaffAuthorityStatus: "ready",
+        localEntryStatus: "ready",
+        online: false,
+        staffSignedIn: true,
+        syncFlow: {
+          eventAppendToken: 3,
+          localOnlyEventCount: 2,
+          pendingEventCount: 2,
+          pendingUploadEventCount: 0,
+          source: "runtime",
+          staffProof: "present",
+          status: "pending_sync",
+        },
+        terminalId: "terminal-1",
+        terminalSource: "local",
+      },
+      onNavigateBack: vi.fn(),
+    });
+
+    const { POSRegisterView } = await import("./POSRegisterView");
+    render(<POSRegisterView />);
+
+    expect(screen.getByText("register-checkout-panel")).toBeInTheDocument();
+    expect(screen.getByText("Ready for product lookup")).toBeInTheDocument();
+    expect(
+      screen.queryByText("App session unverified"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/reconciliation/i)).not.toBeInTheDocument();
+
+    pressDebugPanelShortcut();
+
+    expect(screen.getByText("app session")).toBeInTheDocument();
+    expect(screen.getByText("Local sale continuation")).toBeInTheDocument();
+    expect(screen.getByText("reconciliation posture")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "App session unverified; local sales stay on this register until cloud validation returns.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/assertion|token|secret|password|otp/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows an operable register as ready when manager review exists elsewhere", async () => {
     const onRetrySync = vi.fn();
     mockUseRegisterViewModel.mockReturnValue({

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -47,6 +47,7 @@ import {
   type RegisterViewModel,
   type RegisterWorkflowMode,
 } from "@/lib/pos/presentation/register/registerUiState";
+import { usePosTerminalAppSessionRecoveryRuntimeInput } from "@/lib/pos/infrastructure/terminal/posTerminalAppSessionRecoveryContext";
 import { useRegisterViewModel } from "@/lib/pos/presentation/register/useRegisterViewModel";
 import { currencyFormatter } from "~/shared/currencyFormatter";
 import { formatStoredAmount } from "~/src/lib/pos/displayAmounts";
@@ -469,6 +470,36 @@ function formatDebugRuntimeMode(value?: string | null) {
   }
 }
 
+function formatDebugAppSessionRecovery(value?: string | null) {
+  switch (value) {
+    case "waiting_for_network":
+      return "Local sale continuation";
+    case "recoverable":
+    case "idle":
+      return "Verified";
+    case "validating":
+      return "Validating";
+    case "retrying":
+      return "Retrying";
+    case "blocked":
+      return "Blocked";
+    default:
+      return "Not reported";
+  }
+}
+
+function getDebugAppSessionReconciliationPosture(value?: string | null) {
+  if (value === "waiting_for_network") {
+    return "App session unverified; local sales stay on this register until cloud validation returns.";
+  }
+
+  if (value === "blocked") {
+    return "App-session recovery is blocked. Keep terminal, drawer, and staff evidence separate before taking support action.";
+  }
+
+  return "No app-session reconciliation posture reported.";
+}
+
 function formatDebugCheckInPublishStatus(value?: string | null) {
   switch (value) {
     case "accepted":
@@ -567,9 +598,11 @@ function usePosDebugPanelToggle() {
 }
 
 function POSLocalDebugStrip({
+  appSessionRecovery,
   debug,
   isVisible,
 }: {
+  appSessionRecovery?: string | null;
   debug: RegisterViewModel["debug"];
   isVisible: boolean;
 }) {
@@ -583,6 +616,11 @@ function POSLocalDebugStrip({
     ["register record", formatDebugStatus(debug.terminalSource)],
     ["staff sign-in", debug.staffSignedIn ? "Signed in" : "Not signed in"],
     ["cashier presence", formatDebugStatus(debug.cashierPresence)],
+    ["app session", formatDebugAppSessionRecovery(appSessionRecovery)],
+    [
+      "reconciliation posture",
+      getDebugAppSessionReconciliationPosture(appSessionRecovery),
+    ],
     [
       "staff authorization",
       debug.syncFlow.staffProof === "present" ? "Ready" : "Needed",
@@ -1040,6 +1078,8 @@ function POSRegisterViewContent({
 }: POSRegisterViewProps) {
   const registerViewModel = useRegisterViewModel();
   const viewModel = injectedViewModel ?? registerViewModel;
+  const appSessionRecovery = usePosTerminalAppSessionRecoveryRuntimeInput();
+  const debugAppSessionRecovery = viewModel.debug?.appSessionRecovery;
   const effectiveWorkflowMode: RegisterWorkflowMode =
     workflowMode ?? viewModel.workflowMode ?? "pos";
   const isPosWorkflow = effectiveWorkflowMode === "pos";
@@ -1529,6 +1569,9 @@ function POSRegisterViewContent({
         <div className="flex h-full min-h-0 flex-col gap-6 overflow-hidden">
           {isPosWorkflow ? (
             <POSLocalDebugStrip
+              appSessionRecovery={
+                debugAppSessionRecovery ?? appSessionRecovery?.status ?? null
+              }
               debug={viewModel.debug}
               isVisible={isDebugPanelVisible}
             />

--- a/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
@@ -434,7 +434,7 @@ describe("registerAndProvisionPosTerminal", () => {
     expect(screen.getByText("Offline diagnostics need attention")).toBeInTheDocument();
     expect(
       screen.getByText((_content, element) =>
-        Boolean(element?.textContent?.trim() === "0 of 6 reporting"),
+        Boolean(element?.textContent?.trim() === "0 of 7 reporting"),
       ),
     ).toBeInTheDocument();
     expect(
@@ -525,16 +525,16 @@ describe("registerAndProvisionPosTerminal", () => {
     );
 
     expect(
-      await screen.findByText("Register ready for offline checkout"),
+      await screen.findByText("This register is ready for checkout"),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "This checkout station has the app shell, terminal setup, staff authority, catalog, and availability data needed for offline POS.",
+        "6 of 7 offline diagnostic signals are reporting here. Missing signals do not block checkout by themselves.",
       ),
     ).toBeInTheDocument();
     expect(
       screen.getByText((_content, element) =>
-        Boolean(element?.textContent?.trim() === "6 of 6 reporting"),
+        Boolean(element?.textContent?.trim() === "6 of 7 reporting"),
       ),
     ).toBeInTheDocument();
   });

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx
@@ -298,6 +298,47 @@ describe("POSTerminalHealthViewContent", () => {
       screen.getByText("Terminal health is not available right now"),
     ).toBeInTheDocument();
   });
+
+  it("shows redacted app-session reconciliation posture without marking cashier continuation as review", () => {
+    render(
+      <POSTerminalHealthViewContent
+        healthSummaries={[
+          {
+            ...baseSummary,
+            health: "online",
+            runtimeStatus: {
+              ...baseSummary.runtimeStatus!,
+              appSessionRecovery: {
+                status: "waiting_for_network",
+              },
+              sync: {
+                ...baseSummary.runtimeStatus!.sync,
+                localOnlyEventCount: 2,
+                pendingEventCount: 2,
+                status: "pending",
+                uploadableEventCount: 0,
+              },
+            },
+          },
+        ]}
+        isLoading={false}
+        orgUrlSlug="acme"
+        storeUrlSlug="osu"
+      />,
+    );
+
+    expect(screen.getByText("Local continuation")).toBeInTheDocument();
+    expect(screen.getAllByText("Needs review")).toHaveLength(1);
+    expect(screen.getByText("App-session posture")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "App session unverified; local sales stay on this terminal until cloud validation returns.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/assertion|token|secret|password|otp/i),
+    ).not.toBeInTheDocument();
+  });
 });
 
 describe("POSTerminalHealthView", () => {

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx
@@ -118,11 +118,10 @@ function buildTerminalOfflineReadiness(
   const appSessionRecovery = runtimeStatus?.appSessionRecovery?.status;
 
   return buildPosOfflineReadinessSummary({
-    appShell: appSessionRecovery
-      ? {
-          ready: appSessionRecovery === "ready",
-        }
+    appSession: appSessionRecovery
+      ? getAppSessionReadinessInput(appSessionRecovery)
       : null,
+    appShell: null,
     terminalSeed: runtimeStatus
       ? { ready: runtimeStatus.localStore.terminalSeedReady }
       : null,
@@ -142,6 +141,18 @@ function buildTerminalOfflineReadiness(
         ? { ageMs: snapshots.availabilityAgeMs, ready: true }
         : null,
   });
+}
+
+function getAppSessionReadinessInput(status: string) {
+  if (status === "waiting_for_network") {
+    return { status: "local_continuation" as const };
+  }
+
+  if (status === "ready") {
+    return { ready: true };
+  }
+
+  return { ready: false };
 }
 
 export function POSTerminalHealthViewContent({
@@ -282,11 +293,13 @@ export function POSTerminalHealthViewContent({
                           </div>
                           <div>
                             <p className="text-xs font-medium uppercase text-muted-foreground">
-                              Active session
+                              App-session posture
                             </p>
                             <p className="mt-1 text-sm text-foreground">
-                              Register session evidence is shown in cash
-                              controls
+                              {runtimeStatus?.appSessionRecovery?.status ===
+                              "waiting_for_network"
+                                ? "Local sale continuation"
+                                : "Register session evidence is shown in cash controls"}
                             </p>
                           </div>
                           <div>

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
@@ -193,6 +193,35 @@ describe("terminal health presentation", () => {
     );
   });
 
+  it("keeps app-session-unverified local continuation out of manager review classification", () => {
+    expect(
+      classifyTerminalHealth({
+        health: "online",
+        runtimeStatus: {
+          appSessionRecovery: { status: "waiting_for_network" },
+          receivedAt: Date.now(),
+          localStore: { available: true, terminalSeedReady: true },
+          sync: {
+            failedEventCount: 0,
+            localOnlyEventCount: 3,
+            pendingEventCount: 3,
+            reviewEventCount: 0,
+            status: "pending",
+            uploadableEventCount: 0,
+          },
+        },
+        syncEvidence: { unresolvedConflictCount: 0 },
+        terminal: { status: "active" },
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        description:
+          "App session unverified; local sales stay on this terminal until cloud validation returns.",
+        label: "Local continuation",
+      }),
+    );
+  });
+
   it("honors backend attention reasons when runtime status is missing", () => {
     expect(
       classifyTerminalHealth({

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
@@ -257,6 +257,15 @@ export function classifyTerminalHealth(
     };
   }
 
+  if (isAppSessionLocalContinuation(runtimeStatus)) {
+    return {
+      description:
+        "App session unverified; local sales stay on this terminal until cloud validation returns.",
+      label: "Local continuation",
+      toneClassName: "border-warning/30 bg-warning/15 text-warning",
+    };
+  }
+
   if (summary.health === "offline") {
     return {
       description: "This terminal is offline.",
@@ -302,4 +311,21 @@ export function classifyTerminalHealth(
     label: "Healthy",
     toneClassName: "border-success/30 bg-success/10 text-success",
   };
+}
+
+function isAppSessionLocalContinuation(
+  runtimeStatus: TerminalHealthClassificationInput["runtimeStatus"],
+) {
+  if (!runtimeStatus) return false;
+  if (runtimeStatus.appSessionRecovery?.status !== "waiting_for_network") {
+    return false;
+  }
+
+  const sync = runtimeStatus.sync;
+  return (
+    (sync?.pendingEventCount ?? 0) > 0 &&
+    (sync?.uploadableEventCount ?? 0) === 0 &&
+    (sync?.reviewEventCount ?? 0) === 0 &&
+    (sync?.failedEventCount ?? 0) === 0
+  );
 }

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts
@@ -4,6 +4,7 @@ import { createLocalCommandGateway } from "./localCommandGateway";
 import {
   createMemoryPosLocalStorageAdapter,
   createPosLocalStore,
+  type PosLocalEventValidationMetadata,
 } from "./posLocalStore";
 
 function saleCommandInput() {
@@ -153,6 +154,178 @@ describe("createLocalCommandGateway", () => {
     });
 
     expect(onEventAppended).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists app-session validation metadata on sale-affecting commands", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    await appendOpenDrawer(store);
+    const gateway = createLocalCommandGateway({
+      store,
+      staffProofToken: "proof-1",
+    });
+
+    await expect(
+      gateway.completeTransaction({
+        ...saleCommandInput(),
+        localTransactionId: "transaction-1",
+        validationMetadata: {
+          flags: [
+            "app-session-unverified",
+            "cloud-validation-uncertain",
+          ],
+          observedAt: 2_000,
+          uploadDeferredUntil: "app-session-validated",
+        },
+        payload: {
+          localTransactionId: "transaction-1",
+          receiptNumber: "LOCAL-1",
+          subtotal: 100,
+          tax: 0,
+          total: 100,
+          payments: [{ method: "cash", amount: 100, timestamp: 1 }],
+        },
+      }),
+    ).resolves.toBe(true);
+
+    await expect(store.listEvents()).resolves.toMatchObject({
+      ok: true,
+      value: expect.arrayContaining([
+        expect.objectContaining({
+          type: "transaction.completed",
+          validationMetadata: {
+            flags: [
+              "app-session-unverified",
+              "cloud-validation-uncertain",
+            ],
+            observedAt: 2_000,
+            uploadDeferredUntil: "app-session-validated",
+          },
+        }),
+      ]),
+    });
+  });
+
+  it("persists app-session validation metadata on drawer lifecycle commands", async () => {
+    const validationMetadata: PosLocalEventValidationMetadata = {
+      flags: [
+        "app-session-unverified",
+        "cloud-validation-uncertain",
+      ],
+      observedAt: 2_000,
+      uploadDeferredUntil: "app-session-validated",
+    };
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    const gateway = createLocalCommandGateway({
+      store,
+      staffProofToken: "proof-1",
+    });
+
+    const opened = await gateway.openDrawer({
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      staffProfileId: "staff-1" as never,
+      registerNumber: "1",
+      validationMetadata,
+      openingFloat: 100,
+    });
+    expect(opened.kind).toBe("ok");
+    if (opened.kind !== "ok") {
+      throw new Error("Expected drawer to open locally");
+    }
+
+    await store.appendEvent({
+      type: "register.closeout_started",
+      terminalId: "terminal-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      localRegisterSessionId: opened.data.localRegisterSessionId,
+      staffProfileId: "staff-1",
+      payload: { countedCash: 100 },
+    });
+
+    await expect(
+      gateway.reopenRegister({
+        terminalId: "terminal-1",
+        storeId: "store-1",
+        registerNumber: "1",
+        localRegisterSessionId: opened.data.localRegisterSessionId,
+        staffProfileId: "staff-1",
+        validationMetadata,
+        reason: "Manager correction",
+      }),
+    ).resolves.toBe(true);
+
+    await expect(store.listEvents()).resolves.toMatchObject({
+      ok: true,
+      value: expect.arrayContaining([
+        expect.objectContaining({
+          type: "register.opened",
+          validationMetadata,
+        }),
+        expect.objectContaining({
+          type: "register.reopened",
+          validationMetadata,
+        }),
+      ]),
+    });
+
+    const seedStore = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    const seedGateway = createLocalCommandGateway({
+      allowExplicitRegisterSessionWithoutProjection: true,
+      store: seedStore,
+      staffProofToken: "proof-1",
+    });
+    await expect(
+      seedGateway.seedRegisterSession({
+        terminalId: "terminal-1",
+        storeId: "store-1",
+        registerNumber: "1",
+        localRegisterSessionId: "drawer-seed-1",
+        staffProfileId: "staff-1",
+        validationMetadata,
+        openingFloat: 100,
+        expectedCash: 100,
+        status: "open",
+      }),
+    ).resolves.toBe(true);
+    await expect(seedStore.listEvents()).resolves.toMatchObject({
+      ok: true,
+      value: [
+        expect.objectContaining({
+          type: "register.opened",
+          validationMetadata,
+        }),
+      ],
+    });
+  });
+
+  it("refuses to open a drawer when staff identity is missing", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    const gateway = createLocalCommandGateway({ store });
+
+    const result = await gateway.openDrawer({
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      staffProfileId: "" as never,
+      registerNumber: "1",
+      openingFloat: 100,
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: expect.objectContaining({
+        message: "Staff sign-in required before selling can continue.",
+      }),
+    });
+    await expect(store.listEvents()).resolves.toEqual({ ok: true, value: [] });
   });
 
   it("reuses an active mapped local drawer instead of appending a duplicate register open", async () => {
@@ -434,6 +607,32 @@ describe("createLocalCommandGateway", () => {
       kind: "user_error",
       error: expect.objectContaining({
         message: "Terminal setup needs repair before selling can continue.",
+      }),
+    });
+    await expect(store.listEvents()).resolves.toMatchObject({
+      ok: true,
+      value: [expect.objectContaining({ type: "register.opened" })],
+    });
+  });
+
+  it("refuses to start a sale when staff identity is missing", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 10_000,
+    });
+    await appendOpenDrawer(store);
+
+    const gateway = createLocalCommandGateway({ store });
+    const result = await gateway.startSession({
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      registerNumber: "1",
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: expect.objectContaining({
+        message: "Staff sign-in required before selling can continue.",
       }),
     });
     await expect(store.listEvents()).resolves.toMatchObject({
@@ -1042,7 +1241,7 @@ describe("createLocalCommandGateway", () => {
     await expect(store.listEvents()).resolves.toEqual({ ok: true, value: [] });
   });
 
-  it("blocks register reopen while drawer lifecycle needs review", async () => {
+  it("allows register reopen while drawer lifecycle review is pending", async () => {
     const store = createPosLocalStore({
       adapter: createMemoryPosLocalStorageAdapter(),
     });
@@ -1073,10 +1272,10 @@ describe("createLocalCommandGateway", () => {
         staffProfileId: "staff-1",
         reason: "Manager correction",
       }),
-    ).resolves.toBe(false);
+    ).resolves.toBe(true);
     await expect(store.listEvents()).resolves.toMatchObject({
       ok: true,
-      value: expect.not.arrayContaining([
+      value: expect.arrayContaining([
         expect.objectContaining({ type: "register.reopened" }),
       ]),
     });

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts
@@ -5,11 +5,13 @@ import type {
 import { ok, userError, type CommandResult } from "~/shared/commandResult";
 
 import { readProjectedLocalRegisterModel } from "./localRegisterReader";
+import { deriveLocalSaleBlocker } from "./saleBlockerPolicy";
 import type {
   PosLocalAppendEventInput,
   PosDrawerAuthorityState,
   PosLocalEventRecord,
   PosLocalCloudMapping,
+  PosLocalEventValidationMetadata,
   PosLocalStoreResult,
   PosTerminalIntegrityState,
   PosProvisionedTerminalSeed,
@@ -72,7 +74,7 @@ export function createLocalCommandGateway(
   appendServiceLine(input: AppendLocalServiceLineInput): Promise<boolean>;
   clearCart(input: ClearLocalCartInput): Promise<boolean>;
   completeTransaction(input: CompleteLocalTransactionInput): Promise<boolean>;
-  openDrawer(input: PosOpenDrawerInput): Promise<LocalOpenDrawerResult>;
+  openDrawer(input: LocalOpenDrawerInput): Promise<LocalOpenDrawerResult>;
   reopenRegister(input: ReopenLocalRegisterInput): Promise<boolean>;
   seedRegisterSession(input: SeedLocalRegisterSessionInput): Promise<boolean>;
   startSession(input: LocalStartSessionInput): Promise<LocalStartSessionResult>;
@@ -111,7 +113,7 @@ export function createLocalCommandGateway(
     return !(await append(input));
   }
 
-  async function appendNewDrawer(input: PosOpenDrawerInput) {
+  async function appendNewDrawer(input: LocalOpenDrawerInput) {
     const localRegisterSessionId = createLocalId("local-register-session");
     const openedAt = clock();
     const appendError = await append({
@@ -125,6 +127,7 @@ export function createLocalCommandGateway(
         options.staffProofToken,
         input.staffProfileId.toString(),
       ),
+      validationMetadata: input.validationMetadata,
       payload: {
         localRegisterSessionId,
         openingFloat: input.openingFloat,
@@ -165,9 +168,11 @@ export function createLocalCommandGateway(
 
   async function canAppendSaleAffectingEvent(input: {
     localRegisterSessionId?: string;
+    staffProfileId?: string;
     storeId: string;
     terminalId: string;
   }) {
+    if (!hasCommandIdentity(input)) return false;
     const model = await readModel(input);
     if (!model.ok) return false;
     if (model.value.canSell) {
@@ -191,19 +196,12 @@ export function createLocalCommandGateway(
   }
 
   async function canAppendRegisterReopen(input: ReopenLocalRegisterInput) {
+    if (!hasCommandIdentity(input)) return false;
     const model = await readModel({
       storeId: input.storeId,
       terminalId: input.terminalId,
     });
     if (!model.ok) return false;
-    if (
-      hasLifecycleReviewForRegisterSession(
-        model.value.sourceEvents,
-        input.localRegisterSessionId,
-      )
-    ) {
-      return false;
-    }
     if (!model.value.activeRegisterSession) {
       if (
         !options.allowExplicitRegisterSessionWithoutProjection ||
@@ -219,10 +217,34 @@ export function createLocalCommandGateway(
       return drawerAuthority.ok && !drawerAuthority.blocked;
     }
 
-    return !model.value.saleBlockReason;
+    const drawerAuthority = await readDrawerAuthorityBlock({
+      localRegisterSessionId: input.localRegisterSessionId,
+      storeId: input.storeId,
+      terminalId: input.terminalId,
+    });
+    if (!drawerAuthority.ok || drawerAuthority.blocked) return false;
+
+    const blocker = deriveLocalSaleBlocker({
+      activeRegisterSession: {
+        canReopen:
+          model.value.activeRegisterSession.localRegisterSessionId ===
+          input.localRegisterSessionId,
+        localRegisterSessionId:
+          model.value.activeRegisterSession.localRegisterSessionId,
+        status: model.value.activeRegisterSession.status,
+      },
+      hasLocalEventDestination: true,
+      hasRequiredIdentities: true,
+      terminalIntegrity:
+        model.value.saleBlockReason === "terminal_integrity"
+          ? { status: "requires_reprovision" }
+          : { status: "healthy" },
+    });
+    return !blocker;
   }
 
   async function canSeedRegisterSession(input: SeedLocalRegisterSessionInput) {
+    if (!hasCommandIdentity(input)) return false;
     const model = await readModel({
       storeId: input.storeId,
       terminalId: input.terminalId,
@@ -263,6 +285,7 @@ export function createLocalCommandGateway(
         localRegisterSessionId: input.localRegisterSessionId,
         localPosSessionId: input.localPosSessionId,
         staffProfileId: input.staffProfileId,
+        validationMetadata: input.validationMetadata,
         payload: input.payload,
       });
     },
@@ -277,6 +300,7 @@ export function createLocalCommandGateway(
         localRegisterSessionId: input.localRegisterSessionId,
         localPosSessionId: input.localPosSessionId,
         staffProfileId: input.staffProfileId,
+        validationMetadata: input.validationMetadata,
         payload: {
           localPosSessionId: input.localPosSessionId,
           ...input.payload,
@@ -294,6 +318,7 @@ export function createLocalCommandGateway(
         localRegisterSessionId: input.localRegisterSessionId,
         localPosSessionId: input.localPosSessionId,
         staffProfileId: input.staffProfileId,
+        validationMetadata: input.validationMetadata,
         payload: {
           localPosSessionId: input.localPosSessionId,
           checkoutStateVersion: input.checkoutStateVersion,
@@ -336,6 +361,7 @@ export function createLocalCommandGateway(
         localRegisterSessionId: input.localRegisterSessionId,
         localPosSessionId: input.localPosSessionId,
         staffProfileId: input.staffProfileId,
+        validationMetadata: input.validationMetadata,
         ...(hasPriorSaleActivity
           ? {
               staffProofToken: resolveStaffProofToken(
@@ -366,13 +392,23 @@ export function createLocalCommandGateway(
           options.staffProofToken,
           input.staffProfileId,
         ),
+        validationMetadata: input.validationMetadata,
         payload: input.payload,
       });
     },
 
     async openDrawer(
-      input: PosOpenDrawerInput,
+      input: LocalOpenDrawerInput,
     ): Promise<LocalOpenDrawerResult> {
+      if (!hasCommandIdentity({ ...input, localRegisterSessionId: "pending" })) {
+        return toLocalUserError(
+          blockedSaleMessage(
+            !input.staffProfileId
+              ? "missing_identity"
+              : "missing_event_destination",
+          ),
+        );
+      }
       const existingModel = await readModel({
         storeId: input.storeId.toString(),
         terminalId: input.terminalId.toString(),
@@ -384,9 +420,8 @@ export function createLocalCommandGateway(
         existingModel.value.saleBlockReason === "drawer_authority" &&
         existingModel.value.drawerAuthorityReason === "cloud_closed";
       const isLifecycleReviewDrawerBlock =
-        existingModel.value.saleBlockReason === "lifecycle_needs_review" ||
-        (existingModel.value.saleBlockReason === "drawer_authority" &&
-          existingModel.value.drawerAuthorityReason === "lifecycle_rejected");
+        existingModel.value.saleBlockReason === "drawer_authority" &&
+        existingModel.value.drawerAuthorityReason === "lifecycle_rejected";
       if (
         existingModel.value.saleBlockReason &&
         !isClosedCloudDrawerBlock &&
@@ -455,6 +490,7 @@ export function createLocalCommandGateway(
           options.staffProofToken,
           input.staffProfileId,
         ),
+        validationMetadata: input.validationMetadata,
         payload: {
           reason: input.reason,
         },
@@ -474,6 +510,7 @@ export function createLocalCommandGateway(
           options.staffProofToken,
           input.staffProfileId,
         ),
+        validationMetadata: input.validationMetadata,
         payload: {
           localRegisterSessionId: input.localRegisterSessionId,
           openingFloat: input.openingFloat,
@@ -487,6 +524,15 @@ export function createLocalCommandGateway(
     async startSession(
       input: LocalStartSessionInput,
     ): Promise<LocalStartSessionResult> {
+      if (!hasCommandIdentity({ ...input, localRegisterSessionId: "pending" })) {
+        return toLocalUserError(
+          blockedSaleMessage(
+            !input.staffProfileId
+              ? "missing_identity"
+              : "missing_event_destination",
+          ),
+        );
+      }
       const model = await readModel({
         storeId: input.storeId.toString(),
         terminalId: input.terminalId.toString(),
@@ -551,6 +597,7 @@ export function createLocalCommandGateway(
         localRegisterSessionId,
         localPosSessionId,
         staffProfileId: input.staffProfileId?.toString(),
+        validationMetadata: input.validationMetadata,
         payload: {
           localPosSessionId,
           localRegisterSessionId,
@@ -582,6 +629,7 @@ export function createLocalCommandGateway(
           options.staffProofToken,
           input.staffProfileId,
         ),
+        validationMetadata: input.validationMetadata,
         payload: {
           countedCash: input.countedCash,
           notes: input.notes ?? null,
@@ -630,28 +678,6 @@ function hasLocalSaleActivity(
   });
 }
 
-function hasLifecycleReviewForRegisterSession(
-  events: PosLocalEventRecord[],
-  localRegisterSessionId: string,
-) {
-  return events.some((event) => {
-    if (
-      event.localRegisterSessionId !== localRegisterSessionId ||
-      event.sync.status !== "needs_review" ||
-      !event.sync.uploaded
-    ) {
-      return false;
-    }
-
-    return (
-      event.type === "register.opened" ||
-      event.type === "register.closeout_started" ||
-      event.type === "register.reopened" ||
-      event.type === "transaction.completed"
-    );
-  });
-}
-
 function isOpenLocalRegisterSessionStatus(status: string) {
   return status === "open" || status === "active";
 }
@@ -671,8 +697,14 @@ function blockedSaleMessage(reason?: string) {
   if (reason === "drawer_authority") {
     return "Drawer setup needs repair before selling can continue.";
   }
-  if (reason === "lifecycle_needs_review") {
-    return "Drawer sync needs review before selling can continue.";
+  if (reason === "missing_event_destination") {
+    return "Local sale recording is not ready on this terminal.";
+  }
+  if (reason === "missing_identity") {
+    return "Staff sign-in required before selling can continue.";
+  }
+  if (reason === "drawer_closed") {
+    return "Open the drawer before starting a sale.";
   }
   return "Open the drawer before starting a sale.";
 }
@@ -683,7 +715,22 @@ type LocalCommandContext = {
   registerNumber?: string;
   localRegisterSessionId: string;
   staffProfileId: string;
+  validationMetadata?: PosLocalEventValidationMetadata;
 };
+
+function hasCommandIdentity(input: {
+  localRegisterSessionId?: string;
+  staffProfileId?: string;
+  storeId?: string;
+  terminalId?: string;
+}) {
+  return Boolean(
+    input.localRegisterSessionId &&
+      input.staffProfileId &&
+      input.storeId &&
+      input.terminalId,
+  );
+}
 
 type LocalStartSessionInput = {
   terminalId: string;
@@ -692,6 +739,11 @@ type LocalStartSessionInput = {
   localRegisterSessionId?: string;
   staffProfileId?: string;
   localPosSessionId?: string;
+  validationMetadata?: PosLocalEventValidationMetadata;
+};
+
+type LocalOpenDrawerInput = PosOpenDrawerInput & {
+  validationMetadata?: PosLocalEventValidationMetadata;
 };
 
 type LocalSaleCommandContext = LocalCommandContext & {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
@@ -869,6 +869,97 @@ describe("posLocalStore", () => {
     );
   });
 
+  it("persists app-session/cloud-validation uncertainty metadata through local review without storing unsafe details", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      createLocalId: () => "local-event-1",
+    });
+
+    await expect(
+      store.appendEvent({
+        type: "transaction.completed",
+        terminalId: "local-terminal-1",
+        storeId: "store_cloud_1",
+        localRegisterSessionId: "local-register-session-1",
+        localPosSessionId: "local-session-1",
+        localTransactionId: "local-transaction-1",
+        staffProfileId: "staff_cloud_1",
+        staffProofToken: "proof-token-1",
+        validationMetadata: {
+          flags: [
+            "app-session-unverified",
+            "cloud-validation-uncertain",
+          ],
+          observedAt: 2_000,
+          uploadDeferredUntil: "app-session-validated",
+        },
+        payload: {
+          customerEmail: "customer@example.com",
+          payments: [{ method: "cash", amount: 25, timestamp: 2_000 }],
+          rawRecoveryReason: "raw-terminal-proof should not be metadata",
+        },
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      value: expect.objectContaining({
+        validationMetadata: {
+          flags: [
+            "app-session-unverified",
+            "cloud-validation-uncertain",
+          ],
+          observedAt: 2_000,
+          uploadDeferredUntil: "app-session-validated",
+        },
+      }),
+    });
+
+    await expect(
+      store.markEventsNeedsReview(
+        ["local-event-1"],
+        "Cloud sync needs review before this local event can finish.",
+        { uploaded: true },
+      ),
+    ).resolves.toEqual({
+      ok: true,
+      value: [
+        expect.objectContaining({
+          validationMetadata: {
+            flags: [
+              "app-session-unverified",
+              "cloud-validation-uncertain",
+            ],
+            observedAt: 2_000,
+            uploadDeferredUntil: "app-session-validated",
+          },
+        }),
+      ],
+    });
+
+    const listed = await store.listEvents();
+    expect(listed).toEqual({
+      ok: true,
+      value: [
+        expect.objectContaining({
+          validationMetadata: {
+            flags: [
+              "app-session-unverified",
+              "cloud-validation-uncertain",
+            ],
+            observedAt: 2_000,
+            uploadDeferredUntil: "app-session-validated",
+          },
+        }),
+      ],
+    });
+    const serializedMetadata = JSON.stringify(
+      listed.ok ? listed.value[0]?.validationMetadata : null,
+    );
+    expect(serializedMetadata).not.toContain("proof-token-1");
+    expect(serializedMetadata).not.toContain("customer@example.com");
+    expect(serializedMetadata).not.toContain("payments");
+    expect(serializedMetadata).not.toContain("raw-terminal-proof");
+  });
+
   it("persists upload proof on pending uploadable events so offline sync survives reload", async () => {
     const adapter = createMemoryPosLocalStorageAdapter();
     const store = createPosLocalStore({

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
@@ -36,6 +36,19 @@ export type PosLocalSyncEventStatus =
   | "needs_review"
   | "failed";
 
+export type PosLocalEventValidationFlag =
+  | "app-session-unverified"
+  | "cloud-validation-uncertain";
+
+export type PosLocalEventUploadDeferral =
+  | "app-session-validated";
+
+export interface PosLocalEventValidationMetadata {
+  flags: PosLocalEventValidationFlag[];
+  observedAt?: number;
+  uploadDeferredUntil?: PosLocalEventUploadDeferral;
+}
+
 export function canUploadPosLocalEventType(type: PosLocalEventType): boolean {
   return (
     type === "register.opened" ||
@@ -73,6 +86,7 @@ export interface PosLocalEventRecord {
   localTransactionId?: string;
   staffProfileId?: string;
   staffProofToken?: string;
+  validationMetadata?: PosLocalEventValidationMetadata;
   payload: unknown;
   createdAt: number;
   sync: {
@@ -295,6 +309,7 @@ export type PosLocalAppendEventInput = {
   localTransactionId?: string;
   staffProfileId?: string;
   staffProofToken?: string;
+  validationMetadata?: PosLocalEventValidationMetadata;
   initialSyncStatus?: PosLocalSyncEventStatus;
   payload: unknown;
 };
@@ -376,6 +391,9 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
       transaction,
       input,
     );
+    const validationMetadata = normalizeEventValidationMetadata(
+      input.validationMetadata,
+    );
     const event: PosLocalEventRecord = {
       localEventId: createLocalId("event"),
       schemaVersion: POS_LOCAL_STORE_SCHEMA_VERSION,
@@ -398,6 +416,7 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
       ...(shouldPersistStaffProofToken(input)
         ? { staffProofToken: input.staffProofToken }
         : {}),
+      ...(validationMetadata ? { validationMetadata } : {}),
       payload: input.payload,
       createdAt: clock(),
       sync: { status: input.initialSyncStatus ?? getInitialSyncStatus(input.type) },
@@ -1538,6 +1557,31 @@ function normalizeCashierPresenceRecord(
         role === "cashier" || role === "manager",
     ),
     username: normalizeUsername(record.username),
+  };
+}
+
+function normalizeEventValidationMetadata(
+  metadata?: PosLocalEventValidationMetadata,
+): PosLocalEventValidationMetadata | undefined {
+  if (!metadata) return undefined;
+
+  const flags = Array.from(new Set(metadata.flags)).filter(
+    (flag): flag is PosLocalEventValidationFlag =>
+      flag === "app-session-unverified" ||
+      flag === "cloud-validation-uncertain",
+  );
+
+  if (flags.length === 0) return undefined;
+
+  return {
+    flags,
+    ...(typeof metadata.observedAt === "number" &&
+    Number.isFinite(metadata.observedAt)
+      ? { observedAt: metadata.observedAt }
+      : {}),
+    ...(metadata.uploadDeferredUntil === "app-session-validated"
+      ? { uploadDeferredUntil: metadata.uploadDeferredUntil }
+      : {}),
   };
 }
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts
@@ -826,7 +826,7 @@ describe("projectLocalRegisterReadModel", () => {
     expect(model.drawerAuthorityReason).toBe("cloud_closed");
   });
 
-  it("blocks selling when an uploaded register lifecycle event needs review", () => {
+  it("keeps selling available when uploaded lifecycle review does not invalidate local authority", () => {
     const model = projectLocalRegisterReadModel({
       events: [
         event({
@@ -840,8 +840,8 @@ describe("projectLocalRegisterReadModel", () => {
       isOnline: true,
     });
 
-    expect(model.canSell).toBe(false);
-    expect(model.saleBlockReason).toBe("lifecycle_needs_review");
+    expect(model.canSell).toBe(true);
+    expect(model.saleBlockReason).toBeUndefined();
     expect(model.syncStatus.state).toBe("needs_review");
   });
 });

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts
@@ -5,6 +5,10 @@ import type {
 } from "@/lib/pos/application/dto";
 
 import { derivePosLocalSyncStatus } from "./syncStatus";
+import {
+  deriveLocalSaleBlocker,
+  type PosLocalSaleBlockReason,
+} from "./saleBlockerPolicy";
 import type {
   PosLocalCloudMapping,
   PosLocalEventRecord,
@@ -12,11 +16,6 @@ import type {
   PosTerminalIntegrityState,
   PosProvisionedTerminalSeed,
 } from "./posLocalStore";
-
-export type PosLocalSaleBlockReason =
-  | "terminal_integrity"
-  | "drawer_authority"
-  | "lifecycle_needs_review";
 
 export type PosLocalRegisterReadModelErrorCode =
   | "malformed_payload"
@@ -416,7 +415,6 @@ export function projectLocalRegisterReadModel(input: {
   const saleBlockReason = getSaleBlockReason({
     activeRegisterSession,
     drawerAuthority: input.drawerAuthority,
-    events: orderedEvents,
     terminalIntegrity: input.terminalIntegrity,
   });
   const canSell =
@@ -457,50 +455,24 @@ export function projectLocalRegisterReadModel(input: {
 function getSaleBlockReason(input: {
   activeRegisterSession: PosLocalCashDrawerReadModel | null;
   drawerAuthority?: PosDrawerAuthorityState | null;
-  events: PosLocalEventRecord[];
   terminalIntegrity?: PosTerminalIntegrityState | null;
 }): PosLocalSaleBlockReason | undefined {
-  if (
-    input.terminalIntegrity &&
-    input.terminalIntegrity.status !== "healthy"
-  ) {
-    return "terminal_integrity";
-  }
-
-  if (input.drawerAuthority?.status === "blocked") {
-    return "drawer_authority";
-  }
-
-  const activeRegisterSession = input.activeRegisterSession;
-  if (
-    activeRegisterSession &&
-    input.events.some((event) =>
-      isBlockingLifecycleReviewEvent(event, activeRegisterSession),
-    )
-  ) {
-    return "lifecycle_needs_review";
-  }
-
-  return undefined;
-}
-
-function isBlockingLifecycleReviewEvent(
-  event: PosLocalEventRecord,
-  activeRegisterSession: PosLocalCashDrawerReadModel,
-) {
-  if (event.sync.status !== "needs_review" || !event.sync.uploaded) {
-    return false;
-  }
-  if (
-    event.type !== "register.opened" &&
-    event.type !== "register.closeout_started" &&
-    event.type !== "register.reopened" &&
-    event.type !== "transaction.completed"
-  ) {
-    return false;
-  }
-
-  return registerLifecycleEventMatchesActiveSession(event, activeRegisterSession);
+  return (
+    deriveLocalSaleBlocker({
+      activeRegisterSession: input.activeRegisterSession
+        ? {
+            canReopen: false,
+            localRegisterSessionId:
+              input.activeRegisterSession.localRegisterSessionId,
+            status: input.activeRegisterSession.status,
+          }
+        : null,
+      drawerAuthority: input.drawerAuthority,
+      hasLocalEventDestination: true,
+      hasRequiredIdentities: true,
+      terminalIntegrity: input.terminalIntegrity,
+    })?.reason ?? undefined
+  );
 }
 
 function createMappingIndex(mappings: PosLocalCloudMapping[]) {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/saleBlockerPolicy.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/saleBlockerPolicy.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveLocalSaleBlocker } from "./saleBlockerPolicy";
+
+describe("deriveLocalSaleBlocker", () => {
+  it("does not hard-block local sales for cloud-validation uncertainty", () => {
+    expect(
+      deriveLocalSaleBlocker({
+        activeRegisterSession: {
+          status: "active",
+          localRegisterSessionId: "drawer-1",
+          canReopen: false,
+        },
+        hasLocalEventDestination: true,
+        hasRequiredIdentities: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("hard-blocks terminal integrity, missing destination, missing identities, and non-reopenable closed drawers", () => {
+    expect(
+      deriveLocalSaleBlocker({
+        activeRegisterSession: {
+          status: "active",
+          localRegisterSessionId: "drawer-1",
+          canReopen: false,
+        },
+        hasLocalEventDestination: true,
+        hasRequiredIdentities: true,
+        terminalIntegrity: {
+          status: "requires_reprovision",
+        },
+      })?.reason,
+    ).toBe("terminal_integrity");
+
+    expect(
+      deriveLocalSaleBlocker({
+        activeRegisterSession: {
+          status: "active",
+          localRegisterSessionId: "drawer-1",
+          canReopen: false,
+        },
+        hasLocalEventDestination: false,
+        hasRequiredIdentities: true,
+      })?.reason,
+    ).toBe("missing_event_destination");
+
+    expect(
+      deriveLocalSaleBlocker({
+        activeRegisterSession: {
+          status: "active",
+          localRegisterSessionId: "drawer-1",
+          canReopen: false,
+        },
+        hasLocalEventDestination: true,
+        hasRequiredIdentities: false,
+      })?.reason,
+    ).toBe("missing_identity");
+
+    expect(
+      deriveLocalSaleBlocker({
+        activeRegisterSession: {
+          status: "closing",
+          localRegisterSessionId: "drawer-1",
+          canReopen: false,
+        },
+        hasLocalEventDestination: true,
+        hasRequiredIdentities: true,
+      })?.reason,
+    ).toBe("drawer_closed");
+  });
+});

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/saleBlockerPolicy.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/saleBlockerPolicy.ts
@@ -1,0 +1,54 @@
+import type {
+  PosDrawerAuthorityState,
+  PosTerminalIntegrityState,
+} from "./posLocalStore";
+
+export type PosLocalSaleBlockReason =
+  | "terminal_integrity"
+  | "drawer_authority"
+  | "missing_event_destination"
+  | "missing_identity"
+  | "drawer_closed";
+
+export type PosLocalSaleBlocker = {
+  reason: PosLocalSaleBlockReason;
+};
+
+export function deriveLocalSaleBlocker(input: {
+  activeRegisterSession: {
+    canReopen: boolean;
+    localRegisterSessionId?: string | null;
+    status?: string | null;
+  } | null;
+  drawerAuthority?: Pick<PosDrawerAuthorityState, "status"> | null;
+  hasLocalEventDestination: boolean;
+  hasRequiredIdentities: boolean;
+  terminalIntegrity?: Pick<PosTerminalIntegrityState, "status"> | null;
+}): PosLocalSaleBlocker | null {
+  if (input.terminalIntegrity?.status !== undefined) {
+    if (input.terminalIntegrity.status !== "healthy") {
+      return { reason: "terminal_integrity" };
+    }
+  }
+
+  if (!input.hasLocalEventDestination) {
+    return { reason: "missing_event_destination" };
+  }
+
+  if (!input.hasRequiredIdentities) {
+    return { reason: "missing_identity" };
+  }
+
+  if (input.drawerAuthority?.status === "blocked") {
+    return { reason: "drawer_authority" };
+  }
+
+  if (
+    input.activeRegisterSession?.status === "closing" &&
+    !input.activeRegisterSession.canReopen
+  ) {
+    return { reason: "drawer_closed" };
+  }
+
+  return null;
+}

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.test.ts
@@ -663,6 +663,57 @@ describe("syncContract", () => {
       .not.toHaveProperty("staffProofToken");
   });
 
+  it("defers app-session-unverified events until supported validation is present", () => {
+    const event = buildLocalEvent({
+      localEventId: "event-offline-sale",
+      type: "transaction.completed",
+      validationMetadata: {
+        flags: [
+          "app-session-unverified",
+          "cloud-validation-uncertain",
+        ],
+        observedAt: 2_000,
+        uploadDeferredUntil: "app-session-validated",
+      },
+      payload: {
+        localPosSessionId: "local-session-1",
+        localTransactionId: "local-txn-1",
+        receiptNumber: "LOCAL-1-000001",
+        subtotal: 25,
+        tax: 0,
+        total: 25,
+        customerEmail: "customer@example.com",
+        payments: [{ method: "cash", amount: 25, timestamp: 4 }],
+      },
+    });
+
+    expect(isSyncablePosLocalEvent(event)).toBe(false);
+    expect(buildPosLocalSyncUploadEvents([event], [event])).toEqual([]);
+
+    expect(
+      isSyncablePosLocalEvent(event, {
+        appSessionValidation: "supported",
+      }),
+    ).toBe(true);
+    expect(
+      buildPosLocalSyncUploadEvents([event], [event], {
+        appSessionValidation: "supported",
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        localEventId: "event-offline-sale",
+        eventType: "sale_completed",
+      }),
+    ]);
+    expect(
+      JSON.stringify(
+        buildPosLocalSyncUploadEvents([event], [event], {
+          appSessionValidation: "supported",
+        }),
+      ),
+    ).toContain("customer@example.com");
+  });
+
   it("uses stored upload sequence instead of recomputing from currently uploadable rows", () => {
     const events: PosLocalEventRecord[] = [
       buildLocalEvent({

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.ts
@@ -9,6 +9,9 @@ import type {
 } from "../../../../../shared/posLocalSyncContract";
 
 export type PosLocalUploadEvent = PosLocalSyncUploadEvent;
+export type PosLocalSyncUploadSupport = {
+  appSessionValidation?: "supported" | "unverified";
+};
 type PosLocalUploadEventWithoutSequence = {
   [EventType in PosLocalUploadEvent["eventType"]]: Omit<
     Extract<PosLocalUploadEvent, { eventType: EventType }>,
@@ -19,6 +22,7 @@ type PosLocalUploadEventWithoutSequence = {
 export function buildPosLocalSyncUploadEvents(
   eventsToUpload: PosLocalEventRecord[],
   allEvents: PosLocalEventRecord[],
+  uploadSupport: PosLocalSyncUploadSupport = {},
 ): PosLocalUploadEvent[] {
   const orderedEvents = [...allEvents].sort(
     (left, right) => left.sequence - right.sequence,
@@ -28,6 +32,7 @@ export function buildPosLocalSyncUploadEvents(
   for (const event of [...eventsToUpload].sort(
     (left, right) => left.sequence - right.sequence,
   )) {
+    if (!isSyncablePosLocalEvent(event, uploadSupport)) continue;
     const uploadEvent = toUploadEvent(event, orderedEvents);
     if (!uploadEvent) continue;
     const sequence = event.uploadSequence;
@@ -38,14 +43,31 @@ export function buildPosLocalSyncUploadEvents(
   return uploadEvents;
 }
 
-export function isSyncablePosLocalEvent(event: PosLocalEventRecord): boolean {
+export function isSyncablePosLocalEvent(
+  event: PosLocalEventRecord,
+  uploadSupport: PosLocalSyncUploadSupport | number = {},
+): boolean {
+  const support = typeof uploadSupport === "number" ? {} : uploadSupport;
+
   return (
     Boolean(
       event.localRegisterSessionId &&
         event.staffProfileId &&
         typeof event.uploadSequence === "number",
     ) &&
-    canUploadPosLocalEventType(event.type)
+    canUploadPosLocalEventType(event.type) &&
+    !isUploadDeferredByValidation(event, support)
+  );
+}
+
+export function isUploadDeferredByValidation(
+  event: PosLocalEventRecord,
+  uploadSupport: PosLocalSyncUploadSupport = {},
+): boolean {
+  return (
+    event.validationMetadata?.uploadDeferredUntil ===
+      "app-session-validated" &&
+    uploadSupport.appSessionValidation !== "supported"
   );
 }
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts
@@ -315,6 +315,68 @@ describe("terminalRuntimeStatus", () => {
     );
   });
 
+  it("reports uncertainty metadata as support-safe counts without exposing payload details", () => {
+    const input = {
+      clock: () => 2_000,
+      events: [
+        buildLocalEvent({
+          localEventId: "event-offline-sale",
+          localPosSessionId: "sale-1",
+          localTransactionId: "transaction-1",
+          payload: {
+            customerEmail: "customer@example.com",
+            payments: [{ amount: 10_000, method: "cash" }],
+            rawTerminalProof: "terminal-proof-secret",
+          },
+          sequence: 2,
+          type: "transaction.completed",
+          uploadSequence: 2,
+          validationMetadata: {
+            flags: [
+              "app-session-unverified",
+              "cloud-validation-uncertain",
+            ],
+            observedAt: 1_500,
+            uploadDeferredUntil: "app-session-validated",
+          },
+        }),
+      ],
+      source: "support-diagnostics",
+    } satisfies PosTerminalRuntimeStatusInput;
+
+    const status = buildPosTerminalRuntimeStatus(input);
+    const diagnostics = buildPosTerminalRuntimeCopyDiagnostics(input);
+
+    expect(status.sync).toEqual(
+      expect.objectContaining({
+        localOnlyEventCount: 1,
+        pendingEventCount: 1,
+        uploadableEventCount: 0,
+      }),
+    );
+    expect(diagnostics.counts).toEqual(
+      expect.objectContaining({
+        appSessionUnverifiedEventCount: 1,
+        cloudValidationUncertainEventCount: 1,
+        deferredUploadEventCount: 1,
+        localOnlyEventCount: 1,
+        uploadableEventCount: 0,
+      }),
+    );
+    expect(diagnostics.events).toEqual([
+      expect.objectContaining({
+        localEventId: "event-offline-sale",
+        status: "pending",
+        type: "transaction.completed",
+        uploadSequence: 2,
+      }),
+    ]);
+    const serialized = JSON.stringify({ diagnostics, status });
+    expect(serialized).not.toContain("payments");
+    expect(serialized).not.toContain("customer@example.com");
+    expect(serialized).not.toContain("terminal-proof-secret");
+  });
+
   it.each([
     {
       expected: "ready",

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts
@@ -12,7 +12,10 @@ import {
   type PosProvisionedTerminalSeed,
 } from "./posLocalStore";
 import { derivePosLocalSyncStatus } from "./syncStatus";
-import { isSyncablePosLocalEvent } from "./syncContract";
+import {
+  isSyncablePosLocalEvent,
+  isUploadDeferredByValidation,
+} from "./syncContract";
 import type { PosLocalSyncTrigger } from "./syncScheduler";
 
 type ReportTerminalRuntimeStatusArgs = FunctionArgs<
@@ -117,6 +120,9 @@ export type PosTerminalRuntimeStatusInput = {
 
 export type PosTerminalRuntimeCopyDiagnostics = {
   counts: {
+    appSessionUnverifiedEventCount: number;
+    cloudValidationUncertainEventCount: number;
+    deferredUploadEventCount: number;
     failedEventCount: number;
     localOnlyEventCount: number;
     pendingEventCount: number;
@@ -301,6 +307,7 @@ export function buildPosTerminalRuntimeCopyDiagnostics(
 ): PosTerminalRuntimeCopyDiagnostics {
   const now = input.clock?.() ?? Date.now();
   const sync = buildSyncMetrics(input);
+  const validation = buildValidationMetadataMetrics(input.events);
   const localStoreFailure = toSafeFailureMessage(input.localStoreFailureMessage);
   const syncFailure = toSafeFailureMessage(input.syncDebug?.lastFailure);
   const staffAuthorityStatus = normalizeStaffAuthorityStatus(
@@ -313,6 +320,11 @@ export function buildPosTerminalRuntimeCopyDiagnostics(
   return {
     ...(appSessionRecovery ? { appSessionRecovery } : {}),
     counts: {
+      appSessionUnverifiedEventCount:
+        validation.appSessionUnverifiedEventCount,
+      cloudValidationUncertainEventCount:
+        validation.cloudValidationUncertainEventCount,
+      deferredUploadEventCount: validation.deferredUploadEventCount,
       failedEventCount: sync.failedEventCount,
       localOnlyEventCount: sync.localOnlyEventCount,
       pendingEventCount: sync.pendingEventCount,
@@ -421,6 +433,20 @@ export function buildPosTerminalRuntimeCopyDiagnostics(
         ? { registerReadModelRefreshedAt: input.snapshots.registerReadModelRefreshedAt }
         : {}),
     },
+  };
+}
+
+function buildValidationMetadataMetrics(events: PosLocalEventRecord[]) {
+  return {
+    appSessionUnverifiedEventCount: events.filter((event) =>
+      event.validationMetadata?.flags.includes("app-session-unverified"),
+    ).length,
+    cloudValidationUncertainEventCount: events.filter((event) =>
+      event.validationMetadata?.flags.includes("cloud-validation-uncertain"),
+    ).length,
+    deferredUploadEventCount: events.filter((event) =>
+      isUploadDeferredByValidation(event),
+    ).length,
   };
 }
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -1233,6 +1233,201 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     expect(store.markEventsSynced).not.toHaveBeenCalled();
   });
 
+  it("defers app-session-unverified uploads while recovery is waiting for network", async () => {
+    const appSessionRecovery = {
+      assertion: "present" as const,
+      status: "waiting_for_network" as const,
+    };
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            localEventId: "event-offline-sale",
+            localPosSessionId: "local-session-1",
+            localTransactionId: "local-txn-1",
+            payload: {
+              localPosSessionId: "local-session-1",
+              localTransactionId: "local-txn-1",
+              receiptNumber: "LOCAL-1-000001",
+              subtotal: 25,
+              tax: 0,
+              total: 25,
+              customerEmail: "customer@example.com",
+              payments: [{ method: "cash", amount: 25, timestamp: 2 }],
+            },
+            sequence: 1,
+            type: "transaction.completed",
+            validationMetadata: {
+              flags: [
+                "app-session-unverified",
+                "cloud-validation-uncertain",
+              ],
+              observedAt: 2_000,
+              uploadDeferredUntil: "app-session-validated",
+            },
+          }),
+        ],
+      })),
+      markEventsSynced: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+    };
+
+    const { result } = renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        appSessionRecovery,
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(result.current?.debug).toEqual(
+        expect.objectContaining({
+          appSessionUnverifiedEventCount: 1,
+          cloudValidationUncertainEventCount: 1,
+          deferredUploadEventCount: 1,
+          pendingUploadEventCount: 0,
+        }),
+      ),
+    );
+    expect(result.current?.copyDiagnostics?.counts).toEqual(
+      expect.objectContaining({
+        appSessionUnverifiedEventCount: 1,
+        cloudValidationUncertainEventCount: 1,
+        deferredUploadEventCount: 1,
+      }),
+    );
+    expect(mocks.ingestLocalEvents).not.toHaveBeenCalled();
+    expect(store.markEventsSynced).not.toHaveBeenCalled();
+    expect(JSON.stringify(result.current?.copyDiagnostics)).not.toContain(
+      "customer@example.com",
+    );
+    expect(JSON.stringify(result.current?.copyDiagnostics)).not.toContain(
+      "payments",
+    );
+  });
+
+  it("uploads app-session-unverified history after supported recovery is present", async () => {
+    const appSessionRecovery = {
+      assertion: "present" as const,
+      status: "recoverable" as const,
+    };
+    mocks.ingestLocalEvents.mockResolvedValue({
+      kind: "ok",
+      data: {
+        accepted: [
+          {
+            localEventId: "event-offline-sale",
+            sequence: 1,
+            status: "projected",
+          },
+        ],
+        held: [],
+        mappings: [],
+        conflicts: [],
+        syncCursor: {
+          localRegisterSessionId: "register-1",
+          acceptedThroughSequence: 1,
+        },
+      },
+    });
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            localEventId: "event-offline-sale",
+            localPosSessionId: "local-session-1",
+            localTransactionId: "local-txn-1",
+            payload: {
+              localPosSessionId: "local-session-1",
+              localTransactionId: "local-txn-1",
+              receiptNumber: "LOCAL-1-000001",
+              subtotal: 25,
+              tax: 0,
+              total: 25,
+              payments: [{ method: "cash", amount: 25, timestamp: 2 }],
+            },
+            sequence: 1,
+            type: "transaction.completed",
+            validationMetadata: {
+              flags: [
+                "app-session-unverified",
+                "cloud-validation-uncertain",
+              ],
+              observedAt: 2_000,
+              uploadDeferredUntil: "app-session-validated",
+            },
+          }),
+        ],
+      })),
+      markEventsSynced: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+      writeLocalCloudMapping: vi.fn(async () => ({
+        ok: true,
+        value: {},
+      })),
+    };
+
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        appSessionRecovery,
+        eventAppendToken: 1,
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(
+      () =>
+        expect(mocks.ingestLocalEvents).toHaveBeenCalledWith(
+          expect.objectContaining({
+            events: [
+              expect.objectContaining({
+                eventType: "sale_completed",
+                localEventId: "event-offline-sale",
+              }),
+            ],
+          }),
+        ),
+      { timeout: 5_000 },
+    );
+    expect(store.markEventsSynced).toHaveBeenCalledWith(["event-offline-sale"], {
+      uploaded: true,
+    });
+  });
+
   it("returns failure when local cloud mapping persistence fails", async () => {
     const store = {
       writeLocalCloudMapping: vi.fn(async () => ({

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -18,7 +18,9 @@ import {
 import {
   buildPosLocalSyncUploadEvents,
   isSyncablePosLocalEvent,
+  isUploadDeferredByValidation,
   type PosLocalUploadEvent,
+  type PosLocalSyncUploadSupport,
 } from "./syncContract";
 import {
   createPosLocalSyncScheduler,
@@ -74,6 +76,9 @@ export type PosLocalRuntimeSyncDebug = {
     | "not_ready"
     | "pending"
     | "rejected";
+  appSessionUnverifiedEventCount?: number;
+  cloudValidationUncertainEventCount?: number;
+  deferredUploadEventCount?: number;
   failureCount?: number;
   failedEventCount?: number;
   lastBatchEventCount?: number;
@@ -150,6 +155,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
   const onRetrySync = input.onRetrySync;
   const source = input.source ?? "sync-runtime";
   const staffProfileId = input.staffProfileId;
+  const uploadSupport = getAppSessionUploadSupport(input.appSessionRecovery);
   const lastRuntimeStatusSignatureRef = useRef<string | null>(null);
   const requestRetry = useCallback(() => {
     setRefreshToken((current) => current + 1);
@@ -274,7 +280,11 @@ export function usePosLocalSyncRuntimeStatus(input: {
         setRuntimeStatusObservationToken((current) => current + 1);
         setDebug((current) => ({
           ...current,
-          ...buildRuntimeSyncDebug(refreshedEvents.value.events, mode),
+          ...buildRuntimeSyncDebug(
+            refreshedEvents.value.events,
+            mode,
+            uploadSupport,
+          ),
         }));
         return true;
       };
@@ -283,7 +293,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
       setRuntimeStatusObservationToken((current) => current + 1);
       setDebug((current) => ({
         ...current,
-        ...buildRuntimeSyncDebug(eventsResult.value.events, mode),
+        ...buildRuntimeSyncDebug(eventsResult.value.events, mode, uploadSupport),
         lastTrigger: trigger,
         lastTriggerAt: Date.now(),
         lastTriggerPriority: triggerPriority,
@@ -347,11 +357,15 @@ export function usePosLocalSyncRuntimeStatus(input: {
                 isUploadedReviewEvent
               );
             })
-            .filter((event) => isSyncablePosLocalEvent(event));
+            .filter((event) => isSyncablePosLocalEvent(event, uploadSupport));
           if (!shouldStop()) {
             setDebug((current) => ({
               ...current,
-              ...buildRuntimeSyncDebug(pending.value.events, mode),
+              ...buildRuntimeSyncDebug(
+                pending.value.events,
+                mode,
+                uploadSupport,
+              ),
             }));
           }
           return uploadableEvents.map((event) => ({
@@ -414,6 +428,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
           const uploadedEvents = buildPosLocalSyncUploadEvents(
             eventsToUpload,
             latestEvents.value.events,
+            uploadSupport,
           );
           const locallySettledEventIds = collectLocallySettledSkippedReviewEventIds(
             eventsToUpload,
@@ -645,6 +660,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
     manualRetryToken,
     mode,
     onLocalEventsChanged,
+    input.appSessionRecovery,
     storeFactory,
     storeId,
     terminalId,
@@ -1599,16 +1615,20 @@ async function readScopedPosLocalUploadEvents(input: {
 function buildRuntimeSyncDebug(
   events: PosLocalEventRecord[],
   mode: PosLocalSyncRuntimeMode,
+  uploadSupport: PosLocalSyncUploadSupport = {},
 ): PosLocalRuntimeSyncDebug {
   const pendingUploadCandidates = events.filter(isPendingUploadCandidate);
   const pendingUploadableEvents = pendingUploadCandidates.filter(
-    isSyncablePosLocalEvent,
+    (event) => isSyncablePosLocalEvent(event, uploadSupport),
+  );
+  const deferredUploadEvents = pendingUploadCandidates.filter((event) =>
+    isUploadDeferredByValidation(event, uploadSupport),
   );
   const nextPendingUploadableEvent = [...pendingUploadableEvents]
     .sort(compareUploadableEventOrder)
     .at(0);
   const localOnlyEvents = pendingUploadCandidates.filter(
-    (event) => !isSyncablePosLocalEvent(event),
+    (event) => !isSyncablePosLocalEvent(event, uploadSupport),
   );
   const reviewEvents = events.filter(
     (event) => event.sync.status === "needs_review",
@@ -1620,6 +1640,13 @@ function buildRuntimeSyncDebug(
     .at(0);
 
   return {
+    appSessionUnverifiedEventCount: events.filter((event) =>
+      event.validationMetadata?.flags.includes("app-session-unverified"),
+    ).length,
+    cloudValidationUncertainEventCount: events.filter((event) =>
+      event.validationMetadata?.flags.includes("cloud-validation-uncertain"),
+    ).length,
+    deferredUploadEventCount: deferredUploadEvents.length,
     failedEventCount: failedEvents.length,
     localOnlyEventCount: localOnlyEvents.length,
     mode,
@@ -1630,6 +1657,21 @@ function buildRuntimeSyncDebug(
     nextPendingUploadSequence: nextPendingUploadableEvent?.uploadSequence,
     pendingUploadEventCount: pendingUploadableEvents.length,
     reviewEventCount: reviewEvents.length,
+  };
+}
+
+function getAppSessionUploadSupport(
+  recovery?: PosTerminalRuntimeAppSessionRecoveryInput | null,
+): PosLocalSyncUploadSupport {
+  if (!recovery) {
+    return { appSessionValidation: "supported" };
+  }
+
+  return {
+    appSessionValidation:
+      recovery.status === "idle" || recovery.status === "recoverable"
+        ? "supported"
+        : "unverified",
   };
 }
 

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -335,6 +335,7 @@ export interface RegisterViewModel {
   hasActiveStore: boolean;
   debug?: {
     activeStoreSource: "live" | "local" | "missing";
+    appSessionRecovery?: string | null;
     authDialogOpen: boolean;
     cashierPresence: CashierPresenceRestoreStatus;
     hasLiveActiveStore: boolean;

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -10534,6 +10534,52 @@ describe("useRegisterViewModel", () => {
     expect(toast.success).not.toHaveBeenCalled();
   });
 
+  it("marks local sale events as app-session-unverified while recovery waits for network", async () => {
+    mockUsePosTerminalAppSessionRecoveryRuntimeInput.mockReturnValue({
+      reason: "network_offline",
+      routeScope: "pos_hub",
+      status: "waiting_for_network",
+    });
+    mockCompleteTransaction.mockResolvedValueOnce(
+      userError({
+        code: "unavailable",
+        message: "Connection unavailable.",
+      }),
+    );
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    await act(async () => {
+      await result.current.checkout.onAddPayment("cash", 120);
+    });
+
+    await act(async () => {
+      await result.current.checkout.onCompleteTransaction();
+    });
+
+    await waitFor(() =>
+      expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "transaction.completed",
+          validationMetadata: expect.objectContaining({
+            flags: [
+              "app-session-unverified",
+              "cloud-validation-uncertain",
+            ],
+            uploadDeferredUntil: "app-session-validated",
+          }),
+        }),
+      ),
+    );
+  });
+
   it("does not resurrect a cloud-backed sale after completing it locally", async () => {
     mockCompleteTransaction.mockResolvedValueOnce(
       userError({

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -38,6 +38,7 @@ import {
   createPosLocalStore,
   type PosLocalActiveCashierPresenceRecord,
   type PosLocalEventRecord,
+  type PosLocalEventValidationMetadata,
 } from "@/lib/pos/infrastructure/local/posLocalStore";
 import { createLocalCommandGateway } from "@/lib/pos/infrastructure/local/localCommandGateway";
 import {
@@ -123,6 +124,24 @@ type LocalAuthenticatedStaff = {
   activeRoles: string[];
   displayName: string;
 } | null;
+
+function buildLocalSaleValidationMetadata(
+  appSessionRecoveryStatus?: string | null,
+): PosLocalEventValidationMetadata | undefined {
+  if (
+    !appSessionRecoveryStatus ||
+    appSessionRecoveryStatus === "idle" ||
+    appSessionRecoveryStatus === "recoverable"
+  ) {
+    return undefined;
+  }
+
+  return {
+    flags: ["app-session-unverified", "cloud-validation-uncertain"],
+    observedAt: Date.now(),
+    uploadDeferredUntil: "app-session-validated",
+  };
+}
 
 type RestoredCashierPresence = {
   activeRoles?: string[];
@@ -1856,6 +1875,11 @@ export function useRegisterViewModel(): RegisterViewModel {
       }),
     [localStore, terminal?._id],
   );
+  const appSessionRecovery = usePosTerminalAppSessionRecoveryRuntimeInput();
+  const localSaleValidationMetadata = useMemo(
+    () => buildLocalSaleValidationMetadata(appSessionRecovery?.status),
+    [appSessionRecovery?.status],
+  );
   useEffect(() => {
     let cancelled = false;
 
@@ -2561,7 +2585,6 @@ export function useRegisterViewModel(): RegisterViewModel {
   const hasRecoverableDrawerAuthorityBlock =
     localDrawerAuthorityReason === "authority_unknown";
   const hasLifecycleReviewDrawerBlock =
-    localSaleAuthorityBlockReason === "lifecycle_needs_review" ||
     localDrawerAuthorityReason === "lifecycle_rejected";
   const hasLocalSaleAuthorityBlock = Boolean(localSaleAuthorityBlockReason);
   const requiresDrawerGate = Boolean(
@@ -2948,6 +2971,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         registerNumber,
         localRegisterSessionId,
         staffProfileId: actingStaffProfileId,
+        validationMetadata: localSaleValidationMetadata,
         openingFloat: usableActiveRegisterSession.openingFloat,
         expectedCash: usableActiveRegisterSession.expectedCash,
         notes: usableActiveRegisterSession.notes ?? null,
@@ -2964,6 +2988,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       localRegisterReadModel?.activeRegisterSession?.localRegisterSessionId,
       localRegisterReadModel?.canSell,
       localCommandGateway,
+      localSaleValidationMetadata,
       locallyOperableRegisterSession?.localRegisterSessionId,
       noteLocalRegisterEventChanged,
       registerNumber,
@@ -3007,6 +3032,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         registerNumber,
         localRegisterSessionId,
         localPosSessionId: operableActiveSession._id.toString(),
+        validationMetadata: localSaleValidationMetadata,
       });
       if (localSession.kind !== "ok") {
         toast.error("Unable to start this sale. Try again.");
@@ -3056,6 +3082,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       staffProfileId,
       registerNumber,
       localRegisterSessionId,
+      validationMetadata: localSaleValidationMetadata,
     });
 
     if (result.kind !== "ok") {
@@ -3084,6 +3111,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     hasProvisionedLocalSyncSeed,
     isProjectedLocalActiveSaleLockedToAnotherStaff,
     localCommandGateway,
+    localSaleValidationMetadata,
     locallyOperableRegisterSession,
     noteLocalRegisterEventChanged,
     staffProfileId,
@@ -3264,6 +3292,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         localRegisterSessionId: localEventRegisterSessionId ?? registerNumber,
         localPosSessionId: operableActiveSession._id.toString(),
         staffProfileId,
+        validationMetadata: localSaleValidationMetadata,
         checkoutStateVersion: args.checkoutStateVersion,
         payments: args.nextPayments,
         stage: args.stage,
@@ -3290,6 +3319,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       activeStoreId,
       hasProvisionedLocalSyncSeed,
       localCommandGateway,
+      localSaleValidationMetadata,
       noteLocalRegisterEventChanged,
       registerNumber,
       refreshLocalRegisterReadModel,
@@ -3619,6 +3649,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         staffProfileId: actingStaffProfileId,
         registerNumber,
         localRegisterSessionId,
+        validationMetadata: localSaleValidationMetadata,
       });
 
       if (result.kind !== "ok") {
@@ -3661,6 +3692,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     hasProvisionedLocalSyncSeed,
     holdCurrentSession,
     localCommandGateway,
+    localSaleValidationMetadata,
     locallyOperableRegisterSession?.localRegisterSessionId,
     noteLocalRegisterEventChanged,
     projectedLocalActiveSale,
@@ -3720,6 +3752,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       terminalId: terminal._id as Id<"posTerminal">,
       staffProfileId,
       registerNumber,
+      validationMetadata: localSaleValidationMetadata,
       openingFloat: parsedOpeningFloat,
       notes: trimOptional(drawerNotes),
     });
@@ -3754,6 +3787,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     drawerOpeningFloat,
     hasProvisionedLocalSyncSeed,
     localCommandGateway,
+    localSaleValidationMetadata,
     noteLocalRegisterEventChanged,
     registerNumber,
     terminal?._id,
@@ -3801,6 +3835,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       registerNumber,
       localRegisterSessionId: registerSessionId,
       staffProfileId,
+      validationMetadata: localSaleValidationMetadata,
       countedCash: parsedCountedCash,
       notes: trimmedCloseoutNotes ?? null,
     });
@@ -3857,6 +3892,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     closeoutCountedCash,
     closeoutNotes,
     localCommandGateway,
+    localSaleValidationMetadata,
     localStore,
     localRegisterReadModel,
     locallyOperableRegisterSession?.localRegisterSessionId,
@@ -3921,6 +3957,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       registerNumber,
       localRegisterSessionId: registerSessionId,
       staffProfileId,
+      validationMetadata: localSaleValidationMetadata,
       reason: "Register closeout reopened from POS drawer gate.",
     });
     setIsReopeningCloseout(false);
@@ -3950,6 +3987,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     closeoutBlockedRegisterSession,
     isCashierManager,
     localCommandGateway,
+    localSaleValidationMetadata,
     localRegisterReadModel,
     noteLocalRegisterEventChanged,
     registerNumber,
@@ -4158,6 +4196,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         localRegisterSessionId: localEventRegisterSessionId ?? registerNumber,
         localPosSessionId: input.localPosSessionId,
         staffProfileId,
+        validationMetadata: localSaleValidationMetadata,
         payload: input.payload,
       });
     },
@@ -4165,6 +4204,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       localEventRegisterSessionId,
       activeStoreId,
       localCommandGateway,
+      localSaleValidationMetadata,
       registerNumber,
       staffProfileId,
       terminal?._id,
@@ -4250,6 +4290,7 @@ export function useRegisterViewModel(): RegisterViewModel {
             localRegisterSessionId: localEventRegisterSessionId ?? registerNumber,
             localPosSessionId,
             staffProfileId,
+            validationMetadata: localSaleValidationMetadata,
             payload: serviceLineStateToLocalPayload(serviceLine),
           });
 
@@ -4276,6 +4317,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       activeStoreId,
       ensureLocalPosSessionId,
       localCommandGateway,
+      localSaleValidationMetadata,
       localEventRegisterSessionId,
       registerNumber,
       staffProfileId,
@@ -4324,6 +4366,7 @@ export function useRegisterViewModel(): RegisterViewModel {
               localRegisterSessionId: localEventRegisterSessionId ?? registerNumber,
               localPosSessionId,
               staffProfileId,
+              validationMetadata: localSaleValidationMetadata,
               payload: serviceLineStateToLocalPayload(nextLine),
             });
             if (!savedLocally) {
@@ -4358,6 +4401,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       activeStoreId,
       ensureLocalPosSessionId,
       localCommandGateway,
+      localSaleValidationMetadata,
       localEventRegisterSessionId,
       registerNumber,
       serviceLineDrafts,
@@ -4398,6 +4442,7 @@ export function useRegisterViewModel(): RegisterViewModel {
             localRegisterSessionId: localEventRegisterSessionId ?? registerNumber,
             localPosSessionId,
             staffProfileId,
+            validationMetadata: localSaleValidationMetadata,
             payload: {
               ...serviceLineStateToLocalPayload(existing),
               quantity: 0,
@@ -4425,6 +4470,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     activeStoreId,
     ensureLocalPosSessionId,
     localCommandGateway,
+    localSaleValidationMetadata,
     localEventRegisterSessionId,
     registerNumber,
     serviceLineDrafts,
@@ -5379,6 +5425,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         localPosSessionId,
         localTransactionId,
         staffProfileId,
+        validationMetadata: localSaleValidationMetadata,
         payload: buildSalePayload({
           localTransactionId,
           receiptNumber,
@@ -5415,6 +5462,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     customerInfo,
     hasProvisionedLocalSyncSeed,
     localCommandGateway,
+    localSaleValidationMetadata,
     noteLocalRegisterEventChanged,
     readCurrentLocalRegisterModel,
     registerNumber,
@@ -5687,7 +5735,6 @@ export function useRegisterViewModel(): RegisterViewModel {
     activeCloseoutRegisterSession ||
     activeOpeningFloatCorrectionRegisterSession,
   );
-  const appSessionRecovery = usePosTerminalAppSessionRecoveryRuntimeInput();
   const localRuntimeSyncSource = usePosLocalSyncRuntimeStatus({
     appSessionRecovery,
     drainOnAppend: true,
@@ -5994,6 +6041,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         : activeStoreId
           ? "local"
           : "missing",
+      appSessionRecovery: appSessionRecovery?.status ?? null,
       authDialogOpen: Boolean(authDialog?.open),
       cashierPresence: cashierPresenceRestore.status,
       hasLiveActiveStore: Boolean(activeStore),

--- a/packages/athena-webapp/src/offline/posOfflineReadiness.test.ts
+++ b/packages/athena-webapp/src/offline/posOfflineReadiness.test.ts
@@ -5,6 +5,7 @@ import { buildPosOfflineReadinessSummary } from "./posOfflineReadiness";
 describe("buildPosOfflineReadinessSummary", () => {
   it("keeps each offline readiness domain distinct", () => {
     const summary = buildPosOfflineReadinessSummary({
+      appSession: { ready: true },
       appShell: { ready: true },
       availabilitySnapshot: { ready: true, ageMs: 10 * 60_000 },
       registerCatalog: { ready: true, ageMs: 20 * 60_000 },
@@ -15,9 +16,10 @@ describe("buildPosOfflineReadinessSummary", () => {
 
     expect(summary.status).toBe("ready");
     expect(summary.title).toBe("Register ready for offline checkout");
-    expect(summary.readyCount).toBe(6);
+    expect(summary.readyCount).toBe(7);
     expect(summary.signals.map((signal) => signal.domain)).toEqual([
       "app_shell",
+      "app_session",
       "terminal_seed",
       "staff_authority",
       "register_catalog",
@@ -29,6 +31,7 @@ describe("buildPosOfflineReadinessSummary", () => {
 
   it("reports stale snapshots as diagnostic attention without authorizing sales", () => {
     const summary = buildPosOfflineReadinessSummary({
+      appSession: { ready: true },
       appShell: { ready: true },
       availabilitySnapshot: { ready: true, ageMs: 49 * 60 * 60_000 },
       registerCatalog: { ready: true, ageMs: 5 * 60_000 },
@@ -62,6 +65,30 @@ describe("buildPosOfflineReadinessSummary", () => {
       description: "App shell status has not reported to this page yet.",
       domain: "app_shell",
       status: "unknown",
+    });
+  });
+
+  it("treats app-session-unverified continuation as support-safe diagnostics", () => {
+    const summary = buildPosOfflineReadinessSummary({
+      appSession: {
+        status: "local_continuation",
+      },
+      appShell: { ready: true },
+      availabilitySnapshot: { ready: true, ageMs: 10 * 60_000 },
+      registerCatalog: { ready: true, ageMs: 20 * 60_000 },
+      serviceCatalog: { ready: true, ageMs: 30 * 60_000 },
+      staffAuthority: { ready: true },
+      terminalSeed: { ready: true },
+    });
+
+    expect(summary.status).toBe("ready");
+    expect(summary.description).toContain("local sale continuation");
+    expect(
+      summary.signals.find((signal) => signal.domain === "app_session"),
+    ).toMatchObject({
+      description:
+        "App session is unverified while offline. Sales can continue locally and sync later for reconciliation.",
+      status: "local_continuation",
     });
   });
 });

--- a/packages/athena-webapp/src/offline/posOfflineReadiness.ts
+++ b/packages/athena-webapp/src/offline/posOfflineReadiness.ts
@@ -1,5 +1,6 @@
 export type PosOfflineReadinessDomain =
   | "app_shell"
+  | "app_session"
   | "terminal_seed"
   | "staff_authority"
   | "register_catalog"
@@ -7,6 +8,7 @@ export type PosOfflineReadinessDomain =
   | "availability_snapshot";
 
 export type PosOfflineReadinessSignalStatus =
+  | "local_continuation"
   | "ready"
   | "needs_attention"
   | "unknown";
@@ -19,6 +21,7 @@ export type PosOfflineReadinessSignalInput = {
 };
 
 export type PosOfflineReadinessInput = {
+  appSession?: PosOfflineReadinessSignalInput | null;
   appShell?: PosOfflineReadinessSignalInput | null;
   availabilitySnapshot?: PosOfflineReadinessSignalInput | null;
   registerCatalog?: PosOfflineReadinessSignalInput | null;
@@ -70,6 +73,18 @@ const DOMAIN_DEFINITIONS: Array<{
       readyDescription: "App shell recovery is ready.",
     },
     getInput: (input) => input.appShell,
+  },
+  {
+    definition: {
+      domain: "app_session",
+      label: "App session",
+      missingDescription:
+        "App-session continuity has not reported to this page yet.",
+      needsAttentionDescription:
+        "App-session continuity needs an online refresh before POS route recovery is reliable.",
+      readyDescription: "App-session continuity is verified for POS.",
+    },
+    getInput: (input) => input.appSession,
   },
   {
     definition: {
@@ -140,7 +155,7 @@ export function buildPosOfflineReadinessSummary(
   const signals = DOMAIN_DEFINITIONS.map(({ definition, getInput }) =>
     buildSignal(definition, getInput(input)),
   );
-  const readyCount = signals.filter((signal) => signal.status === "ready").length;
+  const readyCount = signals.filter((signal) => isReadyLike(signal.status)).length;
   const needsAttentionCount = signals.filter(
     (signal) => signal.status === "needs_attention",
   ).length;
@@ -152,7 +167,7 @@ export function buildPosOfflineReadinessSummary(
         : "unknown";
 
   return {
-    description: getSummaryDescription(status, readyCount, signals.length),
+    description: getSummaryDescription(status, readyCount, signals),
     readyCount,
     signals,
     status,
@@ -208,6 +223,13 @@ function getSignalDescription(
   input: PosOfflineReadinessSignalInput,
   status: PosOfflineReadinessSignalStatus,
 ) {
+  if (
+    definition.domain === "app_session" &&
+    status === "local_continuation"
+  ) {
+    return "App session is unverified while offline. Sales can continue locally and sync later for reconciliation.";
+  }
+
   if (status === "needs_attention") {
     if (
       definition.staleAfterMs &&
@@ -240,9 +262,17 @@ function getSummaryTitle(status: PosOfflineReadinessSignalStatus) {
 function getSummaryDescription(
   status: PosOfflineReadinessSignalStatus,
   readyCount: number,
-  totalCount: number,
+  signals: PosOfflineReadinessSignal[],
 ) {
+  const hasLocalContinuation = signals.some(
+    (signal) => signal.status === "local_continuation",
+  );
+
   if (status === "ready") {
+    if (hasLocalContinuation) {
+      return "This checkout station has the local POS state needed for local sale continuation while app-session validation waits for the network.";
+    }
+
     return "This checkout station has the app shell, terminal setup, staff authority, catalog, and availability data needed for offline POS.";
   }
 
@@ -250,7 +280,11 @@ function getSummaryDescription(
     return "One or more offline diagnostic signals need attention. This view is diagnostic only.";
   }
 
-  return `${readyCount} of ${totalCount} offline diagnostic signals are reporting here. Missing signals do not block checkout by themselves.`;
+  return `${readyCount} of ${signals.length} offline diagnostic signals are reporting here. Missing signals do not block checkout by themselves.`;
+}
+
+function isReadyLike(status: PosOfflineReadinessSignalStatus) {
+  return status === "ready" || status === "local_continuation";
 }
 
 function formatAge(ageMs: number) {

--- a/packages/athena-webapp/src/routes/_authed.test.tsx
+++ b/packages/athena-webapp/src/routes/_authed.test.tsx
@@ -578,7 +578,7 @@ describe("Authed layout", () => {
     },
   );
 
-  it.each(["idle", "validating", "retrying", "waiting_for_network"])(
+  it.each(["idle", "validating", "retrying"])(
     "keeps POS mutations paused while app-session recovery is %s",
     (status) => {
       mocked.useAuth.mockReturnValue({
@@ -600,10 +600,7 @@ describe("Authed layout", () => {
       expect(screen.queryByTestId("authed-outlet")).not.toBeInTheDocument();
       expect(
         screen.getByRole("heading", {
-          name:
-            status === "waiting_for_network"
-              ? "POS terminal recovery waiting for network"
-              : "POS terminal recovery in progress",
+          name: "POS terminal recovery in progress",
         }),
       ).toBeInTheDocument();
       expect(screen.queryByTestId("app-sidebar")).not.toBeInTheDocument();
@@ -611,6 +608,33 @@ describe("Authed layout", () => {
       expect(mocked.navigate).not.toHaveBeenCalled();
     },
   );
+
+  it("renders the POS shell while app-session recovery waits for network with local continuity evidence", () => {
+    mocked.useAuth.mockReturnValue({
+      user: null,
+      isLoading: false,
+    });
+    mocked.useLocalPosEntryContext.mockReturnValue(readyLocalPosEntryContext());
+    mocked.usePosTerminalAppSessionRecovery.mockReturnValue(
+      recoveryState("waiting_for_network"),
+    );
+    mocked.readStoredPosAppAccountId.mockReturnValue("stored-app-user-1");
+    mocked.useRouterState.mockImplementation(({ select }) =>
+      select({ location: { pathname: "/wigclub/store/wigclub/pos/register" } }),
+    );
+
+    render(<Layout />);
+
+    expect(screen.getByTestId("authed-outlet")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", {
+        name: "POS terminal recovery waiting for network",
+      }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("app-sidebar")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("app-header")).not.toBeInTheDocument();
+    expect(mocked.navigate).not.toHaveBeenCalled();
+  });
 
   it.each([
     ["/wigclub/store/wigclub/products", "Products"],

--- a/packages/athena-webapp/src/routes/_authed.tsx
+++ b/packages/athena-webapp/src/routes/_authed.tsx
@@ -69,7 +69,6 @@ const POS_RECOVERY_SHELL_PENDING_STATUSES = new Set([
   "idle",
   "validating",
   "retrying",
-  "waiting_for_network",
 ]);
 
 function getPosHubRouteParams(pathname?: string) {
@@ -435,6 +434,11 @@ export default function Layout() {
     isAppUserMissing &&
     hasLocalPosRecoveryTarget &&
     posTerminalAppSessionRecovery.status === "recoverable";
+  const isNetworkWaitingPosAppSessionRecovery =
+    routeWantsPos &&
+    isAppUserMissing &&
+    hasLocalPosRecoveryTarget &&
+    posTerminalAppSessionRecovery.status === "waiting_for_network";
   const isPendingPosAppSessionRecovery =
     routeWantsPos &&
     isAppUserMissing &&
@@ -472,6 +476,7 @@ export default function Layout() {
   const shouldRenderPosTerminalShell =
     canRenderRehydratingPosShell ||
     isRecoveredPosAppSession ||
+    isNetworkWaitingPosAppSessionRecovery ||
     canRenderSignedInPosRegisterShell;
   const shouldRenderPendingPosTerminalShell =
     isPendingPosAppSessionRecovery || isClassifyingPosAppSession;

--- a/packages/athena-webapp/src/tests/pos/offlineSalesContinuity.spec.ts
+++ b/packages/athena-webapp/src/tests/pos/offlineSalesContinuity.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const POS_REGISTER_PATH = "/wigclub/store/wigclub/pos/register";
+
+async function waitForRenderedRegisterShell(page: Page) {
+  await expect(page.locator("#app")).not.toBeEmpty({ timeout: 30_000 });
+  await expect(page.locator("body")).toContainText(
+    /checkout|product lookup|register|drawer/i,
+    { timeout: 30_000 },
+  );
+  await expect(page.locator("body")).not.toContainText(
+    /sign in to athena|one-time code|terminal recovery|session recovery|recovery in progress|waiting for network/i,
+  );
+}
+
+async function waitForPosAppShellServiceWorker(page: Page) {
+  await page.waitForFunction(async () => {
+    if (!("serviceWorker" in navigator) || !("caches" in window)) {
+      return false;
+    }
+
+    const registration = await navigator.serviceWorker.ready;
+    if (!registration.active) return false;
+
+    const cacheNames = await caches.keys();
+    return cacheNames.some((name) =>
+      name.startsWith("athena-pos-app-shell-"),
+    );
+  });
+}
+
+async function warmPosRegisterRoute(page: Page) {
+  await page.goto(POS_REGISTER_PATH, { waitUntil: "load" });
+  await waitForRenderedRegisterShell(page);
+  await waitForPosAppShellServiceWorker(page);
+  await page.reload({ waitUntil: "load" });
+  await waitForRenderedRegisterShell(page);
+}
+
+test.describe("POS offline sales continuity", () => {
+  test("keeps the register shell redacted after a no-network hard reload", async ({
+    context,
+    page,
+  }) => {
+    await warmPosRegisterRoute(page);
+
+    await context.setOffline(true);
+
+    try {
+      await page.reload({ waitUntil: "domcontentloaded" });
+      await waitForRenderedRegisterShell(page);
+      await expect(page).toHaveURL(new RegExp(`${POS_REGISTER_PATH}/?$`));
+      await expect(page.locator("body")).not.toContainText(
+        /assertion|bearer|password|secret|syncSecret|token|otp/i,
+      );
+    } finally {
+      await context.setOffline(false);
+    }
+  });
+});

--- a/scripts/harness-app-registry.test.ts
+++ b/scripts/harness-app-registry.test.ts
@@ -890,6 +890,7 @@ describe("HARNESS_APP_REGISTRY", () => {
       "src/lib/pos/infrastructure/local",
       "src/lib/pos/presentation/register",
       "src/tests/pos/offlineRouteAccess.spec.ts",
+      "src/tests/pos/offlineSalesContinuity.spec.ts",
     ]);
     expect(offlineRouteScenario?.commands).toEqual([
       {
@@ -900,7 +901,7 @@ describe("HARNESS_APP_REGISTRY", () => {
       {
         kind: "raw",
         command:
-          "bun run --filter '@athena/webapp' test:e2e -- src/tests/pos/offlineRouteAccess.spec.ts",
+          "bun run --filter '@athena/webapp' test:e2e -- src/tests/pos/offlineRouteAccess.spec.ts src/tests/pos/offlineSalesContinuity.spec.ts",
       },
       {
         kind: "raw",

--- a/scripts/harness-app-registry.ts
+++ b/scripts/harness-app-registry.ts
@@ -717,6 +717,7 @@ export const HARNESS_APP_REGISTRY = [
           "src/lib/pos/infrastructure/local",
           "src/lib/pos/presentation/register",
           "src/tests/pos/offlineRouteAccess.spec.ts",
+          "src/tests/pos/offlineSalesContinuity.spec.ts",
         ],
         commands: [
           {
@@ -727,7 +728,7 @@ export const HARNESS_APP_REGISTRY = [
           {
             kind: "raw",
             command:
-              "bun run --filter '@athena/webapp' test:e2e -- src/tests/pos/offlineRouteAccess.spec.ts",
+              "bun run --filter '@athena/webapp' test:e2e -- src/tests/pos/offlineRouteAccess.spec.ts src/tests/pos/offlineSalesContinuity.spec.ts",
           },
           {
             kind: "raw",

--- a/scripts/harness-audit.test.ts
+++ b/scripts/harness-audit.test.ts
@@ -1095,6 +1095,11 @@ async function createFixtureRepo() {
     "export {};\n",
     rootDir
   );
+  await write(
+    "packages/athena-webapp/src/tests/pos/offlineSalesContinuity.spec.ts",
+    "export {};\n",
+    rootDir
+  );
   await write("packages/athena-webapp/src/test/setup.ts", "export {};\n", rootDir);
   await write("packages/athena-webapp/convex/http.ts", "export {};\n", rootDir);
   await write("packages/athena-webapp/convex/http/router.ts", "export {};\n", rootDir);


### PR DESCRIPTION
## Summary
- keep POS register sales usable through app-session recovery and cloud uncertainty while retaining hard blockers for missing local authority and validation failures
- persist sale validation metadata on local sale, drawer, and session lifecycle events for later upload/review
- add POS shell continuity E2E coverage, sale-blocker policy coverage, harness mapping, graphify updates, solution note, and the moved plan plus requirements docs

## Linear
Refs V26-673, V26-674, V26-675, V26-676, V26-677, V26-679, V26-680

## Validation
- bun run pr:athena
- pre-push validation suite from git push
- reviewer loop unanimous: correctness, security, testing, maintainability

## Notes
- lint:frontend:changed reports one warning in usePosLocalSyncRuntime.ts about uploadSupport; the lint command exits 0 and the warning is non-blocking in the existing gate.