### PR TITLE
fix(pos): recover duplicate drawer open retries

### DIFF
--- a/docs/solutions/logic-errors/athena-pos-drawer-authority-replacement-recovery-2026-06-06.md
+++ b/docs/solutions/logic-errors/athena-pos-drawer-authority-replacement-recovery-2026-06-06.md
@@ -1,0 +1,84 @@
+---
+title: Athena POS Drawer Authority Replacement Recovery
+date: 2026-06-06
+category: logic-errors
+module: athena-webapp
+problem_type: pos_drawer_authority_replacement_recovery
+component: pos-register
+symptoms:
+  - "A terminal can keep showing the open-drawer gate after a drawer was reopened"
+  - "A lifecycle-review block on an old local drawer can survive a successful replacement open"
+  - "Retrying open drawer can create repeated replacement drawer attempts"
+root_cause: recoverable_drawer_authority_blocks_were_not_reconciled_after_replacement_open_mapping
+resolution_type: mapped_replacement_open_clears_superseded_recoverable_blocks
+severity: high
+tags:
+  - pos
+  - local-first
+  - drawer-authority
+  - sync
+  - recovery
+---
+
+# Athena POS Drawer Authority Replacement Recovery
+
+## Problem
+
+Drawer authority is stored per local register session so one rejected drawer does
+not erase unrelated local activity. That is the right safety boundary, but it
+creates a recovery trap when the server accepts a replacement `register.opened`
+event and maps it to the same cloud drawer as the blocked local session.
+
+If the old local session keeps a recoverable `lifecycle_rejected` or
+`authority_unknown` block after the replacement open is accepted, the read model
+can keep projecting the register as unsellable. The cashier then sees the drawer
+gate again even though the drawer recovery already succeeded.
+
+## Solution
+
+Treat an accepted replacement open as the authority handoff for older
+recoverable local drawer blocks when all of these are true:
+
+- The replacement `register.opened` event synced successfully.
+- The server returned a `registerSession` mapping for the replacement local
+  session.
+- An older local drawer block maps to the same cloud register session.
+- The older block reason is recoverable, such as `lifecycle_rejected` or
+  `authority_unknown`.
+- The replacement open is newer than the blocked local drawer.
+
+Clear only those superseded recoverable blocks. Do not clear hard
+`cloud_closed` blocks this way; a server-closed drawer is not repaired merely by
+another local open attempt.
+
+## Regression Targets
+
+- Sync runtime tests should prove a replacement `register.opened` clears an
+  older recoverable drawer-authority block when both local sessions map to the
+  same cloud drawer.
+- Sync runtime tests should prove the replacement open is still marked synced
+  after the superseded block is cleared.
+- Register read-model tests should keep `cloud_closed` as a hard sale block so
+  stale closed-drawer recovery does not weaken drawer lifecycle safety.
+- Projection tests should prove lifecycle-review failures on an already-open
+  drawer do not create endless replacement opens.
+
+## Prevention
+
+- Do not clear drawer authority from retry intent alone. Wait for a successful
+  server mapping that proves the replacement open was accepted.
+- Keep recoverable lifecycle review separate from hard cloud-closed drawer
+  state. They have different recovery semantics.
+- When adding a new drawer-authority block reason, decide whether a later mapped
+  replacement open may supersede it and cover that decision with sync runtime
+  tests.
+- Keep duplicate-open protection in the projection path and stale-closed-drawer
+  recovery in the sync/runtime path. Collapsing them makes it easy to either
+  loop replacement opens or block valid recovery.
+
+## Related
+
+- [Athena POS Stale Terminal Sale Blocks](./athena-pos-stale-terminal-sale-block-2026-05-29.md)
+- [Athena POS Local First Register](../architecture/athena-pos-always-local-first-register-2026-05-14.md)
+- [Athena POS Offline Sales Continuity](../architecture/athena-pos-offline-sales-continuity-2026-06-04.md)
+- [Athena POS Hub App Session Continuity](../architecture/athena-pos-hub-app-session-continuity-2026-06-02.md)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6186 nodes · 6678 edges · 1762 communities detected
+- 6188 nodes · 6682 edges · 1762 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1776,7 +1776,7 @@
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
 2. `buildDailyCloseSnapshotWithCtx()` - 28 edges
-3. `projectLocalRegisterReadModel()` - 24 edges
+3. `projectLocalRegisterReadModel()` - 26 edges
 4. `buildDailyOpeningSnapshotWithCtx()` - 17 edges
 5. `useRegisterViewModel()` - 17 edges
 6. `getStoreConfigV2()` - 17 edges
