### PR TITLE
feat(pos): harden offline terminal continuity

### DIFF
--- a/docs/solutions/architecture/athena-pos-local-first-entry-readiness-2026-05-14.md
+++ b/docs/solutions/architecture/athena-pos-local-first-entry-readiness-2026-05-14.md
@@ -48,15 +48,21 @@ commands as separate layers:
 - Cashier commands remain local-first. Browser connectivity can trigger sync,
   but it does not decide whether cashier work is first recorded locally.
 
-Live daily-operation snapshots are authoritative once present: a not-started
-Opening Handoff blocks POS, and a completed Daily Close blocks POS unless that
-close lifecycle has been reopened. While those live snapshots are unresolved, a
-valid local readiness record can allow entry.
+Live Daily Close snapshots remain authoritative once present: a completed Daily
+Close blocks POS unless that close lifecycle has been reopened. Opening Handoff
+is more nuanced for operability: if POS already recorded a local store-day start
+for the same store and operating date, live Opening Handoff arrears should stay
+review work instead of sending the cashier back to the start-day gate. A
+not-started Opening Handoff only blocks POS when there is no matching local
+started/reopened readiness record yet.
 
 ## Prevention
 
 - Do not put analytics, summary, or admin-card data in the `/pos` render gate.
 - Do not use `navigator.onLine` as POS entry authority.
+- Do not let a live not-started Opening Handoff snapshot overwrite a matching
+  local started/reopened readiness record. Demoting that record can strand a
+  cashier after offline sales when the network returns.
 - Do not encode daily-opening or daily-close state as register events.
 - Keep local drawer closeout separate from store-day close. Drawer closeout is
   register state; Daily Close is a store-day boundary.

--- a/docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md
+++ b/docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md
@@ -38,6 +38,11 @@ Use POS-only local-first infrastructure:
 - Upload local events in strict register-session sequence through the POS sync boundary.
 - Accept each local event once, record local-to-cloud mappings, and return stable outcomes when the same event is retried.
 - Project accepted events into existing Athena records: register sessions, POS sessions, transactions, transaction items, payment allocations, inventory changes, cash controls, and workflow/audit surfaces.
+- Treat terminal-ingested events with a missing offline staff proof as
+  automatically syncable when the terminal is active, the staff profile still
+  belongs to the store, and the staff role still permits the event. A supplied
+  but invalid proof remains live permission evidence and must create review
+  instead of being masked by stored-staff trust.
 - Preserve completed local sales when inventory, payment, or permission drift appears. Create manager-review reconciliation records instead of rewriting or hiding local history.
 
 ## Boundaries

--- a/docs/solutions/architecture/athena-pos-offline-route-access-2026-06-03.md
+++ b/docs/solutions/architecture/athena-pos-offline-route-access-2026-06-03.md
@@ -50,6 +50,9 @@ Keep offline POS route access as a static shell plus local POS state:
   duplicate registration loops.
 - POS route entry remains local-first through `_authed.tsx`,
   `useGetActiveStore.ts`, local terminal seed, and existing register guards.
+- The app build version checker must not auto-reload the live sales entry
+  surface (`/pos` or `/pos/register`) when a new static build is detected. Keep
+  polling so the app can refresh after the operator leaves live selling.
 - Offline readiness copy is diagnostic only. It distinguishes app shell,
   app-session continuity, terminal setup, staff authority, register catalog,
   service catalog, and availability snapshot readiness without becoming sale

--- a/docs/solutions/architecture/athena-terminal-scoped-cashier-presence-2026-06-04.md
+++ b/docs/solutions/architecture/athena-terminal-scoped-cashier-presence-2026-06-04.md
@@ -65,6 +65,12 @@ token. When proof or freshness is stale or only local continuity evidence is
 available, preserve cashier context only for operator guidance and block
 sale-affecting commands until sign-in supplies a valid proof.
 
+Offline route entry can come from the provisioned terminal seed when live store
+metadata is unavailable. In that state, restore cashier presence by active
+store, terminal, and operating date, then validate the stored organization from
+the presence record itself. Do not require live organization metadata before
+showing the returning-cashier PIN unlock.
+
 Do not render generic username/PIN sign-in as the first reload state for a valid
 presence record. Generic sign-in erases the operator's mental model that the
 same cashier is still associated with the terminal. Prefer a PIN-only unlock

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1829 files · ~0 words
+- 1834 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6157 nodes · 6631 edges · 1757 communities detected
+- 6182 nodes · 6666 edges · 1762 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1767,6 +1767,11 @@
 - [[_COMMUNITY_Community 1754|Community 1754]]
 - [[_COMMUNITY_Community 1755|Community 1755]]
 - [[_COMMUNITY_Community 1756|Community 1756]]
