### PR TITLE
Add POS remote monitoring trace parity

### DIFF
--- a/docs/plans/2026-06-05-001-feat-pos-remote-monitoring-traces-plan.html
+++ b/docs/plans/2026-06-05-001-feat-pos-remote-monitoring-traces-plan.html
@@ -1,0 +1,310 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Plan: Make POS Flow Traces Remote-Monitorable</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f7f7f5;
+        --panel: #ffffff;
+        --text: #151923;
+        --muted: #5d6575;
+        --border: #dadde3;
+        --accent: #3256a8;
+        --accent-soft: #eef3ff;
+        --warn: #7c4b00;
+        --warn-soft: #fff7e8;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.55;
+      }
+      main {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 48px 24px 72px;
+      }
+      header {
+        border-bottom: 1px solid var(--border);
+        margin-bottom: 28px;
+        padding-bottom: 24px;
+      }
+      h1 {
+        font-size: 38px;
+        line-height: 1.05;
+        margin: 8px 0 12px;
+        letter-spacing: 0;
+      }
+      h2 {
+        font-size: 22px;
+        margin: 32px 0 12px;
+        letter-spacing: 0;
+      }
+      h3 {
+        font-size: 16px;
+        margin: 24px 0 8px;
+        letter-spacing: 0;
+      }
+      p { margin: 8px 0 14px; }
+      ul { padding-left: 22px; }
+      li { margin: 6px 0; }
+      a { color: var(--accent); text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      .meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        color: var(--muted);
+        font-size: 13px;
+      }
+      .pill {
+        border: 1px solid var(--border);
+        border-radius: 999px;
+        background: var(--panel);
+        padding: 4px 10px;
+      }
+      .summary {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 20px;
+        margin: 20px 0;
+      }
+      .toc {
+        background: var(--accent-soft);
+        border: 1px solid #ccd8ff;
+        border-radius: 8px;
+        padding: 16px 18px;
+      }
+      .toc ol {
+        margin: 8px 0 0;
+        padding-left: 22px;
+        columns: 2;
+      }
+      section {
+        background: var(--panel);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 22px;
+        margin: 18px 0;
+      }
+      .callout {
+        background: var(--warn-soft);
+        border: 1px solid #f1d7a8;
+        border-radius: 8px;
+        color: var(--warn);
+        padding: 14px 16px;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 14px;
+      }
+      .unit {
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 16px;
+        background: #fbfbfc;
+      }
+      .unit h3 { margin-top: 0; }
+      table {
+        border-collapse: collapse;
+        width: 100%;
+        margin: 10px 0;
+      }
+      th, td {
+        border: 1px solid var(--border);
+        padding: 10px;
+        vertical-align: top;
+        text-align: left;
+      }
+      th { background: #f0f2f5; }
+      code, pre {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+      }
+      code {
+        background: #f0f2f5;
+        border-radius: 4px;
+        padding: 1px 4px;
+      }
+      pre {
+        overflow-x: auto;
+        background: #101827;
+        color: #edf2ff;
+        border-radius: 8px;
+        padding: 16px;
+      }
+      @media (max-width: 760px) {
+        main { padding: 28px 16px 48px; }
+        h1 { font-size: 30px; }
+        .grid { grid-template-columns: 1fr; }
+        .toc ol { columns: 1; }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div class="meta">
+          <span class="pill">feat</span>
+          <span class="pill">active</span>
+          <span class="pill">June 5, 2026</span>
+        </div>
+        <h1>Make POS Flow Traces Remote-Monitorable</h1>
+        <p class="summary">
+          This plan strengthens Athena POS evidence so remote operators can monitor store sales from cloud surfaces without needing the cashier browser. It aligns online commands and offline sync projection across POS session traces, register session traces, operational events, and Daily Operations timeline links.
+        </p>
+        <p>
+          Markdown source:
+          <a href="2026-06-05-001-feat-pos-remote-monitoring-traces-plan.md">docs/plans/2026-06-05-001-feat-pos-remote-monitoring-traces-plan.md</a>
+        </p>
+      </header>
+
+      <nav class="toc" aria-label="Plan contents">
+        <strong>Contents</strong>
+        <ol>
+          <li><a href="#requirements">Requirements</a></li>
+          <li><a href="#decisions">Key decisions</a></li>
+          <li><a href="#design">Design shape</a></li>
+          <li><a href="#units">Implementation units</a></li>
+          <li><a href="#risks">Risks</a></li>
+          <li><a href="#validation">Validation</a></li>
+        </ol>
+      </nav>
+
+      <section>
+        <h2>Problem Frame</h2>
+        <p>
+          POS is already local-first and can continue selling when cloud validation is unavailable, but the remote-monitoring story is uneven. Some online actions write rich workflow and operational evidence, some synced offline actions write partial evidence, and some trace identifiers are computed but not surfaced.
+        </p>
+        <div class="callout">
+          Planning assumption: Daily Operations remains a committed-milestone feed. Full in-progress cart reconstruction belongs in POS session traces and support surfaces.
+        </div>
+      </section>
+
+      <section id="requirements">
+        <h2>Requirements</h2>
+        <ul>
+          <li>Remote operators can monitor committed POS activity from cloud surfaces.</li>
+          <li>Online and synced offline sales produce comparable POS session trace, register session trace, and operational event evidence.</li>
+          <li>Register session traces distinguish sale total, cash delta, tender summary, and transaction identity.</li>
+          <li>Synced offline closeout and reopen/review outcomes produce operator-visible evidence equivalent to online cash-control actions.</li>
+          <li>Daily Operations links committed sale, register, review, and sync-conflict milestones to the relevant transaction, register, or trace surface.</li>
+          <li>POS register and Cash Controls expose trace links where trace ids exist.</li>
+        </ul>
+      </section>
+
+      <section id="decisions">
+        <h2>Key Technical Decisions</h2>
+        <ul>
+          <li>Reuse existing evidence rails instead of creating a new monitoring subsystem.</li>
+          <li>Keep Daily Operations milestone-oriented and keep detailed cart reconstruction in workflow traces.</li>
+          <li>Normalize sale evidence at server command and sync projection boundaries.</li>
+          <li>Enrich register-session trace inputs with transaction and tender context.</li>
+          <li>Write operational events during offline closeout projection instead of relying only on read-model synthesis.</li>
+          <li>Keep local-only cart events local unless implementation proves completed-sale payloads are insufficient.</li>
+        </ul>
+      </section>
+
+      <section id="design">
+        <h2>Design Shape</h2>
+        <pre><code>POS register view
+  -> local POS event log
+  -> online POS commands
+
+local POS event log -> local sync projection
+online POS commands -> POS trace + register trace + operational events
+local sync projection -> POS trace + register trace + operational events
+
+operational events -> Daily Operations timeline
+register traces -> Cash Controls register detail
+POS traces -> POS transaction and support trace surfaces
+local backlog/conflicts -> Terminal Health diagnostics</code></pre>
+      </section>
+
+      <section id="units">
+        <h2>Implementation Units</h2>
+        <div class="grid">
+          <article class="unit">
+            <h3>U1. Define POS Monitoring Evidence Contract</h3>
+            <p>Extend trace and event input shapes so sale total, cash delta, tender summary, payment count, transaction identity, actor, and sync origin can be represented consistently.</p>
+            <p><strong>Primary files:</strong> <code>registerSessionTracing.ts</code>, <code>posSessionTracing.ts</code>, <code>projectLocalEvents.ts</code>, <code>sync/types.ts</code>.</p>
+          </article>
+          <article class="unit">
+            <h3>U2. Align Online Sale Completion Evidence</h3>
+            <p>Thread transaction context into online register sale traces and ensure completed online sales produce monitorable operational evidence.</p>
+            <p><strong>Primary files:</strong> <code>completeTransaction.ts</code>, <code>registerSessions.ts</code>.</p>
+          </article>
+          <article class="unit">
+            <h3>U3. Align Offline Sync Projection Evidence</h3>
+            <p>Make accepted offline sale and closeout projection emit POS traces, register traces, and operational events equivalent to online actions.</p>
+            <p><strong>Primary files:</strong> <code>projectLocalEvents.ts</code>, <code>localSyncRepository.ts</code>.</p>
+          </article>
+          <article class="unit">
+            <h3>U4. Surface Remote Monitoring Links</h3>
+            <p>Render transaction, register, and trace links across Daily Operations, POS register controls, Cash Controls, and transaction surfaces.</p>
+            <p><strong>Primary files:</strong> <code>dailyOperations.ts</code>, <code>DailyOperationsView.tsx</code>, <code>SessionManager.tsx</code>.</p>
+          </article>
+          <article class="unit">
+            <h3>U5. Make Review Evidence Monitorable</h3>
+            <p>Ensure sync conflicts and manager-review outcomes are visible through operational events and linked review surfaces.</p>
+            <p><strong>Primary files:</strong> <code>projectLocalEvents.ts</code>, <code>deposits.ts</code>, <code>closeouts.ts</code>, <code>syncStatusPresentation.ts</code>.</p>
+          </article>
+          <article class="unit">
+            <h3>U6. Validation, Documentation, Delivery Readiness</h3>
+            <p>Run focused parity tests, update durable solution documentation, and refresh generated artifacts when Convex changes require it.</p>
+            <p><strong>Primary files:</strong> focused Convex tests, React tests, and a new <code>docs/solutions</code> note.</p>
+          </article>
+        </div>
+      </section>
+
+      <section id="risks">
+        <h2>Risks</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Risk</th>
+              <th>Mitigation</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Trace noise overwhelms Daily Operations.</td>
+              <td>Limit Daily Operations to committed milestones and review states.</td>
+            </tr>
+            <tr>
+              <td>Online and offline evidence drift again.</td>
+              <td>Centralize evidence shaping where practical and add parity tests.</td>
+            </tr>
+            <tr>
+              <td>Sync retries duplicate evidence.</td>
+              <td>Guard event writes with local event ids, mappings, or projection idempotency checks.</td>
+            </tr>
+            <tr>
+              <td>Non-cash drawer trace copy becomes misleading.</td>
+              <td>Separate sale total from cash delta and test non-cash copy explicitly.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="validation">
+        <h2>Validation Strategy</h2>
+        <ul>
+          <li>Projection tests for offline sale, closeout, retry, and review evidence.</li>
+          <li>Online command tests for sale completion trace and operational event parity.</li>
+          <li>Register trace tests for cash and non-cash sale copy.</li>
+          <li>Daily Operations read-model and React tests for transaction/register/trace links.</li>
+          <li>POS register tests for active sale trace link rendering.</li>
+          <li>Cash Controls tests for synced closeout and review trace visibility.</li>
+        </ul>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/plans/2026-06-05-001-feat-pos-remote-monitoring-traces-plan.md
+++ b/docs/plans/2026-06-05-001-feat-pos-remote-monitoring-traces-plan.md
@@ -1,0 +1,519 @@
+---
+title: feat: Make POS Flow Traces Remote-Monitorable
+type: feat
+status: active
+date: 2026-06-05
+---
+
+# feat: Make POS Flow Traces Remote-Monitorable
+
+## Summary
+
+This plan makes Athena POS evidence reliable enough for a remote operator to monitor store sales from cloud surfaces without needing access to the cashier browser. It strengthens the existing POS session traces, register session traces, operational events, and Daily Operations timeline so online and offline checkout leave comparable server-side evidence after sync.
+
+---
+
+## Problem Frame
+
+POS is already local-first and can continue selling when cloud validation is unavailable, but the remote-monitoring story is uneven. Some online actions write rich workflow and operational evidence, some synced offline actions write only partial evidence, and the active register UI computes trace links that are not surfaced to operators.
+
+Remote operators need to answer what happened, who did it, which register and cashier were involved, what sale was completed, how it was paid, what cash impact it had, and whether any synced local history still needs review.
+
+---
+
+## Assumptions
+
+*This plan was authored from the user's approved design direction in this thread without a dedicated brainstorm document for POS remote-monitoring traces. The items below are explicit planning assumptions for review before implementation.*
+
+- Daily Operations should remain a committed-milestone feed, not a raw cart mutation log.
+- Full in-progress sale reconstruction belongs in POS session workflow traces and support views.
+- Register session traces should represent drawer lifecycle and sale impact, including non-cash sale references, without pretending every sale is a cash movement.
+- Offline projection should converge to the same operator-facing evidence family as online commands whenever cloud validation accepts the event.
+
+---
+
+## Requirements
+
+- R1. Remote operators can monitor committed POS activity from cloud surfaces without inspecting IndexedDB or the local browser.
+- R2. Online and synced offline sales produce comparable POS session trace, register session trace, and operational event evidence.
+- R3. Register session traces distinguish sale total, cash delta, tender summary, and transaction identity so non-cash sales are not represented only as zero-value cash movements.
+- R4. Synced offline register closeout and reopen/review outcomes produce operator-visible evidence equivalent to online cash-control actions.
+- R5. Daily Operations surfaces committed sale, register open, register close, reopen, review, and sync-conflict milestones with direct links to relevant transaction, register, or trace surfaces.
+- R6. POS register and Cash Controls surfaces expose available trace links for active sales, held sales, completed transactions, and register sessions.
+- R7. The implementation preserves POS local-first operation: local events remain the cashier durability layer, and cloud evidence is produced by online commands or sync projection after server acceptance.
+- R8. Tests cover the parity contract across online sale completion, offline sale projection, offline closeout projection, non-cash sale trace copy, timeline linking, and active trace-link rendering.
+
+---
+
+## Scope Boundaries
+
+- This plan does not add a new monitoring product or dashboard outside existing Daily Operations, Cash Controls, POS transaction, POS register, terminal health, and workflow trace surfaces.
+- This plan does not make non-POS Athena routes offline-first.
+- This plan does not change the POS payment authorization model, payment-provider integrations, or offline payment confirmation policy.
+- This plan does not trace every cashier keystroke or search query.
+- This plan does not require every local-only cart event to upload as an independent sync event.
+- This plan does not resolve every manager-review policy question for offline reopen. It ensures any retained review path is visible and traceable.
+
+### Deferred to Follow-Up Work
+
+- A dedicated remote live-operations dashboard: defer until Daily Operations and trace parity prove the right evidence shape.
+- Cross-terminal real-time offline coordination: defer because POS local-first sync intentionally reconciles after connectivity returns.
+- Historical backfill of workflow trace events for already-projected sales: defer unless operations needs legacy trace completeness.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts` records online POS session lifecycle traces for item add/update/remove and session state transitions.
+- `packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts` defines POS session trace stages and operator-readable trace event messages.
+- `packages/athena-webapp/convex/operations/registerSessionTracing.ts` defines register session trace stages for drawer lifecycle, sale/void cash movements, deposits, closeout, approvals, and item adjustments.
+- `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts` records online register-session sale impact before the final transaction evidence is fully threaded into the drawer trace.
+- `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts` projects offline register open, sale completion, sale clear, register close, and register reopen events into cloud records and trace surfaces.
+- `packages/athena-webapp/convex/pos/application/sync/types.ts` currently narrows sync projection trace input so offline register sale trace cannot carry transaction identity or tender detail.
+- `packages/athena-webapp/convex/operations/dailyOperations.ts` reads `operationalEvent` rows and compensates for closeout records that have no operational event.
+- `packages/athena-webapp/src/components/operations/DailyOperationsView.tsx` renders store-day timeline events and inline links.
+- `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts` already computes `activeSessionTraceId`.
+- `packages/athena-webapp/src/components/pos/SessionManager.tsx` does not render the active sale trace link, while `packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx` renders held sale trace links.
+- `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx` exposes register support evidence and register trace links.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md` says local events are the durable field POS record, then accepted events project into cash controls, inventory, transactions, payments, and workflow/audit surfaces.
+- `docs/solutions/architecture/athena-pos-quick-add-operational-event-tracing-2026-05-30.md` reserves workflow traces for lifecycle domains that already own traces and keeps operational audit rows for operator-visible milestones.
+- `docs/solutions/logic-errors/athena-offline-pos-sale-operations-timeline-links-2026-06-05.md` keeps offline sale timeline copy server-owned and links Daily Operations timeline events to projected POS transactions.
+- `docs/solutions/logic-errors/athena-pos-register-sync-and-catalog-recovery-2026-05-26.md` warns against adding a second POS closeout status model outside the shared local-sync and cash-control sources.
+- `docs/solutions/architecture/athena-pos-terminal-health-visibility-2026-05-20.md` keeps terminal health as support telemetry, not the primary source of needs-review copy.
+
+### External References
+
+- External research skipped. The repo has direct, current patterns for POS workflow traces, operational events, local sync projection, Daily Operations timeline links, and Cash Controls evidence.
+
+---
+
+## Key Technical Decisions
+
+- Use existing evidence rails instead of creating a monitoring subsystem: POS session traces, register session traces, operational events, and existing views already model the required lifecycle boundaries.
+- Keep Daily Operations milestone-oriented: show committed sales, register open/close/reopen, sync projection, and review states, while leaving in-progress cart detail to workflow traces and support surfaces.
+- Normalize sale evidence at server boundaries: online commands and offline projection should call shared evidence builders or shared data-shaping helpers so copy, metadata, and links do not drift.
+- Enrich register-session trace inputs: carry transaction id, transaction number, sale total, cash delta, payment methods, and payment count separately.
+- Project offline closeout into an operational event: do not rely on Daily Operations to synthesize closeout rows when projection can write the same operator evidence as online closeout.
+- Keep local-only cart events local unless they are needed for cloud trace reconstruction: the sync contract may continue folding line and payment details into `sale_completed`, but projection should use those details to produce a useful POS session trace.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should Daily Operations include in-progress cart mutations? No. It should show committed business milestones and review states. Detailed in-progress reconstruction belongs in POS workflow/support traces.
+- Should offline projection use a separate audit model? No. It should reuse existing workflow trace and operational event rails.
+- Should trace parity require changing POS payment authorization? No. It only changes evidence and monitoring metadata.
+
+### Deferred to Implementation
+
+- Exact helper boundaries for shared sale/register evidence builders: defer until implementation because the smallest useful extraction depends on current test seams.
+- Exact wording for non-cash register trace messages: defer to implementation with `docs/product-copy-tone.md` guidance and tests asserting the operational meaning.
+- Whether offline reopen can auto-project in all cases: defer policy-sensitive cases to implementation, but every retained review outcome must produce visible operational evidence.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+  POSUI["POS register view"]
+  LocalLog["Local POS event log"]
+  OnlineCommands["Online POS commands"]
+  SyncProjection["Local sync projection"]
+  PosTrace["POS session workflow trace"]
+  RegisterTrace["Register session workflow trace"]
+  OpsEvents["Operational events"]
+  DailyOps["Daily Operations timeline"]
+  CashControls["Cash Controls register detail"]
+  TransactionView["POS transaction detail"]
+  TerminalHealth["Terminal Health diagnostics"]
+
+  POSUI --> LocalLog
+  POSUI --> OnlineCommands
+  LocalLog --> SyncProjection
+  OnlineCommands --> PosTrace
+  OnlineCommands --> RegisterTrace
+  OnlineCommands --> OpsEvents
+  SyncProjection --> PosTrace
+  SyncProjection --> RegisterTrace
+  SyncProjection --> OpsEvents
+  OpsEvents --> DailyOps
+  RegisterTrace --> CashControls
+  PosTrace --> TransactionView
+  LocalLog --> TerminalHealth
+```
+
+Remote monitoring should read server evidence after online command completion or sync projection. Terminal Health can expose local backlog and conflict diagnostics, but it should not be the primary sales monitoring feed.
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1["U1 Evidence contract"]
+  U2["U2 Online sale/register parity"]
+  U3["U3 Offline projection parity"]
+  U4["U4 Monitoring surfaces"]
+  U5["U5 Sync review evidence"]
+  U6["U6 Validation and docs"]
+
+  U1 --> U2
+  U1 --> U3
+  U2 --> U4
+  U3 --> U4
+  U3 --> U5
+  U4 --> U6
+  U5 --> U6
+```
+
+- U1. **Define POS Monitoring Evidence Contract**
+
+**Goal:** Establish a shared server-side evidence shape for sale and register milestones so online commands and sync projection can emit comparable trace details and operational event metadata.
+
+**Requirements:** R1, R2, R3, R5, R7
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/registerSessionTracing.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/types.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Test: `packages/athena-webapp/convex/operations/registerSessionTracing.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts`
+
+**Approach:**
+- Extend register-session trace inputs to represent sale total, cash delta, tender summary, payment count, transaction id, transaction number, and sync origin as separate values.
+- Keep current trace stages where possible. Prefer enriching `sale_recorded` before introducing new stages.
+- Add a small shared evidence builder or value-shaping helper only if it prevents copy/metadata drift between online command and sync projection paths.
+- Keep operational event metadata compact and linkable: local event id, transaction id/number, register session id, cashier/staff id, terminal/register identifiers, line count, total, payment method labels, cash delta, and sync origin.
+
+**Execution note:** Implement test-first. Start with failing trace-builder and sync-projection tests that prove the desired evidence fields exist.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts` sale-projected message and metadata construction.
+- `packages/athena-webapp/convex/operations/registerSessionTracing.ts` trace event `details` and `subjectRefs` construction.
+- `packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts` POS session trace event builder.
+
+**Test scenarios:**
+- Happy path: register sale trace with a cash payment includes transaction identity, total, cash delta, payment method, payment count, and actor staff id.
+- Happy path: register sale trace with card or mobile money includes transaction identity and total while cash delta remains zero or absent with non-cash copy.
+- Edge case: malformed or unknown payment method labels are normalized for operator copy without surfacing raw backend enum noise.
+- Integration: sync projection repository accepts enriched register trace input without losing existing opened/closed trace behavior.
+
+**Verification:**
+- Trace event details and subject refs can link a register-session sale event back to the POS transaction.
+- Non-cash sale trace copy reads as a sale recorded on the drawer, not as an unexplained zero cash movement.
+
+---
+
+- U2. **Align Online Sale Completion Evidence**
+
+**Goal:** Make online completed sales emit POS session trace, register session trace, and operational event evidence that remote operators can use consistently.
+
+**Requirements:** R1, R2, R3, R5, R8
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts`
+- Modify: `packages/athena-webapp/convex/operations/registerSessions.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts`
+- Test: `packages/athena-webapp/convex/pos/application/completeTransaction.test.ts`
+- Test: `packages/athena-webapp/convex/cashControls/registerSessions.test.ts`
+- Test: `packages/athena-webapp/convex/operations/registerSessions.trace.test.ts`
+
+**Approach:**
+- Thread transaction id and transaction number into the online register-session sale trace after transaction creation.
+- Preserve expected-cash updates for cash payments while adding trace evidence for non-cash completed sales.
+- Ensure online completed sales either already create a suitable operational event or are routed through the shared evidence builder to create one with the same fields as offline projected sales.
+- Keep void and adjustment behavior compatible with existing approval and cash settlement traces.
+
+**Execution note:** Use characterization-first coverage around current online completion trace behavior, then update expectations for richer evidence.
+
+**Patterns to follow:**
+- `recordRegisterSessionSale` in `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts`.
+- `recordRegisterSessionTransaction` in `packages/athena-webapp/convex/operations/registerSessions.ts`.
+- Existing transaction void operational event in `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts`.
+
+**Test scenarios:**
+- Happy path: online cash sale completion records register expected cash and emits a register trace with transaction number and cash delta.
+- Happy path: online card/mobile-money sale completion emits a register trace that names the transaction and tender without increasing expected cash.
+- Happy path: online completed sale emits or preserves an operational event that Daily Operations can link to the transaction.
+- Edge case: split tender sale records both payment count and distinct payment method labels.
+- Error path: failed payment allocation or transaction creation does not leave orphan trace or operational event rows.
+
+**Verification:**
+- Online sales become monitorable from register trace and Daily Operations without requiring transaction-detail reconstruction.
+- Existing cash-control invariants and idempotency behavior remain unchanged.
+
+---
+
+- U3. **Align Offline Sync Projection Evidence**
+
+**Goal:** Make accepted offline history project into the same evidence family as online commands, including closeout and retained reopen review evidence.
+
+**Requirements:** R2, R3, R4, R5, R7, R8
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/types.ts`
+- Modify: `packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts`
+- Test: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts`
+
+**Approach:**
+- Enrich offline `sale_completed` register trace calls with transaction id, transaction number, total, cash delta, tender summary, and sync origin.
+- Reconstruct POS session trace details from `sale_completed` payload lines and payments enough to support remote support review after projection.
+- Add an operational event for projected `register_closed` that mirrors online `register_session_closed` evidence.
+- For `register_reopened`, either project a traceable reopen when policy permits or create an explicit operational review event when policy still requires manager review.
+- Keep local event upload semantics stable. Do not make local-only cart events independently uploadable unless implementation proves the completed-sale payload is insufficient.
+
+**Execution note:** Implement test-first from sync projection tests because the desired parity can be asserted without browser runtime.
+
+**Patterns to follow:**
+- `recordSaleProjectedEvent` and `recordSaleWorkflowEvidence` in `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`.
+- Online closeout operational event in `packages/athena-webapp/convex/cashControls/closeouts.ts`.
+- Daily Operations closeout record compensation test in `packages/athena-webapp/convex/operations/dailyOperations.test.ts`.
+
+**Test scenarios:**
+- Happy path: projected offline cash sale creates POS session trace, register session trace, and operational event with matching transaction identifiers.
+- Happy path: projected offline non-cash sale creates register trace evidence that names tender and transaction while cash delta stays zero.
+- Happy path: projected zero-variance offline closeout creates a `register_session_closed` or equivalent operational event and register trace.
+- Happy path: projected variance-approved closeout records counted cash, expected cash, variance, staff, and local event id in operational metadata.
+- Edge case: duplicate sync retry returns idempotent mappings without duplicating operational events or trace events.
+- Error path: closeout that still requires review creates a review-visible conflict/event without patching the register session.
+- Integration: projected sale after accepted register open links sale, transaction, register session, POS session trace, and Daily Operations timeline.
+
+**Verification:**
+- Offline open, sale, closeout, and reopen/review outcomes are monitorable after sync from the same cloud surfaces as online work.
+- Sync retries remain idempotent.
+
+---
+
+- U4. **Surface Remote Monitoring Links and Timeline Context**
+
+**Goal:** Make the enriched evidence reachable from Daily Operations, Cash Controls, POS transaction detail, and the POS register controls.
+
+**Requirements:** R1, R5, R6, R8
+
+**Dependencies:** U2, U3
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/operations/dailyOperations.ts`
+- Modify: `packages/athena-webapp/src/components/operations/DailyOperationsView.tsx`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/registerUiState.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`
+- Modify: `packages/athena-webapp/src/components/pos/SessionManager.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/session/HeldSessionsList.tsx`
+- Modify: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`
+- Test: `packages/athena-webapp/convex/operations/dailyOperations.test.ts`
+- Test: `packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/SessionManager.test.tsx`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- Test: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx`
+
+**Approach:**
+- Extend Daily Operations read model links so sale, register, closeout, and review events can navigate to transaction, register session, or workflow trace surfaces.
+- Render active sale trace link in `SessionManager` using `activeSessionTraceId`, matching the held-session trace link pattern without crowding checkout controls.
+- Ensure Cash Controls register detail displays support trace context for projected offline closeout and projected/reviewed reopen outcomes.
+- Keep operator copy calm and operational per `docs/product-copy-tone.md`.
+
+**Execution note:** Use test-first React coverage for active trace link rendering and Daily Operations link selection.
+
+**Patterns to follow:**
+- Existing inline transaction/product timeline link rendering in `DailyOperationsView`.
+- `WorkflowTraceRouteLink` usage in `HeldSessionsList` and Cash Controls.
+- `RegisterSessionView` support evidence section.
+
+**Test scenarios:**
+- Happy path: Daily Operations sale event renders an inline transaction link and keeps readable sale/tender copy.
+- Happy path: Daily Operations closeout event renders a register link and closeout summary.
+- Happy path: POS register active session with `activeSessionTraceId` renders a trace link; active session without trace id omits it.
+- Edge case: held sessions continue rendering trace links without duplicate links when active session also has a trace.
+- Edge case: timeline event with transaction and register links uses the most relevant link for that event type.
+- Integration: Cash Controls register detail exposes support trace link for a synced offline closeout register session.
+
+**Verification:**
+- A remote operator can click from Daily Operations into the relevant transaction, register, or trace without guessing identifiers.
+- POS register trace links add support visibility without interrupting cashier flow.
+
+---
+
+- U5. **Make Review and Conflict Evidence Monitorable**
+
+**Goal:** Ensure local sync conflicts and manager-review outcomes are visible as operational monitoring events instead of only local sync status badges.
+
+**Requirements:** R1, R4, R5, R7, R8
+
+**Dependencies:** U3
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/deposits.ts`
+- Modify: `packages/athena-webapp/convex/cashControls/closeouts.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts`
+- Test: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts`
+- Test: `packages/athena-webapp/convex/cashControls/deposits.test.ts`
+- Test: `packages/athena-webapp/convex/cashControls/closeouts.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.test.ts`
+
+**Approach:**
+- When projection cannot apply accepted local history without review, write or ensure an operational event that is visible to Daily Operations and Cash Controls.
+- Preserve completed local sales and local closeout evidence while marking the review state.
+- When reviewed synced closeout activity is applied, ensure the resulting operational event points back to the reviewed local event and register session.
+- Keep sync-status presentation consistent with operational events, not as a competing source of truth.
+
+**Execution note:** Start with tests around existing review paths so implementation does not accidentally hide or duplicate manager-review work.
+
+**Patterns to follow:**
+- `syncStatusPresentation.ts` review copy for register closeout variance.
+- `deposits.ts` reviewed synced closeout application events.
+- `closeouts.ts` approval/rejection operational events and trace stages.
+
+**Test scenarios:**
+- Happy path: local sync closeout variance conflict creates an operator-visible review event with counted cash, expected cash, variance, staff, and local event id.
+- Happy path: reviewed synced closeout application emits one operational event and closes the review loop.
+- Edge case: repeated sync conflict detection does not create duplicate review events.
+- Error path: rejected closeout/reopen review preserves the local event evidence and marks the trace or operational event as requiring correction.
+- Integration: Daily Operations attention/timeline surfaces can show the review state and link to Cash Controls.
+
+**Verification:**
+- Remote operators can see why synced local history needs review and where to resolve it.
+- Review copy stays aligned between POS status, Cash Controls, and Daily Operations.
+
+---
+
+- U6. **Validation, Documentation, and Delivery Readiness**
+
+**Goal:** Prove the cross-surface evidence contract and capture durable learning for future POS trace work.
+
+**Requirements:** R8
+
+**Dependencies:** U4, U5
+
+**Files:**
+- Create: `docs/solutions/logic-errors/athena-pos-remote-monitoring-trace-parity-2026-06-05.md`
+- Modify: `docs/plans/2026-06-05-001-feat-pos-remote-monitoring-traces-plan.md`
+- Modify: `docs/plans/2026-06-05-001-feat-pos-remote-monitoring-traces-plan.html`
+- Test: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts`
+- Test: `packages/athena-webapp/convex/operations/dailyOperations.test.ts`
+- Test: `packages/athena-webapp/convex/operations/registerSessions.trace.test.ts`
+- Test: `packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/SessionManager.test.tsx`
+- Test: `packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx`
+
+**Approach:**
+- Add a solution note after implementation explaining the final evidence boundary and parity pattern.
+- Keep the validation map current if this work introduces or changes registered POS local-sync or trace boundaries.
+- Run graphify rebuild after code changes because AGENTS requires it for code modifications.
+- Review generated Convex API artifacts if Convex function/type changes require regeneration.
+
+**Execution note:** Sensor-only for docs, but feature tests from prior units must be green before this unit is complete.
+
+**Patterns to follow:**
+- Existing solution docs under `docs/solutions/architecture/` and `docs/solutions/logic-errors/`.
+- Existing plan HTML artifacts in `docs/plans/`.
+
+**Test scenarios:**
+- Integration: focused Convex tests prove online/offline trace parity and Daily Operations timeline links.
+- Integration: focused React tests prove remote-monitoring links render without breaking POS checkout controls.
+- Regression: existing POS local-first tests still pass for local sale continuation, pending sync, and review presentation.
+
+**Verification:**
+- The implementation has a durable learning note, focused tests, and generated artifacts in the expected state.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** POS register view writes local events, online POS commands write cloud state directly, local sync projection writes cloud state later, and both paths must converge through POS session traces, register session traces, and operational events.
+- **Error propagation:** Trace and operational event writes should remain best-effort where existing patterns are best-effort, but missing primary business writes must still fail through existing command/projection behavior.
+- **State lifecycle risks:** Duplicate sync retries can duplicate evidence unless idempotency keys, local event ids, or existing mappings guard trace/event creation.
+- **API surface parity:** Sync projection repository types, online command helpers, and trace recorders must carry the same sale evidence shape.
+- **Integration coverage:** Unit tests alone are insufficient. The plan needs projection tests, command tests, read-model tests, and component tests that cover cross-layer evidence flow.
+- **Unchanged invariants:** Local events remain the first durable cashier record; POS does not block sales for remote monitoring; review/reconciliation preserves completed local history.
+
+```mermaid
+flowchart TB
+  LocalAuthority["Local cashier authority"]
+  CloudProjection["Cloud projection"]
+  WorkflowEvidence["Workflow traces"]
+  OperationalEvidence["Operational events"]
+  RemoteSurfaces["Remote operator surfaces"]
+  ReviewWork["Review/reconciliation work"]
+
+  LocalAuthority --> CloudProjection
+  CloudProjection --> WorkflowEvidence
+  CloudProjection --> OperationalEvidence
+  WorkflowEvidence --> RemoteSurfaces
+  OperationalEvidence --> RemoteSurfaces
+  CloudProjection --> ReviewWork
+  ReviewWork --> RemoteSurfaces
+```
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Trace noise overwhelms Daily Operations | Keep Daily Operations limited to committed milestones and review states; leave cart mutation details in workflow traces. |
+| Online and offline paths drift again | Centralize evidence shaping where practical and add parity tests for both paths. |
+| Sync retries duplicate operational events | Use local event ids, mappings, or existing projection idempotency checks before writing event rows. |
+| Non-cash register trace copy becomes misleading | Separate sale total from cash delta and assert non-cash copy in tests. |
+| Review policy for offline reopen is broader than this plan | Keep policy-specific reopen auto-projection decisions deferred, but require every outcome to be operator-visible. |
+| Convex generated API drift | Regenerate and inspect generated artifacts if function/type changes require it. |
+
+---
+
+## Documentation / Operational Notes
+
+- Update `docs/solutions/` after implementation with the final trace parity boundary and validation lessons.
+- Use `docs/product-copy-tone.md` for all operator-facing timeline and trace copy.
+- Treat this as a POS operational-observability change, not a checkout behavior change.
+- Production rollout should be safe for active checkout because it does not change local sale authority or payment semantics, but deploy validation should include POS register and Daily Operations smoke coverage.
+
+---
+
+## Alternative Approaches Considered
+
+- Add a new remote monitoring dashboard first: rejected for this slice because evidence quality is the blocker. A dashboard would inherit the same gaps.
+- Upload every local cart event independently: rejected for now because completed sale payloads already carry line/payment evidence and raw cart-event feeds would add sync noise.
+- Keep closeout timeline synthesis only in Daily Operations: rejected because projection can write durable operational evidence at the server boundary, which avoids one-off read-model compensation.
+
+---
+
+## Success Metrics
+
+- A remote operator can answer who opened a register, who completed each sale, which register and terminal were involved, what receipt/total/tender were used, and what cash impact the sale had.
+- Online and offline accepted sales have comparable transaction, POS session trace, register session trace, and operational event evidence.
+- Synced offline closeout and review outcomes appear in Daily Operations and Cash Controls without synthetic-only timeline logic.
+- Active and held sale trace links are reachable from POS register controls when trace ids exist.
+
+---
+
+## Sources & References
+
+- Related requirements: `docs/brainstorms/2026-06-04-pos-offline-app-session-sales-continuity-requirements.md`
+- Related requirements: `docs/brainstorms/2026-05-13-pos-local-first-register-requirements.md`
+- Related requirements: `docs/brainstorms/2026-05-07-daily-operations-lifecycle-requirements.md`
+- Related solution: `docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md`
+- Related solution: `docs/solutions/architecture/athena-pos-quick-add-operational-event-tracing-2026-05-30.md`
+- Related solution: `docs/solutions/logic-errors/athena-offline-pos-sale-operations-timeline-links-2026-06-05.md`
+- Related code: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Related code: `packages/athena-webapp/convex/operations/registerSessionTracing.ts`
+- Related code: `packages/athena-webapp/convex/pos/application/commands/posSessionTracing.ts`
+- Related code: `packages/athena-webapp/convex/operations/dailyOperations.ts`

--- a/docs/solutions/logic-errors/athena-pos-remote-monitoring-trace-parity-2026-06-05.md
+++ b/docs/solutions/logic-errors/athena-pos-remote-monitoring-trace-parity-2026-06-05.md
@@ -1,0 +1,62 @@
+---
+title: Athena POS Remote Monitoring Trace Parity
+date: 2026-06-05
+category: logic-errors
+module: athena-webapp
+component: pos-monitoring
+problem_type: pos_trace_parity
+resolution_type: sale_and_closeout_evidence_contract
+severity: medium
+tags:
+  - pos
+  - workflow-traces
+  - operational-events
+  - local-sync
+  - monitoring
+---
+
+# Athena POS Remote Monitoring Trace Parity
+
+## Problem
+
+Remote POS monitoring breaks down when sale completion, offline sync projection,
+and register closeout evidence are not emitted through the same operator-visible
+surfaces. Cash-only traces can make non-cash sales look invisible, and register
+closeouts projected from local history can update drawer state without leaving a
+Daily Operations event to explain what happened.
+
+## Boundary
+
+Use workflow traces for lifecycle evidence owned by a POS session or register
+session. Use operational events for durable monitoring rows that should appear in
+Daily Operations and other operator review surfaces. A completed sale may need
+both: a register-session workflow trace for drawer/session lifecycle context and
+a `pos_transaction_completed` operational event for the transaction timeline.
+
+## Solution
+
+Completed POS sales should record sale evidence even when the cash drawer delta
+is zero. Pass the sale total, payment count, normalized payment-method labels,
+transaction id, transaction number, and sync origin into the register-session
+trace. Keep `amount` and `cashDelta` as the cash impact, not the sale total, so
+card-only and mixed-tender sales are monitorable without inflating expected cash.
+
+Online completion should also emit a `pos_transaction_completed` operational
+event with the transaction as the subject, the register session as context, and
+payment metadata. Daily Operations can then route the event to the transaction
+first while still showing register context.
+
+Offline sync projection should mirror the same sale evidence contract when it
+replays local `sale_completed` history. For offline register closeout, update the
+register session and record the closeout trace, then create a
+`register_session_closed` operational event using the synced occurrence time.
+That prevents closeout history from depending only on synthesized register
+session rows.
+
+## Prevention
+
+When adding POS sale or register-session monitoring, test online completion and
+local-sync projection separately. Include at least one non-cash sale case where
+`saleTotal` is non-zero and `cashDelta` is zero. For closeouts, assert both the
+register-session trace and the operational event so Daily Operations has a
+durable row to display.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6182 nodes · 6666 edges · 1762 communities detected
+- 6186 nodes · 6678 edges · 1762 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1794,7 +1794,7 @@
   packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts → packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
 - `completeTransaction()` --calls--> `calculateTotalPaid()`  [EXTRACTED]
   packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts → packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
-- `completeTransaction()` --calls--> `calculateCanonicalTransactionTotals()`  [EXTRACTED]
+- `completeTransaction()` --calls--> `recordCompletedSaleOperationalEvent()`  [EXTRACTED]
   packages/athena-webapp/src/lib/pos/application/useCases/completeTransaction.ts → packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
 
 ## Communities
@@ -1845,7 +1845,7 @@ Nodes (12): createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), norm
 
 ### Community 11 - "Community 11"
 Cohesion: 0.11
-Nodes (30): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildRegisterCloseoutTimelineEvents(), buildWeekMetricForDate(), buildWeekMetrics(), compareDailyOperationsTimelineEvents(), compareTimelineEvents() (+22 more)
+Nodes (32): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildRegisterCloseoutTimelineEvents(), buildWeekMetricForDate(), buildWeekMetrics(), compareDailyOperationsTimelineEvents(), compareTimelineEvents() (+24 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.11
@@ -1860,28 +1860,28 @@ Cohesion: 0.12
 Nodes (31): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+23 more)
 
 ### Community 15 - "Community 15"
+Cohesion: 0.13
+Nodes (27): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+19 more)
+
+### Community 16 - "Community 16"
 Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
-### Community 16 - "Community 16"
+### Community 17 - "Community 17"
 Cohesion: 0.12
 Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
 
-### Community 17 - "Community 17"
+### Community 18 - "Community 18"
 Cohesion: 0.18
 Nodes (30): asRecord(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale(), getPhase() (+22 more)
 
-### Community 18 - "Community 18"
+### Community 19 - "Community 19"
 Cohesion: 0.15
 Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
 
-### Community 19 - "Community 19"
+### Community 20 - "Community 20"
 Cohesion: 0.14
 Nodes (24): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+16 more)
-
-### Community 20 - "Community 20"
-Cohesion: 0.15
-Nodes (24): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+16 more)
 
 ### Community 21 - "Community 21"
 Cohesion: 0.2
@@ -2277,15 +2277,15 @@ Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalize
 
 ### Community 119 - "Community 119"
 Cohesion: 0.39
-Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 120 - "Community 120"
-Cohesion: 0.42
-Nodes (7): getRegisterCatalogPrice(), listRegisterCatalog(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
+Cohesion: 0.39
+Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
 ### Community 121 - "Community 121"
-Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Cohesion: 0.42
+Nodes (7): getRegisterCatalogPrice(), listRegisterCatalog(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
 
 ### Community 122 - "Community 122"
 Cohesion: 0.5
@@ -2544,16 +2544,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 186 - "Community 186"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 187 - "Community 187"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 188 - "Community 188"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
 
 ### Community 189 - "Community 189"
 Cohesion: 0.43
@@ -2688,8 +2688,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 222 - "Community 222"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 223 - "Community 223"
 Cohesion: 0.33
@@ -2708,64 +2708,64 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 227 - "Community 227"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 228 - "Community 228"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
+
+### Community 228 - "Community 228"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 229 - "Community 229"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 230 - "Community 230"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 231 - "Community 231"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 232 - "Community 232"
+### Community 231 - "Community 231"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 233 - "Community 233"
+### Community 232 - "Community 232"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 233 - "Community 233"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 234 - "Community 234"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 235 - "Community 235"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 236 - "Community 236"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 237 - "Community 237"
+### Community 236 - "Community 236"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 238 - "Community 238"
+### Community 237 - "Community 237"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 239 - "Community 239"
+### Community 238 - "Community 238"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 240 - "Community 240"
+### Community 239 - "Community 239"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 241 - "Community 241"
+### Community 240 - "Community 240"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 241 - "Community 241"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 242 - "Community 242"
 Cohesion: 0.53
@@ -2988,36 +2988,36 @@ Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 297 - "Community 297"
-Cohesion: 0.5
-Nodes (3): createVersionChecker(), shouldAutoReloadForCurrentRoute(), shouldAutoReloadForPath()
-
-### Community 298 - "Community 298"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 299 - "Community 299"
+### Community 298 - "Community 298"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 300 - "Community 300"
+### Community 299 - "Community 299"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 301 - "Community 301"
+### Community 300 - "Community 300"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 301 - "Community 301"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 302 - "Community 302"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 303 - "Community 303"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 304 - "Community 304"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+
+### Community 304 - "Community 304"
+Cohesion: 0.5
+Nodes (3): createVersionChecker(), shouldAutoReloadForCurrentRoute(), shouldAutoReloadForPath()
 
 ### Community 305 - "Community 305"
 Cohesion: 0.4

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1834
-- Graph nodes: 6182
-- Graph edges: 6666
+- Graph nodes: 6186
+- Graph edges: 6678
 - Communities: 1762
 
 ## Graph Hotspots

--- a/packages/athena-webapp/convex/operations/dailyOperations.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.test.ts
@@ -973,6 +973,79 @@ describe("daily operations overview read model", () => {
     });
   });
 
+  it("links projected register closeout operational events without duplicating the fallback closeout row", async () => {
+    const snapshot = await buildDailyOperationsSnapshotWithCtx(
+      buildCtx({
+        dailyClose: [priorClose],
+        dailyOpening: [startedOpening],
+        operationalEvent: [
+          {
+            _id: "event-register-closeout",
+            createdAt: Date.UTC(2026, 4, 8, 20, 45),
+            eventType: "register_session_closed",
+            message: "Register 2 closeout recorded with an exact cash match.",
+            metadata: {
+              countedCash: 450,
+              expectedCash: 450,
+              registerNumber: "2",
+              syncOrigin: "local_sync",
+              variance: 0,
+            },
+            storeId: "store-1",
+            subjectId: "register-2",
+            subjectType: "register_session",
+          },
+        ],
+        registerSession: [
+          {
+            _id: "register-2",
+            closeoutRecords: [
+              {
+                actorStaffProfileId: "staff-1",
+                countedCash: 450,
+                expectedCash: 450,
+                occurredAt: Date.UTC(2026, 4, 8, 20, 45),
+                type: "closed",
+                variance: 0,
+              },
+            ],
+            expectedCash: 450,
+            openedAt: Date.UTC(2026, 4, 8, 8),
+            openingFloat: 100,
+            organizationId: "org-1",
+            registerNumber: "Register 2",
+            status: "closed",
+            storeId: "store-1",
+          },
+        ],
+        store: [store],
+      }),
+      { operatingDate: "2026-05-08", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(
+      snapshot.timeline.filter(
+        (event) => event.type === "register_session_closed",
+      ),
+    ).toHaveLength(1);
+    expect(snapshot.timeline[0]).toMatchObject({
+      id: "event-register-closeout",
+      registerLink: {
+        label: "Register 2",
+        params: {
+          sessionId: "register-2",
+        },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId",
+      },
+      subject: {
+        id: "register-2",
+        label: "Register 2",
+        type: "register_session",
+      },
+      type: "register_session_closed",
+    });
+  });
+
   it("returns the newest timeline events before applying the timeline limit", async () => {
     const events = Array.from({ length: 201 }, (_, index) => ({
       _id: `event-${index}`,

--- a/packages/athena-webapp/convex/operations/dailyOperations.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.ts
@@ -580,15 +580,34 @@ async function mapOperationalTimelineEvent(
             to: "/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug",
           }
         : undefined;
+    const registerNumber =
+      typeof metadata.registerNumber === "string"
+        ? metadata.registerNumber
+        : undefined;
+    const registerLabel =
+      event.subjectType === "register_session"
+        ? event.subjectLabel ?? formatRegisterSessionLabel(registerNumber)
+        : undefined;
+    const registerLink =
+      event.subjectType === "register_session"
+        ? {
+            label: registerLabel ?? "Register session",
+            params: {
+              sessionId: event.subjectId,
+            },
+            to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId",
+          }
+        : undefined;
 
     return {
       createdAt: event.createdAt,
       id: event._id,
       message: event.message,
       productLink,
+      registerLink,
       subject: {
         id: event.subjectId,
-        label: event.subjectLabel,
+        label: event.subjectLabel ?? registerLabel,
         type: event.subjectType,
       },
       transactionLink,

--- a/packages/athena-webapp/convex/operations/registerSessionTracing.test.ts
+++ b/packages/athena-webapp/convex/operations/registerSessionTracing.test.ts
@@ -133,6 +133,53 @@ describe("recordRegisterSessionTraceBestEffort", () => {
     );
   });
 
+  it("records completed sale evidence separately from cash drawer impact", async () => {
+    vi.mocked(createWorkflowTraceWithCtx).mockResolvedValue("trace-1" as never);
+    vi.mocked(registerWorkflowTraceLookupWithCtx).mockResolvedValue(
+      "lookup-1" as never,
+    );
+    vi.mocked(appendWorkflowTraceEventWithCtx).mockResolvedValue(
+      "event-1" as never,
+    );
+    const { ctx } = buildCtx();
+
+    await recordRegisterSessionTraceBestEffort(ctx, {
+      stage: "sale_recorded",
+      session: buildSession(),
+      occurredAt: 222,
+      amount: 0,
+      cashDelta: 0,
+      paymentCount: 1,
+      paymentMethodLabels: ["card"],
+      saleTotal: 12_345,
+      syncOrigin: "local_sync",
+      transactionId: "transaction-1" as Id<"posTransaction">,
+      transactionNumber: "R-001",
+    });
+
+    expect(appendWorkflowTraceEventWithCtx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        details: expect.objectContaining({
+          amount: 0,
+          cashDelta: 0,
+          paymentCount: 1,
+          paymentMethodLabels: ["card"],
+          saleTotal: 12_345,
+          syncOrigin: "local_sync",
+          transactionId: "transaction-1",
+          transactionNumber: "R-001",
+        }),
+        message: `Recorded transaction #R-001 sale of ${formatStoredTraceAmount("GHS", 12_345)} paid by card. No cash drawer impact.`,
+        occurredAt: 222,
+        step: "register_session_sale_recorded",
+        subjectRefs: expect.objectContaining({
+          posTransactionId: "transaction-1",
+        }),
+      }),
+    );
+  });
+
   it("uses the register session store currency when formatting trace money", async () => {
     vi.mocked(createWorkflowTraceWithCtx).mockResolvedValue("trace-1" as never);
     vi.mocked(registerWorkflowTraceLookupWithCtx).mockResolvedValue(

--- a/packages/athena-webapp/convex/operations/registerSessionTracing.ts
+++ b/packages/athena-webapp/convex/operations/registerSessionTracing.ts
@@ -58,11 +58,16 @@ type RegisterSessionTraceArgs = {
   actorUserId?: Id<"athenaUser">;
   countedCash?: number;
   correctedOpeningFloat?: number;
+  cashDelta?: number;
   previousOpeningFloat?: number;
+  paymentCount?: number;
+  paymentMethodLabels?: string[];
   registerSessionExpectedCashDelta?: number;
   reason?: string;
+  saleTotal?: number;
   settlementDirection?: "collect" | "refund" | "none";
   settlementMethod?: string;
+  syncOrigin?: "online" | "local_sync";
   transactionId?: Id<"posTransaction">;
   transactionNumber?: string;
   variance?: number;
@@ -207,14 +212,19 @@ function buildTraceEvent(args: {
         : undefined,
       countedCash: args.input.countedCash ?? args.input.session.countedCash,
       correctedOpeningFloat: args.input.correctedOpeningFloat,
+      cashDelta: args.input.cashDelta,
       expectedCash: args.input.session.expectedCash,
+      paymentCount: args.input.paymentCount,
+      paymentMethodLabels: args.input.paymentMethodLabels,
       previousOpeningFloat: args.input.previousOpeningFloat,
       registerSessionExpectedCashDelta:
         args.input.registerSessionExpectedCashDelta,
       reason: args.input.reason,
       registerStatus: args.input.session.status,
+      saleTotal: args.input.saleTotal,
       settlementDirection: args.input.settlementDirection,
       settlementMethod: args.input.settlementMethod,
+      syncOrigin: args.input.syncOrigin,
       transactionId: args.input.transactionId
         ? String(args.input.transactionId)
         : undefined,
@@ -248,6 +258,25 @@ function buildTraceEvent(args: {
         subjectRefs,
       };
     case "sale_recorded":
+      if (args.input.saleTotal !== undefined) {
+        const tenderSummary = args.input.paymentMethodLabels?.join(", ");
+        const cashDelta = args.input.cashDelta ?? args.input.amount ?? 0;
+        const cashImpact =
+          cashDelta > 0
+            ? ` Cash impact: ${displayTraceAmount(cashDelta, args.currency)}.`
+            : " No cash drawer impact.";
+
+        return {
+          kind: "system_action" as const,
+          step: "register_session_sale_recorded",
+          status: "info" as const,
+          message: `Recorded ${formatTransactionLabel(args.input)} sale of ${displayTraceAmount(args.input.saleTotal, args.currency)}${tenderSummary ? ` paid by ${tenderSummary}` : ""}.${cashImpact}`,
+          occurredAt,
+          details,
+          subjectRefs,
+        };
+      }
+
       return {
         kind: "system_action" as const,
         step: "register_session_sale_recorded",

--- a/packages/athena-webapp/convex/operations/registerSessions.trace.test.ts
+++ b/packages/athena-webapp/convex/operations/registerSessions.trace.test.ts
@@ -591,6 +591,52 @@ describe("register session workflow trace handlers", () => {
     });
   });
 
+  it("records online non-cash sale evidence without changing expected cash", async () => {
+    const ctx = createMutationCtx({
+      sessions: [buildRegisterSession()],
+    });
+
+    const updatedSession = await getHandler(recordRegisterSessionTransaction)(
+      ctx as never,
+      {
+        registerSessionId: "session-1",
+        storeId: "store-1",
+        adjustmentKind: "sale",
+        payments: [{ method: "card", amount: 9_000, timestamp: 1 }],
+        paymentCount: 1,
+        paymentMethodLabels: ["card"],
+        registerNumber: "A1",
+        saleTotal: 9_000,
+        terminalId: "terminal-1",
+        transactionId: "transaction-1",
+        transactionNumber: "R-001",
+      },
+    );
+
+    expect(updatedSession).toEqual(
+      expect.objectContaining({
+        _id: "session-1",
+        expectedCash: 5_000,
+        status: "active",
+      }),
+    );
+    expect(mocks.traceRecord).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        amount: 0,
+        cashDelta: 0,
+        occurredAt: 999,
+        paymentCount: 1,
+        paymentMethodLabels: ["card"],
+        saleTotal: 9_000,
+        stage: "sale_recorded",
+        syncOrigin: "online",
+        transactionId: "transaction-1",
+        transactionNumber: "R-001",
+      }),
+    );
+  });
+
   it("records a void adjustment trace when register-session cash decreases", async () => {
     const ctx = createMutationCtx({
       sessions: [buildRegisterSession({ expectedCash: 13_000, status: "closing" })],

--- a/packages/athena-webapp/convex/operations/registerSessions.ts
+++ b/packages/athena-webapp/convex/operations/registerSessions.ts
@@ -622,8 +622,13 @@ export const recordRegisterSessionTransaction = internalMutation({
     ),
     changeGiven: v.optional(v.number()),
     idempotencyKey: v.optional(v.string()),
+    paymentCount: v.optional(v.number()),
+    paymentMethodLabels: v.optional(v.array(v.string())),
     registerNumber: v.optional(v.string()),
+    saleTotal: v.optional(v.number()),
     terminalId: v.id("posTerminal"),
+    transactionId: v.optional(v.id("posTransaction")),
+    transactionNumber: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const session = await ctx.db.get("registerSession", args.registerSessionId);
@@ -671,7 +676,10 @@ export const recordRegisterSessionTransaction = internalMutation({
       payments: args.payments,
     });
 
-    if (amount > 0) {
+    if (
+      amount > 0 ||
+      (args.adjustmentKind === "sale" && args.saleTotal !== undefined)
+    ) {
       const occurredAt = Date.now();
       const traceResult = await recordRegisterSessionTraceBestEffort(ctx, {
         stage:
@@ -679,6 +687,13 @@ export const recordRegisterSessionTransaction = internalMutation({
         session: updatedSession,
         occurredAt,
         amount,
+        cashDelta: args.adjustmentKind === "sale" ? amount : undefined,
+        paymentCount: args.paymentCount,
+        paymentMethodLabels: args.paymentMethodLabels,
+        saleTotal: args.saleTotal,
+        syncOrigin: args.adjustmentKind === "sale" ? "online" : undefined,
+        transactionId: args.transactionId,
+        transactionNumber: args.transactionNumber,
       });
 
       await persistRegisterSessionWorkflowTraceIdBestEffort(ctx, {

--- a/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
@@ -2,13 +2,19 @@ import { internal } from "../../../_generated/api";
 import type { Doc, Id } from "../../../_generated/dataModel";
 import type { MutationCtx } from "../../../_generated/server";
 import type { ApprovalRequirement } from "../../../../shared/approvalPolicy";
-import { capitalizeWords, generateTransactionNumber } from "../../../utils";
+import {
+  capitalizeWords,
+  currencyFormatter,
+  generateTransactionNumber,
+} from "../../../utils";
+import { toDisplayAmount } from "../../../lib/currency";
 import { buildApprovalRequest } from "../../../operations/approvalRequestHelpers";
 import {
   APPROVAL_ACTIONS,
   consumeCommandApprovalProofWithCtx,
 } from "../../../operations/approvalActions";
 import { recordOperationalEventWithCtx } from "../../../operations/operationalEvents";
+import { calculateRegisterSessionCashDelta } from "../../../operations/registerSessions";
 import {
   recordRetailSalePaymentAllocations,
   recordRetailVoidPaymentAllocations,
@@ -93,6 +99,87 @@ export function buildCompleteTransactionResult(input: {
 
 function calculateTotalPaid(payments: PosPaymentInput[]) {
   return payments.reduce((sum, payment) => sum + payment.amount, 0);
+}
+
+function formatPaymentMethodLabel(method: string) {
+  return method.trim().toLowerCase().replaceAll("_", " ");
+}
+
+function paymentMethodLabels(payments: PosPaymentInput[]) {
+  return Array.from(
+    new Set(
+      payments
+        .map((payment) => formatPaymentMethodLabel(payment.method))
+        .filter(Boolean),
+    ),
+  );
+}
+
+function formatSaleAmount(currency: string | undefined, amount: number) {
+  const storeCurrency = currency?.trim() || "GHS";
+
+  try {
+    return currencyFormatter(storeCurrency).format(toDisplayAmount(amount));
+  } catch {
+    return currencyFormatter("GHS").format(toDisplayAmount(amount));
+  }
+}
+
+async function recordCompletedSaleOperationalEvent(
+  ctx: MutationCtx,
+  args: {
+    completedAt: number;
+    changeGiven?: number;
+    customerProfileId?: Id<"customerProfile">;
+    lineCount: number;
+    organizationId?: Id<"organization">;
+    payments: PosPaymentInput[];
+    posTransactionId: Id<"posTransaction">;
+    registerSessionId?: Id<"registerSession">;
+    staffProfileId?: Id<"staffProfile">;
+    storeCurrency?: string;
+    storeId: Id<"store">;
+    total: number;
+    transactionNumber: string;
+  },
+) {
+  const labels = paymentMethodLabels(args.payments);
+  const paymentSummary =
+    labels.length === 0
+      ? "payment needs review"
+      : labels.length === 1
+        ? labels[0]
+        : labels.length === 2
+          ? `${labels[0]} and ${labels[1]}`
+          : `${labels.slice(0, -1).join(", ")}, and ${labels[labels.length - 1]}`;
+
+  await recordOperationalEventWithCtx(ctx, {
+    storeId: args.storeId,
+    organizationId: args.organizationId,
+    eventType: "pos_transaction_completed",
+    subjectType: "posTransaction",
+    subjectId: args.posTransactionId,
+    message: `POS sale #${args.transactionNumber} completed: ${formatSaleAmount(args.storeCurrency, args.total)}, ${paymentSummary}.`,
+    metadata: {
+      cashDelta: calculateRegisterSessionCashDelta({
+        changeGiven: args.changeGiven,
+        payments: args.payments,
+      }),
+      completedAt: args.completedAt,
+      lineCount: args.lineCount,
+      paymentCount: args.payments.length,
+      paymentMethods: labels,
+      receiptNumber: args.transactionNumber,
+      saleTotal: args.total,
+      syncOrigin: "online",
+      total: args.total,
+      transactionNumber: args.transactionNumber,
+    },
+    actorStaffProfileId: args.staffProfileId,
+    customerProfileId: args.customerProfileId,
+    registerSessionId: args.registerSessionId,
+    posTransactionId: args.posTransactionId,
+  });
 }
 
 async function recordPosSaleInventoryMovement(
@@ -265,8 +352,11 @@ export async function recordRegisterSessionSale(
     payments: PosPaymentInput[];
     registerSessionId: Id<"registerSession">;
     registerNumber?: string;
+    saleTotal?: number;
     storeId: Id<"store">;
     terminalId: Id<"posTerminal">;
+    transactionId?: Id<"posTransaction">;
+    transactionNumber?: string;
   },
 ) {
   await ctx.runMutation(
@@ -275,10 +365,15 @@ export async function recordRegisterSessionSale(
       adjustmentKind: "sale",
       changeGiven: args.changeGiven,
       payments: args.payments,
+      paymentCount: args.payments.length,
+      paymentMethodLabels: paymentMethodLabels(args.payments),
       registerSessionId: args.registerSessionId,
       registerNumber: args.registerNumber,
+      saleTotal: args.saleTotal,
       storeId: args.storeId,
       terminalId: args.terminalId,
+      transactionId: args.transactionId,
+      transactionNumber: args.transactionNumber,
     },
   );
 }
@@ -495,8 +590,11 @@ export async function completeTransaction(
       payments: args.payments,
       registerSessionId: args.registerSessionId,
       registerNumber: args.registerNumber,
+      saleTotal: canonicalTotals.total,
       storeId: args.storeId,
       terminalId: sessionTerminalId,
+      transactionId,
+      transactionNumber,
     });
   }
 
@@ -561,6 +659,22 @@ export async function completeTransaction(
       return transactionItemId;
     }),
   );
+
+  await recordCompletedSaleOperationalEvent(ctx, {
+    completedAt,
+    changeGiven,
+    customerProfileId: args.customerProfileId,
+    lineCount: args.items.length,
+    organizationId: store?.organizationId,
+    payments: args.payments,
+    posTransactionId: transactionId,
+    registerSessionId: args.registerSessionId,
+    staffProfileId: args.staffProfileId,
+    storeCurrency: store?.currency,
+    storeId: args.storeId,
+    total: canonicalTotals.total,
+    transactionNumber,
+  });
 
   return ok({
     transactionId: completionResult.data.transactionId,
@@ -1515,8 +1629,11 @@ export async function createTransactionFromSessionHandler(
       payments: args.payments,
       registerSessionId: resolvedRegisterSessionId.data,
       registerNumber: session.registerNumber,
+      saleTotal: total,
       storeId: session.storeId,
       terminalId: session.terminalId,
+      transactionId,
+      transactionNumber,
     });
   }
 
@@ -1614,6 +1731,22 @@ export async function createTransactionFromSessionHandler(
   await patchPosSession(ctx, args.sessionId, {
     transactionId,
     registerSessionId: resolvedRegisterSessionId.data,
+  });
+
+  await recordCompletedSaleOperationalEvent(ctx, {
+    completedAt,
+    changeGiven,
+    customerProfileId: session.customerProfileId,
+    lineCount: items.length,
+    organizationId: store?.organizationId,
+    payments: args.payments,
+    posTransactionId: transactionId,
+    registerSessionId: resolvedRegisterSessionId.data,
+    staffProfileId: session.staffProfileId,
+    storeCurrency: store?.currency,
+    storeId: session.storeId,
+    total,
+    transactionNumber,
   });
 
   return ok({

--- a/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
+++ b/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
@@ -1117,10 +1117,15 @@ describe("completeTransaction checkout side effects", () => {
       expect.objectContaining({
         adjustmentKind: "sale",
         changeGiven: 2,
+        paymentCount: 1,
+        paymentMethodLabels: ["cash"],
         registerSessionId: "register-1",
         registerNumber: "1",
+        saleTotal: 10,
         storeId: "store-1",
         terminalId: "terminal-1",
+        transactionId: "txn-1",
+        transactionNumber: expect.any(String),
       }),
     );
     expect(recordRetailSalePaymentAllocations).toHaveBeenCalledWith(
@@ -1131,6 +1136,31 @@ describe("completeTransaction checkout side effects", () => {
         posTransactionId: "txn-1",
         registerSessionId: "register-1",
         storeId: "store-1",
+      }),
+    );
+    expect(recordOperationalEventWithCtx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: "pos_transaction_completed",
+        metadata: expect.objectContaining({
+          completedAt: expect.any(Number),
+          cashDelta: 10,
+          lineCount: 1,
+          paymentCount: 1,
+          paymentMethods: ["cash"],
+          receiptNumber: expect.any(String),
+          saleTotal: 10,
+          syncOrigin: "online",
+          total: 10,
+          transactionNumber: expect.any(String),
+        }),
+        message: expect.stringMatching(
+          /^POS sale #.+ completed: GH₵0\.1, cash\.$/,
+        ),
+        posTransactionId: "txn-1",
+        registerSessionId: "register-1",
+        subjectId: "txn-1",
+        subjectType: "posTransaction",
       }),
     );
     expect(recordInventoryMovementWithCtx).toHaveBeenCalledWith(
@@ -1570,13 +1600,42 @@ describe("completeTransaction trace ordering", () => {
     expect(runMutation).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
+        paymentCount: 1,
+        paymentMethodLabels: ["cash"],
         registerSessionId: "register-1",
+        saleTotal: 10,
+        transactionId: "txn-1",
+        transactionNumber: expect.any(String),
       }),
     );
     expect(recordRetailSalePaymentAllocations).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
         registerSessionId: "register-1",
+      }),
+    );
+    expect(recordOperationalEventWithCtx).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        actorStaffProfileId: "staff-1",
+        customerProfileId: "profile-1",
+        eventType: "pos_transaction_completed",
+        metadata: expect.objectContaining({
+          completedAt: expect.any(Number),
+          cashDelta: 10,
+          lineCount: 1,
+          paymentCount: 1,
+          paymentMethods: ["cash"],
+          receiptNumber: expect.any(String),
+          saleTotal: 10,
+          syncOrigin: "online",
+          total: 10,
+          transactionNumber: expect.any(String),
+        }),
+        posTransactionId: "txn-1",
+        registerSessionId: "register-1",
+        subjectId: "txn-1",
+        subjectType: "posTransaction",
       }),
     );
     expect(consumeInventoryHoldsForSession).toHaveBeenCalledWith(

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
@@ -322,6 +322,51 @@ describe("projectLocalSyncEvent", () => {
     ]);
   });
 
+  it("records non-cash projected sale trace evidence without increasing expected cash", async () => {
+    const repository = createProjectionRepository();
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: buildSaleCompletedEvent({
+        payload: {
+          ...buildSaleCompletedEvent().payload,
+          payments: [
+            {
+              localPaymentId: "local-payment-card",
+              method: "card",
+              amount: 25,
+              timestamp: 21,
+            },
+          ],
+        },
+      }),
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("projected");
+    expect(repository.registerSessionPatches).not.toContainEqual({
+      registerSessionId: "register-session-1",
+      patch: expect.objectContaining({
+        expectedCash: expect.any(Number),
+      }),
+    });
+    expect(repository.recordedRegisterSessionTraces).toEqual([
+      expect.objectContaining({
+        amount: 0,
+        cashDelta: 0,
+        paymentCount: 1,
+        paymentMethodLabels: ["card"],
+        saleTotal: 25,
+        stage: "sale_recorded",
+        syncOrigin: "local_sync",
+        transactionId: "transaction-1",
+        transactionNumber: "LR-001",
+      }),
+    ]);
+  });
+
   it("projects service-only sales without product inventory movement or retail allocations", async () => {
     const repository = createProjectionRepository();
 
@@ -706,7 +751,14 @@ describe("projectLocalSyncEvent", () => {
       expect.objectContaining({
         actorStaffProfileId: "staff-2",
         amount: 25,
+        cashDelta: 25,
+        paymentCount: 1,
+        paymentMethodLabels: ["cash"],
+        saleTotal: 25,
         stage: "sale_recorded",
+        syncOrigin: "local_sync",
+        transactionId: "transaction-1",
+        transactionNumber: "000222",
       }),
     ]);
   });
@@ -2580,6 +2632,27 @@ describe("projectLocalSyncEvent", () => {
         }),
       }),
     ]);
+    expect(repository.createdOperationalEvents).toEqual([
+      expect.objectContaining({
+        actorStaffProfileId: "staff-1",
+        createdAt: 30,
+        eventType: "register_session_closed",
+        message: "Register 1 closeout recorded with an exact cash match.",
+        metadata: expect.objectContaining({
+          countedCash: 100,
+          expectedCash: 100,
+          localEventId: "event-register-closed-1",
+          registerNumber: "1",
+          syncOrigin: "local_sync",
+          variance: 0,
+        }),
+        organizationId: "org-1",
+        registerSessionId: "register-session-1",
+        storeId: "store-1",
+        subjectId: "register-session-1",
+        subjectType: "register_session",
+      }),
+    ]);
     expect(reopen.conflicts).toEqual([
       expect.objectContaining({
         summary: "Staff access changed before this POS history synced.",
@@ -2617,6 +2690,48 @@ describe("projectLocalSyncEvent", () => {
         conflictType: "permission",
         summary:
           "Register closeout variance requires manager review before synced closeout can be applied.",
+      }),
+    ]);
+  });
+
+  it("formats manager-reviewed closeout variance in projected operational evidence", async () => {
+    const repository = createProjectionRepository();
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: {
+        localEventId: "event-register-closed-1",
+        localRegisterSessionId: "local-register-1",
+        sequence: 3,
+        eventType: "register_closed",
+        occurredAt: 30,
+        staffProfileId: "staff-1" as never,
+        staffProofToken: "proof-token-1",
+        payload: {
+          countedCash: 90,
+          notes: "Short drawer",
+        },
+      },
+      syncEventId: "sync-event-1",
+      now: 100,
+      options: {
+        allowRegisterCloseoutVarianceProjection: true,
+      },
+    });
+
+    expect(result.status).toBe("projected");
+    expect(repository.createdOperationalEvents).toEqual([
+      expect.objectContaining({
+        eventType: "register_session_closed",
+        message:
+          "Register 1 closeout recorded with a cash variance of GH₵-0.1.",
+        metadata: expect.objectContaining({
+          countedCash: 90,
+          expectedCash: 100,
+          registerNumber: "1",
+          variance: -10,
+        }),
       }),
     ]);
   });

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -1534,11 +1534,15 @@ function recordSaleProjectedEvent(
       payload: input.payload,
     }),
     metadata: {
+      cashDelta: input.payments.expectedCashDelta,
       lineCount: getSaleLineCount(input.payload),
       localEventId: args.event.localEventId,
       localReceiptNumber: input.payload.localReceiptNumber,
+      paymentCount: input.payments.validPayments.length,
       paymentMethods: getPaymentMethodLabels(input.payments.validPayments),
       receiptNumber: input.payload.receiptNumber,
+      saleTotal: input.payload.totals.total,
+      syncOrigin: "local_sync",
       total: input.payload.totals.total,
       transactionNumber: input.payload.receiptNumber,
     },
@@ -1685,12 +1689,19 @@ async function recordSaleWorkflowEvidence(
 
   const registerSessionTraceResult =
     await repository.recordRegisterSessionWorkflowTrace?.({
-    stage: "sale_recorded",
-    session: input.session.registerSession,
-    occurredAt: args.event.occurredAt,
-    amount: input.payments.expectedCashDelta,
-    actorStaffProfileId: args.event.staffProfileId,
-  });
+      stage: "sale_recorded",
+      session: input.session.registerSession,
+      occurredAt: args.event.occurredAt,
+      amount: input.payments.expectedCashDelta,
+      cashDelta: input.payments.expectedCashDelta,
+      paymentCount: input.payments.transactionPayments.length,
+      paymentMethodLabels: getPaymentMethodLabels(input.payments.validPayments),
+      saleTotal: input.payload.totals.total,
+      syncOrigin: "local_sync",
+      transactionId: input.sale.transactionId,
+      transactionNumber: input.payload.receiptNumber,
+      actorStaffProfileId: args.event.staffProfileId,
+    });
   if (registerSessionTraceResult) {
     await persistRegisterSessionWorkflowTraceId(repository, {
       registerSessionId: input.session.registerSession._id,
@@ -2194,6 +2205,8 @@ async function projectRegisterClosed(
     return { status: "conflicted", mappings: [], conflicts: [conflict] };
   }
 
+  const store = await repository.getStore(args.storeId);
+
   await repository.patchRegisterSession(registerSession._id, {
     status: "closed",
     countedCash,
@@ -2238,6 +2251,28 @@ async function projectRegisterClosed(
       workflowTraceId: registerSession.workflowTraceId,
     });
   }
+  await repository.createOperationalEvent({
+    storeId: args.storeId,
+    organizationId: store?.organizationId,
+    eventType: "register_session_closed",
+    subjectType: "register_session",
+    subjectId: registerSession._id,
+    message:
+      variance === 0
+        ? `Register ${registerSession.registerNumber ?? registerSession._id} closeout recorded with an exact cash match.`
+        : `Register ${registerSession.registerNumber ?? registerSession._id} closeout recorded with a cash variance of ${formatSaleTotal(store?.currency, variance)}.`,
+    metadata: {
+      countedCash,
+      expectedCash: registerSession.expectedCash,
+      localEventId: args.event.localEventId,
+      registerNumber: registerSession.registerNumber,
+      syncOrigin: "local_sync",
+      variance,
+    },
+    createdAt: args.event.occurredAt,
+    actorStaffProfileId: args.event.staffProfileId,
+    registerSessionId: registerSession._id,
+  });
   const mapping = await createMapping(repository, args, {
     localIdKind: "closeout",
     localId: args.event.localEventId,

--- a/packages/athena-webapp/convex/pos/application/sync/types.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/types.ts
@@ -486,8 +486,15 @@ export type SyncProjectionRepository = {
     amount?: number;
     actorStaffProfileId?: Id<"staffProfile">;
     actorUserId?: Id<"athenaUser">;
+    cashDelta?: number;
     countedCash?: number;
+    paymentCount?: number;
+    paymentMethodLabels?: string[];
     reason?: string;
+    saleTotal?: number;
+    syncOrigin?: "online" | "local_sync";
+    transactionId?: Id<"posTransaction">;
+    transactionNumber?: string;
     variance?: number;
   }): Promise<PosSyncWorkflowTraceResult>;
 };

--- a/packages/athena-webapp/src/components/pos/SessionManager.test.tsx
+++ b/packages/athena-webapp/src/components/pos/SessionManager.test.tsx
@@ -57,6 +57,20 @@ vi.mock("../common/FadeIn", () => ({
   FadeIn: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
 }));
 
+vi.mock("~/src/components/traces/WorkflowTraceRouteLink", () => ({
+  WorkflowTraceRouteLink: ({
+    children,
+    traceId,
+  }: {
+    children?: React.ReactNode;
+    traceId: string;
+  }) => (
+    <a data-trace-id={traceId} href={`/traces/${encodeURIComponent(traceId)}`}>
+      {children ?? "View trace"}
+    </a>
+  ),
+}));
+
 vi.mock("./session/HeldSessionsList", () => ({
   HeldSessionsList: () => <div>held-sessions-list</div>,
 }));
@@ -88,6 +102,10 @@ describe("SessionManager", () => {
     expect(
       screen.queryByRole("button", { name: /hold/i }),
     ).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View trace" })).toHaveAttribute(
+      "data-trace-id",
+      "pos_session:ses-001",
+    );
     expect(
       screen.getByRole("button", { name: /clear sale/i }),
     ).toBeInTheDocument();

--- a/packages/athena-webapp/src/components/pos/SessionManager.tsx
+++ b/packages/athena-webapp/src/components/pos/SessionManager.tsx
@@ -8,6 +8,7 @@ import {
 import { PlayCircle, Clock, Plus, Ban } from "lucide-react";
 
 import type { RegisterSessionPanelState } from "@/lib/pos/presentation/register/registerUiState";
+import { WorkflowTraceRouteLink } from "~/src/components/traces/WorkflowTraceRouteLink";
 
 import { HeldSessionsList } from "./session/HeldSessionsList";
 
@@ -38,16 +39,26 @@ export function SessionManager({ sessionPanel }: SessionManagerProps) {
       )}
 
       {sessionPanel.activeSessionNumber && (
-        <Button
-          variant="outline"
-          size="sm"
-          className="flex h-10 items-center gap-2 px-4"
-          onClick={() => void sessionPanel.onVoidCurrentSession()}
-          disabled={!sessionPanel.canClearSale}
-        >
-          <Ban className="h-4 w-4 text-destructive" />
-          Clear sale
-        </Button>
+        <>
+          {sessionPanel.activeSessionTraceId ? (
+            <WorkflowTraceRouteLink
+              traceId={sessionPanel.activeSessionTraceId}
+              className="px-2 text-xs font-medium text-muted-foreground hover:text-primary"
+            >
+              View trace
+            </WorkflowTraceRouteLink>
+          ) : null}
+          <Button
+            variant="outline"
+            size="sm"
+            className="flex h-10 items-center gap-2 px-4"
+            onClick={() => void sessionPanel.onVoidCurrentSession()}
+            disabled={!sessionPanel.canClearSale}
+          >
+            <Ban className="h-4 w-4 text-destructive" />
+            Clear sale
+          </Button>
+        </>
       )}
 
       {sessionPanel.heldSessions.length > 0 && (


### PR DESCRIPTION
## Summary
- add monitorable completed-sale evidence for online and local-sync POS sales with shared sale metadata
- record register closeout operational events and preserve Daily Operations register links
- surface active POS session trace navigation and add plan/solution documentation

## Validation
- bun run --filter '@athena/webapp' typecheck\n- bun run --filter '@athena/webapp' test convex/operations/dailyOperations.test.ts convex/operations/registerSessionTracing.test.ts convex/operations/registerSessions.trace.test.ts convex/pos/application/completeTransaction.test.ts convex/pos/application/sync/projectLocalEvents.test.ts src/components/pos/SessionManager.test.tsx\n- bun run pr:athena\n\n## Review\n- correctness reviewer: approved\n- testing reviewer: approved after Daily Operations and trace-link coverage fixes\n- project standards reviewer: approved after solution path and money-formatting fixes\n- adversarial reviewer: approved after parity metadata and typecheck fixes