@@ -1864,16 +1864,16 @@ Cohesion: 0.13
 Nodes (27): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+19 more)
 
 ### Community 16 - "Community 16"
+Cohesion: 0.16
+Nodes (32): asRecord(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale(), getPhase() (+24 more)
+
+### Community 17 - "Community 17"
 Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
-### Community 17 - "Community 17"
+### Community 18 - "Community 18"
 Cohesion: 0.12
 Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
-
-### Community 18 - "Community 18"
-Cohesion: 0.18
-Nodes (30): asRecord(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale(), getPhase() (+22 more)
 
 ### Community 19 - "Community 19"
 Cohesion: 0.15
@@ -2988,36 +2988,36 @@ Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 297 - "Community 297"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (3): createVersionChecker(), shouldAutoReloadForCurrentRoute(), shouldAutoReloadForPath()
 
 ### Community 298 - "Community 298"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 299 - "Community 299"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 300 - "Community 300"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 301 - "Community 301"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 302 - "Community 302"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 303 - "Community 303"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 304 - "Community 304"
-Cohesion: 0.5
-Nodes (3): createVersionChecker(), shouldAutoReloadForCurrentRoute(), shouldAutoReloadForPath()
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 305 - "Community 305"
 Cohesion: 0.4

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6188 nodes · 6682 edges · 1762 communities detected
+- 6189 nodes · 6684 edges · 1762 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1817,11 +1817,11 @@ Nodes (47): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(),
 
 ### Community 4 - "Community 4"
 Cohesion: 0.06
-Nodes (27): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatCompactTextList(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary() (+19 more)
+Nodes (24): assertPosLocalStoreOk(), clearAcceptedTerminalIntegrityState(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents() (+16 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.06
-Nodes (25): assertPosLocalStoreOk(), clearAcceptedTerminalIntegrityState(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds() (+17 more)
+Nodes (27): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatCompactTextList(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary() (+19 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.1
@@ -2688,8 +2688,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 222 - "Community 222"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 223 - "Community 223"
 Cohesion: 0.33
@@ -2708,64 +2708,64 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 227 - "Community 227"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
-
-### Community 228 - "Community 228"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 228 - "Community 228"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 229 - "Community 229"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 230 - "Community 230"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 231 - "Community 231"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 232 - "Community 232"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 231 - "Community 231"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 232 - "Community 232"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
 ### Community 233 - "Community 233"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 234 - "Community 234"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 235 - "Community 235"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 236 - "Community 236"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 237 - "Community 237"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 238 - "Community 238"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 239 - "Community 239"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 241 - "Community 241"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 242 - "Community 242"
 Cohesion: 0.53

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1834
-- Graph nodes: 6188
-- Graph edges: 6682
+- Graph nodes: 6189
+- Graph edges: 6684
 - Communities: 1762
 
 ## Graph Hotspots
@@ -17,9 +17,9 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `useRegisterViewModel.ts` (59 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `projectLocalEvents.ts` (49 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `usePosLocalSyncRuntime.ts` (47 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
 - `harness-inferential-review.ts` (46 edges, Community 6) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
-- `RegisterSessionView.tsx` (46 edges, Community 4) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
-- `usePosLocalSyncRuntime.ts` (46 edges, Community 5) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
+- `RegisterSessionView.tsx` (46 edges, Community 5) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
 - `storefrontJourneyEvents.ts` (45 edges, Community 7) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 
 ## Registered Packages

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1834
-- Graph nodes: 6186
-- Graph edges: 6678
+- Graph nodes: 6188
+- Graph edges: 6682
 - Communities: 1762
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -21,7 +21,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - `dailyClose.ts` (65 edges, Community 1) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `useRegisterViewModel.ts` (59 edges, Community 2) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `projectLocalEvents.ts` (49 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
-- `RegisterSessionView.tsx` (46 edges, Community 4) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
+- `usePosLocalSyncRuntime.ts` (47 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
@@ -2306,7 +2306,7 @@ describe("projectLocalSyncEvent", () => {
     ]);
   });
 
-  it("conflicts register opens when the terminal already has an open drawer", async () => {
+  it("maps duplicate register opens to the terminal's existing active drawer", async () => {
     const repository = createProjectionRepository({
       blockingRegisterSession: {
         _id: "register-session-open",
@@ -2337,11 +2337,14 @@ describe("projectLocalSyncEvent", () => {
       now: 100,
     });
 
-    expect(result.status).toBe("conflicted");
-    expect(result.conflicts).toEqual([
+    expect(result.status).toBe("projected");
+    expect(result.conflicts).toEqual([]);
+    expect(result.mappings).toEqual([
       expect.objectContaining({
-        conflictType: "permission",
-        summary: "A register session is already open for this terminal.",
+        localIdKind: "registerSession",
+        localId: "local-register-2",
+        cloudTable: "registerSession",
+        cloudId: "register-session-open",
       }),
     ]);
   });

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -427,6 +427,16 @@ async function projectRegisterOpened(
     registerNumber: terminalRegisterNumber,
   });
   if (blockingRegisterSession) {
+    if (isPosUsableRegisterSession(blockingRegisterSession)) {
+      const mapping = await createMapping(repository, args, {
+        localIdKind: "registerSession",
+        localId: args.event.localRegisterSessionId,
+        cloudTable: "registerSession",
+        cloudId: blockingRegisterSession._id,
+      });
+      return { status: "projected", mappings: [mapping], conflicts: [] };
+    }
+
     const conflict = await createConflict(repository, args, {
       conflictType: "permission",
       summary: "A register session is already open for this terminal.",

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts
@@ -844,6 +844,46 @@ describe("projectLocalRegisterReadModel", () => {
     expect(model.saleBlockReason).toBeUndefined();
     expect(model.syncStatus.state).toBe("needs_review");
   });
+
+  it("keeps the current drawer active when a later duplicate drawer open needs review", () => {
+    const model = projectLocalRegisterReadModel({
+      mappings: [
+        {
+          entity: "registerSession",
+          localId: "local-register-1",
+          cloudId: "cloud-register-1",
+          mappedAt: 1_001,
+        },
+      ],
+      events: [
+        event({
+          sequence: 1,
+          type: "register.opened",
+          payload: { openingFloat: 100 },
+          sync: { status: "synced", uploaded: true },
+        }),
+        event({
+          sequence: 2,
+          uploadSequence: 2,
+          type: "register.opened",
+          localEventId: "duplicate-open",
+          localRegisterSessionId: "local-register-2",
+          payload: { localRegisterSessionId: "local-register-2", openingFloat: 500 },
+          sync: { status: "needs_review", uploaded: true },
+        }),
+      ],
+      isOnline: true,
+    });
+
+    expect(model.activeRegisterSession).toMatchObject({
+      localRegisterSessionId: "local-register-1",
+      cloudRegisterSessionId: "cloud-register-1",
+      openingFloat: 100,
+    });
+    expect(model.canSell).toBe(true);
+    expect(model.saleBlockReason).toBeUndefined();
+    expect(model.syncStatus.state).toBe("needs_review");
+  });
 });
 
 function errorCodes(errors: PosLocalRegisterReadModelError[]) {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts
@@ -184,6 +184,14 @@ export function projectLocalRegisterReadModel(input: {
         errors.push(errorFor(event, "missing_register_session"));
         continue;
       }
+      if (
+        activeRegisterSession &&
+        isOpenLocalRegisterSessionStatus(activeRegisterSession.status) &&
+        isUploadedRegisterOpenReview(event) &&
+        !registerLifecycleEventMatchesActiveSession(event, activeRegisterSession)
+      ) {
+        continue;
+      }
 
       const payload = asRecord(event.payload);
       const openingFloat = numberField(payload, "openingFloat") ?? 0;
@@ -919,6 +927,16 @@ function registerStatus(
     value === "closed"
     ? value
     : undefined;
+}
+
+function isOpenLocalRegisterSessionStatus(
+  status: PosLocalCashDrawerReadModel["status"],
+) {
+  return status === "open" || status === "active";
+}
+
+function isUploadedRegisterOpenReview(event: PosLocalEventRecord) {
+  return event.sync.status === "needs_review" && event.sync.uploaded === true;
 }
 
 function serviceModeField(

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -1734,6 +1734,133 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     });
   });
 
+  it("clears older recoverable drawer blocks when a replacement open maps to the same cloud drawer", async () => {
+    mocks.ingestLocalEvents.mockResolvedValue({
+      kind: "ok",
+      data: {
+        accepted: [
+          {
+            localEventId: "event-new-open",
+            sequence: 1,
+            status: "projected",
+          },
+        ],
+        held: [],
+        mappings: [
+          {
+            cloudId: "register-cloud-1",
+            localId: "register-new",
+            localIdKind: "registerSession",
+            createdAt: 20,
+          },
+        ],
+        conflicts: [],
+        syncCursor: {
+          localRegisterSessionId: "register-new",
+          acceptedThroughSequence: 1,
+        },
+      },
+    });
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            createdAt: 1,
+            localEventId: "event-old-open",
+            localRegisterSessionId: "register-old",
+            sequence: 1,
+            sync: { status: "synced", uploaded: true },
+            type: "register.opened",
+          }),
+          buildLocalEvent({
+            createdAt: 20,
+            localEventId: "event-new-open",
+            localRegisterSessionId: "register-new",
+            payload: { localRegisterSessionId: "register-new" },
+            sequence: 2,
+            sync: { status: "pending" },
+            type: "register.opened",
+            uploadSequence: 1,
+          }),
+        ],
+      })),
+      clearDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
+      listLocalCloudMappings: vi.fn(async () => ({
+        ok: true,
+        value: [
+          {
+            cloudId: "register-cloud-1",
+            entity: "registerSession",
+            localId: "register-old",
+            mappedAt: 1,
+          },
+        ],
+      })),
+      markEventsSynced: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      readDrawerAuthorityState: vi.fn(async (input: {
+        localRegisterSessionId: string;
+        storeId: string;
+        terminalId: string;
+      }) => ({
+        ok: true,
+        value:
+          input.localRegisterSessionId === "register-old"
+            ? {
+                cloudRegisterSessionId: "register-cloud-1",
+                localRegisterSessionId: "register-old",
+                observedAt: 10,
+                reason: "lifecycle_rejected" as const,
+                status: "blocked" as const,
+                storeId: "store-1",
+                terminalId: "local-terminal-1",
+              }
+            : null,
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+      writeLocalCloudMapping: vi.fn(async () => ({
+        ok: true,
+        value: {},
+      })),
+    };
+
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(store.clearDrawerAuthorityState).toHaveBeenCalledWith({
+        localRegisterSessionId: "register-old",
+        storeId: "store-1",
+        terminalId: "local-terminal-1",
+      }),
+    );
+    expect(store.markEventsSynced).toHaveBeenCalledWith(["event-new-open"], {
+      uploaded: true,
+    });
+  });
+
   it("clears stale recoverable drawer blocks when lifecycle events are already settled", async () => {
     const store = {
       listEvents: vi.fn(async () => ({

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -155,7 +155,10 @@ export function usePosLocalSyncRuntimeStatus(input: {
   const onRetrySync = input.onRetrySync;
   const source = input.source ?? "sync-runtime";
   const staffProfileId = input.staffProfileId;
-  const uploadSupport = getAppSessionUploadSupport(input.appSessionRecovery);
+  const uploadSupport = useMemo(
+    () => getAppSessionUploadSupport(input.appSessionRecovery),
+    [input.appSessionRecovery],
+  );
   const lastRuntimeStatusSignatureRef = useRef<string | null>(null);
   const requestRetry = useCallback(() => {
     setRefreshToken((current) => current + 1);
@@ -554,6 +557,12 @@ export function usePosLocalSyncRuntimeStatus(input: {
             locallySettledEventIds,
             syncedEventIds,
           );
+          await clearSupersededRecoverableDrawerAuthorityBlocks({
+            acceptedEvents: result.data.accepted,
+            events: latestEvents.value.events,
+            returnedMappings: result.data.mappings,
+            store,
+          });
           await clearRecoverableDrawerAuthorityForSyncedEvents({
             events: latestEvents.value.events,
             reviewEventIds: localReviewEventIds,
@@ -665,6 +674,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
     storeId,
     terminalId,
     refreshToken,
+    uploadSupport,
   ]);
 
   const runtimeStatusSyncDebug = useMemo<PosTerminalRuntimeSyncDebugInput>(
@@ -1339,6 +1349,135 @@ function isRecoverableDrawerAuthorityReason(
   reason: PosDrawerAuthorityState["reason"] | undefined,
 ) {
   return reason === "lifecycle_rejected" || reason === "authority_unknown";
+}
+
+async function clearSupersededRecoverableDrawerAuthorityBlocks(input: {
+  acceptedEvents: Array<{
+    localEventId: string;
+    status: string;
+  }>;
+  events: PosLocalEventRecord[];
+  returnedMappings: Array<{
+    cloudId: string;
+    localId: string;
+    localIdKind: string;
+  }>;
+  store: PosLocalRuntimeStore;
+}) {
+  const clearDrawerAuthorityState:
+    | PosLocalRuntimeStore["clearDrawerAuthorityState"]
+    | undefined = (
+    input.store as {
+      clearDrawerAuthorityState?: PosLocalRuntimeStore["clearDrawerAuthorityState"];
+    }
+  ).clearDrawerAuthorityState;
+  const readDrawerAuthorityState:
+    | PosLocalRuntimeStore["readDrawerAuthorityState"]
+    | undefined = (
+    input.store as {
+      readDrawerAuthorityState?: PosLocalRuntimeStore["readDrawerAuthorityState"];
+    }
+  ).readDrawerAuthorityState;
+  const listLocalCloudMappings:
+    | PosLocalRuntimeStore["listLocalCloudMappings"]
+    | undefined = (
+    input.store as {
+      listLocalCloudMappings?: PosLocalRuntimeStore["listLocalCloudMappings"];
+    }
+  ).listLocalCloudMappings;
+  if (
+    !clearDrawerAuthorityState ||
+    !readDrawerAuthorityState ||
+    !listLocalCloudMappings
+  ) {
+    return;
+  }
+
+  const acceptedProjectedEventIds = new Set(
+    input.acceptedEvents
+      .filter((event) => event.status === "projected")
+      .map((event) => event.localEventId),
+  );
+  const replacementDrawerOpenings = input.returnedMappings
+    .filter((mapping) => mapping.localIdKind === "registerSession")
+    .map((mapping) => {
+      const event = input.events.find(
+        (candidate) =>
+          candidate.type === "register.opened" &&
+          candidate.localRegisterSessionId === mapping.localId &&
+          acceptedProjectedEventIds.has(candidate.localEventId),
+      );
+      return event
+        ? {
+            cloudRegisterSessionId: mapping.cloudId,
+            event,
+          }
+        : null;
+    })
+    .filter((entry): entry is {
+      cloudRegisterSessionId: string;
+      event: PosLocalEventRecord;
+    } => Boolean(entry));
+  if (replacementDrawerOpenings.length === 0) {
+    return;
+  }
+
+  const mappings = await listLocalCloudMappings();
+  assertPosLocalStoreOk(mappings);
+
+  for (const replacement of replacementDrawerOpenings) {
+    const supersededRegisterSessionIds = mappings.value
+      .filter(
+        (mapping) =>
+          mapping.entity === "registerSession" &&
+          mapping.cloudId === replacement.cloudRegisterSessionId &&
+          mapping.localId !== replacement.event.localRegisterSessionId,
+      )
+      .map((mapping) => mapping.localId);
+    const uniqueSupersededRegisterSessionIds = [
+      ...new Set(supersededRegisterSessionIds),
+    ];
+
+    for (const localRegisterSessionId of uniqueSupersededRegisterSessionIds) {
+      const terminalIds = [
+        ...new Set(
+          input.events
+            .filter(
+              (event) =>
+                event.storeId === replacement.event.storeId &&
+                event.localRegisterSessionId === localRegisterSessionId,
+            )
+            .map((event) => event.terminalId),
+        ),
+      ];
+      for (const terminalId of terminalIds) {
+        const drawerAuthority: PosLocalStoreResult<PosDrawerAuthorityState | null> =
+          await readDrawerAuthorityState({
+          localRegisterSessionId,
+          storeId: replacement.event.storeId,
+          terminalId,
+        });
+        assertPosLocalStoreOk(drawerAuthority);
+        if (
+          drawerAuthority.value?.status !== "blocked" ||
+          !isRecoverableDrawerAuthorityReason(drawerAuthority.value.reason) ||
+          drawerAuthority.value.observedAt > replacement.event.createdAt ||
+          (drawerAuthority.value.cloudRegisterSessionId &&
+            drawerAuthority.value.cloudRegisterSessionId !==
+              replacement.cloudRegisterSessionId)
+        ) {
+          continue;
+        }
+
+        const result: PosLocalStoreResult<null> = await clearDrawerAuthorityState({
+          localRegisterSessionId,
+          storeId: replacement.event.storeId,
+          terminalId,
+        });
+        assertPosLocalStoreOk(result);
+      }
+    }
+  }
 }
 
 async function clearSettledRecoverableDrawerAuthorityBlock(input: {


### PR DESCRIPTION
## Summary
- map duplicate local register open retries to the existing active cloud drawer instead of creating lifecycle-review conflicts
- keep the local register read model on the already-open mapped drawer when later uploaded duplicate opens need review
- add regression coverage for backend projection and local drawer recovery

## Validation
- bun --filter '@athena/webapp' test src/lib/pos/infrastructure/local/registerReadModel.test.ts convex/pos/application/sync/projectLocalEvents.test.ts
- bun --filter '@athena/webapp' lint:convex:changed
- bun --filter '@athena/webapp' lint:frontend:changed
- bun --filter '@athena/webapp' audit:convex
- bun run graphify:rebuild
- pre-push hook passed: graphify check, harness review, TypeScript, build, 933-test POS workflow batch, 2,727-test webapp batch, offline e2e, behavior harness

## Prod
- Deployed Convex prod from this clean worktree
- Deployed athena-webapp local build: silent-eagle-flies (20260606170155)