+- [[_COMMUNITY_Community 1757|Community 1757]]
+- [[_COMMUNITY_Community 1758|Community 1758]]
+- [[_COMMUNITY_Community 1759|Community 1759]]
+- [[_COMMUNITY_Community 1760|Community 1760]]
+- [[_COMMUNITY_Community 1761|Community 1761]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1812,15 +1817,15 @@ Nodes (47): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(),
 
 ### Community 4 - "Community 4"
 Cohesion: 0.06
-Nodes (25): assertPosLocalStoreOk(), clearAcceptedTerminalIntegrityState(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds() (+17 more)
+Nodes (27): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatCompactTextList(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary() (+19 more)
 
 ### Community 5 - "Community 5"
-Cohesion: 0.1
-Nodes (45): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectHarnessSafetySignalFindings(), collectHarnessScriptTestUpdateFindings(), createOutput() (+37 more)
+Cohesion: 0.06
+Nodes (25): assertPosLocalStoreOk(), clearAcceptedTerminalIntegrityState(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds() (+17 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.06
-Nodes (27): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatCompactTextList(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary() (+19 more)
+Cohesion: 0.1
+Nodes (45): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectHarnessSafetySignalFindings(), collectHarnessScriptTestUpdateFindings(), createOutput() (+37 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.09
@@ -1835,64 +1840,64 @@ Cohesion: 0.08
 Nodes (20): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+12 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.11
-Nodes (23): canonicalize(), canonicalJson(), createLocalSyncIngestionService(), ingestLocalEventsWithCtx(), isNonEmptyString(), isNonNegativeFiniteNumber(), isOptionalNonEmptyString(), isRecord() (+15 more)
-
-### Community 11 - "Community 11"
 Cohesion: 0.07
 Nodes (12): createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), normalizeCashierPresenceRecord(), normalizeDrawerAuthorityState(), normalizeStaffAuthorityRecord(), normalizeTerminalIntegrityState(), normalizeUsername(), PosLocalStoreSchemaError (+4 more)
 
+### Community 11 - "Community 11"
+Cohesion: 0.11
+Nodes (30): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildRegisterCloseoutTimelineEvents(), buildWeekMetricForDate(), buildWeekMetrics(), compareDailyOperationsTimelineEvents(), compareTimelineEvents() (+22 more)
+
 ### Community 12 - "Community 12"
-Cohesion: 0.12
-Nodes (31): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+23 more)
+Cohesion: 0.11
+Nodes (23): canonicalize(), canonicalJson(), createLocalSyncIngestionService(), ingestLocalEventsWithCtx(), isNonEmptyString(), isNonNegativeFiniteNumber(), isOptionalNonEmptyString(), isRecord() (+15 more)
 
 ### Community 13 - "Community 13"
 Cohesion: 0.08
-Nodes (20): formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels(), getSkuDetailEntries() (+12 more)
+Nodes (21): formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels(), getSkuDetailEntries() (+13 more)
 
 ### Community 14 - "Community 14"
+Cohesion: 0.12
+Nodes (31): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+23 more)
+
+### Community 15 - "Community 15"
 Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
-### Community 15 - "Community 15"
+### Community 16 - "Community 16"
 Cohesion: 0.12
 Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
 
-### Community 16 - "Community 16"
+### Community 17 - "Community 17"
 Cohesion: 0.18
 Nodes (30): asRecord(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale(), getPhase() (+22 more)
 
-### Community 17 - "Community 17"
+### Community 18 - "Community 18"
 Cohesion: 0.15
 Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
 
-### Community 18 - "Community 18"
+### Community 19 - "Community 19"
 Cohesion: 0.14
 Nodes (24): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+16 more)
 
-### Community 19 - "Community 19"
+### Community 20 - "Community 20"
 Cohesion: 0.15
 Nodes (24): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+16 more)
 
-### Community 20 - "Community 20"
+### Community 21 - "Community 21"
 Cohesion: 0.2
 Nodes (28): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftCreatedMessage(), buildCycleCountDraftSavedMessage(), buildCycleCountDraftSubmissionKey(), buildCycleCountDraftSubmittedMessage(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx() (+20 more)
 
-### Community 21 - "Community 21"
+### Community 22 - "Community 22"
 Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
-### Community 22 - "Community 22"
+### Community 23 - "Community 23"
 Cohesion: 0.08
 Nodes (7): buildMissingDraftResult(), getApprovalRequestCopy(), handleDecideApprovalRequest(), handleDiscardCycleCountDraft(), handleRefreshCycleCountDraftLineBaseline(), handleSaveCycleCountDraftLine(), handleSubmitCycleCountDraft()
 
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.15
 Nodes (22): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildInferentialSummaryNote(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem() (+14 more)
-
-### Community 24 - "Community 24"
-Cohesion: 0.14
-Nodes (25): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildWeekMetricForDate(), buildWeekMetrics(), compareTimelineEvents(), emptyCloseSummary(), getCloseItemCounts() (+17 more)
 
 ### Community 25 - "Community 25"
 Cohesion: 0.1
@@ -1927,20 +1932,20 @@ Cohesion: 0.17
 Nodes (18): buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsTransactionSearch(), getDailyOperationsMetricLabels(), getLocalDateFromOperatingDate(), getLocalOperatingDate(), getLocalOperatingDateRange(), getLocalOperatingDateRangeFromSearch() (+10 more)
 
 ### Community 33 - "Community 33"
+Cohesion: 0.09
+Nodes (2): buildCashControlsDashboardSnapshot(), sumDepositsBySession()
+
+### Community 34 - "Community 34"
 Cohesion: 0.1
 Nodes (4): listCompletedTransactionsForDay(), listSessionItems(), listTransactionItems(), readAllQueryResults()
 
-### Community 34 - "Community 34"
+### Community 35 - "Community 35"
 Cohesion: 0.16
 Nodes (20): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle(), formatSignedQuantity() (+12 more)
 
-### Community 35 - "Community 35"
+### Community 36 - "Community 36"
 Cohesion: 0.15
 Nodes (16): buildGitProcessEnv(), collectCommandsForChangedFiles(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets() (+8 more)
-
-### Community 36 - "Community 36"
-Cohesion: 0.1
-Nodes (2): buildCashControlsDashboardSnapshot(), sumDepositsBySession()
 
 ### Community 37 - "Community 37"
 Cohesion: 0.2
@@ -2087,16 +2092,16 @@ Cohesion: 0.31
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getOperationalWorkItemStatus() (+5 more)
 
 ### Community 73 - "Community 73"
-Cohesion: 0.15
-Nodes (2): handleKeyDown(), isDebugShortcut()
-
-### Community 74 - "Community 74"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 75 - "Community 75"
+### Community 74 - "Community 74"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
+
+### Community 75 - "Community 75"
+Cohesion: 0.26
+Nodes (12): bestFuzzyTokenScore(), compactSearchText(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreCompactFieldContains(), scoreFuzzySearchEntry() (+4 more)
 
 ### Community 76 - "Community 76"
 Cohesion: 0.26
@@ -2171,12 +2176,12 @@ Cohesion: 0.24
 Nodes (7): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), useConvexRegisterServiceCatalog(), usePrewarmRegisterCatalogOfflineSnapshots()
 
 ### Community 94 - "Community 94"
-Cohesion: 0.29
-Nodes (10): bestFuzzyTokenScore(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreFuzzySearchEntry(), scoreFuzzyTokenMatch(), scoreQueryTokenForEntry() (+2 more)
-
-### Community 95 - "Community 95"
 Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
+
+### Community 95 - "Community 95"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 96 - "Community 96"
 Cohesion: 0.36
@@ -2195,196 +2200,196 @@ Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
 ### Community 100 - "Community 100"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 101 - "Community 101"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 102 - "Community 102"
-Cohesion: 0.24
+### Community 101 - "Community 101"
+Cohesion: 0.25
 Nodes (5): blocked(), evaluateLocalPosReadiness(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 103 - "Community 103"
+### Community 102 - "Community 102"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 104 - "Community 104"
+### Community 103 - "Community 103"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 105 - "Community 105"
+### Community 104 - "Community 104"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
 
-### Community 106 - "Community 106"
+### Community 105 - "Community 105"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 107 - "Community 107"
+### Community 106 - "Community 106"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 108 - "Community 108"
+### Community 107 - "Community 107"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 109 - "Community 109"
+### Community 108 - "Community 108"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 110 - "Community 110"
+### Community 109 - "Community 109"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 111 - "Community 111"
+### Community 110 - "Community 110"
 Cohesion: 0.24
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
-### Community 112 - "Community 112"
+### Community 111 - "Community 111"
 Cohesion: 0.22
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 113 - "Community 113"
+### Community 112 - "Community 112"
 Cohesion: 0.31
 Nodes (7): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), parseVariantDisplayMoney(), saveProduct(), updateVariantSku()
 
-### Community 114 - "Community 114"
+### Community 113 - "Community 113"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 115 - "Community 115"
+### Community 114 - "Community 114"
 Cohesion: 0.29
 Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
 
-### Community 116 - "Community 116"
+### Community 115 - "Community 115"
 Cohesion: 0.22
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 117 - "Community 117"
+### Community 116 - "Community 116"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 118 - "Community 118"
+### Community 117 - "Community 117"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 119 - "Community 119"
+### Community 118 - "Community 118"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 120 - "Community 120"
-Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
-
-### Community 121 - "Community 121"
+### Community 119 - "Community 119"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 122 - "Community 122"
+### Community 120 - "Community 120"
 Cohesion: 0.42
 Nodes (7): getRegisterCatalogPrice(), listRegisterCatalog(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
 
-### Community 123 - "Community 123"
+### Community 121 - "Community 121"
+Cohesion: 0.39
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+
+### Community 122 - "Community 122"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 124 - "Community 124"
+### Community 123 - "Community 123"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 125 - "Community 125"
+### Community 124 - "Community 124"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 126 - "Community 126"
+### Community 125 - "Community 125"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 127 - "Community 127"
+### Community 126 - "Community 126"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 128 - "Community 128"
+### Community 127 - "Community 127"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 129 - "Community 129"
+### Community 128 - "Community 128"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 130 - "Community 130"
+### Community 129 - "Community 129"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 131 - "Community 131"
+### Community 130 - "Community 130"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 132 - "Community 132"
+### Community 131 - "Community 131"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 133 - "Community 133"
+### Community 132 - "Community 132"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 134 - "Community 134"
+### Community 133 - "Community 133"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 135 - "Community 135"
+### Community 134 - "Community 134"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 136 - "Community 136"
+### Community 135 - "Community 135"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 137 - "Community 137"
+### Community 136 - "Community 136"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 138 - "Community 138"
+### Community 137 - "Community 137"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 139 - "Community 139"
+### Community 138 - "Community 138"
 Cohesion: 0.43
 Nodes (6): assertActiveTerminal(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 140 - "Community 140"
+### Community 139 - "Community 139"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 141 - "Community 141"
+### Community 140 - "Community 140"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
+
+### Community 141 - "Community 141"
+Cohesion: 0.25
+Nodes (0):
 
 ### Community 142 - "Community 142"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 143 - "Community 143"
-Cohesion: 0.25
-Nodes (0):
-
-### Community 144 - "Community 144"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 145 - "Community 145"
+### Community 144 - "Community 144"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 146 - "Community 146"
+### Community 145 - "Community 145"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 147 - "Community 147"
+### Community 146 - "Community 146"
 Cohesion: 0.25
 Nodes (0):
+
+### Community 147 - "Community 147"
+Cohesion: 0.29
+Nodes (2): handleKeyDown(), isDebugShortcut()
 
 ### Community 148 - "Community 148"
 Cohesion: 0.25
@@ -2500,159 +2505,159 @@ Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 176 - "Community 176"
 Cohesion: 0.29
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 177 - "Community 177"
-Cohesion: 0.48
-Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
+Cohesion: 0.33
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
 ### Community 178 - "Community 178"
-Cohesion: 0.33
-Nodes (2): handleReset(), handleSubmit()
-
-### Community 179 - "Community 179"
 Cohesion: 0.29
 Nodes (0):
 
+### Community 179 - "Community 179"
+Cohesion: 0.48
+Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
+
 ### Community 180 - "Community 180"
-Cohesion: 0.52
-Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
+Cohesion: 0.33
+Nodes (2): handleReset(), handleSubmit()
 
 ### Community 181 - "Community 181"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 182 - "Community 182"
-Cohesion: 0.33
-Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
+Cohesion: 0.52
+Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
 ### Community 183 - "Community 183"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 184 - "Community 184"
+Cohesion: 0.33
+Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
+
+### Community 185 - "Community 185"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 187 - "Community 187"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 186 - "Community 186"
+### Community 188 - "Community 188"
 Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
-### Community 187 - "Community 187"
+### Community 189 - "Community 189"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 188 - "Community 188"
+### Community 190 - "Community 190"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 189 - "Community 189"
+### Community 191 - "Community 191"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 190 - "Community 190"
+### Community 192 - "Community 192"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 191 - "Community 191"
+### Community 193 - "Community 193"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 192 - "Community 192"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 193 - "Community 193"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 194 - "Community 194"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 195 - "Community 195"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 196 - "Community 196"
 Cohesion: 0.47
 Nodes (4): buildOperationalEvent(), matchesExistingEvent(), metadataDedupeKeysMatch(), recordOperationalEventWithCtx()
 
-### Community 195 - "Community 195"
-Cohesion: 0.4
-Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
-
-### Community 196 - "Community 196"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 197 - "Community 197"
 Cohesion: 0.4
-Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
+Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
 
 ### Community 198 - "Community 198"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 199 - "Community 199"
+Cohesion: 0.4
+Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
+
+### Community 200 - "Community 200"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 201 - "Community 201"
 Cohesion: 0.53
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 200 - "Community 200"
+### Community 202 - "Community 202"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 201 - "Community 201"
+### Community 203 - "Community 203"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 202 - "Community 202"
+### Community 204 - "Community 204"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 203 - "Community 203"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 204 - "Community 204"
-Cohesion: 0.53
-Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
-
 ### Community 205 - "Community 205"
 Cohesion: 0.33
-Nodes (1): DataTableToolbar()
+Nodes (0):
 
 ### Community 206 - "Community 206"
 Cohesion: 0.53
-Nodes (2): SelectedProductsProvider(), useSelectedProducts()
+Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
 ### Community 207 - "Community 207"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): DataTableToolbar()
 
 ### Community 208 - "Community 208"
-Cohesion: 0.47
-Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
+Cohesion: 0.53
+Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
 ### Community 209 - "Community 209"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 210 - "Community 210"
+Cohesion: 0.47
+Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
+
+### Community 211 - "Community 211"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 212 - "Community 212"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 211 - "Community 211"
+### Community 213 - "Community 213"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 212 - "Community 212"
+### Community 214 - "Community 214"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
-
-### Community 213 - "Community 213"
-Cohesion: 0.33
-Nodes (1): ResizeObserverStub
-
-### Community 214 - "Community 214"
-Cohesion: 0.4
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
 ### Community 215 - "Community 215"
 Cohesion: 0.33
@@ -2719,108 +2724,108 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 231 - "Community 231"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 232 - "Community 232"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 233 - "Community 233"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 234 - "Community 234"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 235 - "Community 235"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 236 - "Community 236"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 237 - "Community 237"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 238 - "Community 238"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 239 - "Community 239"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 241 - "Community 241"
+### Community 242 - "Community 242"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 242 - "Community 242"
+### Community 243 - "Community 243"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 244 - "Community 244"
+### Community 245 - "Community 245"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 245 - "Community 245"
+### Community 246 - "Community 246"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 246 - "Community 246"
+### Community 247 - "Community 247"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 247 - "Community 247"
+### Community 248 - "Community 248"
 Cohesion: 0.5
 Nodes (2): createAuthorizedRegisterDepositCtx(), createQueryCtx()
 
-### Community 248 - "Community 248"
+### Community 249 - "Community 249"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 249 - "Community 249"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 250 - "Community 250"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 251 - "Community 251"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 252 - "Community 252"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
-
-### Community 253 - "Community 253"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 254 - "Community 254"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 255 - "Community 255"
-Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
-
-### Community 256 - "Community 256"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 256 - "Community 256"
+Cohesion: 0.7
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
 ### Community 257 - "Community 257"
 Cohesion: 0.4
@@ -2831,24 +2836,24 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 259 - "Community 259"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 260 - "Community 260"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 261 - "Community 261"
+### Community 262 - "Community 262"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 262 - "Community 262"
+### Community 263 - "Community 263"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
-
-### Community 263 - "Community 263"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 264 - "Community 264"
 Cohesion: 0.4
@@ -2867,12 +2872,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 268 - "Community 268"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 269 - "Community 269"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 269 - "Community 269"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 270 - "Community 270"
 Cohesion: 0.4
@@ -2891,28 +2896,28 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 274 - "Community 274"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 275 - "Community 275"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
-### Community 275 - "Community 275"
+### Community 276 - "Community 276"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 276 - "Community 276"
+### Community 277 - "Community 277"
 Cohesion: 0.5
 Nodes (2): buildTerminalOfflineReadiness(), getAppSessionReadinessInput()
 
-### Community 277 - "Community 277"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 278 - "Community 278"
 Cohesion: 0.4
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 279 - "Community 279"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 280 - "Community 280"
 Cohesion: 0.4
@@ -2923,48 +2928,48 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 282 - "Community 282"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 283 - "Community 283"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 283 - "Community 283"
+### Community 284 - "Community 284"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 284 - "Community 284"
+### Community 285 - "Community 285"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 285 - "Community 285"
+### Community 286 - "Community 286"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 286 - "Community 286"
+### Community 287 - "Community 287"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 287 - "Community 287"
-Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 288 - "Community 288"
 Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 289 - "Community 289"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 290 - "Community 290"
 Cohesion: 0.6
-Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 291 - "Community 291"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
 ### Community 292 - "Community 292"
-Cohesion: 0.6
-Nodes (3): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 293 - "Community 293"
 Cohesion: 0.4
@@ -2983,84 +2988,84 @@ Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 297 - "Community 297"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (3): createVersionChecker(), shouldAutoReloadForCurrentRoute(), shouldAutoReloadForPath()
 
 ### Community 298 - "Community 298"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 299 - "Community 299"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 300 - "Community 300"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 301 - "Community 301"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 302 - "Community 302"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 303 - "Community 303"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
-
-### Community 304 - "Community 304"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 304 - "Community 304"
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 305 - "Community 305"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 306 - "Community 306"
-Cohesion: 0.6
-Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 307 - "Community 307"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 307 - "Community 307"
+Cohesion: 0.6
+Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+
 ### Community 308 - "Community 308"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 309 - "Community 309"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 309 - "Community 309"
+### Community 310 - "Community 310"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 310 - "Community 310"
+### Community 311 - "Community 311"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 311 - "Community 311"
+### Community 312 - "Community 312"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 312 - "Community 312"
+### Community 313 - "Community 313"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 313 - "Community 313"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 314 - "Community 314"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 315 - "Community 315"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
-
-### Community 316 - "Community 316"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 316 - "Community 316"
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 317 - "Community 317"
 Cohesion: 0.5
@@ -3071,72 +3076,72 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 319 - "Community 319"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 320 - "Community 320"
 Cohesion: 0.67
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 320 - "Community 320"
+### Community 321 - "Community 321"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 321 - "Community 321"
+### Community 322 - "Community 322"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 322 - "Community 322"
+### Community 323 - "Community 323"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 323 - "Community 323"
+### Community 324 - "Community 324"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 324 - "Community 324"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 325 - "Community 325"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 326 - "Community 326"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 327 - "Community 327"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 327 - "Community 327"
+### Community 328 - "Community 328"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 328 - "Community 328"
+### Community 329 - "Community 329"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 329 - "Community 329"
+### Community 330 - "Community 330"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 330 - "Community 330"
+### Community 331 - "Community 331"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 331 - "Community 331"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 332 - "Community 332"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 333 - "Community 333"
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+
+### Community 334 - "Community 334"
 Cohesion: 0.67
 Nodes (2): lookupByBarcode(), mapSkuToCatalogResult()
 
-### Community 334 - "Community 334"
+### Community 335 - "Community 335"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
-
-### Community 335 - "Community 335"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 336 - "Community 336"
 Cohesion: 0.5
@@ -3151,28 +3156,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 339 - "Community 339"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 340 - "Community 340"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 340 - "Community 340"
+### Community 341 - "Community 341"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 341 - "Community 341"
+### Community 342 - "Community 342"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 342 - "Community 342"
-Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 343 - "Community 343"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 344 - "Community 344"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 345 - "Community 345"
 Cohesion: 0.5
@@ -3183,24 +3188,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 347 - "Community 347"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 348 - "Community 348"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 349 - "Community 349"
 Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 350 - "Community 350"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 351 - "Community 351"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 352 - "Community 352"
 Cohesion: 0.5
@@ -3219,8 +3224,8 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 356 - "Community 356"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 357 - "Community 357"
 Cohesion: 0.5
@@ -3228,47 +3233,47 @@ Nodes (0):
 
 ### Community 358 - "Community 358"
 Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 359 - "Community 359"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 360 - "Community 360"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 361 - "Community 361"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 362 - "Community 362"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 363 - "Community 363"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 364 - "Community 364"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 365 - "Community 365"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 366 - "Community 366"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 367 - "Community 367"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 368 - "Community 368"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 369 - "Community 369"
 Cohesion: 0.5
@@ -3276,19 +3281,19 @@ Nodes (0):
 
 ### Community 370 - "Community 370"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 371 - "Community 371"
-Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
-
-### Community 372 - "Community 372"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 372 - "Community 372"
+Cohesion: 0.67
+Nodes (2): useGetArchivedProducts(), useGetProducts()
+
 ### Community 373 - "Community 373"
 Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
 
 ### Community 374 - "Community 374"
 Cohesion: 0.5
@@ -3296,23 +3301,23 @@ Nodes (0):
 
 ### Community 375 - "Community 375"
 Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 376 - "Community 376"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 377 - "Community 377"
+Cohesion: 0.67
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
+
+### Community 378 - "Community 378"
 Cohesion: 0.67
 Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
-### Community 377 - "Community 377"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 378 - "Community 378"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 379 - "Community 379"
-Cohesion: 0.67
-Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 380 - "Community 380"
 Cohesion: 0.5
@@ -3320,55 +3325,55 @@ Nodes (0):
 
 ### Community 381 - "Community 381"
 Cohesion: 0.67
-Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
+Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
 ### Community 382 - "Community 382"
-Cohesion: 0.83
-Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
-
-### Community 383 - "Community 383"
-Cohesion: 0.83
-Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
-
-### Community 384 - "Community 384"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 383 - "Community 383"
+Cohesion: 0.67
+Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
+
+### Community 384 - "Community 384"
+Cohesion: 0.83
+Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
+
 ### Community 385 - "Community 385"
 Cohesion: 0.83
-Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
+Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
 ### Community 386 - "Community 386"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 387 - "Community 387"
+Cohesion: 0.83
+Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
+
+### Community 388 - "Community 388"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 389 - "Community 389"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 388 - "Community 388"
+### Community 390 - "Community 390"
 Cohesion: 0.83
 Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
-### Community 389 - "Community 389"
+### Community 391 - "Community 391"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 390 - "Community 390"
+### Community 392 - "Community 392"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 391 - "Community 391"
+### Community 393 - "Community 393"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 392 - "Community 392"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 393 - "Community 393"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 394 - "Community 394"
 Cohesion: 0.5
@@ -3395,76 +3400,76 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 400 - "Community 400"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 401 - "Community 401"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 402 - "Community 402"
 Cohesion: 0.67
 Nodes (2): useOptionalStoreContext(), useStoreContext()
 
-### Community 401 - "Community 401"
+### Community 403 - "Community 403"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 402 - "Community 402"
+### Community 404 - "Community 404"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 403 - "Community 403"
+### Community 405 - "Community 405"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 404 - "Community 404"
+### Community 406 - "Community 406"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 405 - "Community 405"
+### Community 407 - "Community 407"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 406 - "Community 406"
+### Community 408 - "Community 408"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 407 - "Community 407"
+### Community 409 - "Community 409"
 Cohesion: 0.67
 Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
-### Community 408 - "Community 408"
+### Community 410 - "Community 410"
 Cohesion: 0.67
 Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
-### Community 409 - "Community 409"
+### Community 411 - "Community 411"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 410 - "Community 410"
+### Community 412 - "Community 412"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 411 - "Community 411"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 412 - "Community 412"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 413 - "Community 413"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 414 - "Community 414"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 415 - "Community 415"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 416 - "Community 416"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 417 - "Community 417"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 418 - "Community 418"
 Cohesion: 0.67
@@ -3495,16 +3500,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 425 - "Community 425"
-Cohesion: 1.0
-Nodes (2): buildCtx(), createDb()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 426 - "Community 426"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 427 - "Community 427"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildCtx(), createDb()
 
 ### Community 428 - "Community 428"
 Cohesion: 0.67
@@ -3515,16 +3520,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 430 - "Community 430"
-Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 431 - "Community 431"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 432 - "Community 432"
-Cohesion: 0.67
-Nodes (1): PosServerError
+Cohesion: 1.0
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 433 - "Community 433"
 Cohesion: 0.67
@@ -3532,7 +3537,7 @@ Nodes (0):
 
 ### Community 434 - "Community 434"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 435 - "Community 435"
 Cohesion: 0.67
@@ -3543,28 +3548,28 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 437 - "Community 437"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 438 - "Community 438"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 439 - "Community 439"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 440 - "Community 440"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 441 - "Community 441"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 442 - "Community 442"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 443 - "Community 443"
 Cohesion: 0.67
@@ -3575,52 +3580,52 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 445 - "Community 445"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 446 - "Community 446"
-Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 447 - "Community 447"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 448 - "Community 448"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 449 - "Community 449"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 450 - "Community 450"
-Cohesion: 1.0
-Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 451 - "Community 451"
 Cohesion: 0.67
-Nodes (1): View()
+Nodes (0):
 
 ### Community 452 - "Community 452"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 453 - "Community 453"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
 ### Community 454 - "Community 454"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 455 - "Community 455"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 456 - "Community 456"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 457 - "Community 457"
 Cohesion: 0.67
@@ -3631,32 +3636,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 459 - "Community 459"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+
+### Community 460 - "Community 460"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 460 - "Community 460"
-Cohesion: 1.0
-Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
-
 ### Community 461 - "Community 461"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 462 - "Community 462"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 463 - "Community 463"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
 ### Community 464 - "Community 464"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (1): FadeIn()
 
 ### Community 465 - "Community 465"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 466 - "Community 466"
 Cohesion: 0.67
@@ -3664,11 +3669,11 @@ Nodes (0):
 
 ### Community 467 - "Community 467"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 468 - "Community 468"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 469 - "Community 469"
 Cohesion: 0.67
@@ -3740,83 +3745,83 @@ Nodes (0):
 
 ### Community 486 - "Community 486"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 487 - "Community 487"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (0):
 
 ### Community 488 - "Community 488"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 489 - "Community 489"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 490 - "Community 490"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 491 - "Community 491"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 492 - "Community 492"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TableSkeleton()
 
 ### Community 493 - "Community 493"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
+Cohesion: 0.67
+Nodes (1): TransactionsSkeleton()
 
 ### Community 494 - "Community 494"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (1): NotFound()
 
 ### Community 495 - "Community 495"
-Cohesion: 0.67
-Nodes (1): Badge()
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
 ### Community 496 - "Community 496"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): AppContextMenu()
 
 ### Community 497 - "Community 497"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): Badge()
 
 ### Community 498 - "Community 498"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (0):
 
 ### Community 499 - "Community 499"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): LoadingButton()
 
 ### Community 500 - "Community 500"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): onChange()
 
 ### Community 501 - "Community 501"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): AlertModal()
 
 ### Community 502 - "Community 502"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): OverlayModal()
 
 ### Community 503 - "Community 503"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Skeleton()
 
 ### Community 504 - "Community 504"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 505 - "Community 505"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 506 - "Community 506"
 Cohesion: 0.67
@@ -3844,7 +3849,7 @@ Nodes (0):
 
 ### Community 512 - "Community 512"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 513 - "Community 513"
 Cohesion: 0.67
@@ -3852,27 +3857,27 @@ Nodes (0):
 
 ### Community 514 - "Community 514"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 515 - "Community 515"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 516 - "Community 516"
-Cohesion: 1.0
-Nodes (2): getApprovalGuidance(), presentCommandToast()
-
-### Community 517 - "Community 517"
-Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
-
-### Community 518 - "Community 518"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 519 - "Community 519"
+### Community 517 - "Community 517"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 518 - "Community 518"
 Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
+Nodes (2): getApprovalGuidance(), presentCommandToast()
+
+### Community 519 - "Community 519"
+Cohesion: 0.67
+Nodes (1): isInMaintenanceMode()
 
 ### Community 520 - "Community 520"
 Cohesion: 0.67
@@ -3880,15 +3885,15 @@ Nodes (0):
 
 ### Community 521 - "Community 521"
 Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 522 - "Community 522"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 523 - "Community 523"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 524 - "Community 524"
 Cohesion: 0.67
@@ -3896,43 +3901,43 @@ Nodes (0):
 
 ### Community 525 - "Community 525"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 526 - "Community 526"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 527 - "Community 527"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (1): App()
 
 ### Community 528 - "Community 528"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 529 - "Community 529"
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+
+### Community 530 - "Community 530"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 530 - "Community 530"
+### Community 531 - "Community 531"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 532 - "Community 532"
 Cohesion: 1.0
 Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
-### Community 531 - "Community 531"
+### Community 533 - "Community 533"
 Cohesion: 1.0
 Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
-### Community 532 - "Community 532"
-Cohesion: 0.67
-Nodes (1): hashPassword()
-
-### Community 533 - "Community 533"
-Cohesion: 0.67
-Nodes (1): createVersionChecker()
-
 ### Community 534 - "Community 534"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): hashPassword()
 
 ### Community 535 - "Community 535"
 Cohesion: 0.67
@@ -3940,11 +3945,11 @@ Nodes (0):
 
 ### Community 536 - "Community 536"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 537 - "Community 537"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 538 - "Community 538"
 Cohesion: 0.67
@@ -3952,19 +3957,19 @@ Nodes (0):
 
 ### Community 539 - "Community 539"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 540 - "Community 540"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 541 - "Community 541"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 542 - "Community 542"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 543 - "Community 543"
 Cohesion: 0.67
@@ -3975,32 +3980,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 545 - "Community 545"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 546 - "Community 546"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 547 - "Community 547"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 548 - "Community 548"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 549 - "Community 549"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 550 - "Community 550"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 551 - "Community 551"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 552 - "Community 552"
 Cohesion: 0.67
@@ -4063,8 +4068,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 567 - "Community 567"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 568 - "Community 568"
 Cohesion: 0.67
@@ -4072,11 +4077,11 @@ Nodes (0):
 
 ### Community 569 - "Community 569"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
 
 ### Community 570 - "Community 570"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 571 - "Community 571"
 Cohesion: 1.0
@@ -4091,24 +4096,24 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 574 - "Community 574"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 575 - "Community 575"
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
+
+### Community 576 - "Community 576"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 576 - "Community 576"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
-
 ### Community 577 - "Community 577"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 578 - "Community 578"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 579 - "Community 579"
 Cohesion: 1.0
@@ -8822,1352 +8827,1368 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1757 - "Community 1757"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1758 - "Community 1758"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1759 - "Community 1759"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1760 - "Community 1760"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1761 - "Community 1761"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 577`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 579`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 578`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 580`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 579`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 581`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 580`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 582`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 581`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 583`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 582`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 584`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 583`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 585`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 584`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 586`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 585`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 587`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 586`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 588`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 587`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 589`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 590`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 591`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 592`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 593`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 594`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 595`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
+- **Thin community `Community 596`** (2 nodes): `posSessionItems.ts`, `userErrorFromSessionItemFailure()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 597`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 598`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 599`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 600`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 601`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 602`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 603`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 604`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 605`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 606`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 607`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 608`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 609`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 610`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 611`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 612`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 613`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 614`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 615`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 616`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 617`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 618`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 619`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 620`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 621`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 622`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 623`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 624`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 625`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 626`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 627`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 628`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
+- **Thin community `Community 629`** (2 nodes): `requireRegisterCatalogStoreAccess()`, `catalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
+- **Thin community `Community 630`** (2 nodes): `transactions.ts`, `mapCorrectionError()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 631`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 632`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 633`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 634`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 635`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
+- **Thin community `Community 636`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 637`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 638`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 639`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 640`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 641`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 642`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 643`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 644`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 645`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 646`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 647`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 648`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 649`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 650`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 651`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 652`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 653`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 654`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 655`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 656`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 657`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 658`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 659`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 660`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 661`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 662`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 663`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 664`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 665`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 666`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 667`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 668`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 669`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 670`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 671`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 672`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 673`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 674`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 675`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 676`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 677`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 678`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 679`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 680`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 681`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 682`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 683`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 684`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 685`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 686`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 687`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 688`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 689`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 690`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 691`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 692`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 693`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 694`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 695`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 696`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 697`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 698`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 699`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 700`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 701`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 702`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 703`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 704`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 705`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 706`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 707`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 708`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 709`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 710`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 711`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 712`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 713`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 714`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 715`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 716`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 717`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 718`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 719`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 720`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 721`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 722`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 723`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 724`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 725`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 726`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 727`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 728`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 729`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 730`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 731`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 732`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 733`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 734`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 735`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 736`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 737`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 738`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 739`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 740`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 741`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 742`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 743`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 744`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 745`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 746`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 747`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 748`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 749`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 750`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 751`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 752`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 753`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 754`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 755`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 756`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 757`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 758`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 759`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 760`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 761`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 762`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 763`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 764`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 765`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 766`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 767`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 768`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 769`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 770`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 771`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 772`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 773`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 774`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 775`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 776`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 777`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 778`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 779`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 780`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 781`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 782`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 783`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 784`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 785`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 786`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 787`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 788`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 789`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 790`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 791`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 792`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 793`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 794`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 795`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 796`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 797`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 798`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 799`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 800`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 801`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 802`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 803`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 804`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 805`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 806`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 807`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 808`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 809`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 810`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 811`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 812`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 813`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 814`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 815`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 816`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 817`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 818`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 819`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 820`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 821`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 822`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 823`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 824`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 825`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 826`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 827`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 828`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 829`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 830`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 831`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 832`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 833`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 834`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 835`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 836`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 837`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 838`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
+- **Thin community `Community 839`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 840`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 841`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 842`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 843`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 844`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 845`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 846`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 847`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 848`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 849`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 850`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 851`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 852`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 853`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 854`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 855`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 856`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 857`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 858`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 859`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 860`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 861`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 862`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 863`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 864`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 865`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 866`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 867`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 868`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 869`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 870`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 871`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 872`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 873`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 874`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 875`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 876`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 877`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 878`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 879`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 880`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 881`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 882`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 883`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 884`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 885`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 886`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 887`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 888`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 889`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 890`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 891`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 892`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 893`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 894`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 895`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 896`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 897`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 898`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 899`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 900`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 901`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 902`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 903`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 904`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 905`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 906`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 907`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 908`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 909`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 910`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 911`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 912`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 913`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 914`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 915`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 916`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 917`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 918`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 919`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 920`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 921`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 922`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 923`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 924`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 925`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 926`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 927`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 928`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 929`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 930`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 931`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 932`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 933`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 934`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 935`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 936`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 937`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 938`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 939`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 940`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 941`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 942`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 943`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 944`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 945`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 946`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 947`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 948`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 949`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 950`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 951`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 952`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 953`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 954`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 955`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 956`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 957`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 958`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 959`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 960`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 961`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 962`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 963`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 964`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 965`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 966`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 967`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 968`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 969`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 970`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 971`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 972`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 973`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 974`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 975`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 976`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 977`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 978`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 979`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 980`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 981`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 982`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 983`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 984`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 985`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 986`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 987`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 988`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 989`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 990`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 991`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 992`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 993`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 994`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 995`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (1 nodes): `api.d.ts`
+- **Thin community `Community 996`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (1 nodes): `api.js`
+- **Thin community `Community 997`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 998`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (1 nodes): `server.d.ts`
+- **Thin community `Community 999`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (1 nodes): `server.js`
+- **Thin community `Community 1000`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (1 nodes): `app.ts`
+- **Thin community `Community 1001`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1002`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1003`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1004`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1005`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (1 nodes): `auth.ts`
+- **Thin community `Community 1006`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1007`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1008`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1009`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `countries.ts`
+- **Thin community `Community 1010`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `email.ts`
+- **Thin community `Community 1011`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1012`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `payment.ts`
+- **Thin community `Community 1013`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `crons.ts`
+- **Thin community `Community 1014`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1015`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `internal.ts`
+- **Thin community `Community 1016`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1017`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1018`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1019`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1020`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1021`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1022`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1023`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1024`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1025`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1026`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1027`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `env.ts`
+- **Thin community `Community 1028`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1029`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `auth.ts`
+- **Thin community `Community 1030`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1031`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `colors.ts`
+- **Thin community `Community 1032`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `index.ts`
+- **Thin community `Community 1033`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1034`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `products.ts`
+- **Thin community `Community 1035`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1036`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `stores.ts`
+- **Thin community `Community 1037`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `bag.ts`
+- **Thin community `Community 1038`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `guest.ts`
+- **Thin community `Community 1039`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `index.ts`
+- **Thin community `Community 1040`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `me.ts`
+- **Thin community `Community 1041`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `offers.ts`
+- **Thin community `Community 1042`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1043`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1044`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1045`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1046`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1047`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1048`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1049`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1050`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1051`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `user.ts`
+- **Thin community `Community 1052`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1053`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `index.ts`
+- **Thin community `Community 1054`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1055`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `http.ts`
+- **Thin community `Community 1056`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1057`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1058`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1059`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `categories.ts`
+- **Thin community `Community 1060`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `colors.ts`
+- **Thin community `Community 1061`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1062`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 1063`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1064`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1065`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1066`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1067`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `pos.ts`
+- **Thin community `Community 1068`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1069`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1070`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1071`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1072`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1073`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1074`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1075`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1076`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1077`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1078`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1079`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1080`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1081`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1082`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1083`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1084`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `types.ts`
+- **Thin community `Community 1085`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1086`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1087`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1088`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1089`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1090`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1091`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `dto.ts`
+- **Thin community `Community 1092`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1093`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1094`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `types.ts`
+- **Thin community `Community 1095`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `types.ts`
+- **Thin community `Community 1096`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1097`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `customers.ts`
+- **Thin community `Community 1098`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `register.ts`
+- **Thin community `Community 1099`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `sync.ts`
+- **Thin community `Community 1100`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `schema.ts`
+- **Thin community `Community 1101`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1102`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `index.ts`
+- **Thin community `Community 1103`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1104`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1105`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1106`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1107`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1108`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `category.ts`
+- **Thin community `Community 1109`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `color.ts`
+- **Thin community `Community 1110`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1111`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1112`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `index.ts`
+- **Thin community `Community 1113`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1114`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1115`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `organization.ts`
+- **Thin community `Community 1116`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1117`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `product.ts`
+- **Thin community `Community 1118`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1119`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1120`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `store.ts`
+- **Thin community `Community 1121`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1122`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `index.ts`
+- **Thin community `Community 1123`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1124`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1125`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1126`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1127`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1128`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1129`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1130`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `index.ts`
+- **Thin community `Community 1131`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1132`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1133`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1134`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1135`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1136`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1137`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1138`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1139`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1140`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1141`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1142`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `customer.ts`
+- **Thin community `Community 1143`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1144`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1145`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1146`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1147`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `index.ts`
+- **Thin community `Community 1148`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1149`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1150`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1151`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1152`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1153`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1154`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1155`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1156`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1157`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1158`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1159`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1160`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1161`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1162`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1163`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1164`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1165`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `index.ts`
+- **Thin community `Community 1166`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1167`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1168`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1169`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1170`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1171`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1172`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `index.ts`
+- **Thin community `Community 1173`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1174`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1175`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1176`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1177`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1178`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1179`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `bag.ts`
+- **Thin community `Community 1180`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1181`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1182`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1183`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `guest.ts`
+- **Thin community `Community 1184`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `index.ts`
+- **Thin community `Community 1185`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `offer.ts`
+- **Thin community `Community 1186`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1187`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1188`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `review.ts`
+- **Thin community `Community 1189`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1190`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1191`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1192`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1193`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1194`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1195`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1196`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1197`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1198`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `bag.ts`
+- **Thin community `Community 1199`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1200`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `customer.ts`
+- **Thin community `Community 1201`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `guest.ts`
+- **Thin community `Community 1202`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1203`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1204`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1205`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1206`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `payment.ts`
+- **Thin community `Community 1207`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1208`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1209`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1210`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `users.ts`
+- **Thin community `Community 1211`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `payment.ts`
+- **Thin community `Community 1212`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1213`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1214`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1215`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1216`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1217`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `index.ts`
+- **Thin community `Community 1218`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1219`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1220`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1221`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `auth.ts`
+- **Thin community `Community 1222`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1223`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1224`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1225`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1226`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1227`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1228`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1229`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1230`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1231`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1232`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1233`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1234`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1235`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1236`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1237`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `constants.ts`
+- **Thin community `Community 1238`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1239`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1240`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1241`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `types.ts`
+- **Thin community `Community 1242`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1243`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1244`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1245`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1246`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1247`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `data-table-toolbar.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `data-table.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1248`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1249`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -10179,1011 +10200,1021 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1253`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1254`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1255`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1256`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1257`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1258`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1259`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1260`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `constants.ts`
+- **Thin community `Community 1261`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1262`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1263`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1264`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `data.ts`
+- **Thin community `Community 1265`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1266`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1267`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1268`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1269`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1270`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1271`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1272`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1273`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1274`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `constants.ts`
+- **Thin community `Community 1275`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1276`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1277`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1278`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `data.ts`
+- **Thin community `Community 1279`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1280`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1281`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1282`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1283`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1284`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1285`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1286`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1287`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1288`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1289`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1290`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1291`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `constants.ts`
+- **Thin community `Community 1292`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1293`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1294`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1295`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1296`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1297`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1298`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1299`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1300`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1301`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1302`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1303`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1304`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1305`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1306`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1307`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1308`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1309`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1310`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1311`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1312`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1313`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1314`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1315`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1316`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1317`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1318`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1319`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1320`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1321`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1322`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1323`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `constants.ts`
+- **Thin community `Community 1324`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1325`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1326`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1327`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `data.ts`
+- **Thin community `Community 1328`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1329`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1330`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `constants.ts`
+- **Thin community `Community 1331`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1332`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1333`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1334`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1335`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `data.ts`
+- **Thin community `Community 1336`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1337`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `constants.ts`
+- **Thin community `Community 1338`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1339`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1340`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1341`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1342`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `data.ts`
+- **Thin community `Community 1343`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1344`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1345`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1346`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1347`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1348`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1349`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1350`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1351`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1352`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1353`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1354`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1355`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1356`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1357`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1358`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1359`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1360`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1361`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1362`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1363`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1364`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1365`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1366`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1367`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1368`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `POSSettingsView.test.tsx`
+- **Thin community `Community 1369`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1370`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `POSTerminalHealthView.test.tsx`
+- **Thin community `Community 1371`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1372`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1373`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1374`** (1 nodes): `POSSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `types.ts`
+- **Thin community `Community 1375`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1376`** (1 nodes): `POSTerminalHealthView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1377`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1378`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1379`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1380`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1381`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1382`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1383`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1384`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1385`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1386`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1387`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1388`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1389`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1390`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `data.ts`
+- **Thin community `Community 1391`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1392`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1393`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1394`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1395`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1396`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1397`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1398`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1399`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1400`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1401`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1402`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1403`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `constants.ts`
+- **Thin community `Community 1404`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1405`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1406`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1407`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `data.ts`
+- **Thin community `Community 1408`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `types.ts`
+- **Thin community `Community 1409`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1410`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1411`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1412`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1413`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1414`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `index.tsx`
+- **Thin community `Community 1415`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1416`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1417`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1418`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1419`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1420`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1421`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1422`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1423`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `index.tsx`
+- **Thin community `Community 1424`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1425`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1426`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1427`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `button.tsx`
+- **Thin community `Community 1428`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1429`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `card.tsx`
+- **Thin community `Community 1430`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1431`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1432`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `command.tsx`
+- **Thin community `Community 1433`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1434`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1435`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1436`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `form.tsx`
+- **Thin community `Community 1437`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1438`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1439`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `input.tsx`
+- **Thin community `Community 1440`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1441`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1442`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1443`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1444`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1445`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1446`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `select.tsx`
+- **Thin community `Community 1447`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1448`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1449`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1450`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `table.tsx`
+- **Thin community `Community 1451`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1452`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1453`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1454`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1455`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1456`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1457`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1458`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1459`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `constants.ts`
+- **Thin community `Community 1460`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1461`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1462`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1463`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `data.ts`
+- **Thin community `Community 1464`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1465`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1466`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1467`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1468`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1469`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1470`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1471`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1472`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1473`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1474`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1475`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `index.ts`
+- **Thin community `Community 1476`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1477`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1478`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1479`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1480`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1481`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1482`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1483`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1484`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1485`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1486`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1487`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `aws.ts`
+- **Thin community `Community 1488`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `constants.ts`
+- **Thin community `Community 1489`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `countries.ts`
+- **Thin community `Community 1490`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1491`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1492`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1493`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1494`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1495`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1496`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `dto.ts`
+- **Thin community `Community 1497`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `ports.ts`
+- **Thin community `Community 1498`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `constants.ts`
+- **Thin community `Community 1499`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1500`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1501`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `index.ts`
+- **Thin community `Community 1502`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1503`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `types.ts`
+- **Thin community `Community 1504`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1505`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1506`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1507`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1508`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1509`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1510`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1511`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1512`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1513`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1514`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1515`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `category.ts`
+- **Thin community `Community 1516`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `product.ts`
+- **Thin community `Community 1517`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `store.ts`
+- **Thin community `Community 1518`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1519`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `user.ts`
+- **Thin community `Community 1520`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1521`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1522`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1523`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1524`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1525`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1526`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1527`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1528`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1529`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1530`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `index.tsx`
+- **Thin community `Community 1531`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `index.tsx`
+- **Thin community `Community 1532`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `index.tsx`
+- **Thin community `Community 1533`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1534`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1535`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1536`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1537`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1538`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `index.tsx`
+- **Thin community `Community 1539`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1540`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1541`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1542`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `home.tsx`
+- **Thin community `Community 1543`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1544`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1545`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1546`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `index.tsx`
+- **Thin community `Community 1547`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1548`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `index.tsx`
+- **Thin community `Community 1549`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1550`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1551`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1552`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `index.tsx`
+- **Thin community `Community 1553`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1554`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1555`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1556`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1557`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1558`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1559`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `index.tsx`
+- **Thin community `Community 1560`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1561`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1562`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1563`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1564`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1565`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1566`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1567`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1568`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1569`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `index.tsx`
+- **Thin community `Community 1570`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1571`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `index.tsx`
+- **Thin community `Community 1572`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `new.tsx`
+- **Thin community `Community 1573`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `index.tsx`
+- **Thin community `Community 1574`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `new.tsx`
+- **Thin community `Community 1575`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1576`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1577`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `index.tsx`
+- **Thin community `Community 1578`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `new.tsx`
+- **Thin community `Community 1579`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `index.tsx`
+- **Thin community `Community 1580`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1581`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1582`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1583`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1584`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1585`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1586`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1587`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1588`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `index.tsx`
+- **Thin community `Community 1589`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1590`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1591`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1592`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1593`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1594`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1595`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1596`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1597`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1598`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1599`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1600`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1601`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1602`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1603`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1604`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1605`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1606`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1607`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1608`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1609`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1610`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1611`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1612`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1613`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `setup.ts`
+- **Thin community `Community 1614`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1615`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `types.ts`
+- **Thin community `Community 1616`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1617`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1618`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1619`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1620`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1621`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `types.ts`
+- **Thin community `Community 1622`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1623`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1624`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1625`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1626`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1627`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1628`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1629`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1630`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1631`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `schema.ts`
+- **Thin community `Community 1632`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1633`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1634`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1635`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1636`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1637`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1638`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1639`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1640`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1641`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `types.ts`
+- **Thin community `Community 1642`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1643`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1644`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1645`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1646`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1647`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1648`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1649`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `constants.ts`
+- **Thin community `Community 1650`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1651`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `About.tsx`
+- **Thin community `Community 1652`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1653`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1654`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1655`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1656`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1657`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1658`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1659`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1660`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1661`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1662`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `types.ts`
+- **Thin community `Community 1663`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1664`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1665`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1666`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1667`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1668`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1669`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1670`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1671`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1672`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1673`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1674`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `button.tsx`
+- **Thin community `Community 1675`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `card.tsx`
+- **Thin community `Community 1676`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1677`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `command.tsx`
+- **Thin community `Community 1678`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1679`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1680`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1681`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `form.tsx`
+- **Thin community `Community 1682`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1683`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1684`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1685`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1686`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `input.tsx`
+- **Thin community `Community 1687`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `label.tsx`
+- **Thin community `Community 1688`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1689`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1690`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1691`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `index.ts`
+- **Thin community `Community 1692`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `types.ts`
+- **Thin community `Community 1693`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1694`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1695`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1696`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1697`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `select.tsx`
+- **Thin community `Community 1698`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1699`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1700`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `table.tsx`
+- **Thin community `Community 1701`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1702`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1703`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1704`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1705`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1706`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `config.ts`
+- **Thin community `Community 1707`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1708`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1709`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1710`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1711`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `constants.ts`
+- **Thin community `Community 1712`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `countries.ts`
+- **Thin community `Community 1713`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1714`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1715`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1716`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1717`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `index.ts`
+- **Thin community `Community 1718`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `store.ts`
+- **Thin community `Community 1719`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `bag.ts`
+- **Thin community `Community 1720`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1721`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `category.ts`
+- **Thin community `Community 1722`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `organization.ts`
+- **Thin community `Community 1723`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `product.ts`
+- **Thin community `Community 1724`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `store.ts`
+- **Thin community `Community 1725`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1726`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `user.ts`
+- **Thin community `Community 1727`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `states.ts`
+- **Thin community `Community 1728`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1729`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1730`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1731`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1732`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1733`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1734`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1735`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `index.tsx`
+- **Thin community `Community 1736`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1737`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `index.tsx`
+- **Thin community `Community 1738`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1739`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1740`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1741`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1742`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1743`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `index.tsx`
+- **Thin community `Community 1744`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1745`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1746`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1747`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1748`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1749`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `index.js`
+- **Thin community `Community 1750`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1751`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1752`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1753`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1754`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1755`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1756`** (1 nodes): `harness-app-registry.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1757`** (1 nodes): `athena-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1758`** (1 nodes): `storefront-runtime-api.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1759`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1760`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1761`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -11202,4 +11233,4 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 4` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 5` be split into smaller, more focused modules?**
-  _Cohesion score 0.1 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.06 - nodes in this community are weakly interconnected._

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,19 +7,19 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1829
-- Graph nodes: 6157
-- Graph edges: 6631
-- Communities: 1757
+- Code files discovered: 1834
+- Graph nodes: 6182
+- Graph edges: 6666
+- Communities: 1762
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (84 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `useRegisterViewModel.ts` (59 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `projectLocalEvents.ts` (49 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
-- `harness-inferential-review.ts` (46 edges, Community 5) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
-- `usePosLocalSyncRuntime.ts` (46 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
-- `RegisterSessionView.tsx` (45 edges, Community 6) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
+- `harness-inferential-review.ts` (46 edges, Community 6) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
+- `RegisterSessionView.tsx` (46 edges, Community 4) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
+- `usePosLocalSyncRuntime.ts` (46 edges, Community 5) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
 - `storefrontJourneyEvents.ts` (45 edges, Community 7) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 
 ## Registered Packages

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -21,7 +21,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `useRegisterViewModel.ts` (59 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `projectLocalEvents.ts` (49 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
-- `usePosLocalSyncRuntime.ts` (46 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
+- `RegisterSessionView.tsx` (46 edges, Community 4) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (14 edges, Community 70) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 132) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 131) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 70) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `createRedisCluster()` (3 edges, Community 70) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `deleteKeysIndividually()` (3 edges, Community 70) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/cashControls/deposits.test.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.test.ts
@@ -725,6 +725,644 @@ describe("cash control deposits", () => {
     );
   });
 
+  it("applies proofless staff-access sync reviews after manager approval", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx({
+      operationalEvent: [],
+      posLocalSyncConflict: [
+        {
+          _id: "sync_conflict_open",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_open",
+          sequence: 6,
+          conflictType: "permission",
+          status: "needs_review",
+          summary: "Staff access changed before this POS history synced.",
+          details: {
+            eventType: "register_opened",
+            hasStaffProof: false,
+            staffProfileId: "staff_1",
+          },
+          createdAt: 1,
+        },
+        {
+          _id: "sync_conflict_sale",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_sale",
+          sequence: 7,
+          conflictType: "permission",
+          status: "needs_review",
+          summary: "Staff access changed before this POS history synced.",
+          details: {
+            eventType: "sale_completed",
+            hasStaffProof: false,
+            staffProfileId: "staff_1",
+          },
+          createdAt: 2,
+        },
+      ],
+      posLocalSyncEvent: [
+        {
+          _id: "sync_event_open",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_open",
+          sequence: 6,
+          eventType: "register_opened",
+          occurredAt: 2,
+          staffProfileId: "staff_1",
+          payload: {
+            openingFloat: 35000,
+            registerNumber: "1",
+          },
+          status: "conflicted",
+          submittedAt: 4,
+          acceptedAt: 4,
+        },
+        {
+          _id: "sync_event_sale",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_sale",
+          sequence: 7,
+          eventType: "sale_completed",
+          occurredAt: 3,
+          staffProfileId: "staff_1",
+          payload: {
+            localPosSessionId: "local-pos-session-1",
+            localTransactionId: "local-transaction-1",
+            localReceiptNumber: "881GJJ-001",
+            receiptNumber: "881GJJ-001",
+            registerNumber: "1",
+            totals: {
+              subtotal: 15000,
+              tax: 0,
+              total: 15000,
+            },
+            items: [
+              {
+                localTransactionItemId: "local-item-1",
+                productId: "product_1",
+                productSkuId: "product_sku_1",
+                productName: "Wig Cap",
+                productSku: "CAP-1",
+                quantity: 1,
+                unitPrice: 15000,
+              },
+            ],
+            payments: [
+              {
+                localPaymentId: "local-payment-1",
+                method: "cash",
+                amount: 15000,
+                timestamp: 3,
+              },
+            ],
+          },
+          status: "conflicted",
+          submittedAt: 4,
+          acceptedAt: 4,
+        },
+      ],
+      posLocalSyncMapping: [
+        {
+          _id: "sync_mapping_register",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localIdKind: "registerSession",
+          localId: "local-register-1",
+          cloudTable: "registerSession",
+          cloudId: "session_open",
+        },
+      ],
+      registerSession: [
+        {
+          _id: "session_open",
+          expectedCash: 35000,
+          openedAt: 1,
+          openingFloat: 35000,
+          organizationId: "org_1",
+          registerNumber: "1",
+          status: "active",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+        },
+      ],
+      posTerminal: [
+        {
+          _id: "terminal_1",
+          registerNumber: "1",
+          registeredByUserId: "athena_user_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+      product: [
+        {
+          _id: "product_1",
+          storeId: "store_1",
+        },
+      ],
+      productSku: [
+        {
+          _id: "product_sku_1",
+          images: [],
+          inventoryCount: 10,
+          price: 15000,
+          productId: "product_1",
+          quantityAvailable: 10,
+          sku: "CAP-1",
+          storeId: "store_1",
+        },
+      ],
+      staffProfile: [
+        {
+          _id: "manager_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+        {
+          _id: "staff_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+      staffRoleAssignment: [
+        {
+          _id: "role_1",
+          organizationId: "org_1",
+          role: "manager",
+          staffProfileId: "manager_1",
+          status: "active",
+          storeId: "store_1",
+        },
+        {
+          _id: "role_2",
+          organizationId: "org_1",
+          role: "cashier",
+          staffProfileId: "staff_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+    });
+
+    const result = await getHandler(resolveRegisterSessionSyncReview)(
+      ctx as never,
+      {
+        actorStaffProfileId: "manager_1" as Id<"staffProfile">,
+        registerSessionId: "session_open" as Id<"registerSession">,
+        storeId: "store_1" as Id<"store">,
+      },
+    );
+
+    expect(result).toEqual(
+      ok({
+        action: "resolved",
+        projectedCount: 1,
+        registerSession: expect.objectContaining({ _id: "session_open" }),
+        resolvedCount: 2,
+      }),
+    );
+    expect(ctx.tables.get("posLocalSyncConflict")).toEqual([
+      expect.objectContaining({
+        _id: "sync_conflict_open",
+        resolvedByStaffProfileId: "manager_1",
+        status: "resolved",
+      }),
+      expect.objectContaining({
+        _id: "sync_conflict_sale",
+        resolvedByStaffProfileId: "manager_1",
+        status: "resolved",
+      }),
+    ]);
+    expect(ctx.tables.get("posLocalSyncEvent")).toEqual([
+      expect.objectContaining({
+        _id: "sync_event_open",
+        projectedAt: expect.any(Number),
+        status: "projected",
+      }),
+      expect.objectContaining({
+        _id: "sync_event_sale",
+        projectedAt: expect.any(Number),
+        status: "projected",
+      }),
+    ]);
+    expect(ctx.tables.get("posTransaction")).toEqual([
+      expect.objectContaining({
+        registerSessionId: "session_open",
+        total: 15000,
+        transactionNumber: "881GJJ-001",
+      }),
+    ]);
+    expect(ctx.tables.get("registerSession")).toEqual([
+      expect.objectContaining({
+        _id: "session_open",
+        expectedCash: 50000,
+      }),
+    ]);
+  });
+
+  it("does not apply staff-access reviews that had an invalid proof", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx({
+      posLocalSyncConflict: [
+        {
+          _id: "sync_conflict_sale",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_sale",
+          sequence: 7,
+          conflictType: "permission",
+          status: "needs_review",
+          summary: "Staff access changed before this POS history synced.",
+          details: {
+            eventType: "sale_completed",
+            hasStaffProof: true,
+            staffProfileId: "staff_1",
+          },
+          createdAt: 2,
+        },
+      ],
+      posLocalSyncEvent: [
+        {
+          _id: "sync_event_sale",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_sale",
+          sequence: 7,
+          eventType: "sale_completed",
+          occurredAt: 3,
+          staffProfileId: "staff_1",
+          payload: {},
+          status: "conflicted",
+          submittedAt: 4,
+          acceptedAt: 4,
+        },
+      ],
+      posLocalSyncMapping: [
+        {
+          _id: "sync_mapping_register",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localIdKind: "registerSession",
+          localId: "local-register-1",
+          cloudTable: "registerSession",
+          cloudId: "session_open",
+        },
+      ],
+      registerSession: [
+        {
+          _id: "session_open",
+          expectedCash: 35000,
+          openedAt: 1,
+          openingFloat: 35000,
+          organizationId: "org_1",
+          registerNumber: "1",
+          status: "active",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+        },
+      ],
+      staffProfile: [
+        {
+          _id: "manager_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+        {
+          _id: "staff_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+      staffRoleAssignment: [
+        {
+          _id: "role_1",
+          organizationId: "org_1",
+          role: "manager",
+          staffProfileId: "manager_1",
+          status: "active",
+          storeId: "store_1",
+        },
+        {
+          _id: "role_2",
+          organizationId: "org_1",
+          role: "cashier",
+          staffProfileId: "staff_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+    });
+
+    await expect(
+      getHandler(resolveRegisterSessionSyncReview)(ctx as never, {
+        actorStaffProfileId: "manager_1" as Id<"staffProfile">,
+        registerSessionId: "session_open" as Id<"registerSession">,
+        storeId: "store_1" as Id<"store">,
+      }),
+    ).resolves.toEqual(
+      userError({
+        code: "precondition_failed",
+        message:
+          "This register review still needs attention before the synced activity can be applied.",
+      }),
+    );
+  });
+
+  it("automatically applies proofless staff-access synced sales without manager approval", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx({
+      operationalEvent: [],
+      posLocalSyncConflict: [
+        {
+          _id: "sync_conflict_sale",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_sale",
+          sequence: 7,
+          conflictType: "permission",
+          status: "needs_review",
+          summary: "Staff access changed before this POS history synced.",
+          details: {
+            eventType: "sale_completed",
+            hasStaffProof: false,
+            staffProfileId: "staff_1",
+          },
+          createdAt: 2,
+        },
+      ],
+      posLocalSyncEvent: [
+        {
+          _id: "sync_event_sale",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_sale",
+          sequence: 7,
+          eventType: "sale_completed",
+          occurredAt: 3,
+          staffProfileId: "staff_1",
+          payload: {
+            localPosSessionId: "local-pos-session-1",
+            localTransactionId: "local-transaction-1",
+            localReceiptNumber: "881GJJ-002",
+            receiptNumber: "881GJJ-002",
+            registerNumber: "1",
+            totals: {
+              subtotal: 15000,
+              tax: 0,
+              total: 15000,
+            },
+            items: [
+              {
+                localTransactionItemId: "local-item-1",
+                productId: "product_1",
+                productSkuId: "product_sku_1",
+                productName: "Wig Cap",
+                productSku: "CAP-1",
+                quantity: 1,
+                unitPrice: 15000,
+              },
+            ],
+            payments: [
+              {
+                localPaymentId: "local-payment-1",
+                method: "cash",
+                amount: 15000,
+                timestamp: 3,
+              },
+            ],
+          },
+          status: "conflicted",
+          submittedAt: 4,
+          acceptedAt: 4,
+        },
+      ],
+      posLocalSyncMapping: [
+        {
+          _id: "sync_mapping_register",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localIdKind: "registerSession",
+          localId: "local-register-1",
+          cloudTable: "registerSession",
+          cloudId: "session_open",
+        },
+      ],
+      registerSession: [
+        {
+          _id: "session_open",
+          expectedCash: 35000,
+          openedAt: 1,
+          openingFloat: 35000,
+          organizationId: "org_1",
+          registerNumber: "1",
+          status: "active",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+        },
+      ],
+      posTerminal: [
+        {
+          _id: "terminal_1",
+          registerNumber: "1",
+          registeredByUserId: "athena_user_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+      product: [
+        {
+          _id: "product_1",
+          storeId: "store_1",
+        },
+      ],
+      productSku: [
+        {
+          _id: "product_sku_1",
+          images: [],
+          inventoryCount: 10,
+          price: 15000,
+          productId: "product_1",
+          quantityAvailable: 10,
+          sku: "CAP-1",
+          storeId: "store_1",
+        },
+      ],
+      staffProfile: [
+        {
+          _id: "staff_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+      staffRoleAssignment: [
+        {
+          _id: "role_1",
+          organizationId: "org_1",
+          role: "cashier",
+          staffProfileId: "staff_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+    });
+
+    const result = await getHandler(resolveRegisterSessionSyncReview)(
+      ctx as never,
+      {
+        registerSessionId: "session_open" as Id<"registerSession">,
+        storeId: "store_1" as Id<"store">,
+      },
+    );
+
+    expect(result).toEqual(
+      ok({
+        action: "resolved",
+        projectedCount: 1,
+        registerSession: expect.objectContaining({ _id: "session_open" }),
+        resolvedCount: 1,
+      }),
+    );
+    expect(ctx.tables.get("posLocalSyncConflict")).toEqual([
+      expect.objectContaining({
+        _id: "sync_conflict_sale",
+        status: "resolved",
+      }),
+    ]);
+    expect(ctx.tables.get("posLocalSyncConflict")?.[0]).not.toHaveProperty(
+      "resolvedByStaffProfileId",
+    );
+    expect(ctx.tables.get("posLocalSyncEvent")).toEqual([
+      expect.objectContaining({
+        _id: "sync_event_sale",
+        projectedAt: expect.any(Number),
+        status: "projected",
+      }),
+    ]);
+    expect(ctx.tables.get("posTransaction")).toEqual([
+      expect.objectContaining({
+        registerSessionId: "session_open",
+        total: 15000,
+        transactionNumber: "881GJJ-002",
+      }),
+    ]);
+    expect(ctx.tables.get("operationalEvent")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          actorUserId: "athena_user_1",
+          eventType: "register_session_sync_review_resolved",
+          message: "Automatically applied proofless synced register sale.",
+        }),
+      ]),
+    );
+  });
+
+  it("does not automatically apply non-proofless synced reviews", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx({
+      posLocalSyncConflict: [
+        {
+          _id: "sync_conflict_sale",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_sale",
+          sequence: 7,
+          conflictType: "permission",
+          status: "needs_review",
+          summary: "Staff access changed before this POS history synced.",
+          details: {
+            eventType: "sale_completed",
+            hasStaffProof: true,
+            staffProfileId: "staff_1",
+          },
+          createdAt: 2,
+        },
+      ],
+      posLocalSyncEvent: [
+        {
+          _id: "sync_event_sale",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "event_sale",
+          sequence: 7,
+          eventType: "sale_completed",
+          occurredAt: 3,
+          staffProfileId: "staff_1",
+          payload: {},
+          status: "conflicted",
+          submittedAt: 4,
+          acceptedAt: 4,
+        },
+      ],
+      posLocalSyncMapping: [
+        {
+          _id: "sync_mapping_register",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localIdKind: "registerSession",
+          localId: "local-register-1",
+          cloudTable: "registerSession",
+          cloudId: "session_open",
+        },
+      ],
+      registerSession: [
+        {
+          _id: "session_open",
+          expectedCash: 35000,
+          openedAt: 1,
+          openingFloat: 35000,
+          organizationId: "org_1",
+          registerNumber: "1",
+          status: "active",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+        },
+      ],
+    });
+
+    const result = await getHandler(resolveRegisterSessionSyncReview)(
+      ctx as never,
+      {
+        registerSessionId: "session_open" as Id<"registerSession">,
+        storeId: "store_1" as Id<"store">,
+      },
+    );
+
+    expect(result).toEqual(
+      userError({
+        code: "precondition_failed",
+        message:
+          "This register review is not eligible for automatic sync repair.",
+      }),
+    );
+    expect(ctx.tables.get("posLocalSyncEvent")).toEqual([
+      expect.objectContaining({
+        _id: "sync_event_sale",
+        status: "conflicted",
+      }),
+    ]);
+    expect(ctx.tables.get("posTransaction") ?? []).toEqual([]);
+  });
+
   it("lets managers override and project server-rejected synced sales", async () => {
     const ctx = createAuthorizedRegisterDepositCtx({
       operationalEvent: [],

--- a/packages/athena-webapp/convex/cashControls/deposits.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.ts
@@ -45,6 +45,8 @@ const STAFF_ROLE_LOOKUP_LIMIT = 20;
 const TIMELINE_LIMIT = 200;
 const REGISTER_NOT_OPEN_SYNC_REVIEW_SUMMARY =
   "Register was not open before this sale synced.";
+const STAFF_ACCESS_SYNC_REVIEW_SUMMARY =
+  "Staff access changed before this POS history synced.";
 const SERVICE_CUSTOMER_ATTRIBUTION_SYNC_REVIEW_SUMMARY =
   "Service line is missing customer attribution.";
 const CLOSED_REGISTER_SYNCED_CLOSEOUT_SUMMARY =
@@ -103,6 +105,16 @@ const registerSessionSyncReviewResultValidator = v.union(
     error: userErrorValidator,
   }),
 );
+
+function isProoflessStaffAccessSyncReview(
+  conflict: RegisterSessionSyncConflict,
+) {
+  return (
+    conflict.conflictType === "permission" &&
+    conflict.summary === STAFF_ACCESS_SYNC_REVIEW_SUMMARY &&
+    conflict.details?.hasStaffProof === false
+  );
+}
 
 type StaffNameMap = Map<Id<"staffProfile">, string>;
 
@@ -1089,7 +1101,7 @@ export const recordRegisterSessionDeposit = mutation({
 
 export const resolveRegisterSessionSyncReview = mutation({
   args: {
-    actorStaffProfileId: v.id("staffProfile"),
+    actorStaffProfileId: v.optional(v.id("staffProfile")),
     decision: v.optional(v.union(v.literal("approved"), v.literal("rejected"))),
     registerSessionId: v.id("registerSession"),
     storeId: v.id("store"),
@@ -1114,16 +1126,27 @@ export const resolveRegisterSessionSyncReview = mutation({
       });
     }
 
-    const canResolveReview = await staffProfileCanResolveSyncReview(ctx, {
-      organizationId: store.organizationId,
-      staffProfileId: args.actorStaffProfileId,
-      storeId: args.storeId,
-    });
-    if (!canResolveReview) {
+    const decision = args.decision ?? "approved";
+    const isAutomaticResolution = !args.actorStaffProfileId;
+    if (decision === "rejected" && isAutomaticResolution) {
       return userError({
-        code: "authorization_failed",
-        message: "Only managers can resolve synced register reviews.",
+        code: "precondition_failed",
+        message:
+          "Automatic sync repair can only apply eligible register activity.",
       });
+    }
+    if (args.actorStaffProfileId) {
+      const canResolveReview = await staffProfileCanResolveSyncReview(ctx, {
+        organizationId: store.organizationId,
+        staffProfileId: args.actorStaffProfileId,
+        storeId: args.storeId,
+      });
+      if (!canResolveReview) {
+        return userError({
+          code: "authorization_failed",
+          message: "Only managers can resolve synced register reviews.",
+        });
+      }
     }
 
     const conflictsBySessionId = await listRegisterSessionSyncReviewConflicts(
@@ -1150,7 +1173,6 @@ export const resolveRegisterSessionSyncReview = mutation({
     const sequences: number[] = [];
     let managerOverrideCount = 0;
     let projectedCloseoutCount = 0;
-    const decision = args.decision ?? "approved";
 
     for (const conflict of conflicts) {
       const terminalId = conflict.terminalId ?? registerSession.terminalId;
@@ -1198,11 +1220,16 @@ export const resolveRegisterSessionSyncReview = mutation({
       }
 
       const shouldApplyManagerOverride =
+        !isAutomaticResolution &&
         syncEvent.status === "rejected" &&
         conflict.conflictType === "server_rejected";
       if (shouldApplyManagerOverride) {
         managerOverrideCount += 1;
       }
+      const shouldApplyProoflessStaffAccessEvent =
+        isProoflessStaffAccessSyncReview(conflict) &&
+        (syncEvent.eventType === "register_opened" ||
+          syncEvent.eventType === "sale_completed");
       const shouldApplyReviewedSale =
         (syncEvent.eventType === "sale_completed" &&
           (!conflict.localRegisterSessionId ||
@@ -1223,7 +1250,19 @@ export const resolveRegisterSessionSyncReview = mutation({
         (shouldApplyManagerOverride &&
           syncEvent.eventType === "register_closed");
 
-      if (!shouldApplyReviewedSale && !shouldApplyReviewedCloseout) {
+      if (isAutomaticResolution && !shouldApplyProoflessStaffAccessEvent) {
+        return userError({
+          code: "precondition_failed",
+          message:
+            "This register review is not eligible for automatic sync repair.",
+        });
+      }
+
+      if (
+        !shouldApplyReviewedSale &&
+        !shouldApplyReviewedCloseout &&
+        !shouldApplyProoflessStaffAccessEvent
+      ) {
         if (
           syncEvent.eventType === "register_closed" &&
           conflict.summary === CLOSED_REGISTER_SYNCED_CLOSEOUT_SUMMARY
@@ -1269,6 +1308,9 @@ export const resolveRegisterSessionSyncReview = mutation({
       if (
         !parsedEvent.ok ||
         (shouldApplyReviewedSale &&
+          parsedEvent.event.eventType !== "sale_completed") ||
+        (shouldApplyProoflessStaffAccessEvent &&
+          parsedEvent.event.eventType !== "register_opened" &&
           parsedEvent.event.eventType !== "sale_completed") ||
         (shouldApplyReviewedCloseout &&
           parsedEvent.event.eventType !== "register_closed")
@@ -1334,7 +1376,9 @@ export const resolveRegisterSessionSyncReview = mutation({
           conflictId,
           {
             resolvedAt,
-            resolvedByStaffProfileId: args.actorStaffProfileId,
+            ...(args.actorStaffProfileId
+              ? { resolvedByStaffProfileId: args.actorStaffProfileId }
+              : {}),
             status: "resolved",
           },
         ),
@@ -1342,7 +1386,9 @@ export const resolveRegisterSessionSyncReview = mutation({
     );
 
     await recordOperationalEventWithCtx(ctx, {
-      actorStaffProfileId: args.actorStaffProfileId,
+      ...(args.actorStaffProfileId
+        ? { actorStaffProfileId: args.actorStaffProfileId }
+        : {}),
       actorUserId: athenaUser._id,
       eventType: "register_session_sync_review_resolved",
       message:
@@ -1350,6 +1396,14 @@ export const resolveRegisterSessionSyncReview = mutation({
           ? conflicts.length === 1
             ? "Rejected synced register review."
             : `Rejected ${conflicts.length} synced register reviews.`
+          : isAutomaticResolution
+            ? projectedTransactionIds.length === 0
+              ? conflicts.length === 1
+                ? "Automatically resolved proofless synced register review."
+                : `Automatically resolved ${conflicts.length} proofless synced register reviews.`
+              : projectedTransactionIds.length === 1
+                ? "Automatically applied proofless synced register sale."
+                : `Automatically applied ${projectedTransactionIds.length} proofless synced register sales.`
           : managerOverrideCount > 0
             ? managerOverrideCount === 1
               ? projectedTransactionIds.length === 1

--- a/packages/athena-webapp/convex/operations/dailyOperations.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.test.ts
@@ -922,6 +922,57 @@ describe("daily operations overview read model", () => {
     expect(snapshot.attentionItems).toEqual([]);
   });
 
+  it("surfaces register closeout records when no operational event was recorded", async () => {
+    const snapshot = await buildDailyOperationsSnapshotWithCtx(
+      buildCtx({
+        dailyClose: [priorClose],
+        dailyOpening: [startedOpening],
+        registerSession: [
+          {
+            _id: "register-2",
+            closeoutRecords: [
+              {
+                actorStaffProfileId: "staff-1",
+                countedCash: 450,
+                expectedCash: 450,
+                occurredAt: Date.UTC(2026, 4, 8, 20, 45),
+                type: "closed",
+                variance: 0,
+              },
+            ],
+            expectedCash: 450,
+            openedAt: Date.UTC(2026, 4, 8, 8),
+            openingFloat: 100,
+            organizationId: "org-1",
+            registerNumber: "Register 2",
+            status: "closed",
+            storeId: "store-1",
+          },
+        ],
+        store: [store],
+      }),
+      { operatingDate: "2026-05-08", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(snapshot.timeline[0]).toMatchObject({
+      id: "register_closeout:register-2:closed:1778273100000",
+      message: "Register 2 closeout recorded with an exact cash match.",
+      registerLink: {
+        label: "Register 2",
+        params: {
+          sessionId: "register-2",
+        },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId",
+      },
+      subject: {
+        id: "register-2",
+        label: "Register 2",
+        type: "register_session",
+      },
+      type: "register_session_closed",
+    });
+  });
+
   it("returns the newest timeline events before applying the timeline limit", async () => {
     const events = Array.from({ length: 201 }, (_, index) => ({
       _id: `event-${index}`,

--- a/packages/athena-webapp/convex/operations/dailyOperations.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.ts
@@ -12,6 +12,7 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 const MAX_OPERATIONS_QUERY_LIMIT = 200;
 const MAX_OPERATIONS_LOOKAHEAD_LIMIT = MAX_OPERATIONS_QUERY_LIMIT + 1;
 const OPEN_WORK_ITEM_STATUSES = ["open", "in_progress"] as const;
+const TIMELINE_REGISTER_SESSION_STATUSES = ["closed", "closing"] as const;
 
 type LinkTarget = {
   label?: string;
@@ -85,6 +86,7 @@ type DailyOperationsTimelineEvent = {
   id: string;
   message: string;
   productLink?: LinkTarget;
+  registerLink?: LinkTarget;
   subject: SourceSubject;
   transactionLink?: LinkTarget;
   type: string;
@@ -463,7 +465,7 @@ async function listTimelineEvents(
 ): Promise<DailyOperationsTimelineEvent[]> {
   if (!args.startAt || !args.endAt) return [];
 
-  const events = await ctx.db
+  const eventsPromise = ctx.db
     .query("operationalEvent")
     .withIndex("by_storeId_createdAt", (q) =>
       q
@@ -473,8 +475,50 @@ async function listTimelineEvents(
     )
     .order("desc")
     .take(MAX_OPERATIONS_QUERY_LIMIT);
+  const registerSessionsPromise = listTimelineRegisterSessions(ctx, args.storeId);
+  const [events, registerSessions] = await Promise.all([
+    eventsPromise,
+    registerSessionsPromise,
+  ]);
+  const operationalCloseoutKeys = new Set(
+    events
+      .map((event) => getOperationalRegisterCloseoutKey(event))
+      .filter((key): key is string => key !== null),
+  );
+  const [operationalTimelineEvents, registerCloseoutTimelineEvents] =
+    await Promise.all([
+      Promise.all(events.map((event) => mapOperationalTimelineEvent(ctx, event))),
+      Promise.resolve(
+        buildRegisterCloseoutTimelineEvents({
+          endAt: args.endAt,
+          operationalCloseoutKeys,
+          registerSessions,
+          startAt: args.startAt,
+        }),
+      ),
+    ]);
 
-  return Promise.all(events.sort(compareTimelineEvents).map(async (event) => {
+  return [
+    ...operationalTimelineEvents,
+    ...registerCloseoutTimelineEvents,
+  ]
+    .sort(compareDailyOperationsTimelineEvents)
+    .slice(0, MAX_OPERATIONS_QUERY_LIMIT);
+}
+
+async function mapOperationalTimelineEvent(
+  ctx: Pick<QueryCtx, "db">,
+  event: {
+    _id: Id<"operationalEvent">;
+    createdAt: number;
+    eventType: string;
+    message: string;
+    metadata?: Record<string, unknown>;
+    subjectId: string;
+    subjectLabel?: string;
+    subjectType: string;
+  },
+): Promise<DailyOperationsTimelineEvent> {
     const metadata = event.metadata ?? {};
     const productId =
       typeof metadata.productId === "string" ? metadata.productId : undefined;
@@ -550,7 +594,141 @@ async function listTimelineEvents(
       transactionLink,
       type: event.eventType,
     };
-  }));
+}
+
+async function listTimelineRegisterSessions(
+  ctx: Pick<QueryCtx, "db">,
+  storeId: Id<"store">,
+) {
+  const sessionBatches = await Promise.all(
+    TIMELINE_REGISTER_SESSION_STATUSES.map((status) =>
+      ctx.db
+        .query("registerSession")
+        .withIndex("by_storeId_status", (q) =>
+          q.eq("storeId", storeId).eq("status", status),
+        )
+        .take(MAX_OPERATIONS_QUERY_LIMIT),
+    ),
+  );
+  const sessionsById = new Map<Id<"registerSession">, Doc<"registerSession">>();
+
+  for (const session of sessionBatches.flat()) {
+    sessionsById.set(session._id, session);
+  }
+
+  return [...sessionsById.values()];
+}
+
+function buildRegisterCloseoutTimelineEvents(args: {
+  endAt: number;
+  operationalCloseoutKeys: Set<string>;
+  registerSessions: Array<Doc<"registerSession">>;
+  startAt: number;
+}): DailyOperationsTimelineEvent[] {
+  return args.registerSessions.flatMap((session) =>
+    (session.closeoutRecords ?? [])
+      .filter(
+        (record) =>
+          record.occurredAt >= args.startAt && record.occurredAt < args.endAt,
+      )
+      .filter(
+        (record) =>
+          !args.operationalCloseoutKeys.has(
+            getRegisterCloseoutKey({
+              occurredAt: record.occurredAt,
+              registerSessionId: session._id,
+              type: record.type,
+            }),
+          ),
+      )
+      .map((record) => {
+        const label = formatRegisterSessionLabel(session.registerNumber);
+        const eventType =
+          record.type === "closed"
+            ? "register_session_closed"
+            : "register_session_closeout_reopened";
+
+        return {
+          createdAt: record.occurredAt,
+          id: `register_closeout:${session._id}:${record.type}:${record.occurredAt}`,
+          message: buildRegisterCloseoutTimelineMessage({
+            label,
+            type: record.type,
+            variance: record.variance,
+          }),
+          registerLink: {
+            label,
+            params: {
+              sessionId: session._id,
+            },
+            to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId",
+          },
+          subject: {
+            id: session._id,
+            label,
+            type: "register_session",
+          },
+          type: eventType,
+        };
+      }),
+  );
+}
+
+function buildRegisterCloseoutTimelineMessage(args: {
+  label: string;
+  type: "closed" | "reopened";
+  variance?: number;
+}) {
+  if (args.type === "reopened") {
+    return `${args.label} closeout reopened for correction.`;
+  }
+
+  if (args.variance && args.variance !== 0) {
+    return `${args.label} closeout recorded with a cash variance of ${args.variance}.`;
+  }
+
+  return `${args.label} closeout recorded with an exact cash match.`;
+}
+
+function formatRegisterSessionLabel(registerNumber?: string) {
+  const trimmed = registerNumber?.trim();
+
+  if (!trimmed) return "Register session";
+  if (/^register\b/i.test(trimmed)) return trimmed;
+  return `Register ${trimmed}`;
+}
+
+function getOperationalRegisterCloseoutKey(event: {
+  createdAt: number;
+  eventType: string;
+  subjectId: string;
+  subjectType: string;
+}) {
+  if (event.subjectType !== "register_session") return null;
+
+  const type =
+    event.eventType === "register_session_closed" ||
+    event.eventType === "register_session_closeout_approved"
+      ? "closed"
+      : event.eventType === "register_session_closeout_reopened"
+        ? "reopened"
+        : null;
+
+  if (!type) return null;
+
+  return getRegisterCloseoutKey({
+    occurredAt: event.createdAt,
+    registerSessionId: event.subjectId,
+    type,
+  });
+}
+
+function getRegisterCloseoutKey(args: {
+  occurredAt: number;
+  registerSessionId: string;
+  type: "closed" | "reopened";
+}) {
+  return `${args.registerSessionId}:${args.type}:${getTimelineMinuteBucket(args.occurredAt)}`;
 }
 
 function getTimelineMinuteBucket(createdAt: number) {
@@ -597,6 +775,24 @@ function compareTimelineEvents(
 
   if (left.createdAt !== right.createdAt) return right.createdAt - left.createdAt;
   return String(right._id).localeCompare(String(left._id));
+}
+
+function compareDailyOperationsTimelineEvents(
+  left: DailyOperationsTimelineEvent,
+  right: DailyOperationsTimelineEvent,
+) {
+  return compareTimelineEvents(
+    {
+      _id: left.id as Id<"operationalEvent">,
+      createdAt: left.createdAt,
+      eventType: left.type,
+    },
+    {
+      _id: right.id as Id<"operationalEvent">,
+      createdAt: right.createdAt,
+      eventType: right.type,
+    },
+  );
 }
 
 async function getDailyCloseRecordForDate(

--- a/packages/athena-webapp/convex/pos/application/commands/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/terminals.ts
@@ -5,6 +5,14 @@ import {
   userError,
   type CommandResult,
 } from "../../../../shared/commandResult";
+import {
+  normalizePosTerminalTransactionCapability,
+  type PosTerminalTransactionCapability,
+} from "../../../../shared/posTerminalCapability";
+import {
+  normalizePosTerminalLoginMode,
+  type PosTerminalLoginMode,
+} from "../../../../shared/posTerminalLoginMode";
 
 import {
   getTerminalByFingerprint,
@@ -85,6 +93,8 @@ export async function registerTerminal(
     syncSecretHash: string;
     displayName: string;
     registerNumber: string;
+    loginMode?: PosTerminalLoginMode;
+    transactionCapability?: PosTerminalTransactionCapability;
     registeredByUserId: Id<"athenaUser">;
     browserInfo: Doc<"posTerminal">["browserInfo"];
   },
@@ -99,6 +109,9 @@ export async function registerTerminal(
       registerNumber: args.registerNumber,
       terminalId: existing?._id,
     });
+    const transactionCapability =
+      normalizePosTerminalTransactionCapability(args.transactionCapability);
+    const loginMode = normalizePosTerminalLoginMode(args.loginMode);
 
     if (existing) {
       if (existing.status !== "active") {
@@ -123,6 +136,8 @@ export async function registerTerminal(
         browserInfo: args.browserInfo,
         status: "active",
         registerNumber: nextRegisterNumber,
+        loginMode,
+        transactionCapability,
       });
 
       return ok({
@@ -133,6 +148,8 @@ export async function registerTerminal(
         browserInfo: args.browserInfo,
         status: "active",
         registerNumber: nextRegisterNumber,
+        loginMode,
+        transactionCapability,
       });
     }
 
@@ -146,6 +163,8 @@ export async function registerTerminal(
       browserInfo: args.browserInfo,
       registeredAt: Date.now(),
       status: "active",
+      loginMode,
+      transactionCapability,
     });
     const terminal = await getTerminalById(ctx, terminalId);
 

--- a/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts
@@ -345,6 +345,61 @@ describe("createLocalSyncIngestionService", () => {
     ]);
   });
 
+  it("projects proofless offline register opens and completed sales for active terminal staff", async () => {
+    const repository = createFakeSyncRepository({
+      existingRegisterSession: null,
+    });
+    const service = createLocalSyncIngestionService({
+      repository,
+      projectionRepository: repository,
+      now: () => 100,
+    });
+    const registerOpened = buildRegisterOpenedEvent({ sequence: 1 });
+    const saleCompleted = buildSaleCompletedEvent({ sequence: 2 });
+    delete registerOpened.staffProofToken;
+    delete saleCompleted.staffProofToken;
+
+    const result = await service.ingestBatch(
+      buildBatch({
+        events: [registerOpened, saleCompleted],
+      }),
+    );
+
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") throw new Error("Expected ok result");
+    expect(result.data.accepted).toEqual([
+      {
+        localEventId: "event-register-opened-1",
+        sequence: 1,
+        status: "projected",
+      },
+      {
+        localEventId: "event-sale-completed-2",
+        sequence: 2,
+        status: "projected",
+      },
+    ]);
+    expect(result.data.conflicts).toEqual([]);
+    expect(repository.events).toEqual([
+      expect.not.objectContaining({ staffProofTokenHash: expect.any(String) }),
+      expect.not.objectContaining({ staffProofTokenHash: expect.any(String) }),
+    ]);
+    expect(repository.createdRegisterSessions).toEqual([
+      expect.objectContaining({
+        openedByStaffProfileId: "staff-1",
+        openingFloat: 100,
+      }),
+    ]);
+    expect(repository.createdTransactions).toEqual([
+      expect.objectContaining({
+        registerSessionId: "register-session-1",
+        staffProfileId: "staff-1",
+        total: 25,
+      }),
+    ]);
+    expect(repository.createdPaymentAllocations).toHaveLength(1);
+  });
+
   it("holds an out-of-order event without projection side effects", async () => {
     const repository = createFakeSyncRepository();
     const service = createLocalSyncIngestionService({

--- a/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts
@@ -98,6 +98,9 @@ type IngestionDependencies = {
 
 const TERMINAL_NOT_PROVISIONED_MESSAGE =
   "This terminal is not provisioned for POS sync.";
+const TERMINAL_INGESTION_PROJECTION_OPTIONS = {
+  trustStoredStaffProof: true,
+} as const;
 
 export function createLocalSyncIngestionService(
   dependencies: IngestionDependencies,
@@ -200,6 +203,7 @@ export function createLocalSyncIngestionService(
                     syncEventId: existing._id,
                     submittedByUserId: batch.submittedByUserId,
                     now: acceptedAt,
+                    options: TERMINAL_INGESTION_PROJECTION_OPTIONS,
                   },
                 );
                 await dependencies.repository.patchEvent(existing._id, {
@@ -347,6 +351,7 @@ export function createLocalSyncIngestionService(
             syncEventId: syncEvent._id,
             submittedByUserId: batch.submittedByUserId,
             now: acceptedAt,
+            options: TERMINAL_INGESTION_PROJECTION_OPTIONS,
           },
         );
         const finalStatus = projection.status;

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
@@ -758,6 +758,34 @@ describe("projectLocalSyncEvent", () => {
     expect(repository.createdTransactions).toHaveLength(0);
   });
 
+  it("does not let stored staff trust override an invalid offline staff proof", async () => {
+    const repository = createProjectionRepository({ validStaffProof: false });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: buildSaleCompletedEvent(),
+      syncEventId: "sync-event-1",
+      now: 100,
+      options: {
+        trustStoredStaffProof: true,
+      },
+    });
+
+    expect(result.status).toBe("conflicted");
+    expect(result.conflicts).toEqual([
+      expect.objectContaining({
+        conflictType: "permission",
+        details: expect.objectContaining({
+          eventType: "sale_completed",
+          hasStaffProof: true,
+          staffProfileId: "staff-1",
+        }),
+      }),
+    ]);
+    expect(repository.createdTransactions).toHaveLength(0);
+  });
+
   it("conflicts active cashier sales without an offline staff proof token", async () => {
     const repository = createProjectionRepository();
     const event = buildSaleCompletedEvent();

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -242,8 +242,10 @@ async function validateProjectionPermission(
         now: args.now,
       })
     : false;
+  const canTrustStoredStaffProof =
+    args.options?.trustStoredStaffProof === true && !args.event.staffProofToken;
   const hasTrustedStoredStaffProof =
-    args.options?.trustStoredStaffProof === true &&
+    canTrustStoredStaffProof &&
     Boolean(staff) &&
     staff?.storeId === args.storeId &&
     staff?.status === "active" &&
@@ -275,7 +277,7 @@ async function validateProjectionPermission(
         })
       : false;
   const hasTrustedStoredCashierOrManagerProof =
-    args.options?.trustStoredStaffProof === true &&
+    canTrustStoredStaffProof &&
     Boolean(staff) &&
     staff?.storeId === args.storeId &&
     staff?.status === "active" &&

--- a/packages/athena-webapp/convex/pos/domain/types.ts
+++ b/packages/athena-webapp/convex/pos/domain/types.ts
@@ -19,6 +19,8 @@ export interface PosTerminalSummary {
   _id: string;
   displayName: string;
   registerNumber?: string;
+  loginMode?: "standard" | "pos_only";
+  transactionCapability?: "products_and_services" | "products_only" | "services_only";
   status?: string;
   registeredAt?: number;
 }

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
@@ -26,6 +26,8 @@ export function mapTerminalRecord(
     fingerprintHash: terminal.fingerprintHash,
     displayName: terminal.displayName,
     registerNumber: terminal.registerNumber,
+    loginMode: terminal.loginMode,
+    transactionCapability: terminal.transactionCapability,
     registeredByUserId: terminal.registeredByUserId,
     browserInfo: terminal.browserInfo,
     registeredAt: terminal.registeredAt,
@@ -57,6 +59,8 @@ export async function getTerminalForRegisterState(
     _id: terminal._id,
     displayName: terminal.displayName,
     registerNumber: terminal.registerNumber,
+    loginMode: terminal.loginMode,
+    transactionCapability: terminal.transactionCapability,
     status: terminal.status,
     registeredAt: terminal.registeredAt,
   };

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -40,6 +40,17 @@ const statusValidator = v.union(
   v.literal("lost"),
 );
 
+const transactionCapabilityValidator = v.union(
+  v.literal("products_and_services"),
+  v.literal("products_only"),
+  v.literal("services_only"),
+);
+
+const loginModeValidator = v.union(
+  v.literal("standard"),
+  v.literal("pos_only"),
+);
+
 const browserInfoValidator = v.object({
   userAgent: v.string(),
   platform: v.optional(v.string()),
@@ -56,6 +67,8 @@ const terminalReturnValidator = v.object({
   fingerprintHash: v.string(),
   displayName: v.string(),
   registerNumber: v.optional(v.string()),
+  loginMode: v.optional(loginModeValidator),
+  transactionCapability: v.optional(transactionCapabilityValidator),
   registeredByUserId: v.id("athenaUser"),
   browserInfo: browserInfoValidator,
   registeredAt: v.number(),
@@ -70,6 +83,8 @@ const terminalProvisioningReturnValidator = v.object({
   syncSecretHash: v.optional(v.string()),
   displayName: v.string(),
   registerNumber: v.optional(v.string()),
+  loginMode: v.optional(loginModeValidator),
+  transactionCapability: v.optional(transactionCapabilityValidator),
   registeredByUserId: v.id("athenaUser"),
   browserInfo: browserInfoValidator,
   registeredAt: v.number(),
@@ -236,6 +251,8 @@ const terminalRegistrationSummaryReturnValidator = v.object({
   _id: v.id("posTerminal"),
   displayName: v.string(),
   registerNumber: v.optional(v.string()),
+  loginMode: v.optional(loginModeValidator),
+  transactionCapability: v.optional(transactionCapabilityValidator),
   registeredByUserId: v.id("athenaUser"),
   browserInfo: browserInfoValidator,
   registeredAt: v.number(),
@@ -488,6 +505,8 @@ export const registerTerminal = mutation({
     syncSecretHash: v.string(),
     displayName: v.string(),
     registerNumber: v.string(),
+    loginMode: v.optional(loginModeValidator),
+    transactionCapability: v.optional(transactionCapabilityValidator),
     browserInfo: browserInfoValidator,
   },
   returns: commandResultValidator(terminalProvisioningReturnValidator),

--- a/packages/athena-webapp/convex/schemas/pos/posTerminal.ts
+++ b/packages/athena-webapp/convex/schemas/pos/posTerminal.ts
@@ -1,11 +1,24 @@
 import { v } from "convex/values";
 
+const transactionCapabilityValidator = v.union(
+  v.literal("products_and_services"),
+  v.literal("products_only"),
+  v.literal("services_only"),
+);
+
+const loginModeValidator = v.union(
+  v.literal("standard"),
+  v.literal("pos_only"),
+);
+
 export const posTerminalSchema = v.object({
   storeId: v.id("store"),
   fingerprintHash: v.string(),
   syncSecretHash: v.optional(v.string()),
   displayName: v.string(),
   registerNumber: v.optional(v.string()),
+  transactionCapability: v.optional(transactionCapabilityValidator),
+  loginMode: v.optional(loginModeValidator),
   registeredByUserId: v.id("athenaUser"),
   browserInfo: v.object({
     userAgent: v.string(),

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -14,8 +14,8 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`src/hooks`](../../src/hooks) — React hooks that fan out auth, shell, and feature state. Currently 43 file(s); key children: use-image-upload.ts, use-mobile.tsx, use-navigate-back.ts, use-navigation-keyboard-shortcuts.ts, use-pagination-persistence.ts.
 - [`src/contexts`](../../src/contexts) — Context providers for app-wide state and wiring. Currently 8 file(s); key children: AppShellFullscreenContext.tsx, ManagerElevationContext.test.tsx, ManagerElevationContext.tsx, OnlineOrderContext.tsx, PermissionsContext.tsx.
 - [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 126 file(s); key children: access, aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts.
-- [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 14 file(s); key children: approvalPolicy.ts, auth.ts, commandResult.test.ts, commandResult.ts, currencyFormatter.test.ts.
-- [`src/utils`](../../src/utils) — Cross-cutting browser helpers and lower-level utilities. Currently 3 file(s); key children: formatNumber.ts, index.ts, versionChecker.ts.
+- [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 16 file(s); key children: approvalPolicy.ts, auth.ts, commandResult.test.ts, commandResult.ts, currencyFormatter.test.ts.
+- [`src/utils`](../../src/utils) — Cross-cutting browser helpers and lower-level utilities. Currently 4 file(s); key children: formatNumber.ts, index.ts, versionChecker.test.ts, versionChecker.ts.
 
 ## Backend and test surfaces
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -155,6 +155,7 @@ This index enumerates the current automated test files and ties them back to the
 
 ## Section `src`
 
+- [`src/auth/convexAuthUrl.test.ts`](../../src/auth/convexAuthUrl.test.ts)
 - [`src/components/View.test.tsx`](../../src/components/View.test.tsx)
 - [`src/components/add-product/ProductStock.test.ts`](../../src/components/add-product/ProductStock.test.ts)
 - [`src/components/add-product/ProductView.test.tsx`](../../src/components/add-product/ProductView.test.tsx)
@@ -321,4 +322,5 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/tests/pos/offlineSalesContinuity.spec.ts`](../../src/tests/pos/offlineSalesContinuity.spec.ts)
 - [`src/tests/pos/simple.test.ts`](../../src/tests/pos/simple.test.ts)
 - [`src/tests/pos/usePrint.test.ts`](../../src/tests/pos/usePrint.test.ts)
+- [`src/utils/versionChecker.test.ts`](../../src/utils/versionChecker.test.ts)
 

--- a/packages/athena-webapp/shared/posTerminalCapability.ts
+++ b/packages/athena-webapp/shared/posTerminalCapability.ts
@@ -1,0 +1,29 @@
+export const POS_TERMINAL_TRANSACTION_CAPABILITIES = [
+  "products_and_services",
+  "products_only",
+  "services_only",
+] as const;
+
+export type PosTerminalTransactionCapability =
+  (typeof POS_TERMINAL_TRANSACTION_CAPABILITIES)[number];
+
+export const DEFAULT_POS_TERMINAL_TRANSACTION_CAPABILITY =
+  "products_and_services" satisfies PosTerminalTransactionCapability;
+
+export function normalizePosTerminalTransactionCapability(
+  value: unknown,
+): PosTerminalTransactionCapability {
+  return POS_TERMINAL_TRANSACTION_CAPABILITIES.includes(
+    value as PosTerminalTransactionCapability,
+  )
+    ? (value as PosTerminalTransactionCapability)
+    : DEFAULT_POS_TERMINAL_TRANSACTION_CAPABILITY;
+}
+
+export function posTerminalCanTransactProducts(value: unknown): boolean {
+  return normalizePosTerminalTransactionCapability(value) !== "services_only";
+}
+
+export function posTerminalCanTransactServices(value: unknown): boolean {
+  return normalizePosTerminalTransactionCapability(value) !== "products_only";
+}

--- a/packages/athena-webapp/shared/posTerminalLoginMode.ts
+++ b/packages/athena-webapp/shared/posTerminalLoginMode.ts
@@ -1,0 +1,18 @@
+export const POS_TERMINAL_LOGIN_MODES = ["standard", "pos_only"] as const;
+
+export type PosTerminalLoginMode = (typeof POS_TERMINAL_LOGIN_MODES)[number];
+
+export const DEFAULT_POS_TERMINAL_LOGIN_MODE =
+  "standard" satisfies PosTerminalLoginMode;
+
+export function normalizePosTerminalLoginMode(
+  value: unknown,
+): PosTerminalLoginMode {
+  return POS_TERMINAL_LOGIN_MODES.includes(value as PosTerminalLoginMode)
+    ? (value as PosTerminalLoginMode)
+    : DEFAULT_POS_TERMINAL_LOGIN_MODE;
+}
+
+export function isPosOnlyTerminalLoginMode(value: unknown): boolean {
+  return normalizePosTerminalLoginMode(value) === "pos_only";
+}

--- a/packages/athena-webapp/src/auth/convexAuthUrl.test.ts
+++ b/packages/athena-webapp/src/auth/convexAuthUrl.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { removeConvexAuthCodeParamFromUrl } from "./convexAuthUrl";
+
+describe("removeConvexAuthCodeParamFromUrl", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("removes code query params before Convex Auth can auto-consume them", () => {
+    const replaceState = vi.fn();
+    const win = {
+      history: {
+        replaceState,
+        state: { retained: true },
+      },
+      location: {
+        href:
+          "https://athena.example.com/wigclub/store/wigclub/pos?code=123456&o=%2Fhome#cart",
+      },
+    } as unknown as Window;
+
+    const removed = removeConvexAuthCodeParamFromUrl(win);
+
+    expect(removed).toBe(true);
+    expect(replaceState).toHaveBeenCalledWith(
+      { retained: true },
+      "",
+      "/wigclub/store/wigclub/pos?o=%2Fhome#cart",
+    );
+  });
+
+  it("leaves URLs alone when there is no code query param", () => {
+    const replaceState = vi.fn();
+    const win = {
+      history: {
+        replaceState,
+        state: null,
+      },
+      location: {
+        href: "https://athena.example.com/wigclub/store/wigclub/pos?o=%2Fhome",
+      },
+    } as unknown as Window;
+
+    const removed = removeConvexAuthCodeParamFromUrl(win);
+
+    expect(removed).toBe(false);
+    expect(replaceState).not.toHaveBeenCalled();
+  });
+});

--- a/packages/athena-webapp/src/auth/convexAuthUrl.ts
+++ b/packages/athena-webapp/src/auth/convexAuthUrl.ts
@@ -1,0 +1,13 @@
+export function removeConvexAuthCodeParamFromUrl(win: Window = window) {
+  const url = new URL(win.location.href);
+
+  if (!url.searchParams.has("code")) {
+    return false;
+  }
+
+  url.searchParams.delete("code");
+  const sanitizedPath = `${url.pathname}${url.search}${url.hash}`;
+  win.history.replaceState(win.history.state, "", sanitizedPath);
+
+  return true;
+}

--- a/packages/athena-webapp/src/components/auth/Login/index.test.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/index.test.tsx
@@ -119,6 +119,33 @@ describe("Login", () => {
     });
   });
 
+  it("defaults POS-only provisioned terminals to POS recovery while keeping email secondary", async () => {
+    mocked.useSearch.mockReturnValue({});
+    mocked.readProvisionedTerminalSeed.mockResolvedValue({
+      ok: true,
+      value: {
+        cloudTerminalId: "terminal-1",
+        displayName: "Front register",
+        loginMode: "pos_only",
+        orgUrlSlug: "wigclub",
+        provisionedAt: 1,
+        schemaVersion: 8,
+        storeId: "store-1",
+        storeUrlSlug: "wigclub",
+        syncSecretHash: "secret-hash",
+        terminalId: "fingerprint-1",
+      },
+    });
+
+    render(<Login />);
+
+    expect(
+      await screen.findByRole("heading", { name: /pos recovery/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /use email code/i }))
+      .toBeInTheDocument();
+  });
+
   it("uses an existing provisioned terminal seed without slugs for store-scoped recovery", async () => {
     const user = userEvent.setup();
     mocked.signIn.mockResolvedValue({ signingIn: true });

--- a/packages/athena-webapp/src/components/auth/Login/index.tsx
+++ b/packages/athena-webapp/src/components/auth/Login/index.tsx
@@ -8,6 +8,7 @@ import {
   createPosLocalStore,
   type PosProvisionedTerminalSeed,
 } from "@/lib/pos/infrastructure/local/posLocalStore";
+import { isPosOnlyTerminalLoginMode } from "~/shared/posTerminalLoginMode";
 
 const POS_ROUTE_PATTERN =
   /^\/(?<orgUrlSlug>[^/]+)\/store\/(?<storeUrlSlug>[^/]+)\/pos(?:\/.*)?$/;
@@ -60,6 +61,11 @@ export function Login() {
 
       if (!cancelled && result.ok) {
         setLocalTerminalSeed(result.value);
+        if (isPosOnlyTerminalLoginMode(result.value?.loginMode)) {
+          setStep((current) =>
+            current === "signIn" ? "posRecovery" : current,
+          );
+        }
       }
     })();
 

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
@@ -966,6 +966,65 @@ describe("RegisterSessionViewContent", () => {
     });
   });
 
+  it("approves proofless staff-access synced activity after manager sign-in", async () => {
+    const user = userEvent.setup();
+    const onAuthenticateStaff = vi.fn().mockResolvedValue(
+      ok({
+        activeRoles: ["manager"],
+        staffProfile: { fullName: "Ato Kofi" },
+        staffProfileId: "manager-1",
+      }),
+    );
+    const onResolveSyncReview = vi
+      .fn()
+      .mockResolvedValue(
+        ok({ action: "resolved", projectedCount: 1, resolvedCount: 3 }),
+      );
+
+    render(
+      <RegisterSessionViewContent
+        currency="GHS"
+        isLoading={false}
+        onRecordDeposit={vi.fn()}
+        {...closeoutHandlers}
+        onAuthenticateStaff={onAuthenticateStaff}
+        onResolveSyncReview={onResolveSyncReview}
+        registerSessionSnapshot={{
+          ...baseSnapshot,
+          registerSession: {
+            ...baseSnapshot.registerSession,
+            localSyncStatus: {
+              status: "needs_review",
+              reconciliationItems: [
+                {
+                  id: "sync_conflict_1",
+                  sequence: 6,
+                  status: "needs_review",
+                  summary:
+                    "Staff access changed before this POS history synced.",
+                  type: "permission",
+                },
+              ],
+            },
+          },
+        }}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Approve synced sales" }));
+    await user.click(
+      screen.getByRole("button", {
+        name: "Confirm staff for Approve synced sales",
+      }),
+    );
+
+    expect(onResolveSyncReview).toHaveBeenCalledWith({
+      actorStaffProfileId: "manager-1",
+      decision: "approved",
+      registerSessionId: "session-1",
+    });
+  });
+
   it("rejects synced register review items after manager sign-in", async () => {
     const user = userEvent.setup();
     const onAuthenticateStaff = vi.fn().mockResolvedValue(

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -10,7 +10,7 @@ import {
   Smartphone,
   WalletCards,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { useAuth } from "@/hooks/useAuth";
@@ -79,6 +79,8 @@ const CLOSED_REGISTER_SYNCED_CLOSEOUT_SUMMARY =
   "register session is not open for synced pos closeout";
 const REGISTER_NOT_OPEN_SYNC_REVIEW_SUMMARY =
   "Register was not open before this sale synced.";
+const STAFF_ACCESS_SYNC_REVIEW_SUMMARY =
+  "Staff access changed before this POS history synced.";
 const SERVICE_CUSTOMER_ATTRIBUTION_SYNC_REVIEW_SUMMARY =
   "Service line is missing customer attribution.";
 
@@ -598,6 +600,43 @@ function hasOnlyRejectedSyncReviewItems(syncStatus: PosSyncStatusPresentation) {
   );
 }
 
+function getAutomaticStaffAccessSyncReviewSignature(
+  registerSession?: RegisterSessionDetail | null,
+) {
+  const syncStatus = buildPosSyncStatusPresentation(
+    registerSession?.localSyncStatus,
+  );
+  if (
+    !registerSession ||
+    syncStatus.status !== "needs_review" ||
+    syncStatus.reconciliationItems.length === 0
+  ) {
+    return null;
+  }
+
+  const unresolvedItems = syncStatus.reconciliationItems.filter(
+    (item) => item.status !== "rejected",
+  );
+  if (
+    unresolvedItems.length === 0 ||
+    unresolvedItems.some(
+      (item) =>
+        item.type !== "permission" ||
+        item.summary?.trim() !== STAFF_ACCESS_SYNC_REVIEW_SUMMARY,
+    )
+  ) {
+    return null;
+  }
+
+  return [
+    registerSession._id,
+    ...unresolvedItems.map(
+      (item) =>
+        `${item.id ?? item.localEventId ?? "event"}:${item.sequence ?? ""}`,
+    ),
+  ].join("|");
+}
+
 function isApprovableRegisterSyncReviewItem(item: PosReconciliationItem) {
   if (item.status === "rejected") {
     return true;
@@ -609,7 +648,8 @@ function isApprovableRegisterSyncReviewItem(item: PosReconciliationItem) {
 
   return (
     item.type === "permission" &&
-    item.summary?.trim() === REGISTER_NOT_OPEN_SYNC_REVIEW_SUMMARY
+    (item.summary?.trim() === REGISTER_NOT_OPEN_SYNC_REVIEW_SUMMARY ||
+      item.summary?.trim() === STAFF_ACCESS_SYNC_REVIEW_SUMMARY)
   );
 }
 
@@ -3269,6 +3309,7 @@ export function RegisterSessionView() {
         storeUrlSlug?: string;
       }
     | undefined;
+  const automaticSyncReviewAttemptRef = useRef<string | null>(null);
 
   const registerSessionSnapshotArgs =
     canQueryProtectedData && params?.sessionId
@@ -3334,6 +3375,50 @@ export function RegisterSessionView() {
     (correctOpeningFloatReference ??
       api.operations.staffCredentials.authenticateStaffCredential) as never,
   );
+  const automaticSyncReviewSignature = useMemo(
+    () =>
+      getAutomaticStaffAccessSyncReviewSignature(
+        registerSessionSnapshot?.registerSession,
+      ),
+    [registerSessionSnapshot?.registerSession],
+  );
+
+  useEffect(() => {
+    const registerSessionId = registerSessionSnapshot?.registerSession?._id;
+    if (
+      !activeStore?._id ||
+      !automaticSyncReviewSignature ||
+      !registerSessionId
+    ) {
+      return;
+    }
+
+    if (automaticSyncReviewAttemptRef.current === automaticSyncReviewSignature) {
+      return;
+    }
+    automaticSyncReviewAttemptRef.current = automaticSyncReviewSignature;
+
+    void runCommand(() =>
+      resolveRegisterSessionSyncReview({
+        decision: "approved",
+        registerSessionId: registerSessionId as Id<"registerSession">,
+        storeId: activeStore._id,
+      }),
+    ).then((result) => {
+      if (result.kind !== "ok") {
+        automaticSyncReviewAttemptRef.current = null;
+        return;
+      }
+      if (result.data.action === "resolved") {
+        toast.success("Synced register activity applied");
+      }
+    });
+  }, [
+    activeStore?._id,
+    automaticSyncReviewSignature,
+    registerSessionSnapshot?.registerSession?._id,
+    resolveRegisterSessionSyncReview,
+  ]);
 
   async function onRecordDeposit(args: RecordRegisterSessionDepositArgs) {
     const result = await runCommand(() =>

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -347,6 +347,30 @@ const quickAddTimelineSnapshot: DailyOperationsSnapshot = {
   ],
 };
 
+const registerCloseoutTimelineSnapshot: DailyOperationsSnapshot = {
+  ...operatingSnapshot,
+  timeline: [
+    {
+      createdAt: Date.UTC(2026, 4, 8, 20, 45),
+      id: "register_closeout:register-2:closed:1778273100000",
+      message: "Register 2 closeout recorded with an exact cash match.",
+      registerLink: {
+        label: "Register 2",
+        params: {
+          sessionId: "register-2",
+        },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId",
+      },
+      subject: {
+        id: "register-2",
+        label: "Register 2",
+        type: "register_session",
+      },
+      type: "register_session_closed",
+    },
+  ],
+};
+
 const posSyncedSaleTimelineSnapshot: DailyOperationsSnapshot = {
   ...operatingSnapshot,
   timeline: [
@@ -947,6 +971,27 @@ describe("DailyOperationsViewContent", () => {
         return (
           node?.textContent ===
           "Kwamina Nuh quick added Vitamilk with quantity 100."
+        );
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("links register closeout timeline events to the register session", () => {
+    renderContent(registerCloseoutTimelineSnapshot);
+
+    const registerLink = screen.getByRole("link", { name: "Register 2" });
+
+    expect(registerLink).toHaveAttribute(
+      "href",
+      expect.stringContaining(
+        "/wigclub/store/osu/cash-controls/registers/register-2?o=",
+      ),
+    );
+    expect(
+      screen.getByText((content, node) => {
+        return (
+          node?.textContent ===
+          "Register 2 closeout recorded with an exact cash match."
         );
       }),
     ).toBeInTheDocument();

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -165,6 +165,12 @@ export type DailyOperationsSnapshot = {
       search?: Record<string, string>;
       to?: string;
     };
+    registerLink?: {
+      label?: string;
+      params?: Record<string, string>;
+      search?: Record<string, string>;
+      to?: string;
+    };
     transactionLink?: {
       label?: string;
       params?: Record<string, string>;
@@ -462,7 +468,8 @@ function TimelineMessage({
   orgUrlSlug: string;
   storeUrlSlug: string;
 }) {
-  const inlineLink = event.transactionLink ?? event.productLink;
+  const inlineLink =
+    event.transactionLink ?? event.registerLink ?? event.productLink;
   const linkLabel = inlineLink?.label?.trim();
   const linkMatch = findTimelineLinkMatch(event.message, linkLabel);
 

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
@@ -1102,6 +1102,51 @@ describe("StockAdjustmentWorkspaceContent", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("ranks direct product-name phrase matches before broader fuzzy hits", async () => {
+    const user = userEvent.setup();
+
+    renderStockAdjustmentWorkspace({
+      inventoryItems: [
+        {
+          _id: "sku-fragrance" as Id<"productSku">,
+          inventoryCount: 8,
+          productCategory: "POS quick add",
+          productName:
+            "Brazilian Hair And Body Fragrance Mist Black Amber Plum",
+          quantityAvailable: 8,
+          sku: "KK38-6Q0-EMF",
+        },
+        {
+          _id: "sku-melt-band" as Id<"productSku">,
+          inventoryCount: 17_000,
+          productCategory: "POS quick add",
+          productName: "Melt Band",
+          quantityAvailable: 17_000,
+          sku: "KK38-MELT-BAND",
+        },
+      ],
+    });
+
+    await user.type(
+      screen.getByRole("textbox", {
+        name: /search products, skus, or barcodes/i,
+      }),
+      "meltband",
+    );
+
+    const table = screen.getByRole("table");
+    const rowNames = within(table)
+      .getAllByRole("row")
+      .map((row) => row.textContent ?? "");
+
+    expect(rowNames.findIndex((text) => text.includes("Melt Band")))
+      .toBeLessThan(
+        rowNames.findIndex((text) =>
+          text.includes("Brazilian Hair And Body Fragrance Mist"),
+        ),
+      );
+  });
+
   it("shows matching SKUs from other categories when the active category has no results", async () => {
     const user = userEvent.setup();
     const onSearchStateChange = vi.fn();

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
@@ -39,8 +39,8 @@ import { getProductName } from "~/src/lib/productUtils";
 import { getOrigin } from "~/src/lib/navigationUtils";
 import { formatStoredCurrencyAmount } from "@/lib/pos/displayAmounts";
 import {
-  matchesSkuSearchTerms,
   normalizeSkuSearchQuery,
+  scoreSkuSearchTerms,
 } from "@/lib/stockOps/skuSearch";
 import type { NormalizedCommandResult } from "../../lib/errors/runCommand";
 import { presentCommandToast } from "../../lib/errors/presentCommandToast";
@@ -410,27 +410,25 @@ function formatInventoryItemPriceLabel(item: InventorySnapshotItem) {
     : "Price pending";
 }
 
-function rowMatchesStockAdjustmentSearch(
-  row: StockAdjustmentRow,
-  query: string,
-) {
-  if (!query) return true;
+function scoreStockAdjustmentSearchRow(row: StockAdjustmentRow, query: string) {
+  if (!query) return 1;
 
+  return scoreSkuSearchTerms(getStockAdjustmentSearchTerms(row), query);
+}
+
+function getStockAdjustmentSearchTerms(row: StockAdjustmentRow) {
   const item = row.inventoryItem;
-  return matchesSkuSearchTerms(
-    [
-      getInventoryItemDisplayName(item),
-      item.sku,
-      item.barcode,
-      item.colorName,
-      item.productCategory,
-      item.size,
-      item.length === null || item.length === undefined
-        ? undefined
-        : String(item.length),
-    ],
-    query,
-  );
+  return [
+    getInventoryItemDisplayName(item),
+    item.sku,
+    item.barcode,
+    item.colorName,
+    item.productCategory,
+    item.size,
+    item.length === null || item.length === undefined
+      ? undefined
+      : String(item.length),
+  ];
 }
 
 function rowMatchesCategoryFilter(row: StockAdjustmentRow, category: string) {
@@ -1977,12 +1975,30 @@ export function StockAdjustmentWorkspaceContent({
     [inventoryItems],
   );
   const queryAvailabilityFilteredRows = useMemo(
-    () =>
-      rows.filter(
-        (row) =>
-          rowMatchesStockAdjustmentSearch(row, normalizedFilterQuery) &&
-          rowMatchesAvailabilityFilter(row, filters.availability),
-      ),
+    () => {
+      const scoredRows = rows
+        .map((row, position) => ({
+          position,
+          row,
+          score: scoreStockAdjustmentSearchRow(row, normalizedFilterQuery),
+        }))
+        .filter(
+          ({ row, score }) =>
+            score > 0 &&
+            rowMatchesAvailabilityFilter(row, filters.availability),
+        );
+
+      if (!normalizedFilterQuery) {
+        return scoredRows.map(({ row }) => row);
+      }
+
+      return scoredRows
+        .sort((left, right) => {
+          if (right.score !== left.score) return right.score - left.score;
+          return left.position - right.position;
+        })
+        .map(({ row }) => row);
+    },
     [filters.availability, normalizedFilterQuery, rows],
   );
   const filteredRows = useMemo(
@@ -2426,11 +2442,23 @@ export function StockAdjustmentWorkspaceContent({
 
   const getFirstFilteredItem = (nextFilters: StockAdjustmentFilterState) => {
     const nextNormalizedQuery = normalizeSkuSearchQuery(nextFilters.query);
-    const nextRows = rows.filter(
-      (row) =>
-        rowMatchesStockAdjustmentSearch(row, nextNormalizedQuery) &&
-        rowMatchesAvailabilityFilter(row, nextFilters.availability),
-    );
+    const nextRows = rows
+      .map((row, position) => ({
+        position,
+        row,
+        score: scoreStockAdjustmentSearchRow(row, nextNormalizedQuery),
+      }))
+      .filter(
+        ({ row, score }) =>
+          score > 0 &&
+          rowMatchesAvailabilityFilter(row, nextFilters.availability),
+      )
+      .sort((left, right) => {
+        if (!nextNormalizedQuery) return left.position - right.position;
+        if (right.score !== left.score) return right.score - left.score;
+        return left.position - right.position;
+      })
+      .map(({ row }) => row);
     const firstExactItem = nextRows.find((row) =>
       rowMatchesCategoryFilter(row, nextFilters.category),
     )?.inventoryItem;

--- a/packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx
+++ b/packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx
@@ -352,7 +352,7 @@ describe("CashierAuthDialog", () => {
 
     await waitFor(() =>
       expect(mocks.toastError).toHaveBeenCalledWith(
-        "This staff sign-in is not available offline on this terminal. Reconnect, then try again.",
+        "Staff list is not ready on this terminal. Reconnect once to refresh staff credentials.",
       ),
     );
     expect(authenticateMutation).not.toHaveBeenCalled();
@@ -468,6 +468,58 @@ describe("CashierAuthDialog", () => {
       "1234",
       expect.objectContaining({ ciphertext: "wrapped-proof-token" }),
     );
+    expect(mocks.toastSuccess).toHaveBeenCalledWith("Signed in as Ama Mensah");
+  });
+
+  it("authenticates a locally authorized cashier offline before a proof has been wrapped", async () => {
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: false,
+    });
+    const readStaffAuthorityForUsername = vi.fn(async () => ({
+      ok: true,
+      value: buildLocalAuthorityRecord({
+        wrappedPosLocalStaffProof: undefined,
+      }),
+    }));
+    mocks.createPosLocalStore.mockReturnValue({
+      readStaffAuthorityForUsername,
+      replaceStaffAuthoritySnapshot: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      upsertStaffAuthorityRecord: vi.fn(async ({ record }) => ({
+        ok: true,
+        value: record,
+      })),
+    });
+    const authenticateMutation = vi.fn();
+
+    const { user, onAuthenticated } = renderDialog({ authenticateMutation });
+
+    await submitCredentials(user);
+
+    await waitFor(() =>
+      expect(onAuthenticated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activeRoles: ["cashier"],
+          localStaffAuthority: expect.objectContaining({
+            staffProfileId,
+            username: "frontdesk",
+          }),
+          staffProfileId,
+        }),
+      ),
+    );
+    expect(onAuthenticated.mock.calls[0][0]).not.toHaveProperty(
+      "posLocalStaffProof",
+    );
+    expect(authenticateMutation).not.toHaveBeenCalled();
+    expect(mocks.verifyLocalPin).toHaveBeenCalledWith(
+      expect.objectContaining({ algorithm: "PBKDF2-SHA256" }),
+      "1234",
+    );
+    expect(mocks.unwrapLocalStaffProofToken).not.toHaveBeenCalled();
     expect(mocks.toastSuccess).toHaveBeenCalledWith("Signed in as Ama Mensah");
   });
 
@@ -657,7 +709,7 @@ describe("CashierAuthDialog", () => {
     await waitFor(() => expect(screen.getByLabelText(/pin/i)).toHaveValue(""));
   });
 
-  it("clears the PIN when an offline staff proof cannot be unwrapped", async () => {
+  it("continues offline when a cached staff proof cannot be unwrapped", async () => {
     Object.defineProperty(window.navigator, "onLine", {
       configurable: true,
       value: false,
@@ -684,13 +736,22 @@ describe("CashierAuthDialog", () => {
     await submitCredentials(user);
 
     await waitFor(() =>
-      expect(mocks.toastError).toHaveBeenCalledWith(
-        "Offline staff sign-in needs a refresh. Reconnect, then try again.",
+      expect(onAuthenticated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activeRoles: ["cashier"],
+          localStaffAuthority: expect.objectContaining({
+            staffProfileId,
+            username: "frontdesk",
+          }),
+          staffProfileId,
+        }),
       ),
     );
     expect(authenticateMutation).not.toHaveBeenCalled();
-    expect(onAuthenticated).not.toHaveBeenCalled();
-    await waitFor(() => expect(screen.getByLabelText(/pin/i)).toHaveValue(""));
+    expect(onAuthenticated.mock.calls[0][0]).not.toHaveProperty(
+      "posLocalStaffProof",
+    );
+    expect(mocks.toastSuccess).toHaveBeenCalledWith("Signed in as Ama Mensah");
   });
 
   it("rejects offline recover mode without claiming other registers were signed out", async () => {

--- a/packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx
+++ b/packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx
@@ -269,7 +269,7 @@ export function CashierAuthDialog({
       return userError({
         code: "precondition_failed",
         message:
-          "This staff sign-in is not available offline on this terminal. Reconnect, then try again.",
+          "Staff list is not ready on this terminal. Reconnect once to refresh staff credentials.",
       });
     }
 
@@ -288,26 +288,41 @@ export function CashierAuthDialog({
       });
     }
 
+    const authenticationResult = {
+      activeRoles: authority.activeRoles,
+      localStaffAuthority: authority,
+      staffProfile: {
+        fullName: authority.displayName ?? null,
+      },
+      staffProfileId: authority.staffProfileId as Id<"staffProfile">,
+    };
+
+    if (!authority.wrappedPosLocalStaffProof) {
+      logger.info("[POS] Offline staff sign-in continuing without staff proof", {
+        staffProfileId: authority.staffProfileId,
+        storeId,
+        terminalId,
+      });
+      return ok(authenticationResult);
+    }
+
     const posLocalStaffProof = await unwrapLocalStaffProofToken(
       authority.verifier,
       args.pin,
       authority.wrappedPosLocalStaffProof,
     );
     if (!posLocalStaffProof || posLocalStaffProof.expiresAt <= Date.now()) {
-      return userError({
-        code: "precondition_failed",
-        message: "Offline staff sign-in needs a refresh. Reconnect, then try again.",
+      logger.info("[POS] Offline staff sign-in continuing with proof refresh due", {
+        staffProfileId: authority.staffProfileId,
+        storeId,
+        terminalId,
       });
+      return ok(authenticationResult);
     }
 
     return ok({
-      activeRoles: authority.activeRoles,
-      localStaffAuthority: authority,
+      ...authenticationResult,
       posLocalStaffProof,
-      staffProfile: {
-        fullName: authority.displayName ?? null,
-      },
-      staffProfileId: authority.staffProfileId as Id<"staffProfile">,
     });
   }
 

--- a/packages/athena-webapp/src/components/pos/ProductEntry.test.tsx
+++ b/packages/athena-webapp/src/components/pos/ProductEntry.test.tsx
@@ -109,9 +109,13 @@ function buildServiceResult(
 }
 
 function renderProductEntryWithServices(input: {
+  canSearchProducts?: boolean;
+  canSearchServices?: boolean;
   lookupMode?: RegisterLookupMode;
+  searchResults?: Product[];
   serviceEntry: RegisterServiceEntryState;
   setProductSearchQuery?: (query: string) => void;
+  onBarcodeSubmit?: () => void;
 }) {
   function Harness() {
     const [lookupMode, setLookupMode] = useState<RegisterLookupMode>(
@@ -121,13 +125,15 @@ function renderProductEntryWithServices(input: {
 
     return (
       <ProductEntry
+        canSearchProducts={input.canSearchProducts}
+        canSearchServices={input.canSearchServices}
         isSearchLoading={false}
         isSearchReady
         lookupMode={lookupMode}
         onAddProduct={vi.fn()}
-        onBarcodeSubmit={vi.fn()}
+        onBarcodeSubmit={input.onBarcodeSubmit ?? vi.fn()}
         productSearchQuery={productSearchQuery}
-        searchResults={[]}
+        searchResults={input.searchResults ?? []}
         serviceEntry={input.serviceEntry}
         setLookupMode={setLookupMode}
         setProductSearchQuery={(query) => {
@@ -429,6 +435,66 @@ describe("ProductEntry", () => {
         screen.getByPlaceholderText(/lookup product or service by name/i),
       ).toHaveFocus(),
     );
+  });
+
+  it("does not surface product results or barcode submit on service-only terminals", async () => {
+    const user = userEvent.setup();
+    const onBarcodeSubmit = vi.fn();
+    const service = buildServiceResult();
+    const serviceEntry: RegisterServiceEntryState = {
+      disabled: false,
+      serviceSearchQuery: "closure",
+      setServiceSearchQuery: vi.fn(),
+      searchResults: [service],
+      isSearchLoading: false,
+      isSearchReady: true,
+      items: [],
+      onAddService: vi.fn(async () => true),
+      onUpdateServiceAmount: vi.fn(),
+      onRemoveService: vi.fn(),
+    };
+
+    renderProductEntryWithServices({
+      canSearchProducts: false,
+      serviceEntry,
+      searchResults: [buildQuickAddedProduct()],
+      onBarcodeSubmit,
+    });
+
+    const input = screen.getByPlaceholderText(/lookup service by name/i);
+    expect(input).toBeInTheDocument();
+    expect(screen.getByText("Closure Repair")).toBeInTheDocument();
+    expect(screen.queryByText("Quick item")).not.toBeInTheDocument();
+    expect(screen.queryByText("No products found")).not.toBeInTheDocument();
+
+    await user.type(input, "{enter}");
+
+    expect(onBarcodeSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does not surface service results on product-only terminals", () => {
+    const serviceEntry: RegisterServiceEntryState = {
+      disabled: false,
+      serviceSearchQuery: "closure",
+      setServiceSearchQuery: vi.fn(),
+      searchResults: [buildServiceResult()],
+      isSearchLoading: false,
+      isSearchReady: true,
+      items: [],
+      onAddService: vi.fn(async () => true),
+      onUpdateServiceAmount: vi.fn(),
+      onRemoveService: vi.fn(),
+    };
+
+    renderProductEntryWithServices({
+      canSearchServices: false,
+      serviceEntry,
+    });
+
+    expect(
+      screen.getByPlaceholderText(/lookup product by name/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Closure Repair")).not.toBeInTheDocument();
   });
 
   it("requires an entered amount before adding a starting-at service", async () => {

--- a/packages/athena-webapp/src/components/pos/ProductEntry.tsx
+++ b/packages/athena-webapp/src/components/pos/ProductEntry.tsx
@@ -49,6 +49,10 @@ interface ProductSearchInputProps {
   setProductSearchQuery: (query: string) => void;
   onBarcodeSubmit: (e: React.FormEvent) => void;
   disabled?: boolean;
+  lookupKind?: "products_services" | "products" | "services";
+  onActivate?: () => void;
+  readOnly?: boolean;
+  submitOnEnter?: boolean;
   className?: string;
   inputClassName?: string;
   placeholder?: string;
@@ -64,6 +68,8 @@ interface ProductEntryProps extends ProductSearchInputProps {
   searchResults: Product[];
   isSearchLoading: boolean;
   isSearchReady: boolean;
+  canSearchProducts?: boolean;
+  canSearchServices?: boolean;
   canQuickAddProduct?: boolean;
   showSearchInput?: boolean;
   containerClassName?: string;
@@ -321,7 +327,11 @@ export const ProductSearchInput = forwardRef<
     onBarcodeSubmit,
     className,
     inputClassName,
-    placeholder = "Lookup product or service by name, bar/qr code, sku, or product url...",
+    lookupKind = "products_services",
+    onActivate,
+    placeholder,
+    readOnly = false,
+    submitOnEnter = true,
   },
   ref,
 ) {
@@ -342,27 +352,45 @@ export const ProductSearchInput = forwardRef<
   const handleClearSearch = () => {
     setProductSearchQuery("");
   };
+  const resolvedPlaceholder =
+    placeholder ??
+    (lookupKind === "services"
+      ? "Lookup service by name or service type..."
+      : lookupKind === "products"
+        ? "Lookup product by name, barcode, SKU, or product URL..."
+        : "Lookup product or service by name, bar/qr code, SKU, or product URL...");
 
   return (
     <div className={cn("relative", className)}>
       <div className="absolute text-gray-500 z-10 left-4 top-1/2 transform -translate-y-1/2 flex items-center gap-2">
-        <Search className="w-4 h-4" />
-        <ScanBarcode className="w-4 h-4" />
+        {lookupKind === "services" ? (
+          <Scissors className="w-4 h-4" />
+        ) : (
+          <>
+            <Search className="w-4 h-4" />
+            <ScanBarcode className="w-4 h-4" />
+          </>
+        )}
       </div>
       <Input
         ref={searchInputRef}
-        placeholder={placeholder}
+        placeholder={resolvedPlaceholder}
         value={productSearchQuery}
         disabled={disabled}
+        readOnly={readOnly}
         onChange={(e) => setProductSearchQuery(e.target.value)}
+        onPointerDown={onActivate}
         onKeyDown={(e) => {
-          if (e.key === "Enter" && productSearchQuery.trim()) {
+          if (submitOnEnter && e.key === "Enter" && productSearchQuery.trim()) {
             e.preventDefault();
             onBarcodeSubmit(e);
           }
         }}
         className={cn(
-          "h-12 pl-20 pr-10 border-gray-200 focus:border-blue-400 rounded-lg text-sm font-medium bg-white/80 backdrop-blur-sm",
+          cn(
+            "h-12 pr-10 border-gray-200 focus:border-blue-400 rounded-lg text-sm font-medium bg-white/80 backdrop-blur-sm",
+            lookupKind === "services" ? "pl-12" : "pl-20",
+          ),
           inputClassName,
         )}
         autoFocus
@@ -402,6 +430,8 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
       isSearchLoading,
       isSearchReady,
       canQuickAddProduct = false,
+      canSearchProducts = true,
+      canSearchServices,
       showSearchInput = true,
       containerClassName,
       lookupPanelClassName,
@@ -425,15 +455,25 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
     const productSearchInputRef = useRef<HTMLInputElement>(null);
 
     const inputIsUrlOrBarcode = isUrlOrBarcode(productSearchQuery);
+    const productLookupEnabled = canSearchProducts;
+    const serviceLookupEnabled =
+      Boolean(serviceEntry) && canSearchServices !== false;
+    const lookupKind =
+      productLookupEnabled && serviceLookupEnabled
+        ? "products_services"
+        : serviceLookupEnabled
+          ? "services"
+          : "products";
 
     const formatter = currencyFormatter(activeStore?.currency || "GHS");
     const serviceSearchQuery = serviceEntry?.serviceSearchQuery ?? "";
     const shouldShowServiceResults =
-      Boolean(serviceEntry) &&
+      serviceLookupEnabled &&
       serviceSearchQuery.trim().length > 0 &&
       serviceEntry!.searchResults.length > 0 &&
-      !inputIsUrlOrBarcode;
+      (!inputIsUrlOrBarcode || !productLookupEnabled);
     const shouldShowProductResults =
+      productLookupEnabled &&
       Boolean(productSearchQuery) &&
       (!shouldShowServiceResults ||
         searchResults.length > 0 ||
@@ -472,7 +512,7 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
 
     const handleOpenQuickAdd = useCallback(
       (selectedProduct?: Product) => {
-        if (!canQuickAddProduct) {
+        if (!productLookupEnabled || !canQuickAddProduct) {
           return;
         }
 
@@ -495,6 +535,7 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
         canQuickAddProduct,
         inputIsUrlOrBarcode,
         onQuickAddOpenChange,
+        productLookupEnabled,
         productSearchQuery,
       ],
     );
@@ -518,7 +559,7 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
           return true;
         },
         openQuickAddProduct: () => {
-          if (!canQuickAddProduct) {
+          if (!productLookupEnabled || !canQuickAddProduct) {
             return false;
           }
 
@@ -526,7 +567,7 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
           return true;
         },
       }),
-      [canQuickAddProduct, handleOpenQuickAdd],
+      [canQuickAddProduct, handleOpenQuickAdd, productLookupEnabled],
     );
 
     const handleQuickAddOpenChange = (open: boolean) => {
@@ -643,7 +684,7 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
       (!showSearchInput &&
         !productSearchQuery &&
         !serviceSearchQuery &&
-        !isQuickAddOpen &&
+        (!productLookupEnabled || !isQuickAddOpen) &&
         !forceQuickAddHost)
     ) {
       return null;
@@ -664,9 +705,11 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
                 <ProductSearchInput
                   ref={productSearchInputRef}
                   disabled={disabled || isQuickAddOpen}
+                  lookupKind={lookupKind}
                   productSearchQuery={productSearchQuery}
                   setProductSearchQuery={setProductSearchQuery}
                   onBarcodeSubmit={onBarcodeSubmit}
+                  submitOnEnter={productLookupEnabled}
                 />
               </div>
             )}
@@ -688,7 +731,7 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
                 formatter={formatter}
                 onClearSearch={handleClearSearch}
                 onQuickAddProduct={
-                  isSearchReady && canQuickAddProduct
+                  productLookupEnabled && isSearchReady && canQuickAddProduct
                     ? handleOpenQuickAdd
                     : undefined
                 }
@@ -700,20 +743,22 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
           </div>
         </div>
 
-        <QuickAddProductDialog
-          open={isQuickAddOpen}
-          onOpenChange={handleQuickAddOpenChange}
-          onSubmit={handleQuickAddSubmit}
-          onAttachBarcode={
-            isAddingVariant ? undefined : handleAttachBarcodeSubmit
-          }
-          existingSkuOptions={existingSkuOptions}
-          initialName={quickAddInitialName}
-          initialLookupCode={quickAddInitialLookupCode}
-          lockProductName={isAddingVariant}
-          referenceVariant={quickAddSourceProduct}
-          submitErrorMessage="Could not quick add this product. Try again."
-        />
+        {productLookupEnabled ? (
+          <QuickAddProductDialog
+            open={isQuickAddOpen}
+            onOpenChange={handleQuickAddOpenChange}
+            onSubmit={handleQuickAddSubmit}
+            onAttachBarcode={
+              isAddingVariant ? undefined : handleAttachBarcodeSubmit
+            }
+            existingSkuOptions={existingSkuOptions}
+            initialName={quickAddInitialName}
+            initialLookupCode={quickAddInitialLookupCode}
+            lockProductName={isAddingVariant}
+            referenceVariant={quickAddSourceProduct}
+            submitErrorMessage="Could not quick add this product. Try again."
+          />
+        ) : null}
       </div>
     );
   },

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.test.tsx
@@ -7,8 +7,33 @@ const useQueryMock = vi.fn();
 const getActiveStoreMock = vi.fn();
 const startStoreDayMock = vi.fn();
 const authenticateStaffCredentialMock = vi.fn();
+const refreshTerminalStaffAuthorityMock = vi.fn();
 const useLocalPosEntryContextMock = vi.fn();
 const useLocalPosReadinessMock = vi.fn();
+const replaceStaffAuthoritySnapshotMock = vi.fn();
+const writeStoreDayReadinessMock = vi.fn();
+
+vi.mock("@/components/pos/CashierAuthDialog", () => ({
+  CashierAuthDialog: ({
+    onAuthenticated,
+    open,
+  }: {
+    onAuthenticated: (result: { staffProfileId: string }) => void;
+    open: boolean;
+  }) =>
+    open ? (
+      <div role="dialog" aria-label="Sign in required">
+        <button
+          type="button"
+          onClick={() => {
+            onAuthenticated({ staffProfileId: "staff-1" });
+          }}
+        >
+          Confirm cashier
+        </button>
+      </div>
+    ) : null,
+}));
 
 vi.mock("@/components/staff-auth/StaffAuthenticationDialog", () => ({
   StaffAuthenticationDialog: ({
@@ -97,10 +122,16 @@ vi.mock("@/components/common/PageHeader", () => ({
 }));
 
 vi.mock("convex/react", () => ({
-  useMutation: (mutationName: string) =>
-    mutationName === "authenticateStaffCredential"
-      ? authenticateStaffCredentialMock
-      : startStoreDayMock,
+  useMutation: (mutationName: string) => {
+    if (mutationName === "authenticateStaffCredential") {
+      return authenticateStaffCredentialMock;
+    }
+    if (mutationName === "refreshTerminalStaffAuthority") {
+      return refreshTerminalStaffAuthorityMock;
+    }
+
+    return startStoreDayMock;
+  },
   useQuery: (...args: unknown[]) => useQueryMock(...args),
 }));
 
@@ -124,6 +155,14 @@ vi.mock("@/lib/pos/infrastructure/local/localPosReadiness", () => ({
     useLocalPosReadinessMock(...args),
 }));
 
+vi.mock("@/lib/pos/infrastructure/local/posLocalStore", () => ({
+  createIndexedDbPosLocalStorageAdapter: vi.fn(() => ({})),
+  createPosLocalStore: vi.fn(() => ({
+    replaceStaffAuthoritySnapshot: replaceStaffAuthoritySnapshotMock,
+    writeStoreDayReadiness: writeStoreDayReadinessMock,
+  })),
+}));
+
 vi.mock("~/convex/_generated/api", () => ({
   api: {
     operations: {
@@ -136,6 +175,7 @@ vi.mock("~/convex/_generated/api", () => ({
       },
       staffCredentials: {
         authenticateStaffCredential: "authenticateStaffCredential",
+        refreshTerminalStaffAuthority: "refreshTerminalStaffAuthority",
       },
     },
   },
@@ -150,6 +190,16 @@ describe("POSRegisterOpeningGuard", () => {
       data: { action: "started" },
       kind: "ok",
     });
+    writeStoreDayReadinessMock.mockResolvedValue({
+      ok: true,
+      value: {
+        storeId: "store-1",
+        operatingDate: "2026-05-09",
+        status: "started",
+        source: "local",
+        updatedAt: new Date(2026, 4, 9, 12).getTime(),
+      },
+    });
     authenticateStaffCredentialMock.mockResolvedValue({
       data: {
         activeRoles: ["cashier"],
@@ -157,6 +207,14 @@ describe("POSRegisterOpeningGuard", () => {
         staffProfileId: "staff-1",
       },
       kind: "ok",
+    });
+    refreshTerminalStaffAuthorityMock.mockResolvedValue({
+      data: [],
+      kind: "ok",
+    });
+    replaceStaffAuthoritySnapshotMock.mockResolvedValue({
+      ok: true,
+      value: [],
     });
     getActiveStoreMock.mockReturnValue({
       activeStore: {
@@ -246,7 +304,7 @@ describe("POSRegisterOpeningGuard", () => {
     expect(screen.queryByText("Register workspace")).not.toBeInTheDocument();
     expect(screen.getByText("Store day not started")).toBeInTheDocument();
     expect(
-      screen.getByText("Start the day when Opening Handoff is ready."),
+      screen.getByText("Start the store day to begin POS sales."),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Start day/i })).toBeEnabled();
     expect(
@@ -255,6 +313,78 @@ describe("POSRegisterOpeningGuard", () => {
       "href",
       "/wigclub/store/wigclub/operations/opening",
     );
+  });
+
+  it("refreshes terminal staff authority while online so credentials are available offline", async () => {
+    useLocalPosEntryContextMock.mockReturnValue({
+      status: "ready",
+      orgUrlSlug: "wigclub",
+      storeUrlSlug: "wigclub",
+      storeId: "store-1",
+      terminalSeed: {
+        cloudTerminalId: "terminal-cloud-1",
+        displayName: "Front register",
+        provisionedAt: 1_778_000_000_000,
+        schemaVersion: 1,
+        storeId: "store-1",
+        syncSecretHash: "secret-hash",
+        terminalId: "terminal-1",
+      },
+      source: "live",
+    });
+    refreshTerminalStaffAuthorityMock.mockResolvedValue({
+      data: [
+        {
+          activeRoles: ["cashier"],
+          credentialId: "credential-1",
+          credentialVersion: 1,
+          displayName: "Ama Mensah",
+          expiresAt: Date.now() + 10_000,
+          issuedAt: Date.now(),
+          organizationId: "org-1",
+          refreshedAt: Date.now(),
+          staffProfileId: "staff-1",
+          status: "active",
+          storeId: "store-1",
+          terminalId: "terminal-cloud-1",
+          username: "frontdesk",
+          verifier: {
+            algorithm: "PBKDF2-SHA256",
+            hash: "hash",
+            iterations: 120000,
+            salt: "salt",
+            version: 1,
+          },
+        },
+      ],
+      kind: "ok",
+    });
+
+    render(
+      <POSRegisterOpeningGuard>
+        <div>Register workspace</div>
+      </POSRegisterOpeningGuard>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(refreshTerminalStaffAuthorityMock).toHaveBeenCalledWith({
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+    });
+    expect(replaceStaffAuthoritySnapshotMock).toHaveBeenCalledWith({
+      records: [
+        expect.objectContaining({
+          staffProfileId: "staff-1",
+          username: "frontdesk",
+        }),
+      ],
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+    });
   });
 
   it("authenticates staff and starts the store day from the POS gate when opening is ready", async () => {
@@ -311,7 +441,7 @@ describe("POSRegisterOpeningGuard", () => {
     });
   });
 
-  it("keeps the POS start action disabled when Opening Handoff needs review", () => {
+  it("starts the store day locally when Opening Handoff needs review so sales can continue", async () => {
     useQueryMock.mockImplementation((queryName: string) => {
       if (queryName === "getDailyOpeningSnapshot") {
         return { status: "needs_attention" };
@@ -326,8 +456,25 @@ describe("POSRegisterOpeningGuard", () => {
     useLocalPosReadinessMock.mockReturnValue({
       status: "blocked",
       reason: "not_started",
+      canStartLocally: true,
       message:
         "Store day not started. Complete Opening Handoff before starting sales.",
+    });
+    useLocalPosEntryContextMock.mockReturnValue({
+      status: "ready",
+      orgUrlSlug: "wigclub",
+      storeUrlSlug: "wigclub",
+      storeId: "store-1",
+      terminalSeed: {
+        cloudTerminalId: "terminal-cloud-1",
+        displayName: "Front register",
+        provisionedAt: 1_778_000_000_000,
+        schemaVersion: 1,
+        storeId: "store-1",
+        syncSecretHash: "secret-hash",
+        terminalId: "terminal-1",
+      },
+      source: "local",
     });
 
     render(
@@ -336,12 +483,31 @@ describe("POSRegisterOpeningGuard", () => {
       </POSRegisterOpeningGuard>,
     );
 
-    expect(screen.getByRole("button", { name: /Start day/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Start day/i })).toBeEnabled();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Start day/i }));
+      await Promise.resolve();
+    });
+
     expect(
-      screen.getByText(
-        "Opening Handoff needs review before the store day can start from POS.",
-      ),
+      screen.getByRole("dialog", { name: "Sign in required" }),
     ).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /Confirm cashier/i }));
+      await Promise.resolve();
+    });
+
+    expect(writeStoreDayReadinessMock).toHaveBeenCalledWith({
+      storeId: "store-1",
+      operatingDate: "2026-05-09",
+      status: "started",
+      source: "local",
+      updatedAt: new Date(2026, 4, 9, 12).getTime(),
+    });
+    expect(startStoreDayMock).not.toHaveBeenCalled();
+    expect(screen.getByText("Register workspace")).toBeInTheDocument();
   });
 
   it("directs the operator to EOD Review when the store day is closed", () => {

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useMemo, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { Link, useParams } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
 import { ArrowUpRight, CheckCircle2, Store } from "lucide-react";
@@ -13,6 +13,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { LoadingButton } from "@/components/ui/loading-button";
 import View from "@/components/View";
+import { CashierAuthDialog } from "@/components/pos/CashierAuthDialog";
 import useGetActiveStore from "@/hooks/useGetActiveStore";
 import { presentCommandToast } from "@/lib/errors/presentCommandToast";
 import {
@@ -23,7 +24,16 @@ import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
 import type { CommandResult } from "~/shared/commandResult";
 import { useLocalPosEntryContext } from "@/lib/pos/infrastructure/local/localPosEntryContext";
-import { useLocalPosReadiness } from "@/lib/pos/infrastructure/local/localPosReadiness";
+import {
+  type LocalPosReadiness,
+  useLocalPosReadiness,
+} from "@/lib/pos/infrastructure/local/localPosReadiness";
+import {
+  createIndexedDbPosLocalStorageAdapter,
+  createPosLocalStore,
+  type PosLocalStaffAuthorityRecord,
+} from "@/lib/pos/infrastructure/local/posLocalStore";
+import { logger } from "@/lib/logger";
 
 type DailyOpeningSnapshot = {
   status?: "blocked" | "needs_attention" | "ready" | "started";
@@ -61,6 +71,10 @@ function getLocalOperatingDateRange(date = new Date()) {
     operatingDate: getLocalOperatingDate(date),
     startAt: localStart.getTime(),
   };
+}
+
+function isBrowserOffline() {
+  return typeof navigator !== "undefined" && navigator.onLine === false;
 }
 
 export function POSRegisterOpeningGuard({
@@ -108,21 +122,113 @@ export function POSRegisterOpeningGuard({
     openingSnapshot: snapshot,
     operatingDate: operatingDateRange.operatingDate,
   });
+  const [locallyStartedDayKey, setLocallyStartedDayKey] = useState<
+    string | null
+  >(null);
+  const localStore = useMemo(
+    () =>
+      createPosLocalStore({
+        adapter: createIndexedDbPosLocalStorageAdapter(),
+      }),
+    [],
+  );
+  const refreshTerminalStaffAuthority = useMutation(
+    api.operations.staffCredentials.refreshTerminalStaffAuthority,
+  );
+  const terminalId =
+    entryContext.status === "ready"
+      ? (entryContext.terminalSeed?.cloudTerminalId as
+          | Id<"posTerminal">
+          | undefined)
+      : undefined;
+  useEffect(() => {
+    if (!storeId || !terminalId || isBrowserOffline()) {
+      return;
+    }
+
+    void (async () => {
+      let result: CommandResult<PosLocalStaffAuthorityRecord[]>;
+      try {
+        result = await (
+          refreshTerminalStaffAuthority as (args: {
+            storeId: Id<"store">;
+            terminalId: Id<"posTerminal">;
+          }) => Promise<CommandResult<PosLocalStaffAuthorityRecord[]>>
+        )({ storeId, terminalId });
+      } catch (error) {
+        logger.warn("[POS] Staff authority background refresh failed", {
+          message: error instanceof Error ? error.message : String(error),
+          storeId,
+          terminalId,
+        });
+        return;
+      }
+
+      if (result.kind !== "ok") {
+        logger.warn("[POS] Staff authority background refresh skipped", {
+          kind: result.kind,
+          storeId,
+          terminalId,
+        });
+        const clearResult = await localStore.replaceStaffAuthoritySnapshot({
+          records: [],
+          storeId,
+          terminalId,
+        });
+        if (!clearResult.ok) {
+          logger.warn("[POS] Staff authority snapshot could not be cleared", {
+            code: clearResult.error.code,
+            storeId,
+            terminalId,
+          });
+        }
+        return;
+      }
+
+      const writeResult = await localStore.replaceStaffAuthoritySnapshot({
+        records: result.data,
+        storeId,
+        terminalId,
+      });
+      if (!writeResult.ok) {
+        logger.warn("[POS] Staff authority background refresh could not be stored", {
+          code: writeResult.error.code,
+          storeId,
+          terminalId,
+        });
+      }
+    })();
+  }, [localStore, refreshTerminalStaffAuthority, storeId, terminalId]);
+  const activeDayKey = storeId
+    ? `${storeId}:${operatingDateRange.operatingDate}`
+    : null;
+  const effectiveReadiness =
+    activeDayKey && locallyStartedDayKey === activeDayKey
+      ? ({
+          status: "ready",
+          source: "local_readiness",
+          storeDayStatus: "started",
+        } satisfies LocalPosReadiness)
+      : localReadiness;
 
   if (isLoadingStores && entryContext.status === "loading") {
     return null;
   }
 
-  if (localReadiness.status === "loading") {
+  if (effectiveReadiness.status === "loading") {
     return null;
   }
 
   if (
-    localReadiness.status === "blocked" &&
-    localReadiness.reason === "not_started"
+    effectiveReadiness.status === "blocked" &&
+    effectiveReadiness.reason === "not_started"
   ) {
     return (
       <StoreDayNotStartedState
+        entryContext={entryContext}
+        localReadiness={effectiveReadiness}
+        localStore={localStore}
+        onStarted={() => setLocallyStartedDayKey(activeDayKey)}
         operatingDateRange={operatingDateRange}
         snapshot={snapshot}
         storeId={storeId}
@@ -131,31 +237,39 @@ export function POSRegisterOpeningGuard({
   }
 
   if (
-    localReadiness.status === "blocked" &&
-    localReadiness.reason === "closed"
+    effectiveReadiness.status === "blocked" &&
+    effectiveReadiness.reason === "closed"
   ) {
     return <StoreDayClosedState />;
   }
 
   if (
-    localReadiness.status === "blocked" &&
-    localReadiness.reason === "local_closeout"
+    effectiveReadiness.status === "blocked" &&
+    effectiveReadiness.reason === "local_closeout"
   ) {
     return <>{children}</>;
   }
 
-  if (localReadiness.status === "blocked") {
-    return <POSSetupRequiredState message={localReadiness.message} />;
+  if (effectiveReadiness.status === "blocked") {
+    return <POSSetupRequiredState message={effectiveReadiness.message} />;
   }
 
   return <>{children}</>;
 }
 
 function StoreDayNotStartedState({
+  entryContext,
+  localReadiness,
+  localStore,
+  onStarted,
   operatingDateRange,
   snapshot,
   storeId,
 }: {
+  entryContext: ReturnType<typeof useLocalPosEntryContext>;
+  localReadiness: Extract<LocalPosReadiness, { status: "blocked" }>;
+  localStore: ReturnType<typeof createPosLocalStore>;
+  onStarted: () => void;
   operatingDateRange: ReturnType<typeof getLocalOperatingDateRange>;
   snapshot?: DailyOpeningSnapshot;
   storeId?: Id<"store">;
@@ -173,7 +287,18 @@ function StoreDayNotStartedState({
   );
   const [isStarting, setIsStarting] = useState(false);
   const [isStaffAuthOpen, setIsStaffAuthOpen] = useState(false);
-  const canStartFromGate = Boolean(storeId && snapshot?.status === "ready");
+  const terminalId =
+    entryContext.status === "ready"
+      ? (entryContext.terminalSeed?.cloudTerminalId as
+          | Id<"posTerminal">
+          | undefined)
+      : undefined;
+  const canStartFromGate = Boolean(
+    storeId &&
+      (snapshot?.status === "ready" || localReadiness.canStartLocally),
+  );
+  const shouldStartLocally =
+    Boolean(localReadiness.canStartLocally) && snapshot?.status !== "ready";
 
   const handleStartDay = async (staff: StaffAuthenticationResult) => {
     if (!storeId || isStarting) {
@@ -184,6 +309,25 @@ function StoreDayNotStartedState({
     setIsStarting(true);
 
     try {
+      if (shouldStartLocally) {
+        const result = await localStore.writeStoreDayReadiness({
+          storeId,
+          operatingDate: operatingDateRange.operatingDate,
+          status: "started",
+          source: "local",
+          updatedAt: Date.now(),
+        });
+
+        if (result.ok) {
+          toast.success("Store day started");
+          onStarted();
+          return;
+        }
+
+        toast.error(result.error.message);
+        return;
+      }
+
       const result = await runCommand(() =>
         startStoreDay({
           ...operatingDateRange,
@@ -194,6 +338,7 @@ function StoreDayNotStartedState({
 
       if (result.kind === "ok") {
         toast.success("Store day started");
+        onStarted();
         return;
       }
 
@@ -256,7 +401,7 @@ function StoreDayNotStartedState({
             Store day not started
           </h2>
           <p className="mt-3 max-w-lg text-base leading-7 text-muted-foreground">
-            Start the day when Opening Handoff is ready.
+            Start the store day to begin POS sales.
           </p>
           <div className="mt-8 flex flex-wrap items-center justify-center gap-layout-sm">
             <LoadingButton
@@ -292,26 +437,37 @@ function StoreDayNotStartedState({
           </div>
           {!canStartFromGate ? (
             <p className="mt-layout-md max-w-md text-sm leading-6 text-muted-foreground">
-              Opening Handoff needs review before the store day can start from
-              POS.
+              Terminal setup is required before POS can start the day.
             </p>
           ) : null}
         </div>
       </FadeIn>
-      <StaffAuthenticationDialog
-        copy={{
-          title: "Confirm staff credentials",
-          description: "Start the store day with your staff sign-in.",
-          submitLabel: "Start day",
-        }}
-        getSuccessMessage={() => null}
-        onAuthenticate={(args) => handleAuthenticateStaff(args)}
-        onAuthenticated={(result) => {
-          void handleStartDay(result);
-        }}
-        onDismiss={() => setIsStaffAuthOpen(false)}
-        open={isStaffAuthOpen}
-      />
+      {terminalId && storeId ? (
+        <CashierAuthDialog
+          onAuthenticated={(result) => {
+            void handleStartDay(result);
+          }}
+          onDismiss={() => setIsStaffAuthOpen(false)}
+          open={isStaffAuthOpen}
+          storeId={storeId}
+          terminalId={terminalId}
+        />
+      ) : (
+        <StaffAuthenticationDialog
+          copy={{
+            title: "Confirm staff credentials",
+            description: "Start the store day with your staff sign-in.",
+            submitLabel: "Start day",
+          }}
+          getSuccessMessage={() => null}
+          onAuthenticate={(args) => handleAuthenticateStaff(args)}
+          onAuthenticated={(result) => {
+            void handleStartDay(result);
+          }}
+          onDismiss={() => setIsStaffAuthOpen(false)}
+          open={isStaffAuthOpen}
+        />
+      )}
     </View>
   );
 }

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.test.tsx
@@ -121,9 +121,13 @@ vi.mock("@/components/pos/ProductEntry", async () => {
     ProductEntry: React.forwardRef(
       (
         {
+          canSearchProducts,
+          canSearchServices,
           onAddProduct,
           serviceEntry,
         }: {
+          canSearchProducts?: boolean;
+          canSearchServices?: boolean;
           onAddProduct?: (
             product: {
               id: string;
@@ -156,7 +160,7 @@ vi.mock("@/components/pos/ProductEntry", async () => {
         return (
           <div>
             product-entry
-            {onAddProduct ? (
+            {onAddProduct && canSearchProducts !== false ? (
               <button
                 type="button"
                 onClick={() =>
@@ -172,7 +176,7 @@ vi.mock("@/components/pos/ProductEntry", async () => {
                 mock-add-product
               </button>
             ) : null}
-            {serviceEntry?.onAddService ? (
+            {serviceEntry?.onAddService && canSearchServices !== false ? (
               <button
                 type="button"
                 onClick={() =>
@@ -191,12 +195,37 @@ vi.mock("@/components/pos/ProductEntry", async () => {
         );
       },
     ),
-    ProductSearchInput: React.forwardRef<HTMLInputElement>((_, ref) => (
-      <div>
-        <input ref={ref} aria-label="product search input" />
-        <span>product-search-input</span>
-      </div>
-    )),
+    ProductSearchInput: React.forwardRef<
+      HTMLInputElement,
+      {
+        disabled?: boolean;
+        lookupKind?: string;
+        onActivate?: () => void;
+        readOnly?: boolean;
+      }
+    >(
+      (
+        {
+          disabled,
+          lookupKind = "products_services",
+          onActivate,
+          readOnly,
+        },
+        ref,
+      ) => (
+        <div>
+          <input
+            ref={ref}
+            aria-label="product search input"
+            disabled={disabled}
+            readOnly={readOnly}
+            onPointerDown={onActivate}
+          />
+          <span>product-search-input</span>
+          <span>{`lookup-kind-${lookupKind}`}</span>
+        </div>
+      ),
+    ),
   };
 });
 
@@ -388,8 +417,8 @@ describe("POSRegisterView", () => {
     expect(screen.getByText("closeout-control")).toBeInTheDocument();
     expect(screen.getByText("register-customer-panel")).toBeInTheDocument();
     expect(screen.getByText("product-search-input")).toBeInTheDocument();
-    expect(screen.getByText("Ready for product lookup")).toBeInTheDocument();
-    expect(screen.getByText("⌘+K")).toBeInTheDocument();
+    expect(screen.getByText("Ready for checkout lookup")).toBeInTheDocument();
+    expect(screen.getAllByText("⌘+K").length).toBeGreaterThan(0);
     expect(
       screen.getByRole("region", { name: "Sale summary" }),
     ).toBeInTheDocument();
@@ -402,6 +431,143 @@ describe("POSRegisterView", () => {
       screen.getByTestId("register-main-workspace").closest(".box-border"),
     ).toBeInTheDocument();
     expect(screen.queryByText("cashier-auth-dialog")).not.toBeInTheDocument();
+  });
+
+  it("surfaces service-only lookup without product actions", async () => {
+    mockUseRegisterViewModel.mockReturnValue({
+      hasActiveStore: true,
+      header: {
+        title: "POS",
+        isSessionActive: true,
+      },
+      registerInfo: {
+        registerLabel: "Front Counter",
+        hasTerminal: true,
+      },
+      customerPanel: {},
+      productEntry: {
+        canSearchProducts: false,
+        canSearchServices: true,
+        disabled: false,
+        productSearchQuery: "",
+        setProductSearchQuery: vi.fn(),
+        onBarcodeSubmit: vi.fn(),
+        onAddProduct: vi.fn(async () => true),
+        searchResults: [],
+        isSearchLoading: false,
+        isSearchReady: true,
+        canQuickAddProduct: true,
+      },
+      serviceEntry: {
+        disabled: false,
+        serviceSearchQuery: "",
+        setServiceSearchQuery: vi.fn(),
+        searchResults: [],
+        isSearchLoading: false,
+        isSearchReady: true,
+        items: [],
+        onAddService: vi.fn(async () => true),
+        onUpdateServiceAmount: vi.fn(),
+        onRemoveService: vi.fn(),
+      },
+      cart: {
+        items: [],
+      },
+      checkout: {
+        isTransactionCompleted: false,
+      },
+      sessionPanel: {},
+      cashierCard: {
+        cashierName: "Ato K.",
+        onSignOut: vi.fn(),
+      },
+      closeoutControl: null,
+      authDialog: {
+        open: false,
+      },
+      drawerGate: null,
+      onNavigateBack: vi.fn(),
+    });
+
+    const { POSRegisterView } = await import("./POSRegisterView");
+    render(<POSRegisterView />);
+
+    expect(screen.getByText("lookup-kind-services")).toBeInTheDocument();
+    expect(screen.getByText("Ready for service lookup")).toBeInTheDocument();
+    expect(screen.getByText("Service search")).toBeInTheDocument();
+    expect(screen.queryByText("Barcode")).not.toBeInTheDocument();
+    expect(screen.queryByText("Product search")).not.toBeInTheDocument();
+    expect(screen.queryByText("Quick add product")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "mock-add-product" }))
+      .not.toBeInTheDocument();
+  });
+
+  it("surfaces product-only lookup without service actions", async () => {
+    mockUseRegisterViewModel.mockReturnValue({
+      hasActiveStore: true,
+      header: {
+        title: "POS",
+        isSessionActive: true,
+      },
+      registerInfo: {
+        registerLabel: "Front Counter",
+        hasTerminal: true,
+      },
+      customerPanel: {},
+      productEntry: {
+        canSearchProducts: true,
+        canSearchServices: false,
+        disabled: false,
+        productSearchQuery: "",
+        setProductSearchQuery: vi.fn(),
+        onBarcodeSubmit: vi.fn(),
+        onAddProduct: vi.fn(async () => true),
+        searchResults: [],
+        isSearchLoading: false,
+        isSearchReady: true,
+        canQuickAddProduct: true,
+      },
+      serviceEntry: {
+        disabled: false,
+        serviceSearchQuery: "",
+        setServiceSearchQuery: vi.fn(),
+        searchResults: [],
+        isSearchLoading: false,
+        isSearchReady: true,
+        items: [],
+        onAddService: vi.fn(async () => true),
+        onUpdateServiceAmount: vi.fn(),
+        onRemoveService: vi.fn(),
+      },
+      cart: {
+        items: [],
+      },
+      checkout: {
+        isTransactionCompleted: false,
+      },
+      sessionPanel: {},
+      cashierCard: {
+        cashierName: "Ato K.",
+        onSignOut: vi.fn(),
+      },
+      closeoutControl: null,
+      authDialog: {
+        open: false,
+      },
+      drawerGate: null,
+      onNavigateBack: vi.fn(),
+    });
+
+    const { POSRegisterView } = await import("./POSRegisterView");
+    render(<POSRegisterView />);
+
+    expect(screen.getByText("lookup-kind-products")).toBeInTheDocument();
+    expect(screen.getByText("Ready for product lookup")).toBeInTheDocument();
+    expect(screen.getByText("Barcode")).toBeInTheDocument();
+    expect(screen.getByText("Product search")).toBeInTheDocument();
+    expect(screen.queryByText("Service search")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "mock-add-service" }))
+      .not.toBeInTheDocument();
   });
 
   it("returns focus to the header product search after adding a service", async () => {
@@ -930,7 +1096,7 @@ describe("POSRegisterView", () => {
     render(<POSRegisterView />);
 
     expect(screen.getByText("register-checkout-panel")).toBeInTheDocument();
-    expect(screen.getByText("Ready for product lookup")).toBeInTheDocument();
+    expect(screen.getByText("Ready for checkout lookup")).toBeInTheDocument();
     expect(
       screen.queryByText("App session unverified"),
     ).not.toBeInTheDocument();
@@ -1260,6 +1426,75 @@ describe("POSRegisterView", () => {
     });
   });
 
+  it("starts a new sale before focusing product lookup when the idle header lookup is touched", async () => {
+    const setShowProductLookup = vi.fn();
+    let isSessionActive = false;
+    const onStartNewSession = vi.fn(async () => {
+      isSessionActive = true;
+    });
+    mockUseRegisterViewModel.mockImplementation(() => ({
+      hasActiveStore: true,
+      header: {
+        title: "POS",
+        isSessionActive,
+      },
+      registerInfo: {
+        customerName: "Ama Serwa",
+        registerLabel: "Front Counter",
+        hasTerminal: true,
+      },
+      customerPanel: {},
+      productEntry: {
+        disabled: false,
+        productSearchQuery: "",
+        setProductSearchQuery: vi.fn(),
+        setShowProductLookup,
+        onBarcodeSubmit: vi.fn(),
+        canQuickAddProduct: false,
+      },
+      cart: {
+        items: [],
+      },
+      checkout: {
+        isTransactionCompleted: false,
+      },
+      sessionPanel: {
+        disableNewSession: false,
+        onStartNewSession,
+      },
+      cashierCard: {},
+      closeoutControl: {
+        canCloseout: true,
+        canShowOpeningFloatCorrection: true,
+        canCorrectOpeningFloat: true,
+        onRequestCloseout: vi.fn(),
+        onRequestOpeningFloatCorrection: vi.fn(),
+      },
+      authDialog: {
+        open: false,
+      },
+      drawerGate: null,
+      onNavigateBack: vi.fn(),
+    }));
+
+    const { POSRegisterView } = await import("./POSRegisterView");
+    const { rerender } = render(<POSRegisterView />);
+
+    const searchInput = screen.getByLabelText("product search input");
+    expect(searchInput).not.toBeDisabled();
+    expect(searchInput).not.toHaveAttribute("readonly");
+
+    await userEvent.click(searchInput);
+    expect(onStartNewSession).toHaveBeenCalledTimes(1);
+
+    rerender(<POSRegisterView />);
+
+    await waitFor(() => {
+      expect(setShowProductLookup).toHaveBeenCalledWith(true);
+      expect(screen.getByLabelText("product search input")).toHaveFocus();
+    });
+  });
+
   it("returns focus to the header product search after an item is added", async () => {
     const onAddProduct = vi.fn().mockResolvedValue(true);
 
@@ -1370,7 +1605,7 @@ describe("POSRegisterView", () => {
       screen.getByRole("button", { name: /quick add product/i }),
     );
 
-    expect(screen.getByText("Ready for product lookup")).toBeInTheDocument();
+    expect(screen.getByText("Ready for checkout lookup")).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /add service/i }),
     ).not.toBeInTheDocument();
@@ -1603,6 +1838,61 @@ describe("POSRegisterView", () => {
     expect(screen.queryByText("cart-items")).not.toBeInTheDocument();
     expect(
       screen.queryByText("register-checkout-panel"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("holds a blank register workspace while cashier presence restore is pending", async () => {
+    mockUseRegisterViewModel.mockReturnValue({
+      hasActiveStore: true,
+      header: {
+        title: "POS",
+        isSessionActive: true,
+      },
+      registerInfo: {
+        customerName: undefined,
+        registerLabel: "Front Counter",
+        hasTerminal: true,
+      },
+      customerPanel: {},
+      productEntry: {
+        disabled: true,
+        productSearchQuery: "",
+        setProductSearchQuery: vi.fn(),
+        onBarcodeSubmit: vi.fn(),
+      },
+      cart: {
+        items: [],
+      },
+      checkout: {
+        isTransactionCompleted: false,
+      },
+      sessionPanel: null,
+      cashierCard: null,
+      cashierPresenceRestore: {
+        status: "pending",
+      },
+      closeoutControl: null,
+      authDialog: {
+        open: false,
+      },
+      drawerGate: null,
+      onNavigateBack: vi.fn(),
+    });
+
+    const { POSRegisterView } = await import("./POSRegisterView");
+    render(<POSRegisterView />);
+
+    expect(screen.queryByText("product-search-input")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("register-customer-panel"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("cart-items")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("register-checkout-panel"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("cashier-auth-dialog")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Ready for product lookup"),
     ).not.toBeInTheDocument();
   });
 
@@ -1989,7 +2279,7 @@ describe("POSRegisterView", () => {
 
     await userEvent.click(screen.getByText("show-payment-methods"));
 
-    expect(screen.getByText("Ready for product lookup")).toBeInTheDocument();
+    expect(screen.getByText("Ready for checkout lookup")).toBeInTheDocument();
     expect(screen.getByTestId("cart-items-compact")).toBeInTheDocument();
     expect(screen.queryByText("product-entry")).not.toBeInTheDocument();
 
@@ -2119,12 +2409,12 @@ describe("POSRegisterView", () => {
     const { POSRegisterView } = await import("./POSRegisterView");
     render(<POSRegisterView />);
 
-    expect(screen.getByText("Ready for product lookup")).toBeInTheDocument();
+    expect(screen.getByText("Ready for checkout lookup")).toBeInTheDocument();
     expect(screen.getByTestId("cart-items-compact")).toBeInTheDocument();
 
     await userEvent.click(screen.getByText("start-payment-edit"));
 
-    expect(screen.getByText("Ready for product lookup")).toBeInTheDocument();
+    expect(screen.getByText("Ready for checkout lookup")).toBeInTheDocument();
     expect(screen.queryByTestId("cart-items-compact")).not.toBeInTheDocument();
     expect(
       screen.queryByTestId("cart-items-comfortable"),

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterView.tsx
@@ -26,6 +26,7 @@ import {
   PackagePlus,
   RefreshCw,
   ScanBarcode,
+  Scissors,
   Search,
   ShoppingBasket,
   Settings,
@@ -92,17 +93,37 @@ function useCollapseSidebarForPosFlow() {
 }
 
 function ProductLookupEmptyState({
+  canSearchProducts = true,
+  canSearchServices = true,
   canQuickAddProduct = false,
   onActivate,
   onQuickAddProduct,
   workflowMode,
 }: {
+  canSearchProducts?: boolean;
+  canSearchServices?: boolean;
   canQuickAddProduct?: boolean;
   onActivate?: () => void | Promise<void>;
   onQuickAddProduct?: () => void;
   workflowMode: RegisterWorkflowMode;
 }) {
   const isExpenseWorkflow = workflowMode === "expense";
+  const isServiceOnly = !isExpenseWorkflow && !canSearchProducts && canSearchServices;
+  const isProductOnly = isExpenseWorkflow || (canSearchProducts && !canSearchServices);
+  const title = isExpenseWorkflow
+    ? "Ready for expense entry"
+    : isServiceOnly
+      ? "Ready for service lookup"
+      : isProductOnly
+        ? "Ready for product lookup"
+        : "Ready for checkout lookup";
+  const description = isExpenseWorkflow
+    ? "Search or scan products to add expense items"
+    : isServiceOnly
+      ? "Search services to add service lines to this sale"
+      : isProductOnly
+        ? "Scan a barcode or search products to add items to this sale"
+        : "Scan products or search products and services to add items to this sale";
   const isInteractive = Boolean(onActivate);
   const handleActivate = useCallback(() => {
     void onActivate?.();
@@ -128,11 +149,7 @@ function ProductLookupEmptyState({
 
   return (
     <div
-      aria-label={
-        isExpenseWorkflow
-          ? "Ready for expense entry"
-          : "Ready for product lookup"
-      }
+      aria-label={title}
       className={cn(
         "flex h-full min-h-0 w-full flex-col items-center justify-center rounded-lg border border-border bg-surface-raised p-8 text-center transition focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-4",
         isInteractive
@@ -147,33 +164,42 @@ function ProductLookupEmptyState({
     >
       <div className="flex flex-col items-center text-center">
         <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-surface text-muted-foreground shadow-surface">
-          <Search className="h-7 w-7" />
+          {isServiceOnly ? (
+            <Scissors className="h-7 w-7" />
+          ) : (
+            <Search className="h-7 w-7" />
+          )}
         </div>
         <div className="space-y-1">
-          <p className="text-sm font-medium text-foreground">
-            {isExpenseWorkflow
-              ? "Ready for expense entry"
-              : "Ready for product lookup"}
-          </p>
-          <p className="text-sm text-muted-foreground">
-            {isExpenseWorkflow
-              ? "Search or scan products to add expense items"
-              : "Scan a barcode or search products to add items to this sale"}
-          </p>
+          <p className="text-sm font-medium text-foreground">{title}</p>
+          <p className="text-sm text-muted-foreground">{description}</p>
         </div>
       </div>
       <div className="mt-5 flex flex-wrap items-center justify-center gap-2 text-xs text-muted-foreground">
-        <span className="inline-flex items-center gap-1 rounded-full border border-border bg-surface px-3 py-1">
-          <ScanBarcode className="h-3.5 w-3.5" />
-          Barcode
-        </span>
-        <span className="inline-flex items-center gap-1 rounded-full border border-border bg-surface px-3 py-1">
-          <Search className="h-3.5 w-3.5" />
-          Product search
-          <kbd className="ml-1 rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-semibold leading-none text-muted-foreground">
-            ⌘+K
-          </kbd>
-        </span>
+        {canSearchProducts ? (
+          <span className="inline-flex items-center gap-1 rounded-full border border-border bg-surface px-3 py-1">
+            <ScanBarcode className="h-3.5 w-3.5" />
+            Barcode
+          </span>
+        ) : null}
+        {canSearchProducts ? (
+          <span className="inline-flex items-center gap-1 rounded-full border border-border bg-surface px-3 py-1">
+            <Search className="h-3.5 w-3.5" />
+            Product search
+            <kbd className="ml-1 rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-semibold leading-none text-muted-foreground">
+              ⌘+K
+            </kbd>
+          </span>
+        ) : null}
+        {canSearchServices && !isExpenseWorkflow ? (
+          <span className="inline-flex items-center gap-1 rounded-full border border-border bg-surface px-3 py-1">
+            <Scissors className="h-3.5 w-3.5" />
+            Service search
+            <kbd className="ml-1 rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-semibold leading-none text-muted-foreground">
+              ⌘+K
+            </kbd>
+          </span>
+        ) : null}
         {canQuickAddProduct && onQuickAddProduct ? (
           <Button
             type="button"
@@ -1119,6 +1145,8 @@ function POSRegisterViewContent({
   const isAwaitingCashierAuth = Boolean(viewModel.authDialog?.open);
   const isStaffSignedIn =
     viewModel.debug?.staffSignedIn === true || Boolean(viewModel.cashierCard);
+  const isResolvingCashierPresence =
+    cashierPresenceRestore.status === "pending" && !isStaffSignedIn;
   const onboardingState =
     viewModel.onboarding ??
     ({
@@ -1144,23 +1172,35 @@ function POSRegisterViewContent({
     !viewModel.authDialog &&
     !viewModel.drawerGate &&
     !viewModel.checkout.isTransactionCompleted;
+  const terminalCanSearchProducts =
+    viewModel.productEntry?.canSearchProducts !== false;
+  const terminalCanSearchServices =
+    viewModel.productEntry?.canSearchServices !== false;
+  const terminalCanSearchAnyCatalog =
+    terminalCanSearchProducts || terminalCanSearchServices;
   const canSearchProducts =
     !viewModel.checkout.isTransactionCompleted &&
     !isLocallyClosedPendingSync &&
     !viewModel.drawerGate &&
+    !isResolvingCashierPresence &&
     !isAwaitingCashierAuth &&
     !shouldShowOnboarding &&
     !isResolvingRegisterSetup;
   const isHeaderProductSearchSupported =
-    isSessionActive && canSearchProducts && !viewModel.productEntry.disabled;
+    isSessionActive &&
+    canSearchProducts &&
+    terminalCanSearchAnyCatalog &&
+    !viewModel.productEntry.disabled;
   const canStartSaleFromProductLookup =
     isPosWorkflow &&
     canSearchProducts &&
+    terminalCanSearchAnyCatalog &&
     !isSessionActive &&
     Boolean(viewModel.sessionPanel) &&
     !viewModel.sessionPanel?.disableNewSession;
   const canActivateProductLookup =
     isHeaderProductSearchSupported || canStartSaleFromProductLookup;
+  const canTouchHeaderProductSearch = canActivateProductLookup;
   const isRegisterOperable =
     isPosWorkflow && isHeaderProductSearchSupported && !viewModel.drawerGate;
   const shouldRenderSaleSurface = isPosWorkflow
@@ -1194,6 +1234,7 @@ function POSRegisterViewContent({
     !isPaymentsListExpanded &&
     !shouldShowOnboarding &&
     !isResolvingRegisterSetup &&
+    !isResolvingCashierPresence &&
     !isAwaitingCashierAuth &&
     !viewModel.drawerGate;
   const shouldShowCartSummarySidebar =
@@ -1204,6 +1245,7 @@ function POSRegisterViewContent({
       isPaymentsListExpanded) &&
     !shouldShowPaymentWorkspace &&
     !shouldShowOnboarding &&
+    !isResolvingCashierPresence &&
     !isResolvingRegisterSetup;
   const shouldRenderCartSidebar =
     shouldRenderSaleSurface &&
@@ -1211,9 +1253,11 @@ function POSRegisterViewContent({
     !shouldShowPaymentWorkspace &&
     !shouldShowCartSummarySidebar &&
     !shouldShowOnboarding &&
+    !isResolvingCashierPresence &&
     !isResolvingRegisterSetup;
   const shouldRenderWorkspaceSidebar =
     !shouldShowOnboarding &&
+    !isResolvingCashierPresence &&
     !isResolvingRegisterSetup &&
     (shouldRenderCartSidebar ||
       shouldRenderCheckoutPanel ||
@@ -1315,7 +1359,11 @@ function POSRegisterViewContent({
       return;
     }
 
-    if (!canStartSaleFromProductLookup || !viewModel.sessionPanel) {
+    if (
+      pendingProductLookupFocusAfterSaleStartRef.current ||
+      !canStartSaleFromProductLookup ||
+      !viewModel.sessionPanel
+    ) {
       return;
     }
 
@@ -1331,6 +1379,7 @@ function POSRegisterViewContent({
   const handleProductLookupEmptyStateQuickAdd = useCallback(() => {
     if (
       !isHeaderProductSearchSupported ||
+      !terminalCanSearchProducts ||
       !viewModel.productEntry.canQuickAddProduct
     ) {
       return;
@@ -1350,6 +1399,7 @@ function POSRegisterViewContent({
   }, [
     isEmptyStateQuickAddActive,
     isHeaderProductSearchSupported,
+    terminalCanSearchProducts,
     viewModel.productEntry,
   ]);
 
@@ -1455,6 +1505,8 @@ function POSRegisterViewContent({
       searchResults={viewModel.productEntry.searchResults}
       isSearchLoading={viewModel.productEntry.isSearchLoading}
       isSearchReady={viewModel.productEntry.isSearchReady}
+      canSearchProducts={terminalCanSearchProducts}
+      canSearchServices={terminalCanSearchServices}
       canQuickAddProduct={viewModel.productEntry.canQuickAddProduct}
       onQuickAddOpenChange={setIsEmptyStateQuickAddActive}
       forceQuickAddHost={forceQuickAddHost}
@@ -1533,15 +1585,33 @@ function POSRegisterViewContent({
                 ) : null}
               </div>
 
-              {!shouldShowOnboarding && !isResolvingRegisterSetup ? (
+              {!shouldShowOnboarding &&
+              !isResolvingCashierPresence &&
+              !isResolvingRegisterSetup ? (
                 <ProductSearchInput
                   ref={headerProductSearchInputRef}
-                  disabled={!isHeaderProductSearchSupported}
+                  disabled={!canTouchHeaderProductSearch}
                   productSearchQuery={viewModel.productEntry.productSearchQuery}
                   setProductSearchQuery={
                     viewModel.productEntry.setProductSearchQuery
                   }
                   onBarcodeSubmit={viewModel.productEntry.onBarcodeSubmit}
+                  onActivate={
+                    canTouchHeaderProductSearch
+                      ? handleProductLookupEmptyStateActivate
+                      : undefined
+                  }
+                  readOnly={!canTouchHeaderProductSearch}
+                  lookupKind={
+                    terminalCanSearchProducts && terminalCanSearchServices
+                      ? "products_services"
+                      : terminalCanSearchServices
+                        ? "services"
+                        : "products"
+                  }
+                  submitOnEnter={
+                    isHeaderProductSearchSupported && terminalCanSearchProducts
+                  }
                   className="max-w-[800px] flex-1"
                   inputClassName="h-14"
                 />
@@ -1580,6 +1650,7 @@ function POSRegisterViewContent({
           {isPosWorkflow &&
           shouldRenderSaleSurface &&
           !shouldShowOnboarding &&
+          !isResolvingCashierPresence &&
           !isResolvingRegisterSetup ? (
             <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(20rem,0.48fr)]">
               <RegisterCustomerPanel
@@ -1610,6 +1681,8 @@ function POSRegisterViewContent({
               >
                 {shouldShowOnboarding ? (
                   <POSOnboardingWorkspace onboarding={onboardingState} />
+                ) : isResolvingCashierPresence ? (
+                  <RegisterSetupResolvingWorkspace />
                 ) : isResolvingRegisterSetup ? (
                   <RegisterSetupResolvingWorkspace />
                 ) : isPosWorkflow && viewModel.drawerGate ? (
@@ -1649,8 +1722,11 @@ function POSRegisterViewContent({
                   <div className="grid h-full min-h-0 grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(20rem,0.72fr)]">
                     <ProductLookupEmptyState
                       canQuickAddProduct={
+                        terminalCanSearchProducts &&
                         viewModel.productEntry.canQuickAddProduct
                       }
+                      canSearchProducts={terminalCanSearchProducts}
+                      canSearchServices={terminalCanSearchServices}
                       onActivate={
                         canActivateProductLookup
                           ? handleProductLookupEmptyStateActivate
@@ -1658,6 +1734,7 @@ function POSRegisterViewContent({
                       }
                       onQuickAddProduct={
                         isHeaderProductSearchSupported &&
+                        terminalCanSearchProducts &&
                         viewModel.productEntry.canQuickAddProduct
                           ? handleProductLookupEmptyStateQuickAdd
                           : undefined
@@ -1689,8 +1766,11 @@ function POSRegisterViewContent({
                   <>
                     <ProductLookupEmptyState
                       canQuickAddProduct={
+                        terminalCanSearchProducts &&
                         viewModel.productEntry.canQuickAddProduct
                       }
+                      canSearchProducts={terminalCanSearchProducts}
+                      canSearchServices={terminalCanSearchServices}
                       onActivate={
                         canActivateProductLookup
                           ? handleProductLookupEmptyStateActivate
@@ -1698,6 +1778,7 @@ function POSRegisterViewContent({
                       }
                       onQuickAddProduct={
                         isHeaderProductSearchSupported &&
+                        terminalCanSearchProducts &&
                         viewModel.productEntry.canQuickAddProduct
                           ? handleProductLookupEmptyStateQuickAdd
                           : undefined

--- a/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   rotateRecoveryCode: vi.fn(),
   revokeRecoveryCode: vi.fn(),
   unlockRecoveryCode: vi.fn(),
+  useAuth: vi.fn(),
   useMutation: vi.fn(),
   usePermissions: vi.fn(),
   useQuery: vi.fn(),
@@ -26,6 +27,10 @@ vi.mock("convex/react", () => ({
 
 vi.mock("@/hooks/useGetActiveStore", () => ({
   default: () => ({ activeStore: { _id: "store-1" } }),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => mocks.useAuth(),
 }));
 
 vi.mock("@/hooks/usePermissions", () => ({
@@ -162,6 +167,10 @@ describe("registerAndProvisionPosTerminal", () => {
       hasFullAdminAccess: true,
       isLoading: false,
     });
+    mocks.useAuth.mockReturnValue({
+      isLoading: false,
+      user: { _id: "athena-user-1", email: "pos@wigclub.store" },
+    });
     mocks.useQuery.mockImplementation((ref) =>
       ref === "getRecoveryCodeStatus"
         ? {
@@ -232,6 +241,8 @@ describe("registerAndProvisionPosTerminal", () => {
     await screen.findByLabelText("Terminal name");
     await user.type(screen.getByLabelText("Terminal name"), "  Front counter  ");
     await user.type(screen.getByLabelText("Register number"), "  7  ");
+    await user.click(screen.getByText("Services only"));
+    await user.click(screen.getByText("POS only"));
     await user.click(
       await screen.findByRole("button", { name: "Register terminal" }),
     );
@@ -241,8 +252,10 @@ describe("registerAndProvisionPosTerminal", () => {
         expect.objectContaining({
           displayName: "Front counter",
           fingerprintHash: "fingerprint-1",
+          loginMode: "pos_only",
           registerNumber: "7",
           storeId: "store-1",
+          transactionCapability: "services_only",
         }),
       ),
     );
@@ -252,6 +265,8 @@ describe("registerAndProvisionPosTerminal", () => {
         registerNumber: "7",
         syncSecretHash: "01020304",
         terminalId: "fingerprint-1",
+        loginMode: "pos_only",
+        transactionCapability: "services_only",
       }),
     );
   });
@@ -271,6 +286,8 @@ describe("registerAndProvisionPosTerminal", () => {
       registeredAt: 1,
       registeredByUserId: "user-1",
       registerNumber: "3",
+      loginMode: "pos_only",
+      transactionCapability: "products_only",
       status: "active",
       storeId: "store-1",
     });
@@ -302,8 +319,12 @@ describe("registerAndProvisionPosTerminal", () => {
     );
 
     await screen.findByDisplayValue("Front counter");
+    expect(screen.getByLabelText("Product SKUs only")).toBeChecked();
+    expect(screen.getByLabelText("POS only")).toBeChecked();
     await user.clear(screen.getByLabelText("Terminal name"));
     await user.type(screen.getByLabelText("Terminal name"), "  Front desk  ");
+    await user.click(screen.getByText("Services only"));
+    await user.click(screen.getByText("Standard login"));
     await user.click(
       await screen.findByRole("button", { name: "Save terminal settings" }),
     );
@@ -313,8 +334,10 @@ describe("registerAndProvisionPosTerminal", () => {
         expect.objectContaining({
           displayName: "Front desk",
           fingerprintHash: "fingerprint-1",
+          loginMode: "standard",
           registerNumber: "3",
           storeId: "store-1",
+          transactionCapability: "services_only",
         }),
       ),
     );
@@ -324,6 +347,8 @@ describe("registerAndProvisionPosTerminal", () => {
         registerNumber: "3",
         syncSecretHash: "01020304",
         terminalId: "fingerprint-1",
+        loginMode: "standard",
+        transactionCapability: "services_only",
       }),
     );
   });
@@ -434,8 +459,11 @@ describe("registerAndProvisionPosTerminal", () => {
     expect(screen.getByText("Offline diagnostics need attention")).toBeInTheDocument();
     expect(
       screen.getByText((_content, element) =>
-        Boolean(element?.textContent?.trim() === "0 of 7 reporting"),
+        Boolean(element?.textContent?.trim() === "1 of 7 reporting"),
       ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("App-session continuity is verified for POS."),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
@@ -528,13 +556,14 @@ describe("registerAndProvisionPosTerminal", () => {
       await screen.findByText("This register is ready for checkout"),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
-        "6 of 7 offline diagnostic signals are reporting here. Missing signals do not block checkout by themselves.",
-      ),
+      screen.getByText("Register ready for offline checkout"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("App-session continuity is verified for POS."),
     ).toBeInTheDocument();
     expect(
       screen.getByText((_content, element) =>
-        Boolean(element?.textContent?.trim() === "6 of 7 reporting"),
+        Boolean(element?.textContent?.trim() === "7 of 7 reporting"),
       ),
     ).toBeInTheDocument();
   });
@@ -578,15 +607,19 @@ describe("registerAndProvisionPosTerminal", () => {
     expect(registerTerminalMutation).toHaveBeenCalledWith(
       expect.objectContaining({
         fingerprintHash: "fingerprint-1",
+        loginMode: "standard",
         syncSecretHash: "01020304",
+        transactionCapability: "products_and_services",
       }),
     );
     expect(writeProvisionedTerminalSeed).toHaveBeenCalledWith(
       expect.objectContaining({
         cloudTerminalId: "terminal-1",
+        loginMode: "standard",
         provisionedAt: 123,
         syncSecretHash: "01020304",
         terminalId: "fingerprint-1",
+        transactionCapability: "products_and_services",
       }),
     );
   });

--- a/packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx
+++ b/packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx
@@ -5,10 +5,12 @@ import type { ComponentType, ReactNode } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { LoadingButton } from "@/components/ui/loading-button";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { FadeIn } from "../../common/FadeIn";
 import { PageLevelHeader, PageWorkspace } from "../../common/PageLevelHeader";
 import View from "../../View";
 import useGetActiveStore from "@/hooks/useGetActiveStore";
+import { useAuth } from "@/hooks/useAuth";
 import { api } from "~/convex/_generated/api";
 import {
   BrowserFingerprintResult,
@@ -30,6 +32,18 @@ import {
   createIndexedDbPosLocalStorageAdapter,
   createPosLocalStore,
 } from "@/lib/pos/infrastructure/local/posLocalStore";
+import {
+  DEFAULT_POS_TERMINAL_TRANSACTION_CAPABILITY,
+  normalizePosTerminalTransactionCapability,
+  type PosTerminalTransactionCapability,
+} from "~/shared/posTerminalCapability";
+import {
+  DEFAULT_POS_TERMINAL_LOGIN_MODE,
+  normalizePosTerminalLoginMode,
+  type PosTerminalLoginMode,
+} from "~/shared/posTerminalLoginMode";
+import { usePosTerminalAppSessionRecoveryRuntimeInput } from "@/lib/pos/infrastructure/terminal/posTerminalAppSessionRecoveryContext";
+import type { PosTerminalRuntimeAppSessionRecoveryInput } from "@/lib/pos/infrastructure/local/terminalRuntimeStatus";
 
 type HealthLinkProps = {
   children: ReactNode;
@@ -43,12 +57,55 @@ type HealthLinkProps = {
 
 const HealthLink = Link as unknown as ComponentType<HealthLinkProps>;
 const POS_APP_SHELL_CACHE_PREFIX = "athena-pos-app-shell-";
+const terminalCapabilityOptions: Array<{
+  value: PosTerminalTransactionCapability;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "products_and_services",
+    label: "Product SKUs and services",
+    description: "Use this register for retail items and service work.",
+  },
+  {
+    value: "products_only",
+    label: "Product SKUs only",
+    description: "Use this register for retail items only.",
+  },
+  {
+    value: "services_only",
+    label: "Services only",
+    description: "Use this register for service work only.",
+  },
+];
+const terminalLoginModeOptions: Array<{
+  value: PosTerminalLoginMode;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "standard",
+    label: "Standard login",
+    description: "Show email code first. POS sign in stays available.",
+  },
+  {
+    value: "pos_only",
+    label: "POS only",
+    description: "Show POS sign in first. Email code remains secondary.",
+  },
+];
 
 type FingerprintRegistrationCardProps = {
   displayName: string;
   onDisplayNameChange: (value: string) => void;
   registerNumber: string;
   onRegisterNumberChange: (value: string) => void;
+  transactionCapability: PosTerminalTransactionCapability;
+  onTransactionCapabilityChange: (
+    value: PosTerminalTransactionCapability,
+  ) => void;
+  loginMode: PosTerminalLoginMode;
+  onLoginModeChange: (value: PosTerminalLoginMode) => void;
   canRegister: boolean;
   onRegister: () => void;
   isRegistering: boolean;
@@ -68,6 +125,10 @@ function FingerprintRegistrationCard({
   onDisplayNameChange,
   registerNumber,
   onRegisterNumberChange,
+  transactionCapability,
+  onTransactionCapabilityChange,
+  loginMode,
+  onLoginModeChange,
   canRegister,
   onRegister,
   isRegistering,
@@ -146,6 +207,70 @@ function FingerprintRegistrationCard({
                 : "Use the number printed on the drawer or assigned by the manager"}
             </p>
           </div>
+        </div>
+
+        <div className="space-y-layout-xs">
+          <Label>Terminal can transact</Label>
+          <RadioGroup
+            className="grid gap-layout-sm sm:grid-cols-3"
+            value={transactionCapability}
+            onValueChange={(value) =>
+              onTransactionCapabilityChange(
+                normalizePosTerminalTransactionCapability(value),
+              )
+            }
+          >
+            {terminalCapabilityOptions.map((option) => (
+              <label
+                className="flex min-h-[6.5rem] cursor-pointer flex-col gap-layout-xs rounded-md border border-border bg-background p-layout-sm text-sm transition-colors has-[:checked]:border-action-commit has-[:checked]:bg-action-neutral-soft"
+                key={option.value}
+              >
+                <span className="flex items-start gap-layout-xs">
+                  <RadioGroupItem
+                    aria-label={option.label}
+                    value={option.value}
+                  />
+                  <span className="font-medium text-foreground">
+                    {option.label}
+                  </span>
+                </span>
+                <span className="text-xs leading-5 text-muted-foreground">
+                  {option.description}
+                </span>
+              </label>
+            ))}
+          </RadioGroup>
+        </div>
+
+        <div className="space-y-layout-xs">
+          <Label>Terminal login</Label>
+          <RadioGroup
+            className="grid gap-layout-sm sm:grid-cols-2"
+            value={loginMode}
+            onValueChange={(value) =>
+              onLoginModeChange(normalizePosTerminalLoginMode(value))
+            }
+          >
+            {terminalLoginModeOptions.map((option) => (
+              <label
+                className="flex min-h-[5.75rem] cursor-pointer flex-col gap-layout-xs rounded-md border border-border bg-background p-layout-sm text-sm transition-colors has-[:checked]:border-action-commit has-[:checked]:bg-action-neutral-soft"
+                key={option.value}
+              >
+                <span className="flex items-start gap-layout-xs">
+                  <RadioGroupItem
+                    aria-label={option.label}
+                    value={option.value}
+                  />
+                  <span className="font-medium text-foreground">
+                    {option.label}
+                  </span>
+                </span>
+                <span className="text-xs leading-5 text-muted-foreground">
+                  {option.description}
+                </span>
+              </label>
+            ))}
+          </RadioGroup>
         </div>
 
         {fingerprintError ? (
@@ -491,14 +616,57 @@ function signalFromSnapshot(
   };
 }
 
+function signalFromAppSession(input: {
+  appSessionRecovery?: PosTerminalRuntimeAppSessionRecoveryInput | null;
+  isAuthLoading: boolean;
+  hasUser: boolean;
+}): PosOfflineReadinessInput["appSession"] {
+  if (input.hasUser) {
+    return { ready: true };
+  }
+
+  const status = input.appSessionRecovery?.status;
+  if (!status) {
+    return input.isAuthLoading ? null : { ready: false };
+  }
+
+  if (status === "recoverable") {
+    return { ready: true };
+  }
+
+  if (status === "waiting_for_network") {
+    return { status: "local_continuation" };
+  }
+
+  return { ready: false };
+}
+
 function usePosSettingsOfflineReadiness(input: {
+  appSessionRecovery?: PosTerminalRuntimeAppSessionRecoveryInput | null;
   existingTerminal: ProvisionedTerminalRecord | null;
   storeFactory?: Parameters<typeof registerAndProvisionPosTerminal>[0]["storeFactory"];
+  hasUser: boolean;
+  isAuthLoading: boolean;
   storeId?: string;
   orgUrlSlug?: string;
   storeUrlSlug?: string;
 }) {
+  const {
+    appSessionRecovery,
+    existingTerminal,
+    hasUser,
+    isAuthLoading,
+    orgUrlSlug,
+    storeFactory,
+    storeId,
+    storeUrlSlug,
+  } = input;
   const [signals, setSignals] = useState<PosOfflineReadinessInput>({
+    appSession: signalFromAppSession({
+      appSessionRecovery,
+      hasUser,
+      isAuthLoading,
+    }),
     appShell: null,
     availabilitySnapshot: null,
     registerCatalog: null,
@@ -512,13 +680,18 @@ function usePosSettingsOfflineReadiness(input: {
 
     async function loadReadiness() {
       const appShell = await readPosAppShellReadiness({
-        orgUrlSlug: input.orgUrlSlug,
-        storeUrlSlug: input.storeUrlSlug,
+        orgUrlSlug,
+        storeUrlSlug,
       });
 
-      if (!input.storeId || !input.existingTerminal) {
+      if (!storeId || !existingTerminal) {
         if (!cancelled) {
           setSignals({
+            appSession: signalFromAppSession({
+              appSessionRecovery,
+              hasUser,
+              isAuthLoading,
+            }),
             appShell,
             availabilitySnapshot: { ready: false },
             registerCatalog: { ready: false },
@@ -531,11 +704,16 @@ function usePosSettingsOfflineReadiness(input: {
       }
 
       const store =
-        (input.storeFactory?.() as PosSettingsLocalReadinessStore | undefined) ??
+        (storeFactory?.() as PosSettingsLocalReadinessStore | undefined) ??
         createDefaultLocalReadinessStore();
       if (!store) {
         if (!cancelled) {
           setSignals({
+            appSession: signalFromAppSession({
+              appSessionRecovery,
+              hasUser,
+              isAuthLoading,
+            }),
             appShell,
             availabilitySnapshot: { ready: false },
             registerCatalog: { ready: false },
@@ -557,14 +735,14 @@ function usePosSettingsOfflineReadiness(input: {
         store.readProvisionedTerminalSeed?.() ??
           Promise.resolve({ ok: true as const, value: null }),
         store.getStaffAuthorityReadiness?.({
-          storeId: input.storeId,
-          terminalId: input.existingTerminal._id,
+          storeId,
+          terminalId: existingTerminal._id,
         }) ?? Promise.resolve({ ok: true as const, value: "missing" as const }),
-        store.readRegisterCatalogSnapshot?.({ storeId: input.storeId }) ??
+        store.readRegisterCatalogSnapshot?.({ storeId }) ??
           Promise.resolve({ ok: true as const, value: null }),
-        store.readRegisterServiceCatalogSnapshot?.({ storeId: input.storeId }) ??
+        store.readRegisterServiceCatalogSnapshot?.({ storeId }) ??
           Promise.resolve({ ok: true as const, value: null }),
-        store.readRegisterAvailabilitySnapshot?.({ storeId: input.storeId }) ??
+        store.readRegisterAvailabilitySnapshot?.({ storeId }) ??
           Promise.resolve({ ok: true as const, value: null }),
       ]);
 
@@ -572,6 +750,11 @@ function usePosSettingsOfflineReadiness(input: {
 
       const localTerminalSeed = terminalSeed.ok ? terminalSeed.value : null;
       setSignals({
+        appSession: signalFromAppSession({
+          appSessionRecovery,
+          hasUser,
+          isAuthLoading,
+        }),
         appShell,
         availabilitySnapshot: signalFromSnapshot(availabilitySnapshot),
         registerCatalog: signalFromSnapshot(registerCatalog),
@@ -582,8 +765,8 @@ function usePosSettingsOfflineReadiness(input: {
         terminalSeed: {
           ready:
             Boolean(localTerminalSeed) &&
-            localTerminalSeed?.storeId === input.storeId &&
-            localTerminalSeed?.cloudTerminalId === input.existingTerminal._id,
+            localTerminalSeed?.storeId === storeId &&
+            localTerminalSeed?.cloudTerminalId === existingTerminal._id,
         },
       });
     }
@@ -594,11 +777,14 @@ function usePosSettingsOfflineReadiness(input: {
       cancelled = true;
     };
   }, [
-    input.existingTerminal,
-    input.orgUrlSlug,
-    input.storeFactory,
-    input.storeId,
-    input.storeUrlSlug,
+    appSessionRecovery,
+    existingTerminal,
+    hasUser,
+    isAuthLoading,
+    orgUrlSlug,
+    storeFactory,
+    storeId,
+    storeUrlSlug,
   ]);
 
   return signals;
@@ -610,6 +796,8 @@ export function POSSettingsView({
   storeFactory?: Parameters<typeof registerAndProvisionPosTerminal>[0]["storeFactory"];
 } = {}) {
   const { activeStore } = useGetActiveStore();
+  const { isLoading: isAuthLoading, user } = useAuth();
+  const appSessionRecovery = usePosTerminalAppSessionRecoveryRuntimeInput();
   const routeParams = useParams({ strict: false }) as
     | {
         orgUrlSlug?: string;
@@ -628,6 +816,16 @@ export function POSSettingsView({
   const [nameTouched, setNameTouched] = useState(false);
   const [registerNumber, setRegisterNumber] = useState("");
   const [registerNumberTouched, setRegisterNumberTouched] = useState(false);
+  const [transactionCapability, setTransactionCapability] =
+    useState<PosTerminalTransactionCapability>(
+      DEFAULT_POS_TERMINAL_TRANSACTION_CAPABILITY,
+    );
+  const [transactionCapabilityTouched, setTransactionCapabilityTouched] =
+    useState(false);
+  const [loginMode, setLoginMode] = useState<PosTerminalLoginMode>(
+    DEFAULT_POS_TERMINAL_LOGIN_MODE,
+  );
+  const [loginModeTouched, setLoginModeTouched] = useState(false);
   const [isRegistering, setIsRegistering] = useState(false);
   const [isUpdatingExisting, setIsUpdatingExisting] = useState(false);
   const fingerprintHash = fingerprintResult?.fingerprintHash;
@@ -663,6 +861,24 @@ export function POSSettingsView({
     }
     setRegisterNumber("");
   }, [existingTerminal, registerNumberTouched]);
+
+  useEffect(() => {
+    if (transactionCapabilityTouched) {
+      return;
+    }
+    setTransactionCapability(
+      normalizePosTerminalTransactionCapability(
+        existingTerminal?.transactionCapability,
+      ),
+    );
+  }, [existingTerminal, transactionCapabilityTouched]);
+
+  useEffect(() => {
+    if (loginModeTouched) {
+      return;
+    }
+    setLoginMode(normalizePosTerminalLoginMode(existingTerminal?.loginMode));
+  }, [existingTerminal, loginModeTouched]);
 
   useEffect(() => {
     let cancelled = false;
@@ -763,7 +979,10 @@ export function POSSettingsView({
   ]);
 
   const offlineReadinessSignals = usePosSettingsOfflineReadiness({
+    appSessionRecovery,
     existingTerminal,
+    hasUser: Boolean(user),
+    isAuthLoading,
     orgUrlSlug: routeParams?.orgUrlSlug,
     storeFactory,
     storeId: activeStore?._id,
@@ -804,6 +1023,8 @@ export function POSSettingsView({
         registerTerminalMutation,
         storeFactory,
         storeUrlSlug: routeParams?.storeUrlSlug,
+        loginMode,
+        transactionCapability,
       });
       if (result.kind === "user_error") {
         toast.error(result.error.message);
@@ -817,6 +1038,8 @@ export function POSSettingsView({
       );
       setNameTouched(false);
       setRegisterNumberTouched(false);
+      setLoginModeTouched(false);
+      setTransactionCapabilityTouched(false);
     } catch (error) {
       console.error(error);
       toast.error("Unable to register terminal");
@@ -849,12 +1072,16 @@ export function POSSettingsView({
         registerTerminalMutation,
         storeFactory,
         storeUrlSlug: routeParams?.storeUrlSlug,
+        loginMode,
+        transactionCapability,
       });
       if (result.kind === "user_error") {
         toast.error(result.error.message);
         return;
       }
       setNameTouched(false);
+      setLoginModeTouched(false);
+      setTransactionCapabilityTouched(false);
       toast.success("Terminal settings saved");
     } catch (error) {
       console.error(error);
@@ -886,6 +1113,16 @@ export function POSSettingsView({
               onRegisterNumberChange={(value) => {
                 setRegisterNumberTouched(true);
                 setRegisterNumber(value);
+              }}
+              transactionCapability={transactionCapability}
+              onTransactionCapabilityChange={(value) => {
+                setTransactionCapabilityTouched(true);
+                setTransactionCapability(value);
+              }}
+              loginMode={loginMode}
+              onLoginModeChange={(value) => {
+                setLoginModeTouched(true);
+                setLoginMode(value);
               }}
               canRegister={registrationState.canRegister}
               onRegister={handleRegisterTerminal}

--- a/packages/athena-webapp/src/hooks/useGetTerminal.ts
+++ b/packages/athena-webapp/src/hooks/useGetTerminal.ts
@@ -7,6 +7,8 @@ import {
 } from "@/lib/pos/infrastructure/local/posLocalStore";
 import { readStoredTerminalFingerprintHash } from "@/lib/pos/infrastructure/terminal/fingerprint";
 import type { Id } from "~/convex/_generated/dataModel";
+import type { PosTerminalLoginMode } from "~/shared/posTerminalLoginMode";
+import type { PosTerminalTransactionCapability } from "~/shared/posTerminalCapability";
 import useGetActiveStore from "./useGetActiveStore";
 
 export const useGetTerminal = () => {
@@ -21,6 +23,8 @@ export const useGetTerminal = () => {
       displayName: string;
       localTerminalId?: string;
       registerNumber?: string;
+      loginMode?: PosTerminalLoginMode;
+      transactionCapability?: PosTerminalTransactionCapability;
       status: string;
     };
   } | null>(null);
@@ -64,6 +68,8 @@ export const useGetTerminal = () => {
             displayName: result.value.displayName,
             localTerminalId: result.value.terminalId,
             registerNumber: result.value.registerNumber,
+            loginMode: result.value.loginMode,
+            transactionCapability: result.value.transactionCapability,
             status: "local",
           },
         });

--- a/packages/athena-webapp/src/lib/pos/application/dto.ts
+++ b/packages/athena-webapp/src/lib/pos/application/dto.ts
@@ -6,6 +6,8 @@ import type {
 } from "@/lib/pos/domain";
 import type { Id } from "~/convex/_generated/dataModel";
 import type { CommandResult } from "~/shared/commandResult";
+import type { PosTerminalLoginMode } from "~/shared/posTerminalLoginMode";
+import type { PosTerminalTransactionCapability } from "~/shared/posTerminalCapability";
 
 type PosOperationalRole =
   | "manager"
@@ -20,6 +22,8 @@ export interface PosTerminalDto {
   displayName: string;
   localTerminalId?: string;
   registerNumber?: string;
+  loginMode?: PosTerminalLoginMode;
+  transactionCapability?: PosTerminalTransactionCapability;
   status?: string;
   registeredAt?: number;
 }
@@ -30,6 +34,8 @@ export interface PosRegisteredTerminalDto {
   displayName: string;
   localTerminalId?: string;
   registerNumber?: string;
+  loginMode?: PosTerminalLoginMode;
+  transactionCapability?: PosTerminalTransactionCapability;
   storeId?: Id<"store">;
   fingerprintHash?: string;
   syncSecretHash?: string;

--- a/packages/athena-webapp/src/lib/pos/application/registerAndProvisionPosTerminal.ts
+++ b/packages/athena-webapp/src/lib/pos/application/registerAndProvisionPosTerminal.ts
@@ -1,4 +1,14 @@
 import type { Id } from "~/convex/_generated/dataModel";
+import {
+  DEFAULT_POS_TERMINAL_TRANSACTION_CAPABILITY,
+  normalizePosTerminalTransactionCapability,
+  type PosTerminalTransactionCapability,
+} from "~/shared/posTerminalCapability";
+import {
+  DEFAULT_POS_TERMINAL_LOGIN_MODE,
+  normalizePosTerminalLoginMode,
+  type PosTerminalLoginMode,
+} from "~/shared/posTerminalLoginMode";
 
 import type { BrowserInfo } from "@/lib/browserFingerprint";
 import {
@@ -17,6 +27,8 @@ export type ProvisionedTerminalRecord = {
   syncSecretHash?: string;
   displayName: string;
   registerNumber?: string;
+  loginMode?: PosTerminalLoginMode;
+  transactionCapability?: PosTerminalTransactionCapability;
   registeredByUserId: Id<"athenaUser">;
   browserInfo: BrowserInfo;
   registeredAt: number;
@@ -40,6 +52,8 @@ export async function registerAndProvisionPosTerminal(input: {
   fingerprintHash: string;
   orgUrlSlug?: string;
   registerNumber: string;
+  loginMode?: PosTerminalLoginMode;
+  transactionCapability?: PosTerminalTransactionCapability;
   registerTerminalMutation: (args: {
     browserInfo: BrowserInfo;
     displayName: string;
@@ -47,6 +61,8 @@ export async function registerAndProvisionPosTerminal(input: {
     registerNumber: string;
     storeId: Id<"store">;
     syncSecretHash: string;
+    loginMode: PosTerminalLoginMode;
+    transactionCapability: PosTerminalTransactionCapability;
   }) => Promise<
     | { kind: "ok"; data: ProvisionedTerminalRecord }
     | { kind: "user_error"; error: { message: string } }
@@ -56,12 +72,17 @@ export async function registerAndProvisionPosTerminal(input: {
   now?: () => number;
 }) {
   const syncSecretToken = await createTerminalSyncSecretToken();
+  const transactionCapability =
+    normalizePosTerminalTransactionCapability(input.transactionCapability);
+  const loginMode = normalizePosTerminalLoginMode(input.loginMode);
   const result = await input.registerTerminalMutation({
     storeId: input.activeStoreId,
     fingerprintHash: input.fingerprintHash,
     syncSecretHash: syncSecretToken,
     displayName: input.displayName,
     registerNumber: input.registerNumber,
+    loginMode,
+    transactionCapability,
     browserInfo: input.browserInfo,
   });
   if (result.kind === "user_error") return result;
@@ -78,6 +99,12 @@ export async function registerAndProvisionPosTerminal(input: {
     storeId: input.activeStoreId,
     orgUrlSlug: input.orgUrlSlug,
     registerNumber: result.data.registerNumber,
+    loginMode:
+      result.data.loginMode ?? loginMode ?? DEFAULT_POS_TERMINAL_LOGIN_MODE,
+    transactionCapability:
+      result.data.transactionCapability ??
+      transactionCapability ??
+      DEFAULT_POS_TERMINAL_TRANSACTION_CAPABILITY,
     displayName: result.data.displayName,
     provisionedAt: input.now?.() ?? Date.now(),
     schemaVersion: POS_LOCAL_STORE_SCHEMA_VERSION,

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.test.ts
@@ -243,6 +243,47 @@ describe("localPosReadiness", () => {
     });
   });
 
+  it("treats live Opening Handoff review arrears as locally startable from POS", () => {
+    expect(
+      evaluateLocalPosReadiness({
+        closeSnapshot: { status: "ready" },
+        entryContext,
+        openingSnapshot: { status: "needs_attention" },
+        operatingDate: "2026-05-14",
+        registerReadModel,
+      }),
+    ).toEqual({
+      status: "blocked",
+      reason: "not_started",
+      canStartLocally: true,
+      message:
+        "Store day not started. Complete Opening Handoff before starting sales.",
+    });
+  });
+
+  it("keeps POS open after the day was started locally even when live Opening Handoff still needs review", () => {
+    expect(
+      evaluateLocalPosReadiness({
+        closeSnapshot: { status: "ready" },
+        entryContext,
+        localReadiness: {
+          storeId: "store-1",
+          operatingDate: "2026-05-14",
+          status: "started",
+          source: "local",
+          updatedAt: 1_000,
+        },
+        openingSnapshot: { status: "needs_attention" },
+        operatingDate: "2026-05-14",
+        registerReadModel,
+      }),
+    ).toEqual({
+      status: "ready",
+      source: "local_readiness",
+      storeDayStatus: "started",
+    });
+  });
+
   it("treats reopened completed close snapshots as live reopened readiness", () => {
     expect(
       evaluateLocalPosReadiness({
@@ -581,5 +622,40 @@ describe("localPosReadiness", () => {
       status: "blocked",
       reason: "closed",
     });
+  });
+
+  it("does not overwrite a locally started day with a live not-started opening snapshot", async () => {
+    const writes: unknown[] = [];
+
+    await expect(
+      refreshLocalPosReadinessFromSnapshots({
+        clock: () => 2_100,
+        closeSnapshot: { status: "ready" },
+        entryContext,
+        openingSnapshot: { status: "needs_attention" },
+        operatingDate: "2026-05-14",
+        store: {
+          readStoreDayReadiness: async () => ({
+            ok: true,
+            value: {
+              storeId: "store-1",
+              operatingDate: "2026-05-14",
+              status: "started",
+              source: "local",
+              updatedAt: 2_000,
+            },
+          }),
+          writeStoreDayReadiness: async (readiness) => {
+            writes.push(readiness);
+            return { ok: true, value: readiness };
+          },
+        },
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      value: null,
+    });
+
+    expect(writes).toEqual([]);
   });
 });

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts
@@ -39,6 +39,7 @@ export type LocalPosReadiness =
         | "waiting_for_close_snapshot"
         | "unknown"
         | "local_store_unavailable";
+      canStartLocally?: boolean;
       message: string;
     };
 
@@ -152,16 +153,6 @@ export function evaluateLocalPosReadiness(input: {
     );
   }
 
-  if (
-    input.openingSnapshot?.status &&
-    input.openingSnapshot.status !== "started"
-  ) {
-    return blocked(
-      "not_started",
-      "Store day not started. Complete Opening Handoff before starting sales.",
-    );
-  }
-
   if (input.registerReadModel?.closeoutState?.status === "closed_locally") {
     return blocked(
       "local_closeout",
@@ -206,6 +197,14 @@ export function evaluateLocalPosReadiness(input: {
     };
   }
 
+  if (input.openingSnapshot?.status) {
+    return blocked(
+      "not_started",
+      "Store day not started. Complete Opening Handoff before starting sales.",
+      { canStartLocally: true },
+    );
+  }
+
   if (localReadiness?.status === "closed") {
     return blocked(
       "closed",
@@ -213,10 +212,13 @@ export function evaluateLocalPosReadiness(input: {
     );
   }
 
-  if (localReadiness?.status === "not_started") {
+  if (
+    localReadiness?.status === "not_started"
+  ) {
     return blocked(
       "not_started",
       "Store day not started. Complete Opening Handoff before starting sales.",
+      { canStartLocally: !input.openingSnapshot },
     );
   }
 
@@ -325,7 +327,8 @@ export async function refreshLocalPosReadinessFromSnapshots(input: {
   entryContext: PosLocalEntryContext;
   openingSnapshot?: PosLocalDailyOpeningSnapshot;
   operatingDate: string;
-  store: Pick<PosLocalReadinessStore, "writeStoreDayReadiness">;
+  store: Pick<PosLocalReadinessStore, "writeStoreDayReadiness"> &
+    Partial<Pick<PosLocalReadinessStore, "readStoreDayReadiness">>;
 }): Promise<PosLocalStoreResult<PosLocalStoreDayReadiness | null>> {
   if (input.entryContext.status !== "ready") {
     return { ok: true, value: null };
@@ -341,6 +344,26 @@ export async function refreshLocalPosReadinessFromSnapshots(input: {
 
   if (!readiness || !input.store.writeStoreDayReadiness) {
     return { ok: true, value: null };
+  }
+
+  if (readiness.status === "not_started" && input.store.readStoreDayReadiness) {
+    const existing = await input.store.readStoreDayReadiness({
+      storeId: input.entryContext.storeId,
+      operatingDate: input.operatingDate,
+    });
+    if (!existing.ok) return existing;
+
+    if (
+      localReadinessMatchesInput({
+        entryContext: input.entryContext,
+        localReadiness: existing.value,
+        operatingDate: input.operatingDate,
+      }) &&
+      (existing.value?.status === "started" ||
+        existing.value?.status === "reopened")
+    ) {
+      return { ok: true, value: null };
+    }
   }
 
   return input.store.writeStoreDayReadiness(readiness);
@@ -547,10 +570,12 @@ function readinessStateKeysEqual(
 function blocked(
   reason: Extract<LocalPosReadiness, { status: "blocked" }>["reason"],
   message: string,
+  options?: { canStartLocally?: boolean },
 ): LocalPosReadiness {
   return {
     status: "blocked",
     reason,
+    ...(options?.canStartLocally ? { canStartLocally: true } : {}),
     message,
   };
 }

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.test.ts
@@ -1346,6 +1346,56 @@ describe("posLocalStore", () => {
     });
   });
 
+  it("restores active cashier presence for a terminal without live organization metadata", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 2_000,
+    });
+
+    await store.writeCashierPresence(
+      buildCashierPresenceRecord({
+        organizationId: "org-1",
+        signedInAt: 1_000,
+      }),
+    );
+    await store.writeCashierPresence(
+      buildCashierPresenceRecord({
+        organizationId: "org-2",
+        signedInAt: 1_500,
+      }),
+    );
+
+    await expect(
+      store.readActiveCashierPresence({
+        operatingDate: "2026-06-04",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      value: expect.objectContaining({
+        organizationId: "org-2",
+        signedInAt: 1_500,
+        staffProfileId: "staff-1",
+        username: "frontdesk",
+      }),
+    });
+    await expect(
+      store.readActiveCashierPresence({
+        operatingDate: "2026-06-04",
+        organizationId: "org-1",
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      value: expect.objectContaining({
+        organizationId: "org-1",
+        signedInAt: 1_000,
+      }),
+    });
+  });
+
   it("keeps cashier presence isolated by terminal store organization and operating date", async () => {
     const store = createPosLocalStore({
       adapter: createMemoryPosLocalStorageAdapter(),

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts
@@ -7,6 +7,8 @@ import type {
   PosRegisterCatalogRowDto,
   PosServiceCatalogRowDto,
 } from "@/lib/pos/application/dto";
+import type { PosTerminalLoginMode } from "~/shared/posTerminalLoginMode";
+import type { PosTerminalTransactionCapability } from "~/shared/posTerminalCapability";
 
 export const POS_LOCAL_STORE_SCHEMA_VERSION = 8;
 
@@ -66,6 +68,8 @@ export interface PosProvisionedTerminalSeed {
   storeId: string;
   orgUrlSlug?: string;
   registerNumber?: string;
+  loginMode?: PosTerminalLoginMode;
+  transactionCapability?: PosTerminalTransactionCapability;
   displayName: string;
   provisionedAt: number;
   schemaVersion: number;
@@ -824,6 +828,53 @@ export function createPosLocalStore(options: PosLocalStoreOptions) {
             }
 
             return record;
+          },
+        );
+
+        return { ok: true, value };
+      } catch (error) {
+        return toFailure(error);
+      }
+    },
+
+    async readActiveCashierPresence(input: {
+      now?: number;
+      operatingDate: string;
+      organizationId?: string;
+      storeId: string;
+      terminalId: string;
+    }): Promise<PosLocalStoreResult<PosLocalActiveCashierPresenceRecord | null>> {
+      try {
+        const value = await options.adapter.transaction(
+          "readwrite",
+          ["meta", "cashierPresence"],
+          async (transaction) => {
+            await ensureSupportedSchema(transaction, "readwrite");
+            const now = input.now ?? clock();
+            const records = await transaction.getAll<unknown>("cashierPresence");
+            const candidates: PosLocalActiveCashierPresenceRecord[] = [];
+
+            for (const record of records) {
+              if (!isCashierPresenceRecord(record)) {
+                continue;
+              }
+
+              if (isExpiredCashierPresence(record, now)) {
+                await transaction.delete(
+                  "cashierPresence",
+                  cashierPresenceKey(record),
+                );
+                continue;
+              }
+
+              if (matchesActiveCashierPresenceScope(record, input)) {
+                candidates.push(record);
+              }
+            }
+
+            return candidates.sort(
+              (left, right) => right.signedInAt - left.signedInAt,
+            )[0] ?? null;
           },
         );
 
@@ -1592,6 +1643,23 @@ function matchesCashierPresenceScope(
   return (
     record.operatingDate === scope.operatingDate &&
     record.organizationId === scope.organizationId &&
+    record.storeId === scope.storeId &&
+    record.terminalId === scope.terminalId
+  );
+}
+
+function matchesActiveCashierPresenceScope(
+  record: PosLocalActiveCashierPresenceRecord,
+  scope: {
+    operatingDate: string;
+    organizationId?: string;
+    storeId: string;
+    terminalId: string;
+  },
+) {
+  return (
+    record.operatingDate === scope.operatingDate &&
+    (!scope.organizationId || record.organizationId === scope.organizationId) &&
     record.storeId === scope.storeId &&
     record.terminalId === scope.terminalId
   );

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts
@@ -550,6 +550,8 @@ function terminalFromSeed(seed: PosProvisionedTerminalSeed | null): PosTerminalD
     displayName: seed.displayName,
     localTerminalId: seed.terminalId,
     registerNumber: seed.registerNumber,
+    loginMode: seed.loginMode,
+    transactionCapability: seed.transactionCapability,
     status: "local",
     registeredAt: seed.provisionedAt,
   };

--- a/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.test.ts
@@ -211,6 +211,46 @@ describe("catalogSearch", () => {
     ]);
   });
 
+  it("ranks compact product-name phrase matches before broader fuzzy hits", () => {
+    const result = searchRegisterCatalog(
+      buildRegisterCatalogIndex([
+        {
+          productId: "product-fragrance",
+          productSkuId: "sku-fragrance",
+          name: "Brazilian Hair And Body Fragrance Mist Black Amber Plum",
+          sku: "KK38-6Q0-EMF",
+          barcode: "111222333557",
+          category: "POS quick add",
+          description: null,
+          price: 80,
+          size: null,
+          color: null,
+          length: null,
+        },
+        {
+          productId: "product-melt-band",
+          productSkuId: "sku-melt-band",
+          name: "Melt Band",
+          sku: "KK38-MELT-BAND",
+          barcode: "111222333558",
+          category: "POS quick add",
+          description: null,
+          price: 30,
+          size: null,
+          color: null,
+          length: null,
+        },
+      ]),
+      "meltband",
+    );
+
+    expect(result.intent).toBe("text");
+    expect(result.results.map((row) => row.productSkuId)).toEqual([
+      "sku-melt-band",
+      "sku-fragrance",
+    ]);
+  });
+
   it("requires every text query token to match somewhere in the row", () => {
     const result = searchRegisterCatalog(
       buildRegisterCatalogIndex([

--- a/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts
@@ -35,6 +35,8 @@ export interface RegisterCustomerPanelState {
 
 export interface RegisterProductEntryState {
   disabled: boolean;
+  canSearchProducts?: boolean;
+  canSearchServices?: boolean;
   showProductLookup: boolean;
   setShowProductLookup: (show: boolean) => void;
   productSearchQuery: string;

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -65,6 +65,10 @@ let mockTerminal:
       _id: Id<"posTerminal">;
       displayName: string;
       registerNumber?: string;
+      transactionCapability?:
+        | "products_and_services"
+        | "products_only"
+        | "services_only";
     }
   | null
   | undefined;
@@ -2578,6 +2582,52 @@ describe("useRegisterViewModel", () => {
     );
   });
 
+  it("prefills restored cashier unlock from local presence while offline without live store metadata", async () => {
+    Object.defineProperty(globalThis.navigator, "onLine", {
+      configurable: true,
+      value: false,
+    });
+    mockActiveStore = null;
+    mockRegisterState = undefined;
+    mockActiveSession = null;
+    mockTerminal = {
+      _id: "terminal-1" as Id<"posTerminal">,
+      displayName: "Front Counter",
+      registerNumber: "1",
+    };
+    mockReadCashierPresence.mockResolvedValue({
+      ok: true,
+      value: buildCashierPresence(),
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await waitFor(() =>
+      expect(result.current.cashierPresenceRestore.status).toBe(
+        "validation_pending",
+      ),
+    );
+
+    expect(mockReadCashierPresence).toHaveBeenCalledWith({
+      now: expect.any(Number),
+      operatingDate: getTestOperatingDate(),
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    });
+    expect(result.current.authDialog?.open).toBe(true);
+    expect(result.current.authDialog?.restoredCashier).toEqual({
+      displayName: "Ama Kusi",
+      username: "ama",
+    });
+    expect(result.current.debug).toEqual(
+      expect.objectContaining({
+        activeStoreSource: "local",
+        hasLiveActiveStore: false,
+      }),
+    );
+  });
+
   it("uses the short-lived local POS staff proof for local events", async () => {
     const { useRegisterViewModel } = await import("./useRegisterViewModel");
     const { result } = renderHook(() => useRegisterViewModel());
@@ -4420,6 +4470,109 @@ describe("useRegisterViewModel", () => {
         ([event]) => event?.type === "cart.item_added",
       ),
     ).toHaveLength(1);
+  });
+
+  it("surfaces only service lookup when the terminal is configured for services", async () => {
+    mockTerminal = {
+      ...mockTerminal!,
+      transactionCapability: "services_only",
+    };
+    mockRegisterCatalogRows = [buildRegisterCatalogRow()];
+    mockRegisterCatalogAvailabilityRows = [
+      buildRegisterCatalogAvailabilityRow(),
+    ];
+    mockRegisterServiceCatalogRows = [
+      {
+        serviceCatalogId: "service-1" as Id<"serviceCatalog">,
+        name: "Closure Repair",
+        description: "Repair a closure install.",
+        serviceMode: "repair",
+        pricingModel: "fixed",
+        basePrice: 4500,
+        status: "active",
+      },
+    ];
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    act(() => {
+      result.current.productEntry.setProductSearchQuery("1234567890123");
+    });
+
+    await waitFor(() =>
+      expect(result.current.productEntry.searchResults).toEqual([]),
+    );
+    expect(result.current.productEntry.canSearchProducts).toBe(false);
+    expect(result.current.productEntry.canSearchServices).toBe(true);
+    expect(
+      mockAppendLocalEvent.mock.calls.some(
+        ([event]) => event?.type === "cart.item_added",
+      ),
+    ).toBe(false);
+
+    act(() => {
+      result.current.productEntry.setProductSearchQuery("closure");
+    });
+
+    await waitFor(() =>
+      expect(result.current.serviceEntry?.searchResults).toHaveLength(1),
+    );
+    expect(result.current.serviceEntry?.searchResults[0]).toEqual(
+      expect.objectContaining({ name: "Closure Repair" }),
+    );
+  });
+
+  it("surfaces only product lookup when the terminal is configured for product SKUs", async () => {
+    mockTerminal = {
+      ...mockTerminal!,
+      transactionCapability: "products_only",
+    };
+    mockRegisterCatalogRows = [buildRegisterCatalogRow()];
+    mockRegisterCatalogAvailabilityRows = [
+      buildRegisterCatalogAvailabilityRow(),
+    ];
+    mockRegisterServiceCatalogRows = [
+      {
+        serviceCatalogId: "service-1" as Id<"serviceCatalog">,
+        name: "Closure Repair",
+        description: "Repair a closure install.",
+        serviceMode: "repair",
+        pricingModel: "fixed",
+        basePrice: 4500,
+        status: "active",
+      },
+    ];
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    expect(result.current.productEntry.canSearchProducts).toBe(true);
+    expect(result.current.productEntry.canSearchServices).toBe(false);
+    expect(result.current.serviceEntry).toBeUndefined();
+
+    act(() => {
+      result.current.productEntry.setProductSearchQuery("deep");
+    });
+
+    await waitFor(() =>
+      expect(result.current.productEntry.searchResults).toHaveLength(1),
+    );
+    expect(result.current.productEntry.searchResults[0]).toEqual(
+      expect.objectContaining({ name: "Deep Wave" }),
+    );
   });
 
   it("adds service lines to the register review state and blocks checkout without customer attribution", async () => {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -63,6 +63,11 @@ import { isPosUsableRegisterSessionStatus } from "~/shared/registerSessionStatus
 import { userError, type CommandResult } from "~/shared/commandResult";
 import type { ApprovalRequirement } from "~/shared/approvalPolicy";
 import {
+  normalizePosTerminalTransactionCapability,
+  posTerminalCanTransactProducts,
+  posTerminalCanTransactServices,
+} from "~/shared/posTerminalCapability";
+import {
   useConvexActiveSession,
   useConvexHeldSessions,
   useConvexSessionActions,
@@ -1352,6 +1357,16 @@ export function useRegisterViewModel(): RegisterViewModel {
   const terminalRegisterNumber = terminal?.registerNumber
     ? trimOptional(terminal.registerNumber)
     : undefined;
+  const terminalTransactionCapability =
+    normalizePosTerminalTransactionCapability(
+      terminal?.transactionCapability,
+    );
+  const terminalCanTransactProducts = posTerminalCanTransactProducts(
+    terminalTransactionCapability,
+  );
+  const terminalCanTransactServices = posTerminalCanTransactServices(
+    terminalTransactionCapability,
+  );
   const [localStaffAuthorityStatus, setLocalStaffAuthorityStatus] =
     useState("unknown");
   const activeOperatingDate = useMemo(() => getLocalOperatingDate(), []);
@@ -1930,19 +1945,30 @@ export function useRegisterViewModel(): RegisterViewModel {
       }
 
       const presenceStore = localStore as CashierPresenceStore;
-      if (!activeStoreOrganizationId || !presenceStore.readCashierPresence) {
+      if (
+        !presenceStore.readCashierPresence &&
+        !presenceStore.readActiveCashierPresence
+      ) {
         setCashierPresenceRestore({ status: "missing" });
         return;
       }
 
       const now = Date.now();
-      const presenceResult = await presenceStore.readCashierPresence({
-        now,
-        operatingDate: activeOperatingDate,
-        organizationId: activeStoreOrganizationId,
-        storeId: activeStoreId,
-        terminalId: terminal._id,
-      });
+      const presenceResult =
+        activeStoreOrganizationId && presenceStore.readCashierPresence
+          ? await presenceStore.readCashierPresence({
+              now,
+              operatingDate: activeOperatingDate,
+              organizationId: activeStoreOrganizationId,
+              storeId: activeStoreId,
+              terminalId: terminal._id,
+            })
+          : await presenceStore.readActiveCashierPresence!({
+              now,
+              operatingDate: activeOperatingDate,
+              storeId: activeStoreId,
+              terminalId: terminal._id,
+            });
       if (cancelled) return;
 
       if (staffProfileIdRef.current) {
@@ -1998,10 +2024,17 @@ export function useRegisterViewModel(): RegisterViewModel {
         setStaffProfileId(null);
         setStaffProofToken(null);
         setLocalAuthenticatedStaff(null);
-        if (presenceStore.clearCashierPresence) {
+        const presenceOrganizationId =
+          activeStoreOrganizationId ?? presence.organizationId;
+        if (presenceOrganizationId && presenceStore.clearCashierPresence) {
           await presenceStore.clearCashierPresence({
             operatingDate: activeOperatingDate,
-            organizationId: activeStoreOrganizationId,
+            organizationId: presenceOrganizationId,
+            storeId: activeStoreId,
+            terminalId: terminal._id,
+          });
+        } else if (presenceStore.invalidateCashierPresenceForTerminal) {
+          await presenceStore.invalidateCashierPresenceForTerminal({
             storeId: activeStoreId,
             terminalId: terminal._id,
           });
@@ -2386,6 +2419,25 @@ export function useRegisterViewModel(): RegisterViewModel {
     return adjusted;
   }, [localAvailabilityConsumptionBySkuId, registerCatalogAvailabilityBySkuId]);
   const registerSearchState = useMemo<RegisterCatalogSearchResult>(() => {
+    if (!terminalCanTransactProducts) {
+      const query = productSearchQuery.trim();
+      return query
+        ? {
+            canAutoAdd: false,
+            exactMatch: null,
+            intent: "text",
+            query,
+            results: [],
+          }
+        : {
+            canAutoAdd: false,
+            exactMatch: null,
+            intent: "empty",
+            query: "",
+            results: [],
+          };
+    }
+
     if (registerMetadataSearchState.intent !== "exact") {
       return registerMetadataSearchState;
     }
@@ -2404,7 +2456,12 @@ export function useRegisterViewModel(): RegisterViewModel {
           exactAvailability.quantityAvailable > 0,
       ),
     };
-  }, [localRegisterCatalogAvailabilityBySkuId, registerMetadataSearchState]);
+  }, [
+    localRegisterCatalogAvailabilityBySkuId,
+    productSearchQuery,
+    registerMetadataSearchState,
+    terminalCanTransactProducts,
+  ]);
   const registerSearchProducts = useMemo(
     () =>
       registerSearchState.results.map((row) =>
@@ -2473,6 +2530,10 @@ export function useRegisterViewModel(): RegisterViewModel {
   );
   const serviceSearchResults = useMemo(
     () => {
+      if (!terminalCanTransactServices) {
+        return [];
+      }
+
       const index = buildRegisterServiceCatalogIndex(
         serviceCatalogRows
           .filter((row) => row.status === undefined || row.status === "active")
@@ -2499,7 +2560,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         }),
       );
     },
-    [productSearchQuery, serviceCatalogRows],
+    [productSearchQuery, serviceCatalogRows, terminalCanTransactServices],
   );
   const serviceSubtotal = useMemo(
     () =>
@@ -4226,6 +4287,11 @@ export function useRegisterViewModel(): RegisterViewModel {
             return false;
           }
 
+          if (!terminalCanTransactServices) {
+            toast.error("This terminal is not configured for service sales.");
+            return false;
+          }
+
           if (activeSessionHasBlockedRegisterBinding) {
             toast.error("Drawer closed. Open the drawer before adding services.");
             return false;
@@ -4322,6 +4388,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       registerNumber,
       staffProfileId,
       terminal?._id,
+      terminalCanTransactServices,
     ],
   );
 
@@ -4489,6 +4556,11 @@ export function useRegisterViewModel(): RegisterViewModel {
         return false;
       }
 
+      if (!terminalCanTransactProducts) {
+        toast.error("This terminal is not configured for product sales.");
+        return false;
+      }
+
       if (!product.productId || !product.skuId) {
         toast.error("Item details unavailable. Try another item.");
         return false;
@@ -4639,6 +4711,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       registerCatalogAvailabilityBySkuId,
       registerCatalogSkuIds,
       staffProfileId,
+      terminalCanTransactProducts,
     ],
   );
 
@@ -6126,6 +6199,8 @@ export function useRegisterViewModel(): RegisterViewModel {
       setCustomerInfo,
     },
     productEntry: {
+      canSearchProducts: terminalCanTransactProducts,
+      canSearchServices: terminalCanTransactServices,
       disabled:
         !terminal ||
         !staffProfileId ||
@@ -6144,29 +6219,31 @@ export function useRegisterViewModel(): RegisterViewModel {
       searchResults: registerSearchProducts,
       isSearchLoading: isRegisterSearchLoading,
       isSearchReady: isRegisterCatalogReady,
-      canQuickAddProduct: isCashierManager,
+      canQuickAddProduct: terminalCanTransactProducts && isCashierManager,
     },
-    serviceEntry: {
-      disabled:
-        !terminal ||
-        !staffProfileId ||
-        cashierPresenceBlocksSale ||
-        isProjectedLocalActiveSaleBlockingCurrentStaff ||
-        shouldShowDrawerGate ||
-        cloudRegisterSessionBlocksLocalProjection ||
-        activeSessionHasBlockedRegisterBinding ||
-        isOpeningDrawer,
-      serviceSearchQuery: productSearchQuery,
-      setServiceSearchQuery: setProductSearchQuery,
-      searchResults: serviceSearchResults,
-      isSearchLoading: serviceCatalogResult === undefined,
-      isSearchReady: serviceCatalogResult !== undefined,
-      items: serviceLineDrafts,
-      onAddService: handleAddService,
-      onUpdateServiceAmount: handleUpdateServiceAmount,
-      onRemoveService: handleRemoveService,
-      checkoutBlockMessage: serviceCheckoutBlockMessage,
-    },
+    serviceEntry: terminalCanTransactServices
+      ? {
+          disabled:
+            !terminal ||
+            !staffProfileId ||
+            cashierPresenceBlocksSale ||
+            isProjectedLocalActiveSaleBlockingCurrentStaff ||
+            shouldShowDrawerGate ||
+            cloudRegisterSessionBlocksLocalProjection ||
+            activeSessionHasBlockedRegisterBinding ||
+            isOpeningDrawer,
+          serviceSearchQuery: productSearchQuery,
+          setServiceSearchQuery: setProductSearchQuery,
+          searchResults: serviceSearchResults,
+          isSearchLoading: serviceCatalogResult === undefined,
+          isSearchReady: serviceCatalogResult !== undefined,
+          items: serviceLineDrafts,
+          onAddService: handleAddService,
+          onUpdateServiceAmount: handleUpdateServiceAmount,
+          onRemoveService: handleRemoveService,
+          checkoutBlockMessage: serviceCheckoutBlockMessage,
+        }
+      : undefined,
     cart: {
       items: activeCartItems,
       serviceItems: serviceLineDrafts,

--- a/packages/athena-webapp/src/lib/search/fuzzySearch.ts
+++ b/packages/athena-webapp/src/lib/search/fuzzySearch.ts
@@ -102,6 +102,12 @@ function scoreQueryTokenForEntry<TItem>(
   token: string,
   fieldWeights: FuzzySearchFieldWeights,
 ): number {
+  const compactFieldScore = scoreCompactFieldContains(
+    entry.normalizedFields,
+    token,
+    fieldWeights,
+  );
+
   if (entry.tokens.has(token)) {
     return (
       1 +
@@ -110,15 +116,53 @@ function scoreQueryTokenForEntry<TItem>(
           score +
           scoreFieldContains(entry.normalizedFields[field] ?? "", token, weight)
         );
-      }, 0)
+      }, 0) +
+      compactFieldScore
     );
   }
 
-  return bestFuzzyTokenScore(entry.tokens, token);
+  return Math.max(bestFuzzyTokenScore(entry.tokens, token), compactFieldScore);
 }
 
 function scoreFieldContains(field: string, token: string, score: number): number {
   return field.includes(token) ? score : 0;
+}
+
+function scoreCompactFieldContains(
+  normalizedFields: Record<string, string>,
+  token: string,
+  fieldWeights: FuzzySearchFieldWeights,
+): number {
+  const compactToken = compactSearchText(token);
+
+  if (compactToken.length < 3) return 0;
+
+  let bestScore = 0;
+
+  for (const [field, value] of Object.entries(normalizedFields)) {
+    const compactField = compactSearchText(value);
+
+    if (!compactField) continue;
+
+    const fieldWeight = fieldWeights[field] ?? 1;
+
+    if (compactField === compactToken) {
+      bestScore = Math.max(bestScore, 40 + fieldWeight * 10);
+    } else if (compactField.includes(compactToken)) {
+      bestScore = Math.max(bestScore, 24 + fieldWeight * 8);
+    } else if (
+      compactToken.includes(compactField) &&
+      compactField.length >= Math.max(3, compactToken.length - 2)
+    ) {
+      bestScore = Math.max(bestScore, 16 + fieldWeight * 6);
+    }
+  }
+
+  return bestScore;
+}
+
+function compactSearchText(value: string) {
+  return normalizeFuzzySearchText(value).replace(/\s+/g, "");
 }
 
 function bestFuzzyTokenScore(tokens: Set<string>, queryToken: string): number {

--- a/packages/athena-webapp/src/lib/stockOps/skuSearch.test.ts
+++ b/packages/athena-webapp/src/lib/stockOps/skuSearch.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { matchesSkuSearchTerms, normalizeSkuSearchQuery } from "./skuSearch";
+import {
+  matchesSkuSearchTerms,
+  normalizeSkuSearchQuery,
+  scoreSkuSearchTerms,
+} from "./skuSearch";
 
 describe("skuSearch", () => {
   it("matches exact and prefix text tokens", () => {
@@ -59,5 +63,21 @@ describe("skuSearch", () => {
         normalizeSkuSearchQuery("111222333444"),
       ),
     ).toBe(true);
+  });
+
+  it("scores compact product-name phrases above broader fuzzy matches", () => {
+    const query = normalizeSkuSearchQuery("meltband");
+
+    const directPhraseScore = scoreSkuSearchTerms(
+      ["Hair Band", "Melt Band", "POS quick add"],
+      query,
+    );
+    const broadFuzzyScore = scoreSkuSearchTerms(
+      ["Brazilian Hair And Body Fragrance Mist", "POS quick add"],
+      query,
+    );
+
+    expect(directPhraseScore).toBeGreaterThan(0);
+    expect(directPhraseScore).toBeGreaterThan(broadFuzzyScore);
   });
 });

--- a/packages/athena-webapp/src/lib/stockOps/skuSearch.ts
+++ b/packages/athena-webapp/src/lib/stockOps/skuSearch.ts
@@ -1,6 +1,7 @@
 import {
   createFuzzySearchEntry,
-  searchFuzzyEntries,
+  scoreFuzzySearchEntry,
+  tokenizeFuzzySearchText,
 } from "@/lib/search/fuzzySearch";
 
 export function normalizeSkuSearchQuery(value?: string | null) {
@@ -11,12 +12,21 @@ export function matchesSkuSearchTerms(
   terms: Array<string | number | null | undefined>,
   query: string,
 ) {
-  if (!query) return true;
+  return scoreSkuSearchTerms(terms, query) > 0;
+}
+
+export function scoreSkuSearchTerms(
+  terms: Array<string | number | null | undefined>,
+  query: string,
+) {
+  if (!query) return 1;
 
   if (isBarcodeShapedSearchQuery(query)) {
     const normalizedQuery = normalizeIdentifier(query);
 
-    return terms.some((term) => normalizeIdentifier(term) === normalizedQuery);
+    return terms.some((term) => normalizeIdentifier(term) === normalizedQuery)
+      ? 100
+      : 0;
   }
 
   const searchableText = terms
@@ -24,14 +34,16 @@ export function matchesSkuSearchTerms(
       (term): term is string | number => term !== null && term !== undefined,
     )
     .join(" ");
+  const queryTokens = [...tokenizeFuzzySearchText([query])];
 
-  return (
-    searchFuzzyEntries(
-      [createFuzzySearchEntry(searchableText, { searchableText })],
-      query,
-      { limit: 1 },
-    ).length > 0
+  if (!searchableText || queryTokens.length === 0) return 0;
+
+  const fuzzyScore = scoreFuzzySearchEntry(
+    createFuzzySearchEntry(searchableText, { searchableText }),
+    queryTokens,
   );
+
+  return fuzzyScore;
 }
 
 function isBarcodeShapedSearchQuery(input: string): boolean {

--- a/packages/athena-webapp/src/main.tsx
+++ b/packages/athena-webapp/src/main.tsx
@@ -8,6 +8,7 @@ import "./index.css";
 import { useEffect } from "react";
 import { createVersionChecker } from "./utils/versionChecker";
 import { registerPosAppShellServiceWorker } from "./offline/registerPosAppShellServiceWorker";
+import { removeConvexAuthCodeParamFromUrl } from "./auth/convexAuthUrl";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -62,6 +63,7 @@ function App() {
 const rootElement = document.getElementById("app")!;
 
 if (!rootElement.innerHTML) {
+  removeConvexAuthCodeParamFromUrl();
   registerPosAppShellServiceWorker();
   const root = ReactDOM.createRoot(rootElement);
   root.render(<App />);

--- a/packages/athena-webapp/src/utils/versionChecker.test.ts
+++ b/packages/athena-webapp/src/utils/versionChecker.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+function installInitialScript(src = "http://localhost/assets/index-old.js") {
+  document.body.innerHTML = "";
+  document.head.innerHTML = `<script type="module" src="${src}"></script>`;
+}
+
+async function importVersionChecker() {
+  vi.resetModules();
+  return import("./versionChecker");
+}
+
+describe("versionChecker", () => {
+  beforeEach(() => {
+    installInitialScript();
+    vi.useFakeTimers();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not auto-reload on the live POS register route", async () => {
+    const { shouldAutoReloadForPath } = await importVersionChecker();
+
+    expect(shouldAutoReloadForPath("/wigclub/store/wigclub/pos")).toBe(true);
+    expect(shouldAutoReloadForPath("/wigclub/store/wigclub/pos/")).toBe(true);
+    expect(
+      shouldAutoReloadForPath("/wigclub/store/wigclub/pos/register"),
+    ).toBe(false);
+    expect(
+      shouldAutoReloadForPath("/wigclub/store/wigclub/pos/register/"),
+    ).toBe(false);
+    expect(
+      shouldAutoReloadForPath("/wigclub/store/wigclub/pos/registers"),
+    ).toBe(true);
+    expect(
+      shouldAutoReloadForPath("/wigclub/store/wigclub/pos/transactions"),
+    ).toBe(true);
+  });
+
+  it("keeps polling but skips the reload callback when a new build is detected on a blocked route", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      text: async () =>
+        '<html><head><script type="module" src="/assets/index-new.js"></script></head></html>',
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    const { createVersionChecker } = await importVersionChecker();
+    const onNewVersionAvailable = vi.fn();
+    const checker = createVersionChecker({
+      onNewVersionAvailable,
+      pollingIntervalMs: 60_000,
+      shouldReload: () => false,
+    });
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(onNewVersionAvailable).not.toHaveBeenCalled();
+
+    checker.stop();
+  });
+
+  it("skips reloads on the POS register route when query params are present", async () => {
+    window.history.pushState(
+      {},
+      "",
+      "/wigclub/store/wigclub/pos/register?o=%252Fwigclub%252Fstore%252Fwigclub%252Fpos&terminal=front-counter&debug=true",
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        text: async () =>
+          '<html><head><script type="module" src="/assets/index-new.js"></script></head></html>',
+      })),
+    );
+    const { createVersionChecker } = await importVersionChecker();
+    const onNewVersionAvailable = vi.fn();
+    const checker = createVersionChecker({
+      onNewVersionAvailable,
+      pollingIntervalMs: 60_000,
+    });
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(window.location.pathname).toBe("/wigclub/store/wigclub/pos/register");
+    expect(onNewVersionAvailable).not.toHaveBeenCalled();
+
+    checker.stop();
+  });
+
+  it("reloads when a new build is detected away from blocked routes", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        text: async () =>
+          '<html><head><script type="module" src="/assets/index-new.js"></script></head></html>',
+      })),
+    );
+    const { createVersionChecker } = await importVersionChecker();
+    const onNewVersionAvailable = vi.fn();
+    const checker = createVersionChecker({
+      onNewVersionAvailable,
+      pollingIntervalMs: 60_000,
+      shouldReload: () => true,
+    });
+
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(onNewVersionAvailable).toHaveBeenCalledTimes(1);
+
+    checker.stop();
+  });
+});

--- a/packages/athena-webapp/src/utils/versionChecker.ts
+++ b/packages/athena-webapp/src/utils/versionChecker.ts
@@ -1,5 +1,7 @@
 // This service will check for new versions of the app by detecting changes in bundled assets
 
+const POS_LIVE_SALES_ROUTE_PATTERN = /\/pos\/register\/?$/;
+
 // Store the scripts that were loaded when the app started
 const initialScripts = Array.from(document.querySelectorAll("script"))
   .filter(
@@ -9,14 +11,28 @@ const initialScripts = Array.from(document.querySelectorAll("script"))
   )
   .map((script) => script.src);
 
+export function shouldAutoReloadForPath(pathname: string) {
+  return !POS_LIVE_SALES_ROUTE_PATTERN.test(pathname);
+}
+
+function shouldAutoReloadForCurrentRoute() {
+  if (typeof window === "undefined") {
+    return true;
+  }
+
+  return shouldAutoReloadForPath(window.location.pathname);
+}
+
 /**
  * Creates a version checker that detects when the app has been updated by checking
  * if the HTML entry point references different script files than when the app was loaded.
  */
 export function createVersionChecker({
+  shouldReload = shouldAutoReloadForCurrentRoute,
   pollingIntervalMs = 1 * 60 * 1000, // 1 minute
   onNewVersionAvailable,
 }: {
+  shouldReload?: () => boolean;
   pollingIntervalMs?: number;
   onNewVersionAvailable: () => void;
 }) {
@@ -57,7 +73,9 @@ export function createVersionChecker({
 
       if (hasNewVersion) {
         console.log("New version detected - script references have changed");
-        onNewVersionAvailable();
+        if (shouldReload()) {
+          onNewVersionAvailable();
+        }
       }
     } catch (error) {
       console.error("Failed to check for new version:", error);


### PR DESCRIPTION
## Summary
- preserve POS terminal capability/login-mode metadata through provisioning, sync, and local readiness
- harden offline cashier/register flows across login, POS settings, register guard, product entry, stock adjustment, and daily operations surfaces
- refresh Graphify and generated agent docs for the moved dirty set

## Validation
- bunx vitest run convex/cashControls/deposits.test.ts convex/operations/dailyOperations.test.ts convex/pos/application/sync/ingestLocalEvents.test.ts convex/pos/application/sync/projectLocalEvents.test.ts src/components/auth/Login/index.test.tsx src/components/cash-controls/RegisterSessionView.test.tsx src/components/operations/DailyOperationsView.test.tsx src/components/operations/StockAdjustmentWorkspace.test.tsx src/components/pos/CashierAuthDialog.test.tsx src/components/pos/ProductEntry.test.tsx src/components/pos/register/POSRegisterOpeningGuard.test.tsx src/components/pos/register/POSRegisterView.test.tsx src/components/pos/settings/POSSettingsView.test.tsx src/lib/pos/infrastructure/local/localPosReadiness.test.ts src/lib/pos/infrastructure/local/posLocalStore.test.ts src/lib/pos/presentation/register/catalogSearch.test.ts src/lib/pos/presentation/register/useRegisterViewModel.test.ts src/lib/stockOps/skuSearch.test.ts src/auth/convexAuthUrl.test.ts src/utils/versionChecker.test.ts --maxWorkers=1
- bun run pr:athena