### PR TITLE
Add POS production E2E merge guard

### DIFF
--- a/.github/workflows/athena-pr-tests.yml
+++ b/.github/workflows/athena-pr-tests.yml
@@ -214,6 +214,63 @@ jobs:
       - name: Run repo coverage policy
         run: bun run test:coverage
 
+  athena-prod-pos-e2e:
+    name: Athena POS E2E against Production Backend
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: athena-prod-pos-e2e-${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright browser
+        run: bunx playwright install chromium
+
+      - name: Report POS recovery-code coverage mode
+        env:
+          ATHENA_PROD_POS_RECOVERY_CODE: ${{ secrets.ATHENA_PROD_POS_RECOVERY_CODE }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${ATHENA_PROD_POS_RECOVERY_CODE:-}" ]; then
+            echo "ATHENA_PROD_POS_RECOVERY_CODE is not configured; authenticated POS recovery submit coverage will be skipped."
+            exit 0
+          fi
+          echo "ATHENA_PROD_POS_RECOVERY_CODE is configured; authenticated POS recovery submit coverage will run."
+
+      - name: Run candidate POS E2E against production backend
+        env:
+          ATHENA_POS_E2E_RUN_LOCAL_BUILD: "1"
+          ATHENA_PROD_CONVEX_URL: https://colorless-cardinal-870.convex.cloud
+          ATHENA_PROD_CONVEX_SITE_URL: https://colorless-cardinal-870.convex.site
+          ATHENA_PROD_POS_RECOVERY_CODE: ${{ secrets.ATHENA_PROD_POS_RECOVERY_CODE }}
+          ATHENA_PROD_POS_STORE_ID: nn7byz68a3j4tfjvgdf9evpt3n78kk38
+          ATHENA_PROD_POS_HUB_PATH: /wigclub/store/wigclub/pos
+        run: bun run --filter '@athena/webapp' -- test:e2e:prod:pos
+
+      - name: Upload production POS E2E artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: athena-prod-pos-e2e-artifacts
+          path: |
+            packages/athena-webapp/playwright-report
+            /tmp/athena-webapp-prod-playwright-results
+          if-no-files-found: ignore
+
   storefront-webapp-validation-context:
     name: Storefront Webapp Validation Context
     needs: athena-webapp-validation

--- a/docs/solutions/logic-errors/athena-offline-pos-sale-operations-timeline-links-2026-06-05.md
+++ b/docs/solutions/logic-errors/athena-offline-pos-sale-operations-timeline-links-2026-06-05.md
@@ -40,7 +40,7 @@ Build the operator-facing sale summary when the local event is projected. Store
 receipt number, line count, payment methods, and total in the timeline event
 metadata, and use a calm sentence such as:
 
-`Offline POS sale #R-100 synced: 2 sale lines, GHS 120.00, cash and card.`
+`Sale #R-100 synced: 2 sale lines, GHS 120.00, cash and card.`
 
 Expose a transaction link from the daily operations read model when the event
 subject is a POS transaction. Keep product links server-derived as well, and

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1848 files · ~0 words
+- 1850 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6339 nodes · 6975 edges · 1776 communities detected
+- 6352 nodes · 6992 edges · 1778 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1786,6 +1786,8 @@
 - [[_COMMUNITY_Community 1773|Community 1773]]
 - [[_COMMUNITY_Community 1774|Community 1774]]
 - [[_COMMUNITY_Community 1775|Community 1775]]
+- [[_COMMUNITY_Community 1776|Community 1776]]
+- [[_COMMUNITY_Community 1777|Community 1777]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1831,19 +1833,19 @@ Nodes (49): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(),
 
 ### Community 4 - "Community 4"
 Cohesion: 0.06
-Nodes (24): asRecord(), createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), normalizeCashierPresenceRecord(), normalizeDrawerAuthorityState(), normalizeLocalEventPayload(), normalizePendingCheckoutItemDefinedPayload(), normalizePendingCheckoutItemLocalMetadata() (+16 more)
+Nodes (27): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatCompactTextList(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary() (+19 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.06
-Nodes (24): assertPosLocalStoreOk(), clearAcceptedTerminalIntegrityState(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents() (+16 more)
+Nodes (24): asRecord(), createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), normalizeCashierPresenceRecord(), normalizeDrawerAuthorityState(), normalizeLocalEventPayload(), normalizePendingCheckoutItemDefinedPayload(), normalizePendingCheckoutItemLocalMetadata() (+16 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.1
-Nodes (37): canonicalize(), canonicalJson(), createLocalSyncIngestionService(), ingestLocalEventsWithCtx(), isNonEmptyString(), isNonNegativeFiniteNumber(), isOptionalBoolean(), isOptionalNonEmptyString() (+29 more)
+Cohesion: 0.06
+Nodes (24): assertPosLocalStoreOk(), clearAcceptedTerminalIntegrityState(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents() (+16 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.06
-Nodes (27): applyCloseoutCommandResult(), applyCommandResult(), buildDepositSubmissionKey(), formatCompactTextList(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary() (+19 more)
+Cohesion: 0.1
+Nodes (37): canonicalize(), canonicalJson(), createLocalSyncIngestionService(), ingestLocalEventsWithCtx(), isNonEmptyString(), isNonNegativeFiniteNumber(), isOptionalBoolean(), isOptionalNonEmptyString() (+29 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.1
@@ -1858,12 +1860,12 @@ Cohesion: 0.07
 Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.08
-Nodes (20): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+12 more)
+Cohesion: 0.09
+Nodes (38): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents(), buildWeekMetricForDate(), buildWeekMetrics(), compareDailyOperationsTimelineEvents() (+30 more)
 
 ### Community 12 - "Community 12"
-Cohesion: 0.11
-Nodes (32): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildRegisterCloseoutTimelineEvents(), buildWeekMetricForDate(), buildWeekMetrics(), compareDailyOperationsTimelineEvents(), compareTimelineEvents() (+24 more)
+Cohesion: 0.08
+Nodes (20): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+12 more)
 
 ### Community 13 - "Community 13"
 Cohesion: 0.13
@@ -2206,48 +2208,48 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 98 - "Community 98"
-Cohesion: 0.36
-Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 99 - "Community 99"
 Cohesion: 0.36
-Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
+Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
 ### Community 100 - "Community 100"
+Cohesion: 0.36
+Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
+
+### Community 101 - "Community 101"
 Cohesion: 0.22
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 102 - "Community 102"
+### Community 103 - "Community 103"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.25
 Nodes (5): blocked(), evaluateLocalPosReadiness(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
-
-### Community 108 - "Community 108"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 109 - "Community 109"
 Cohesion: 0.18
@@ -2434,196 +2436,196 @@ Cohesion: 0.25
 Nodes (0):
 
 ### Community 155 - "Community 155"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
-
-### Community 156 - "Community 156"
 Cohesion: 0.25
 Nodes (0):
+
+### Community 156 - "Community 156"
+Cohesion: 0.39
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 157 - "Community 157"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 158 - "Community 158"
-Cohesion: 0.46
-Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
-
-### Community 159 - "Community 159"
-Cohesion: 0.43
-Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
-
-### Community 160 - "Community 160"
 Cohesion: 0.25
 Nodes (0):
 
+### Community 159 - "Community 159"
+Cohesion: 0.46
+Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
+
+### Community 160 - "Community 160"
+Cohesion: 0.43
+Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
+
 ### Community 161 - "Community 161"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 162 - "Community 162"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.33
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.33
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 170 - "Community 170"
+### Community 171 - "Community 171"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 171 - "Community 171"
+### Community 172 - "Community 172"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 172 - "Community 172"
+### Community 173 - "Community 173"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 173 - "Community 173"
+### Community 174 - "Community 174"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 175 - "Community 175"
+### Community 176 - "Community 176"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 177 - "Community 177"
+### Community 178 - "Community 178"
 Cohesion: 0.33
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 178 - "Community 178"
+### Community 179 - "Community 179"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.33
 Nodes (2): handlePinChange(), normalizeOtpCode()
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.33
 Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.33
 Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.33
 Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
-### Community 191 - "Community 191"
+### Community 192 - "Community 192"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 195 - "Community 195"
+### Community 196 - "Community 196"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 197 - "Community 197"
-Cohesion: 0.33
-Nodes (1): ValkeyClient
-
 ### Community 198 - "Community 198"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ValkeyClient
 
 ### Community 199 - "Community 199"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 200 - "Community 200"
-Cohesion: 0.47
-Nodes (4): buildOperationalEvent(), matchesExistingEvent(), metadataDedupeKeysMatch(), recordOperationalEventWithCtx()
-
-### Community 201 - "Community 201"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 201 - "Community 201"
+Cohesion: 0.47
+Nodes (4): buildOperationalEvent(), matchesExistingEvent(), metadataDedupeKeysMatch(), recordOperationalEventWithCtx()
+
 ### Community 202 - "Community 202"
-Cohesion: 0.4
-Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 203 - "Community 203"
 Cohesion: 0.33
@@ -2634,64 +2636,64 @@ Cohesion: 0.4
 Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
 ### Community 205 - "Community 205"
+Cohesion: 0.4
+Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
+
+### Community 206 - "Community 206"
 Cohesion: 0.53
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 206 - "Community 206"
+### Community 207 - "Community 207"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 207 - "Community 207"
+### Community 208 - "Community 208"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 208 - "Community 208"
+### Community 209 - "Community 209"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 209 - "Community 209"
+### Community 210 - "Community 210"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 210 - "Community 210"
+### Community 211 - "Community 211"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 211 - "Community 211"
+### Community 212 - "Community 212"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 212 - "Community 212"
+### Community 213 - "Community 213"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 213 - "Community 213"
+### Community 214 - "Community 214"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 214 - "Community 214"
+### Community 215 - "Community 215"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 215 - "Community 215"
+### Community 216 - "Community 216"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 216 - "Community 216"
+### Community 217 - "Community 217"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 217 - "Community 217"
+### Community 218 - "Community 218"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 218 - "Community 218"
+### Community 219 - "Community 219"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
-
-### Community 219 - "Community 219"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 220 - "Community 220"
 Cohesion: 0.33
@@ -2718,8 +2720,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 226 - "Community 226"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 227 - "Community 227"
 Cohesion: 0.33
@@ -2738,64 +2740,64 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 231 - "Community 231"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
-
-### Community 232 - "Community 232"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 232 - "Community 232"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 233 - "Community 233"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 234 - "Community 234"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 235 - "Community 235"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 236 - "Community 236"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 235 - "Community 235"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 236 - "Community 236"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
 ### Community 237 - "Community 237"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 238 - "Community 238"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 239 - "Community 239"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 240 - "Community 240"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 241 - "Community 241"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 242 - "Community 242"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 243 - "Community 243"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 243 - "Community 243"
+### Community 244 - "Community 244"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 244 - "Community 244"
+### Community 245 - "Community 245"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 245 - "Community 245"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 246 - "Community 246"
 Cohesion: 0.53
@@ -2902,12 +2904,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 272 - "Community 272"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 273 - "Community 273"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 273 - "Community 273"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 274 - "Community 274"
 Cohesion: 0.4
@@ -2926,28 +2928,28 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 278 - "Community 278"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 279 - "Community 279"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
-### Community 280 - "Community 280"
+### Community 279 - "Community 279"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 281 - "Community 281"
+### Community 280 - "Community 280"
 Cohesion: 0.5
 Nodes (2): buildTerminalOfflineReadiness(), getAppSessionReadinessInput()
 
-### Community 282 - "Community 282"
+### Community 281 - "Community 281"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 283 - "Community 283"
+### Community 282 - "Community 282"
 Cohesion: 0.4
 Nodes (1): ResizeObserverStub
+
+### Community 283 - "Community 283"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 284 - "Community 284"
 Cohesion: 0.4
@@ -2958,44 +2960,44 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 286 - "Community 286"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 287 - "Community 287"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 288 - "Community 288"
+### Community 287 - "Community 287"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 289 - "Community 289"
+### Community 288 - "Community 288"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 290 - "Community 290"
+### Community 289 - "Community 289"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 291 - "Community 291"
+### Community 290 - "Community 290"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 292 - "Community 292"
+### Community 291 - "Community 291"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 293 - "Community 293"
+### Community 292 - "Community 292"
 Cohesion: 0.6
 Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
-### Community 294 - "Community 294"
+### Community 293 - "Community 293"
 Cohesion: 0.6
 Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
-### Community 295 - "Community 295"
+### Community 294 - "Community 294"
 Cohesion: 0.6
 Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+
+### Community 295 - "Community 295"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 296 - "Community 296"
 Cohesion: 0.4
@@ -3010,92 +3012,92 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 299 - "Community 299"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 300 - "Community 300"
 Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 301 - "Community 301"
+### Community 300 - "Community 300"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 302 - "Community 302"
+### Community 301 - "Community 301"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 303 - "Community 303"
+### Community 302 - "Community 302"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 304 - "Community 304"
+### Community 303 - "Community 303"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 304 - "Community 304"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 305 - "Community 305"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 306 - "Community 306"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 307 - "Community 307"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
-### Community 308 - "Community 308"
+### Community 307 - "Community 307"
 Cohesion: 0.5
 Nodes (3): createVersionChecker(), shouldAutoReloadForCurrentRoute(), shouldAutoReloadForPath()
+
+### Community 308 - "Community 308"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 309 - "Community 309"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 310 - "Community 310"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 311 - "Community 311"
 Cohesion: 0.6
 Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
 
-### Community 312 - "Community 312"
+### Community 311 - "Community 311"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 313 - "Community 313"
+### Community 312 - "Community 312"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 314 - "Community 314"
+### Community 313 - "Community 313"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 315 - "Community 315"
+### Community 314 - "Community 314"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 316 - "Community 316"
+### Community 315 - "Community 315"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 317 - "Community 317"
+### Community 316 - "Community 316"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
+
+### Community 317 - "Community 317"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 318 - "Community 318"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 319 - "Community 319"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 320 - "Community 320"
 Cohesion: 0.67
 Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
+
+### Community 320 - "Community 320"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 321 - "Community 321"
 Cohesion: 0.5
@@ -3106,68 +3108,68 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 323 - "Community 323"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 324 - "Community 324"
 Cohesion: 0.67
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 325 - "Community 325"
+### Community 324 - "Community 324"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 326 - "Community 326"
+### Community 325 - "Community 325"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 327 - "Community 327"
+### Community 326 - "Community 326"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 328 - "Community 328"
+### Community 327 - "Community 327"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 328 - "Community 328"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 329 - "Community 329"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 330 - "Community 330"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 331 - "Community 331"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 332 - "Community 332"
+### Community 331 - "Community 331"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 333 - "Community 333"
+### Community 332 - "Community 332"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 334 - "Community 334"
+### Community 333 - "Community 333"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 335 - "Community 335"
+### Community 334 - "Community 334"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 336 - "Community 336"
+### Community 335 - "Community 335"
 Cohesion: 0.83
 Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
-### Community 337 - "Community 337"
+### Community 336 - "Community 336"
 Cohesion: 0.83
 Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
-### Community 338 - "Community 338"
+### Community 337 - "Community 337"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+
+### Community 338 - "Community 338"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 339 - "Community 339"
 Cohesion: 0.5
@@ -3178,36 +3180,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 341 - "Community 341"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 342 - "Community 342"
 Cohesion: 0.67
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 343 - "Community 343"
+### Community 342 - "Community 342"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 344 - "Community 344"
+### Community 343 - "Community 343"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 345 - "Community 345"
+### Community 344 - "Community 344"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 346 - "Community 346"
+### Community 345 - "Community 345"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 347 - "Community 347"
+### Community 346 - "Community 346"
 Cohesion: 0.83
 Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
-### Community 348 - "Community 348"
+### Community 347 - "Community 347"
 Cohesion: 0.83
 Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+
+### Community 348 - "Community 348"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 349 - "Community 349"
 Cohesion: 0.5
@@ -3799,79 +3801,79 @@ Nodes (0):
 
 ### Community 496 - "Community 496"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 497 - "Community 497"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 498 - "Community 498"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 499 - "Community 499"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 500 - "Community 500"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 501 - "Community 501"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 502 - "Community 502"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 503 - "Community 503"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 504 - "Community 504"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 504 - "Community 504"
+### Community 505 - "Community 505"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 505 - "Community 505"
+### Community 506 - "Community 506"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 506 - "Community 506"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 507 - "Community 507"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 508 - "Community 508"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 509 - "Community 509"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 510 - "Community 510"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 511 - "Community 511"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 512 - "Community 512"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 513 - "Community 513"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 514 - "Community 514"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 515 - "Community 515"
 Cohesion: 0.67
@@ -3903,11 +3905,11 @@ Nodes (0):
 
 ### Community 522 - "Community 522"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 523 - "Community 523"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 524 - "Community 524"
 Cohesion: 0.67
@@ -3918,32 +3920,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 526 - "Community 526"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 527 - "Community 527"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 527 - "Community 527"
+### Community 528 - "Community 528"
 Cohesion: 0.67
 Nodes (1): isInMaintenanceMode()
 
-### Community 528 - "Community 528"
+### Community 529 - "Community 529"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 529 - "Community 529"
+### Community 530 - "Community 530"
 Cohesion: 1.0
 Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
-### Community 530 - "Community 530"
+### Community 531 - "Community 531"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 531 - "Community 531"
-Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 532 - "Community 532"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 533 - "Community 533"
 Cohesion: 0.67
@@ -3955,35 +3957,35 @@ Nodes (0):
 
 ### Community 535 - "Community 535"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 536 - "Community 536"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): App()
 
 ### Community 537 - "Community 537"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
-
-### Community 538 - "Community 538"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 538 - "Community 538"
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 539 - "Community 539"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 540 - "Community 540"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 541 - "Community 541"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 542 - "Community 542"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 543 - "Community 543"
 Cohesion: 0.67
@@ -3991,7 +3993,7 @@ Nodes (0):
 
 ### Community 544 - "Community 544"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (1): hashPassword()
 
 ### Community 545 - "Community 545"
 Cohesion: 0.67
@@ -3999,11 +4001,11 @@ Nodes (0):
 
 ### Community 546 - "Community 546"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 547 - "Community 547"
-Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 548 - "Community 548"
 Cohesion: 0.67
@@ -4011,19 +4013,19 @@ Nodes (0):
 
 ### Community 549 - "Community 549"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 550 - "Community 550"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 551 - "Community 551"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 552 - "Community 552"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 553 - "Community 553"
 Cohesion: 0.67
@@ -4034,32 +4036,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 555 - "Community 555"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 556 - "Community 556"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 557 - "Community 557"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 558 - "Community 558"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 559 - "Community 559"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 560 - "Community 560"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 561 - "Community 561"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 562 - "Community 562"
 Cohesion: 0.67
@@ -4122,8 +4124,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 577 - "Community 577"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 578 - "Community 578"
 Cohesion: 0.67
@@ -4131,11 +4133,11 @@ Nodes (0):
 
 ### Community 579 - "Community 579"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
 
 ### Community 580 - "Community 580"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 581 - "Community 581"
 Cohesion: 1.0
@@ -4150,24 +4152,24 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 584 - "Community 584"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 585 - "Community 585"
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
+
+### Community 586 - "Community 586"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 586 - "Community 586"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
-
 ### Community 587 - "Community 587"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 588 - "Community 588"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 589 - "Community 589"
 Cohesion: 1.0
@@ -8917,2386 +8919,2394 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1776 - "Community 1776"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1777 - "Community 1777"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 587`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 589`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 588`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 590`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 589`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 591`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 590`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 592`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 591`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 593`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 592`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 594`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 593`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 595`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 594`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 596`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 595`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 597`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 596`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 598`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 597`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 599`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 598`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 600`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 599`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 601`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 600`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 602`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 601`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 603`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 602`** (2 nodes): `createMutationCtx()`, `catalogImport.test.ts`
+- **Thin community `Community 604`** (2 nodes): `createMutationCtx()`, `catalogImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 603`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 605`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 604`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 606`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 605`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 607`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 606`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 608`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 607`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 609`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 608`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 610`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 609`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 611`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 610`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 612`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 611`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 613`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 612`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 614`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 615`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 616`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 617`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 618`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 619`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 620`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 621`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 622`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 623`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 624`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 625`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 626`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 627`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 628`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 629`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 630`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 631`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 632`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 633`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 634`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 635`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 636`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 637`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 638`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 639`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 640`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 641`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 642`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 643`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 644`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
+- **Thin community `Community 645`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 646`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 647`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 648`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 649`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 650`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 651`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 652`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 653`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 654`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 655`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 656`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 657`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 658`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 659`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 660`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 661`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 662`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 663`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 664`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 665`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 666`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 667`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 668`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 669`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 670`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 671`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 672`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 673`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 674`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 675`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 676`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 677`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 678`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 679`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 680`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 681`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 682`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 683`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 684`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 685`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 686`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 687`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 688`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 689`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 690`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 691`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 692`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 693`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 694`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 695`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 696`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 697`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 698`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 699`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 700`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 701`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 702`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 703`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 704`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 705`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 706`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 707`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 708`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 709`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 710`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 711`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 712`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 713`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 714`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 715`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 716`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 717`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 718`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `buildCsvRow()`, `InventoryImportView.test.tsx`
+- **Thin community `Community 719`** (2 nodes): `buildCsvRow()`, `InventoryImportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 720`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 721`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 722`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 723`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 724`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 725`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 726`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 727`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 728`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 729`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 730`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 731`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 732`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 733`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 734`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 735`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 736`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 737`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 738`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `isToday()`, `ExpenseReportsView.tsx`
+- **Thin community `Community 739`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 740`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 741`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 742`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 743`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 744`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 745`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 746`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 747`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 748`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 749`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 750`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 751`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 752`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 753`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 754`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `SKUSelector.tsx`, `SKUSelector()`
+- **Thin community `Community 755`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 756`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 757`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 758`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 759`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 760`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 761`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 762`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 763`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 764`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 765`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 766`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 767`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 768`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 769`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 770`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 771`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 772`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 773`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 774`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 775`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 776`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 777`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 778`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 779`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 780`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 781`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 782`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 783`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 784`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 785`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 786`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 787`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 788`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 789`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 790`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 791`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 792`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 793`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 794`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 795`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 796`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 797`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 798`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 799`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 800`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 801`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 802`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 803`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 804`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 805`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 806`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 807`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 808`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 809`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 810`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 811`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 812`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 813`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 814`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 815`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 816`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 817`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 818`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 819`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 820`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 821`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 822`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 823`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 824`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 825`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 826`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 827`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 828`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 829`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 830`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 831`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 832`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 833`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 834`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 835`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 836`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 837`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 838`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 839`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 840`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 841`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 842`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 843`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 844`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 845`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 846`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 847`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 848`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 849`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 850`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
+- **Thin community `Community 851`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 852`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 853`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 854`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 855`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 856`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 857`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 858`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 859`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 860`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 861`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 862`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 863`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 864`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 865`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 866`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 867`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 868`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 869`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 870`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 871`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 872`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 873`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 874`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 875`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 876`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 877`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 878`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 879`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 880`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 881`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 882`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 883`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 884`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 885`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 886`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 887`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 888`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 889`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 890`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 891`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 892`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 893`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 894`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 895`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 896`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 897`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 898`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 899`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 900`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 901`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 902`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 903`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 904`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 905`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 906`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 907`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 908`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 909`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 910`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 911`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 912`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 913`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 914`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 915`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 916`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 917`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 918`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 919`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 920`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 921`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 922`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 923`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 924`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 925`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 926`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 927`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 928`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 929`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 930`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 931`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 932`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 933`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 934`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 935`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 936`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 937`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 938`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 939`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 940`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 941`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 942`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 943`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 944`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 945`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 946`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 947`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 948`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 949`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 950`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 951`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 952`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 953`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 954`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 955`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 956`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 957`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 958`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 959`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 960`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 961`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 962`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 963`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 964`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 965`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 966`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 967`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 968`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 969`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 970`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 971`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 972`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 973`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 974`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 975`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 976`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 977`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 978`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 979`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 980`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 981`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 982`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 983`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 984`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 985`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 986`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 987`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 988`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 989`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 990`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 991`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 992`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 993`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 994`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 995`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 996`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 997`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 998`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 999`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1000`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1001`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1002`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1003`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1004`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1005`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1006`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1007`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1008`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (1 nodes): `api.js`
+- **Thin community `Community 1009`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1010`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1011`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (1 nodes): `server.js`
+- **Thin community `Community 1012`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (1 nodes): `app.ts`
+- **Thin community `Community 1013`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1014`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1015`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1016`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1017`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (1 nodes): `auth.ts`
+- **Thin community `Community 1018`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1019`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1020`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1021`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (1 nodes): `countries.ts`
+- **Thin community `Community 1022`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (1 nodes): `email.ts`
+- **Thin community `Community 1023`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1024`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (1 nodes): `payment.ts`
+- **Thin community `Community 1025`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (1 nodes): `crons.ts`
+- **Thin community `Community 1026`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1027`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (1 nodes): `internal.ts`
+- **Thin community `Community 1028`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1029`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1030`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1031`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1032`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1033`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1034`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1035`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1036`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1037`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1038`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1039`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `env.ts`
+- **Thin community `Community 1040`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1041`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `auth.ts`
+- **Thin community `Community 1042`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1043`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `colors.ts`
+- **Thin community `Community 1044`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `index.ts`
+- **Thin community `Community 1045`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1046`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `products.ts`
+- **Thin community `Community 1047`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1048`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `stores.ts`
+- **Thin community `Community 1049`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `bag.ts`
+- **Thin community `Community 1050`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `guest.ts`
+- **Thin community `Community 1051`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `index.ts`
+- **Thin community `Community 1052`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `me.ts`
+- **Thin community `Community 1053`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `offers.ts`
+- **Thin community `Community 1054`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1055`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1056`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1057`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1058`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1059`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1060`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1061`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1062`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1063`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `user.ts`
+- **Thin community `Community 1064`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1065`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `index.ts`
+- **Thin community `Community 1066`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1067`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `http.ts`
+- **Thin community `Community 1068`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1069`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1070`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1071`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `categories.ts`
+- **Thin community `Community 1072`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `colors.ts`
+- **Thin community `Community 1073`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1074`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 1075`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1076`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1077`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1078`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1079`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `pos.ts`
+- **Thin community `Community 1080`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1081`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1082`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1083`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1084`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1085`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1086`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1087`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1088`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1089`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1090`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1091`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1092`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1093`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1094`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1095`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1096`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `types.ts`
+- **Thin community `Community 1097`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1098`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1099`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1100`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1101`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1102`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1103`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `dto.ts`
+- **Thin community `Community 1104`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1105`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `posSessionTracing.test.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `searchCatalog.test.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `types.ts`
+- **Thin community `Community 1106`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1107`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1108`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `customers.ts`
+- **Thin community `Community 1109`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `register.ts`
+- **Thin community `Community 1110`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `sync.ts`
+- **Thin community `Community 1111`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `schema.ts`
+- **Thin community `Community 1112`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1113`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `index.ts`
+- **Thin community `Community 1114`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1115`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1116`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1117`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1118`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1119`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `category.ts`
+- **Thin community `Community 1120`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `color.ts`
+- **Thin community `Community 1121`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1122`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1123`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `index.ts`
+- **Thin community `Community 1124`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1125`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1126`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1127`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `organization.ts`
+- **Thin community `Community 1128`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1129`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `product.ts`
+- **Thin community `Community 1130`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1131`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1132`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `store.ts`
+- **Thin community `Community 1133`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1134`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `index.ts`
+- **Thin community `Community 1135`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1136`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1137`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1138`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1139`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1140`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1141`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1142`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `index.ts`
+- **Thin community `Community 1143`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1144`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1145`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1146`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1147`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1148`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1149`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1150`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1151`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1152`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1153`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1154`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `customer.ts`
+- **Thin community `Community 1155`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1156`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1157`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1158`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1159`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `index.ts`
+- **Thin community `Community 1160`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1161`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1162`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1163`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1164`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1165`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1166`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1167`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1168`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1169`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1170`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1171`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1172`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1173`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1174`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1175`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1176`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1177`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1178`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `index.ts`
+- **Thin community `Community 1179`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1180`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1181`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1182`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1183`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1184`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1185`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `index.ts`
+- **Thin community `Community 1186`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1187`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1188`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1189`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1190`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1191`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1192`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `bag.ts`
+- **Thin community `Community 1193`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1194`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1195`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1196`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `guest.ts`
+- **Thin community `Community 1197`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `index.ts`
+- **Thin community `Community 1198`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `offer.ts`
+- **Thin community `Community 1199`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1200`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1201`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `review.ts`
+- **Thin community `Community 1202`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1203`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1204`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1205`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1206`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1207`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1208`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1209`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1210`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1211`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `bag.ts`
+- **Thin community `Community 1212`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1213`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `customer.ts`
+- **Thin community `Community 1214`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `guest.ts`
+- **Thin community `Community 1215`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1216`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1217`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1218`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1219`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `payment.ts`
+- **Thin community `Community 1220`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1221`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1222`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1223`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `users.ts`
+- **Thin community `Community 1224`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `payment.ts`
+- **Thin community `Community 1225`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1226`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1227`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1228`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1229`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1230`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `index.ts`
+- **Thin community `Community 1231`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1232`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1233`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1234`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `auth.ts`
+- **Thin community `Community 1235`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1236`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1237`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1238`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1239`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1240`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1241`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1242`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1243`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1244`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1245`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1246`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1247`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1248`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1249`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1250`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1251`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `constants.ts`
+- **Thin community `Community 1252`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1253`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1254`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1255`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `types.ts`
+- **Thin community `Community 1256`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1257`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1258`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1259`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1260`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1261`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1262`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1263`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1264`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1265`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1266`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1267`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1268`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1269`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1270`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1271`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1272`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1273`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1274`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1275`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1276`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `constants.ts`
+- **Thin community `Community 1277`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1278`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1279`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1280`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `data.ts`
+- **Thin community `Community 1281`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1282`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1283`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1284`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1285`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1286`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1287`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1288`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1289`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1290`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `constants.ts`
+- **Thin community `Community 1291`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1292`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1293`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1294`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `data.ts`
+- **Thin community `Community 1295`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1296`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1297`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1298`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1299`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1300`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1301`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1302`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1303`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1304`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1305`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1306`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1307`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `constants.ts`
+- **Thin community `Community 1308`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1309`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1310`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1311`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1312`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1313`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1314`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1315`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1316`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1317`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1318`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1319`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1320`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1321`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1322`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1323`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1324`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1325`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1326`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1327`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1328`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1329`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1330`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1331`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1332`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1333`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1334`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1335`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1336`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1337`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1338`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1339`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `constants.ts`
+- **Thin community `Community 1340`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1341`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1342`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1343`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `data.ts`
+- **Thin community `Community 1344`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1345`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1346`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `constants.ts`
+- **Thin community `Community 1347`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1348`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1349`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1350`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1351`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `data.ts`
+- **Thin community `Community 1352`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1353`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `constants.ts`
+- **Thin community `Community 1354`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1355`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1356`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1357`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1358`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `data.ts`
+- **Thin community `Community 1359`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1360`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1361`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1362`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1363`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1364`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1365`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1366`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1367`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1368`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1369`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1370`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1371`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1372`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1373`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1374`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1375`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1376`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1377`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1378`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1379`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1380`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1381`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1382`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1383`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1384`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `POSSettingsView.test.tsx`
+- **Thin community `Community 1385`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1386`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `POSTerminalHealthView.test.tsx`
+- **Thin community `Community 1387`** (1 nodes): `POSSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1388`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1389`** (1 nodes): `POSTerminalHealthView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1390`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `types.ts`
+- **Thin community `Community 1391`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1392`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1393`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1394`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1395`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1396`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1397`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1398`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1399`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1400`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1401`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1402`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1403`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1404`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1405`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1406`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1407`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `data.ts`
+- **Thin community `Community 1408`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1409`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1410`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1411`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1412`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1413`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1414`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1415`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1416`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1417`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1418`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1419`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1420`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `constants.ts`
+- **Thin community `Community 1421`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1422`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1423`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1424`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `data.ts`
+- **Thin community `Community 1425`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `types.ts`
+- **Thin community `Community 1426`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1427`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1428`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1429`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1430`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1431`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `index.tsx`
+- **Thin community `Community 1432`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1433`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1434`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1435`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1436`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1437`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1438`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1439`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1440`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `index.tsx`
+- **Thin community `Community 1441`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1442`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1443`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1444`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `button.tsx`
+- **Thin community `Community 1445`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1446`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `card.tsx`
+- **Thin community `Community 1447`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1448`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1449`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `command.tsx`
+- **Thin community `Community 1450`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1451`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1452`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1453`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `form.tsx`
+- **Thin community `Community 1454`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1455`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1456`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `input.tsx`
+- **Thin community `Community 1457`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1458`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1459`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1460`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1461`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1462`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1463`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `select.tsx`
+- **Thin community `Community 1464`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1465`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1466`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1467`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `table.tsx`
+- **Thin community `Community 1468`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1469`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1470`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1471`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1472`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1473`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1474`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1475`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1476`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `constants.ts`
+- **Thin community `Community 1477`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1478`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1479`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1480`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `data.ts`
+- **Thin community `Community 1481`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1482`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1483`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1484`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1485`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1486`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1487`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1488`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1489`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1490`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1491`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1492`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `index.ts`
+- **Thin community `Community 1493`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1494`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1495`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1496`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1497`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1498`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1499`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1500`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1501`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1502`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1503`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1504`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `aws.ts`
+- **Thin community `Community 1505`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `constants.ts`
+- **Thin community `Community 1506`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `countries.ts`
+- **Thin community `Community 1507`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1508`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1509`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1510`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1511`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1512`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1513`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1514`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `dto.ts`
+- **Thin community `Community 1515`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `ports.ts`
+- **Thin community `Community 1516`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `constants.ts`
+- **Thin community `Community 1517`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1518`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1519`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `index.ts`
+- **Thin community `Community 1520`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1521`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `types.ts`
+- **Thin community `Community 1522`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1523`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1524`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1525`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1526`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1527`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1528`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1529`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1530`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1531`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1532`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1533`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `category.ts`
+- **Thin community `Community 1534`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `product.ts`
+- **Thin community `Community 1535`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `store.ts`
+- **Thin community `Community 1536`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1537`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `user.ts`
+- **Thin community `Community 1538`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1539`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1540`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1541`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1542`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1543`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1544`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1545`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1546`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1547`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1548`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `index.tsx`
+- **Thin community `Community 1549`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `index.tsx`
+- **Thin community `Community 1550`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1551`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1552`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1553`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1554`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1555`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1556`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `index.tsx`
+- **Thin community `Community 1557`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1558`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1559`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1560`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `home.tsx`
+- **Thin community `Community 1561`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1562`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1563`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1564`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `index.tsx`
+- **Thin community `Community 1565`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1566`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1567`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `index.tsx`
+- **Thin community `Community 1568`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1569`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1570`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1571`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `index.tsx`
+- **Thin community `Community 1572`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1573`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1574`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1575`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1576`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1577`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1578`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `index.tsx`
+- **Thin community `Community 1579`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1580`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1581`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1582`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1583`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1584`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1585`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1586`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1587`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1588`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `index.tsx`
+- **Thin community `Community 1589`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1590`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1591`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `new.tsx`
+- **Thin community `Community 1592`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1593`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1594`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1595`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1596`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `index.tsx`
+- **Thin community `Community 1597`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `new.tsx`
+- **Thin community `Community 1598`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1599`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1600`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1601`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1602`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1603`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `index.tsx`
+- **Thin community `Community 1604`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1605`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1606`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1607`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `index.tsx`
+- **Thin community `Community 1608`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1609`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1610`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1611`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1612`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1613`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1614`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1615`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1616`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1617`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1618`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1619`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1620`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1621`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1622`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1623`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1624`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1625`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1626`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1627`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1628`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1629`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1630`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1631`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1632`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `setup.ts`
+- **Thin community `Community 1633`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1634`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `types.ts`
+- **Thin community `Community 1635`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1636`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1637`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1638`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1639`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1640`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `types.ts`
+- **Thin community `Community 1641`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1642`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1643`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1644`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1645`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1646`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1647`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1648`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1649`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1650`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `schema.ts`
+- **Thin community `Community 1651`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1652`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1653`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1654`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1655`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1656`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1657`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1658`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1659`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1660`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `types.ts`
+- **Thin community `Community 1661`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1662`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1663`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1664`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1665`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1666`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1667`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1668`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `constants.ts`
+- **Thin community `Community 1669`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1670`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `About.tsx`
+- **Thin community `Community 1671`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1672`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1673`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1674`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1675`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1676`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1677`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1678`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1679`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1680`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1681`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `types.ts`
+- **Thin community `Community 1682`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1683`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1684`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1685`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1686`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1687`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1688`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1689`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1690`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1691`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1692`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1693`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `button.tsx`
+- **Thin community `Community 1694`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `card.tsx`
+- **Thin community `Community 1695`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1696`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `command.tsx`
+- **Thin community `Community 1697`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1698`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1699`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1700`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `form.tsx`
+- **Thin community `Community 1701`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1702`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1703`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1704`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1705`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `input.tsx`
+- **Thin community `Community 1706`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `label.tsx`
+- **Thin community `Community 1707`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1708`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1709`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1710`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `index.ts`
+- **Thin community `Community 1711`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `types.ts`
+- **Thin community `Community 1712`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1713`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1714`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1715`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1716`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `select.tsx`
+- **Thin community `Community 1717`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1718`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1719`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `table.tsx`
+- **Thin community `Community 1720`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1721`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1722`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1723`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1724`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1725`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `config.ts`
+- **Thin community `Community 1726`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1727`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1728`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1729`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1730`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `constants.ts`
+- **Thin community `Community 1731`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `countries.ts`
+- **Thin community `Community 1732`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1733`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1734`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1735`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1736`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `index.ts`
+- **Thin community `Community 1737`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `store.ts`
+- **Thin community `Community 1738`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `bag.ts`
+- **Thin community `Community 1739`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1740`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `category.ts`
+- **Thin community `Community 1741`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `organization.ts`
+- **Thin community `Community 1742`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `product.ts`
+- **Thin community `Community 1743`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `store.ts`
+- **Thin community `Community 1744`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1745`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `user.ts`
+- **Thin community `Community 1746`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `states.ts`
+- **Thin community `Community 1747`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1748`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1749`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1750`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1751`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1752`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1753`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1754`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `index.tsx`
+- **Thin community `Community 1755`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1756`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1757`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1758`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1759`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1760`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1761`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1762`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `index.tsx`
+- **Thin community `Community 1763`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1764`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1765`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1766`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1767`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1768`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `index.js`
+- **Thin community `Community 1769`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1770`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1771`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1772`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1773`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1774`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1775`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1776`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1777`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,20 +7,20 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1848
-- Graph nodes: 6339
-- Graph edges: 6975
-- Communities: 1776
+- Code files discovered: 1850
+- Graph nodes: 6352
+- Graph edges: 6992
+- Communities: 1778
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (84 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `useRegisterViewModel.ts` (68 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `dailyClose.ts` (65 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `projectLocalEvents.ts` (51 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
-- `usePosLocalSyncRuntime.ts` (47 edges, Community 5) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
+- `RegisterSessionView.tsx` (47 edges, Community 4) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
+- `usePosLocalSyncRuntime.ts` (47 edges, Community 6) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
 - `harness-inferential-review.ts` (46 edges, Community 8) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
-- `ingestLocalEvents.ts` (46 edges, Community 6) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
-- `posLocalStore.ts` (46 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
+- `ingestLocalEvents.ts` (46 edges, Community 7) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 
 ## Registered Packages
 - [Athena Webapp](packages/athena-webapp.md)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -21,7 +21,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - `useRegisterViewModel.ts` (68 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `dailyClose.ts` (65 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `projectLocalEvents.ts` (51 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
-- `usePosLocalSyncRuntime.ts` (47 edges, Community 5) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
+- `RegisterSessionView.tsx` (47 edges, Community 4) - [`packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx`](../../../packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/operations/dailyOperations.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.test.ts
@@ -11,6 +11,9 @@ type TableName =
   | "operationalEvent"
   | "operationalWorkItem"
   | "paymentAllocation"
+  | "posLocalSyncConflict"
+  | "posLocalSyncEvent"
+  | "posLocalSyncMapping"
   | "posSession"
   | "posTerminal"
   | "posTransactionAdjustment"
@@ -898,6 +901,10 @@ describe("daily operations overview read model", () => {
     ]);
     expect(
       snapshot.timeline.find((event) => event.id === "event-pos-sale-synced")
+        ?.message,
+    ).toBe("Sale #946956 synced: 3 sale lines, GH₵1,039, cash.");
+    expect(
+      snapshot.timeline.find((event) => event.id === "event-pos-sale-synced")
         ?.transactionLink,
     ).toEqual({
       label: "#946956",
@@ -970,6 +977,109 @@ describe("daily operations overview read model", () => {
         type: "register_session",
       },
       type: "register_session_closed",
+    });
+  });
+
+  it("surfaces pending synced register count submissions for the operating day", async () => {
+    const snapshot = await buildDailyOperationsSnapshotWithCtx(
+      buildCtx({
+        dailyClose: [priorClose],
+        dailyOpening: [startedOpening],
+        posLocalSyncConflict: [
+          {
+            _id: "conflict-register-count",
+            conflictType: "permission",
+            createdAt: Date.UTC(2026, 4, 8, 20, 46),
+            details: {
+              countedCash: 232_500,
+              expectedCash: 190_500,
+              variance: 42_000,
+            },
+            localEventId: "local-closeout-event",
+            localRegisterSessionId: "local-register-1",
+            sequence: 8,
+            status: "needs_review",
+            storeId: "store-1",
+            summary:
+              "Register closeout variance requires manager review before synced closeout can be applied.",
+            terminalId: "terminal-1",
+          },
+        ],
+        posLocalSyncEvent: [
+          {
+            _id: "sync-register-count",
+            acceptedAt: Date.UTC(2026, 4, 8, 20, 46),
+            eventType: "register_closed",
+            localEventId: "local-closeout-event",
+            localRegisterSessionId: "local-register-1",
+            occurredAt: Date.UTC(2026, 4, 8, 20, 45),
+            payload: {
+              countedCash: 232_500,
+            },
+            sequence: 8,
+            staffProfileId: "staff-pos",
+            status: "conflicted",
+            storeId: "store-1",
+            submittedAt: Date.UTC(2026, 4, 8, 20, 46),
+            terminalId: "terminal-1",
+          },
+        ],
+        posLocalSyncMapping: [
+          {
+            _id: "mapping-register-1",
+            cloudId: "register-1",
+            cloudTable: "registerSession",
+            createdAt: Date.UTC(2026, 4, 8, 8),
+            localEventId: "local-open-event",
+            localId: "local-register-1",
+            localIdKind: "registerSession",
+            localRegisterSessionId: "local-register-1",
+            storeId: "store-1",
+            terminalId: "terminal-1",
+          },
+        ],
+        registerSession: [
+          {
+            _id: "register-1",
+            expectedCash: 190_500,
+            openedAt: Date.UTC(2026, 4, 8, 8),
+            openingFloat: 16_000,
+            organizationId: "org-1",
+            registerNumber: "1",
+            status: "active",
+            storeId: "store-1",
+          },
+        ],
+        staffProfile: [
+          {
+            _id: "staff-pos",
+            fullName: "P OS",
+            organizationId: "org-1",
+            storeId: "store-1",
+          },
+        ],
+        store: [store],
+      }),
+      { operatingDate: "2026-05-08", storeId: "store-1" as Id<"store"> },
+    );
+
+    expect(snapshot.timeline[0]).toMatchObject({
+      id: "pos_local_sync_register_count:sync-register-count",
+      message:
+        "P OS submitted Register 1 count of GH₵2,325. Variance GH₵420 needs manager review.",
+      registerLink: {
+        label: "Register 1",
+        params: {
+          sessionId: "register-1",
+        },
+        to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId",
+      },
+      subject: {
+        id: "register-1",
+        label: "Register 1",
+        type: "register_session",
+      },
+      type: "register_session_count_submitted",
     });
   });
 

--- a/packages/athena-webapp/convex/operations/dailyOperations.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.ts
@@ -7,12 +7,19 @@ import {
   listAppliedTransactionAdjustmentsForDay,
 } from "./dailyClose";
 import { buildDailyOpeningSnapshotWithCtx } from "./dailyOpening";
+import { toDisplayAmount } from "../lib/currency";
+import { currencyFormatter } from "../utils";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const MAX_OPERATIONS_QUERY_LIMIT = 200;
 const MAX_OPERATIONS_LOOKAHEAD_LIMIT = MAX_OPERATIONS_QUERY_LIMIT + 1;
 const OPEN_WORK_ITEM_STATUSES = ["open", "in_progress"] as const;
 const TIMELINE_REGISTER_SESSION_STATUSES = ["closed", "closing"] as const;
+const TIMELINE_PENDING_REGISTER_COUNT_STATUSES = [
+  "accepted",
+  "conflicted",
+  "held",
+] as const;
 
 type LinkTarget = {
   label?: string;
@@ -476,9 +483,14 @@ async function listTimelineEvents(
     .order("desc")
     .take(MAX_OPERATIONS_QUERY_LIMIT);
   const registerSessionsPromise = listTimelineRegisterSessions(ctx, args.storeId);
-  const [events, registerSessions] = await Promise.all([
+  const pendingRegisterCountsPromise = listPendingRegisterCountTimelineEvents(
+    ctx,
+    args,
+  );
+  const [events, registerSessions, pendingRegisterCountEvents] = await Promise.all([
     eventsPromise,
     registerSessionsPromise,
+    pendingRegisterCountsPromise,
   ]);
   const operationalCloseoutKeys = new Set(
     events
@@ -501,9 +513,142 @@ async function listTimelineEvents(
   return [
     ...operationalTimelineEvents,
     ...registerCloseoutTimelineEvents,
+    ...pendingRegisterCountEvents,
   ]
     .sort(compareDailyOperationsTimelineEvents)
     .slice(0, MAX_OPERATIONS_QUERY_LIMIT);
+}
+
+async function listPendingRegisterCountTimelineEvents(
+  ctx: Pick<QueryCtx, "db">,
+  args: {
+    endAt: number;
+    startAt: number;
+    storeId: Id<"store">;
+  },
+): Promise<DailyOperationsTimelineEvent[]> {
+  if (!args.startAt || !args.endAt) return [];
+
+  const [store, eventBatches] = await Promise.all([
+    ctx.db.get("store", args.storeId),
+    Promise.all(
+      TIMELINE_PENDING_REGISTER_COUNT_STATUSES.map((status) =>
+        ctx.db
+          .query("posLocalSyncEvent")
+          .withIndex("by_store_status", (q) =>
+            q.eq("storeId", args.storeId).eq("status", status),
+          )
+          .order("desc")
+          .take(MAX_OPERATIONS_QUERY_LIMIT),
+      ),
+    ),
+  ]);
+  const eventsById = new Map<Id<"posLocalSyncEvent">, Doc<"posLocalSyncEvent">>();
+
+  for (const event of eventBatches.flat()) {
+    if (
+      event.eventType !== "register_closed" ||
+      event.occurredAt < args.startAt ||
+      event.occurredAt >= args.endAt
+    ) {
+      continue;
+    }
+
+    eventsById.set(event._id, event);
+  }
+
+  const events = await Promise.all(
+    [...eventsById.values()].map((event) =>
+      mapPendingRegisterCountTimelineEvent(ctx, {
+        currency: store?.currency ?? "GHS",
+        event,
+        storeId: args.storeId,
+      }),
+    ),
+  );
+
+  return events.filter(
+    (event): event is DailyOperationsTimelineEvent => event !== null,
+  );
+}
+
+async function mapPendingRegisterCountTimelineEvent(
+  ctx: Pick<QueryCtx, "db">,
+  args: {
+    currency: string;
+    event: Doc<"posLocalSyncEvent">;
+    storeId: Id<"store">;
+  },
+): Promise<DailyOperationsTimelineEvent | null> {
+  const mapping = await ctx.db
+    .query("posLocalSyncMapping")
+    .withIndex("by_store_terminal_local", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("terminalId", args.event.terminalId)
+        .eq("localRegisterSessionId", args.event.localRegisterSessionId)
+        .eq("localIdKind", "registerSession")
+        .eq("localId", args.event.localRegisterSessionId),
+    )
+    .first();
+
+  if (!mapping || mapping.cloudTable !== "registerSession") return null;
+
+  const registerSession = await ctx.db.get(
+    "registerSession",
+    mapping.cloudId as Id<"registerSession">,
+  );
+
+  if (!registerSession) return null;
+
+  const [staffProfile, conflict] = await Promise.all([
+    ctx.db.get("staffProfile", args.event.staffProfileId),
+    ctx.db
+      .query("posLocalSyncConflict")
+      .withIndex("by_store_terminal_localEvent", (q) =>
+        q
+          .eq("storeId", args.storeId)
+          .eq("terminalId", args.event.terminalId)
+          .eq("localEventId", args.event.localEventId),
+      )
+      .first(),
+  ]);
+  const registerLabel = formatRegisterSessionLabel(
+    registerSession.registerNumber,
+  );
+  const countedCash = numberFromRecord(args.event.payload, "countedCash");
+  const expectedCash =
+    numberFromRecord(conflict?.details, "expectedCash") ??
+    registerSession.expectedCash;
+  const variance =
+    numberFromRecord(conflict?.details, "variance") ??
+    (typeof countedCash === "number" ? countedCash - expectedCash : undefined);
+
+  return {
+    createdAt: args.event.occurredAt,
+    id: `pos_local_sync_register_count:${args.event._id}`,
+    message: buildPendingRegisterCountTimelineMessage({
+      countedCash,
+      currency: args.currency,
+      registerLabel,
+      staffName: staffProfile?.fullName,
+      status: args.event.status,
+      variance,
+    }),
+    registerLink: {
+      label: registerLabel,
+      params: {
+        sessionId: registerSession._id,
+      },
+      to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId",
+    },
+    subject: {
+      id: registerSession._id,
+      label: registerLabel,
+      type: "register_session",
+    },
+    type: "register_session_count_submitted",
+  };
 }
 
 async function mapOperationalTimelineEvent(
@@ -602,7 +747,7 @@ async function mapOperationalTimelineEvent(
     return {
       createdAt: event.createdAt,
       id: event._id,
-      message: event.message,
+      message: normalizeTimelineEventMessage(event.message),
       productLink,
       registerLink,
       subject: {
@@ -613,6 +758,10 @@ async function mapOperationalTimelineEvent(
       transactionLink,
       type: event.eventType,
     };
+}
+
+function normalizeTimelineEventMessage(message: string) {
+  return message.replace(/^Offline POS sale\b/, "Sale");
 }
 
 async function listTimelineRegisterSessions(
@@ -707,6 +856,46 @@ function buildRegisterCloseoutTimelineMessage(args: {
   }
 
   return `${args.label} closeout recorded with an exact cash match.`;
+}
+
+function buildPendingRegisterCountTimelineMessage(args: {
+  countedCash?: number;
+  currency: string;
+  registerLabel: string;
+  staffName?: string;
+  status: Doc<"posLocalSyncEvent">["status"];
+  variance?: number;
+}) {
+  const actor = args.staffName?.trim() || "A POS operator";
+  const amount =
+    typeof args.countedCash === "number"
+      ? ` of ${formatTimelineAmount(args.currency, args.countedCash)}`
+      : "";
+  const reviewSuffix =
+    args.status === "conflicted" && typeof args.variance === "number"
+      ? ` Variance ${formatTimelineAmount(args.currency, args.variance)} needs manager review.`
+      : args.status === "held"
+        ? " Sync is waiting for review."
+        : " Sync is pending.";
+
+  return `${actor} submitted ${args.registerLabel} count${amount}.${reviewSuffix}`;
+}
+
+function formatTimelineAmount(currency: string, amount: number) {
+  const storeCurrency = currency.trim() || "GHS";
+
+  try {
+    return currencyFormatter(storeCurrency).format(toDisplayAmount(amount));
+  } catch {
+    return currencyFormatter("GHS").format(toDisplayAmount(amount));
+  }
+}
+
+function numberFromRecord(record: unknown, key: string) {
+  if (!record || typeof record !== "object") return undefined;
+
+  const value = (record as Record<string, unknown>)[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
 function formatRegisterSessionLabel(registerNumber?: string) {

--- a/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts
@@ -22,7 +22,7 @@ type IndexedFilter = {
 
 function createRegisterCatalogCtx(
   seed: Partial<Record<TableName, Row[]>>,
-  options: { asyncIteratorLimit?: number } = {},
+  options: { asyncIteratorLimit?: number; failOnPaginate?: boolean } = {},
 ) {
   const tables: Record<TableName, Map<string, Row>> = {
     category: new Map(),
@@ -61,6 +61,9 @@ function createRegisterCatalogCtx(
         cursor: string | null;
         numItems: number;
       }) => {
+        if (options.failOnPaginate) {
+          throw new Error("paginate should not be used in this query");
+        }
         const offset = cursor ? Number(cursor) : 0;
         const page = matches.slice(offset, offset + numItems);
         const nextOffset = offset + page.length;
@@ -359,7 +362,7 @@ describe("listRegisterCatalog", () => {
     expect(rows[0]).not.toHaveProperty("quantityAvailable");
   });
 
-  it("does not drop sellable SKUs beyond the first query page", async () => {
+  it("does not rely on pagination for large register catalog snapshots", async () => {
     const products = Array.from({ length: 505 }, (_, index) => ({
       _id: `product-${index}`,
       storeId: "store-a",
@@ -391,7 +394,7 @@ describe("listRegisterCatalog", () => {
         product: products,
         productSku: productSkus,
       },
-      { asyncIteratorLimit: 30 },
+      { asyncIteratorLimit: 30, failOnPaginate: true },
     );
 
     const rows = await listRegisterCatalog(ctx, {

--- a/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts
@@ -31,7 +31,6 @@ type RegisterCatalogAvailabilityRow = {
 };
 
 export const REGISTER_CATALOG_AVAILABILITY_LIMIT = 50;
-const REGISTER_CATALOG_PAGE_SIZE = 500;
 
 async function readCategoryName(
   ctx: QueryCtx,
@@ -120,26 +119,12 @@ async function listScopedRegisterCatalogSkus(
 ) {
   const rows: Array<{ product: Doc<"product">; sku: Doc<"productSku"> }> = [];
   const productCache = new Map<Id<"product">, Doc<"product"> | null>();
-  const skus: Doc<"productSku">[] = [];
-  let cursor: string | null = null;
-
-  while (true) {
-    const page = await ctx.db
-      .query("productSku")
-      .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
-      .paginate({
-        cursor,
-        numItems: REGISTER_CATALOG_PAGE_SIZE,
-      });
-
-    skus.push(...page.page);
-
-    if (page.isDone) {
-      break;
-    }
-
-    cursor = page.continueCursor;
-  }
+  // Convex allows only one paginated query per function; this POS snapshot must read the store catalog in one query.
+  // eslint-disable-next-line @convex-dev/no-collect-in-query
+  const skus = await ctx.db
+    .query("productSku")
+    .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
+    .collect();
 
   for (const sku of skus) {
     let product = productCache.get(sku.productId);

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
@@ -424,7 +424,7 @@ describe("projectLocalSyncEvent", () => {
       expect.objectContaining({
         eventType: "pos_local_sync.sale_projected",
         message:
-          "Offline POS sale #LR-001 synced: 1 sale line, GH₵0.25, cash.",
+          "Sale #LR-001 synced: 1 sale line, GH₵0.25, cash.",
         metadata: expect.objectContaining({
           lineCount: 1,
           localReceiptNumber: "LR-001",
@@ -679,7 +679,7 @@ describe("projectLocalSyncEvent", () => {
       expect.objectContaining({
         eventType: "pos_local_sync.sale_projected",
         message:
-          "Offline POS sale #LR-001 synced: 2 sale lines, GH₵1, cash and card.",
+          "Sale #LR-001 synced: 2 sale lines, GH₵1, cash and card.",
         metadata: expect.objectContaining({
           lineCount: 2,
           paymentMethods: ["cash", "card"],
@@ -755,7 +755,7 @@ describe("projectLocalSyncEvent", () => {
       expect.objectContaining({
         eventType: "pos_local_sync.sale_projected",
         message:
-          "Offline POS sale #LR-001 synced: 1 sale line, GH₵0.25, cash, card, and mobile money.",
+          "Sale #LR-001 synced: 1 sale line, GH₵0.25, cash, card, and mobile money.",
         metadata: expect.objectContaining({
           paymentMethods: ["cash", "card", "mobile money"],
         }),

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -1757,7 +1757,7 @@ function buildSaleProjectedMessage(args: {
   const paymentLabel = getPaymentSummaryLabel(args.payments.validPayments);
 
   return [
-    `Offline POS sale${transactionLabel} synced: ${formatSaleLineCount(lineCount)}`,
+    `Sale${transactionLabel} synced: ${formatSaleLineCount(lineCount)}`,
     formatSaleTotal(args.currency, args.payload.totals.total),
     paymentLabel,
   ].join(", ") + ".";

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -23,6 +23,6 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 6 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCases.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 11 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
 - [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 484 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
-- [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 8 file(s); key children: README.md, SUMMARY.md, pos.
+- [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 9 file(s); key children: README.md, SUMMARY.md, pos, prod.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -329,5 +329,6 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/tests/pos/offlineSalesContinuity.spec.ts`](../../src/tests/pos/offlineSalesContinuity.spec.ts)
 - [`src/tests/pos/simple.test.ts`](../../src/tests/pos/simple.test.ts)
 - [`src/tests/pos/usePrint.test.ts`](../../src/tests/pos/usePrint.test.ts)
+- [`src/tests/prod/posFlow.prod.spec.ts`](../../src/tests/prod/posFlow.prod.spec.ts)
 - [`src/utils/versionChecker.test.ts`](../../src/utils/versionChecker.test.ts)
 

--- a/packages/athena-webapp/docs/agent/validation-guide.md
+++ b/packages/athena-webapp/docs/agent/validation-guide.md
@@ -214,12 +214,13 @@ Use this when POS hub app-session recovery, route-shell continuity, terminal rec
 
 ## POS offline route access and app-shell edits
 
-Touched surfaces: `public/pos-app-shell-sw.js`, `playwright.config.ts`, `src/main.tsx`, `src/offline`, `src/routes/_authed.tsx`, `src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos`, `src/components/pos/PointOfSaleView.tsx`, `src/components/pos/register`, `src/components/pos/settings/POSSettingsView.tsx`, `src/components/pos/terminals/POSTerminalHealthView.tsx`, `src/lib/pos/infrastructure/local`, `src/lib/pos/presentation/register`, `src/tests/pos/offlineRouteAccess.spec.ts`, `src/tests/pos/offlineSalesContinuity.spec.ts`
+Touched surfaces: `public/pos-app-shell-sw.js`, `playwright.config.ts`, `playwright.prod.config.ts`, `src/main.tsx`, `src/offline`, `src/routes/_authed.tsx`, `src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/pos`, `src/components/pos/PointOfSaleView.tsx`, `src/components/pos/register`, `src/components/pos/settings/POSSettingsView.tsx`, `src/components/pos/terminals/POSTerminalHealthView.tsx`, `src/lib/pos/infrastructure/local`, `src/lib/pos/presentation/register`, `src/tests/pos/offlineRouteAccess.spec.ts`, `src/tests/pos/offlineSalesContinuity.spec.ts`, `src/tests/prod/posFlow.prod.spec.ts`
 
 Run:
 
 - `bun run --filter '@athena/webapp' test -- src/offline/posAppShellRoutes.test.ts src/offline/registerPosAppShellServiceWorker.test.ts src/offline/posOfflineReadiness.test.ts src/routes/_authed.test.tsx src/components/pos/PointOfSaleView.test.tsx src/components/pos/settings/POSSettingsView.test.tsx src/components/pos/terminals/POSTerminalHealthView.test.tsx src/components/pos/register/POSRegisterOpeningGuard.test.tsx src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
 - `bun run --filter '@athena/webapp' test:e2e -- src/tests/pos/offlineRouteAccess.spec.ts src/tests/pos/offlineSalesContinuity.spec.ts`
+- `bun run --filter '@athena/webapp' test:e2e:prod:pos`
 - `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
 - `bun run --filter '@athena/webapp' build`
 

--- a/packages/athena-webapp/docs/agent/validation-map.json
+++ b/packages/athena-webapp/docs/agent/validation-map.json
@@ -507,6 +507,7 @@
       "pathPrefixes": [
         "packages/athena-webapp/public/pos-app-shell-sw.js",
         "packages/athena-webapp/playwright.config.ts",
+        "packages/athena-webapp/playwright.prod.config.ts",
         "packages/athena-webapp/src/main.tsx",
         "packages/athena-webapp/src/offline",
         "packages/athena-webapp/src/routes/_authed.tsx",
@@ -518,7 +519,8 @@
         "packages/athena-webapp/src/lib/pos/infrastructure/local",
         "packages/athena-webapp/src/lib/pos/presentation/register",
         "packages/athena-webapp/src/tests/pos/offlineRouteAccess.spec.ts",
-        "packages/athena-webapp/src/tests/pos/offlineSalesContinuity.spec.ts"
+        "packages/athena-webapp/src/tests/pos/offlineSalesContinuity.spec.ts",
+        "packages/athena-webapp/src/tests/prod/posFlow.prod.spec.ts"
       ],
       "commands": [
         {
@@ -528,6 +530,10 @@
         {
           "kind": "raw",
           "command": "bun run --filter '@athena/webapp' test:e2e -- src/tests/pos/offlineRouteAccess.spec.ts src/tests/pos/offlineSalesContinuity.spec.ts"
+        },
+        {
+          "kind": "raw",
+          "command": "bun run --filter '@athena/webapp' test:e2e:prod:pos"
         },
         {
           "kind": "raw",

--- a/packages/athena-webapp/package.json
+++ b/packages/athena-webapp/package.json
@@ -23,7 +23,8 @@
     "storybook:build": "storybook build --config-dir ../../.storybook-athena",
     "build-storybook": "bun run storybook:build",
     "test:e2e": "playwright test --config playwright.config.ts",
-    "test:e2e:headed": "playwright test --config playwright.config.ts --headed"
+    "test:e2e:headed": "playwright test --config playwright.config.ts --headed",
+    "test:e2e:prod:pos": "playwright test --config playwright.prod.config.ts"
   },
   "devDependencies": {
     "@convex-dev/eslint-plugin": "^1.2.2",

--- a/packages/athena-webapp/playwright.prod.config.ts
+++ b/packages/athena-webapp/playwright.prod.config.ts
@@ -1,0 +1,60 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const port = Number(process.env.PLAYWRIGHT_PORT || 4178);
+const runLocalCandidateBuild = process.env.ATHENA_POS_E2E_RUN_LOCAL_BUILD === "1";
+const baseURL =
+  process.env.ATHENA_POS_E2E_BASE_URL ||
+  (runLocalCandidateBuild
+    ? `http://127.0.0.1:${port}`
+    : process.env.ATHENA_PROD_URL || "https://athena.wigclub.store");
+const convexUrl =
+  process.env.ATHENA_PROD_CONVEX_URL ||
+  process.env.VITE_CONVEX_URL ||
+  "https://colorless-cardinal-870.convex.cloud";
+const apiGatewayUrl =
+  process.env.ATHENA_PROD_CONVEX_SITE_URL ||
+  process.env.VITE_API_GATEWAY_URL ||
+  "https://colorless-cardinal-870.convex.site";
+
+export default defineConfig({
+  testDir: "./src/tests/prod",
+  testMatch: "**/*.prod.spec.ts",
+  timeout: 75_000,
+  expect: {
+    timeout: 10_000,
+  },
+  fullyParallel: false,
+  retries: process.env.CI ? 2 : 0,
+  outputDir:
+    process.env.PLAYWRIGHT_OUTPUT_DIR ||
+    "/tmp/athena-webapp-prod-playwright-results",
+  reporter: process.env.CI ? [["github"], ["html"]] : [["list"]],
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "desktop-chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "mobile-chromium",
+      use: { ...devices["Pixel 5"] },
+    },
+  ],
+  webServer: runLocalCandidateBuild
+    ? {
+        command: `bun run build && bun run serve --host 127.0.0.1 --port ${port}`,
+        env: {
+          VITE_CONVEX_URL: convexUrl,
+          VITE_API_GATEWAY_URL: apiGatewayUrl,
+        },
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+        stdout: "pipe",
+        stderr: "pipe",
+      }
+    : undefined,
+});

--- a/packages/athena-webapp/src/components/Navbar.tsx
+++ b/packages/athena-webapp/src/components/Navbar.tsx
@@ -1,14 +1,5 @@
-import {
-  Link,
-  useLoaderData,
-  useNavigate,
-  useParams,
-  useRouterState,
-} from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 import OrganizationSwitcher from "./organization-switcher";
-import { StoreAccordion } from "./StoreAccordion";
-import { Button } from "./ui/button";
-import { ArrowLeftIcon, ChevronLeftIcon } from "@radix-ui/react-icons";
 import { useGetOrganizations } from "@/hooks/useGetOrganizations";
 import useGetActiveStore from "../hooks/useGetActiveStore";
 import { useQuery } from "convex/react";
@@ -17,57 +8,19 @@ import { useEffect } from "react";
 import { toast } from "sonner";
 import { currencyFormatter } from "../lib/utils";
 
-function SettingsHeader() {
-  const navigate = useNavigate();
-  const { storeUrlSlug, orgUrlSlug } = useParams({ strict: false });
-
-  const handleGoBack = () => {
-    if (storeUrlSlug) {
-      navigate({
-        to: "/$orgUrlSlug/store/$storeUrlSlug",
-        params: (prev) => {
-          return {
-            ...prev,
-            orgUrlSlug: prev.orgUrlSlug!,
-            storeUrlSlug,
-          };
-        },
-      });
-    } else {
-      navigate({
-        to: "/$orgUrlSlug/store",
-        params: (prev) => ({
-          ...prev,
-          orgUrlSlug: prev.orgUrlSlug!,
-        }),
-      });
-    }
-  };
-
-  return (
-    <div className="flex items-center gap-1 h-[56px] px-2">
-      <Button
-        variant="ghost"
-        className="h-8 px-2 lg:px-3"
-        onClick={handleGoBack}
-      >
-        <ChevronLeftIcon className="h-4 w-4" />
-      </Button>
-      <p className="text-sm">Settings</p>
-    </div>
-  );
-}
-
 export const AppHeader = () => {
   const organizations = useGetOrganizations();
 
   return (
-    <div className="flex items-center gap-2">
-      <Link to="/" className="flex items-center">
+    <div className="flex min-w-0 items-center gap-2">
+      <Link to="/" className="flex shrink-0 items-center">
         <p className="font-medium">athena</p>
       </Link>
-      <p className="text-muted-foreground">/</p>
-      <OrganizationSwitcher items={organizations || []} />
+      <p className="hidden text-muted-foreground sm:block">/</p>
+      <OrganizationSwitcher
+        className="max-w-[9.5rem] sm:max-w-[14rem]"
+        items={organizations || []}
+      />
     </div>
   );
 };
@@ -141,7 +94,7 @@ const Navbar = () => {
         duration: 4000,
       });
     }
-  }, [newOrder]);
+  }, [formatter, newOrder]);
 
   return (
     <section className={`px-8 border-b w-full flex-none space-y-4`}>

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
@@ -63,13 +63,15 @@ vi.mock("@/hooks/useProtectedAdminPageState", () => protectedPageMocks);
 
 vi.mock("../common/PageHeader", () => ({
   ComposedPageHeader: ({
+    className,
     leadingContent,
     trailingContent,
   }: {
+    className?: string;
     leadingContent: React.ReactNode;
     trailingContent?: React.ReactNode;
   }) => (
-    <div>
+    <div className={className} data-testid="register-session-page-header">
       <div>{leadingContent}</div>
       <div>{trailingContent}</div>
     </div>
@@ -346,11 +348,19 @@ describe("RegisterSessionViewContent", () => {
     expect(screen.getByText("Counted")).toBeInTheDocument();
     expect(screen.getAllByText("$171").length).toBeGreaterThan(0);
     expect(screen.getByText("Linked transactions")).toBeInTheDocument();
-    const transactionRow = screen.getByRole("link", {
+    const transactionRow = screen.getAllByRole("link", {
       name: "Open transaction #TXN-0031",
-    });
+    })[0];
     expect(transactionRow).toBeInTheDocument();
-    expect(screen.getByText(/3 items - Esi Boateng/i)).toBeInTheDocument();
+    const transactionDetails = within(transactionRow);
+    expect(transactionDetails.getByText("Payment")).toHaveClass(
+      "text-xs",
+      "tracking-[0.12em]",
+    );
+    expect(transactionDetails.getByText("Cash")).toHaveClass("text-sm");
+    expect(screen.getAllByText(/3 items - Esi Boateng/i).length).toBeGreaterThan(
+      0,
+    );
     expect(screen.getAllByText("Ama M.").length).toBeGreaterThan(0);
     expect(screen.getByText("Variance review required.")).toBeInTheDocument();
     expect(screen.getByText("Closeout workflow")).toBeInTheDocument();
@@ -361,10 +371,21 @@ describe("RegisterSessionViewContent", () => {
     );
     expect(screen.getByText("Deposit history")).toBeInTheDocument();
     expect(screen.getByText("Record cash deposit")).toBeInTheDocument();
-    expect(screen.getByText("BANK-339")).toBeInTheDocument();
+    expect(screen.getAllByText("BANK-339").length).toBeGreaterThan(0);
     expect(
       screen.getByRole("link", { name: "View trace" }),
     ).toBeInTheDocument();
+    expect(screen.getByTestId("register-session-page-header")).toHaveClass(
+      "h-auto",
+      "min-h-14",
+      "items-start",
+      "border-b",
+      "py-3",
+      "sm:h-[40px]",
+    );
+    expect(screen.getByRole("link", { name: "View trace" })).not.toHaveClass(
+      "w-full",
+    );
   });
 
   it("shows locally closed pending-sync sessions as pending reconciliation", () => {
@@ -2285,10 +2306,10 @@ describe("RegisterSessionViewContent", () => {
       />,
     );
 
-    expect(screen.getByText("Voided")).toBeInTheDocument();
+    expect(screen.getAllByText("Voided").length).toBeGreaterThan(0);
 
     await user.click(
-      screen.getByRole("link", { name: "Open transaction #TXN-0031" }),
+      screen.getAllByRole("link", { name: "Open transaction #TXN-0031" })[0],
     );
 
     expect(routerMocks.navigate).toHaveBeenCalledWith({
@@ -2332,8 +2353,8 @@ describe("RegisterSessionViewContent", () => {
     );
 
     expect(screen.getByText("6 sales")).toBeInTheDocument();
-    expect(screen.getByText("#TXN-0001")).toBeInTheDocument();
-    expect(screen.getByText("#TXN-0005")).toBeInTheDocument();
+    expect(screen.getAllByText("#TXN-0001").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("#TXN-0005").length).toBeGreaterThan(0);
     expect(screen.queryByText("#TXN-0006")).not.toBeInTheDocument();
     expect(
       screen.getByText("Showing latest 5 of 6 linked sales."),

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -33,7 +33,7 @@ import {
   runCommand,
 } from "@/lib/errors/runCommand";
 import { getOrigin } from "@/lib/navigationUtils";
-import { capitalizeWords, currencyFormatter } from "@/lib/utils";
+import { capitalizeWords, cn, currencyFormatter } from "@/lib/utils";
 import {
   formatStoredCurrencyAmount,
   parseDisplayAmountInput,
@@ -920,12 +920,12 @@ function RegisterSessionSyncNotice({
             <p className="text-sm leading-6 text-destructive">{errorMessage}</p>
           ) : null}
         </div>
-        <div className="flex flex-wrap items-center justify-end gap-layout-sm">
+        <div className="flex w-full flex-col gap-layout-sm sm:w-auto sm:flex-row sm:flex-wrap sm:items-center sm:justify-end">
           {syncStatus.status === "needs_review" &&
           hasOnlyRejectedReviewItems &&
           onReviewDecision ? (
             <LoadingButton
-              className="border-border bg-background text-foreground hover:bg-muted"
+              className="w-full border-border bg-background text-foreground hover:bg-muted sm:w-auto"
               disabled={isResolving}
               isLoading={Boolean(isResolving)}
               onClick={() => onReviewDecision("approved")}
@@ -941,7 +941,7 @@ function RegisterSessionSyncNotice({
             storeUrlSlug ? (
             <Button
               asChild
-              className="border-border bg-background text-foreground hover:bg-muted"
+              className="w-full border-border bg-background text-foreground hover:bg-muted sm:w-auto"
               size="sm"
               variant="outline"
             >
@@ -961,7 +961,7 @@ function RegisterSessionSyncNotice({
             <>
               {canApplySyncReview ? (
                 <LoadingButton
-                  className="border-border bg-background text-foreground hover:bg-muted"
+                  className="w-full border-border bg-background text-foreground hover:bg-muted sm:w-auto"
                   disabled={isResolving}
                   isLoading={Boolean(isResolving)}
                   onClick={() => onReviewDecision("approved")}
@@ -973,6 +973,7 @@ function RegisterSessionSyncNotice({
                 </LoadingButton>
               ) : null}
               <Button
+                className="w-full sm:w-auto"
                 disabled={isResolving}
                 onClick={() => onReviewDecision("rejected")}
                 size="sm"
@@ -1064,6 +1065,159 @@ function RegisterSessionSupportEvidence({
         </div>
       </dl>
     </section>
+  );
+}
+
+function RegisterSessionTransactionCard({
+  canOpenTransaction,
+  currency,
+  onOpen,
+  transaction,
+}: {
+  canOpenTransaction: boolean;
+  currency: string;
+  onOpen?: () => void;
+  transaction: RegisterSessionTransaction;
+}) {
+  const PaymentIcon = getPaymentMethodIcon({
+    hasMultiplePaymentMethods: transaction.hasMultiplePaymentMethods,
+    paymentMethod: transaction.paymentMethod,
+  });
+  const transactionLabel = `#${transaction.transactionNumber}`;
+  const isVoidedTransaction =
+    transaction.status === "void" || typeof transaction.voidedAt === "number";
+
+  return (
+    <article
+      aria-label={
+        canOpenTransaction ? `Open transaction ${transactionLabel}` : undefined
+      }
+      className={cn(
+        "rounded-lg border border-border/70 bg-background p-layout-md transition-colors",
+        canOpenTransaction &&
+          "cursor-pointer hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+      )}
+      onClick={canOpenTransaction ? onOpen : undefined}
+      onKeyDown={
+        canOpenTransaction
+          ? (event) => {
+              if (event.key !== "Enter" && event.key !== " ") {
+                return;
+              }
+
+              event.preventDefault();
+              onOpen?.();
+            }
+          : undefined
+      }
+      role={canOpenTransaction ? "link" : undefined}
+      tabIndex={canOpenTransaction ? 0 : undefined}
+    >
+      <div className="flex items-start justify-between gap-layout-md">
+        <div className="min-w-0 space-y-1">
+          <p className="inline-flex min-w-0 items-center gap-1 font-medium text-foreground">
+            <span className="truncate">{transactionLabel}</span>
+            {canOpenTransaction ? (
+              <ArrowUpRight className="h-3.5 w-3.5 shrink-0" />
+            ) : null}
+          </p>
+          <p className="text-xs leading-5 text-muted-foreground">
+            {transaction.itemCount}{" "}
+            {transaction.itemCount === 1 ? "item" : "items"}
+            {transaction.customerName ? ` - ${transaction.customerName}` : ""}
+          </p>
+        </div>
+        <div className="shrink-0 text-right">
+          <p className="font-numeric text-sm tabular-nums text-foreground">
+            {formatCurrency(currency, transaction.total)}
+          </p>
+          {isVoidedTransaction ? (
+            <span className="mt-1 inline-flex rounded-sm border border-destructive/30 bg-destructive/10 px-1.5 py-0.5 text-xs font-medium text-destructive">
+              Voided
+            </span>
+          ) : null}
+        </div>
+      </div>
+      <dl className="mt-layout-md grid gap-layout-sm border-t border-border/70 pt-layout-sm">
+        <div className="flex items-center justify-between gap-layout-sm">
+          <dt className="text-xs font-medium uppercase leading-5 tracking-[0.12em] text-muted-foreground">
+            Payment
+          </dt>
+          <dd className="inline-flex items-center gap-2 text-sm leading-5 text-foreground">
+            <PaymentIcon className="h-4 w-4 text-muted-foreground" />
+            {transaction.hasMultiplePaymentMethods
+              ? "Multiple"
+              : formatPaymentMethod(transaction.paymentMethod)}
+          </dd>
+        </div>
+        <div className="flex items-center justify-between gap-layout-sm">
+          <dt className="text-xs font-medium uppercase leading-5 tracking-[0.12em] text-muted-foreground">
+            Cashier
+          </dt>
+          <dd className="text-right text-sm leading-5 text-foreground">
+            {transaction.cashierName
+              ? formatStaffDisplayName({ fullName: transaction.cashierName })
+              : "N/A"}
+          </dd>
+        </div>
+        <div className="flex items-center justify-between gap-layout-sm">
+          <dt className="text-xs font-medium uppercase leading-5 tracking-[0.12em] text-muted-foreground">
+            Completed
+          </dt>
+          <dd className="text-right text-sm leading-5 text-foreground">
+            {formatTimestamp(transaction.completedAt)}
+          </dd>
+        </div>
+      </dl>
+    </article>
+  );
+}
+
+function RegisterSessionDepositCard({
+  currency,
+  deposit,
+}: {
+  currency: string;
+  deposit: RegisterSessionDeposit;
+}) {
+  return (
+    <article className="rounded-lg border border-border/70 bg-background p-layout-md">
+      <div className="flex items-start justify-between gap-layout-md">
+        <div className="min-w-0 space-y-1">
+          <p className="text-[11px] font-medium uppercase tracking-[0.16em] text-muted-foreground">
+            Recorded
+          </p>
+          <p className="text-sm leading-5 text-foreground">
+            {formatTimestamp(deposit.recordedAt)}
+          </p>
+        </div>
+        <p className="shrink-0 font-numeric text-sm tabular-nums text-foreground">
+          {formatCurrency(currency, deposit.amount)}
+        </p>
+      </div>
+      <dl className="mt-layout-md grid gap-layout-sm border-t border-border/70 pt-layout-sm text-xs text-muted-foreground">
+        <div className="flex items-center justify-between gap-layout-sm">
+          <dt className="font-medium uppercase tracking-[0.14em]">Reference</dt>
+          <dd className="min-w-0 truncate text-right text-foreground">
+            {deposit.reference ?? "N/A"}
+          </dd>
+        </div>
+        <div className="flex items-center justify-between gap-layout-sm">
+          <dt className="font-medium uppercase tracking-[0.14em]">By</dt>
+          <dd className="min-w-0 truncate text-right text-foreground">
+            {deposit.recordedByStaffName
+              ? formatStaffDisplayName({ fullName: deposit.recordedByStaffName })
+              : "N/A"}
+          </dd>
+        </div>
+        <div className="space-y-1">
+          <dt className="font-medium uppercase tracking-[0.14em]">Notes</dt>
+          <dd className="break-words text-foreground">
+            {deposit.notes ?? "N/A"}
+          </dd>
+        </div>
+      </dl>
+    </article>
   );
 }
 
@@ -2040,7 +2194,7 @@ export function RegisterSessionViewContent({
           </div>
         </div>
 
-        <label className="block w-[480px] space-y-2">
+        <label className="block w-full max-w-[480px] space-y-2">
           <span className="text-sm font-medium text-foreground">
             Manager notes
           </span>
@@ -2053,8 +2207,9 @@ export function RegisterSessionViewContent({
           />
         </label>
 
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
           <LoadingButton
+            className="w-full sm:w-auto"
             disabled={Boolean(pendingCloseoutAction)}
             isLoading={pendingCloseoutAction === "approved"}
             onClick={() => void handleReviewCloseout("approved")}
@@ -2063,6 +2218,7 @@ export function RegisterSessionViewContent({
             Approve variance
           </LoadingButton>
           <LoadingButton
+            className="w-full sm:w-auto"
             disabled={Boolean(pendingCloseoutAction)}
             isLoading={pendingCloseoutAction === "rejected"}
             onClick={() => void handleReviewCloseout("rejected")}
@@ -2079,18 +2235,21 @@ export function RegisterSessionViewContent({
     <View
       header={
         <ComposedPageHeader
+          className="h-auto min-h-14 items-start gap-3 border-b border-border bg-background px-4 py-3 sm:h-[40px] sm:items-center sm:border-0 sm:py-6"
           leadingContent={
-            <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
-              <span className="text-sm font-medium text-foreground">
-                {headerTitle}
-              </span>
-              {headerTerminalName ? (
-                <span className="text-sm text-muted-foreground">
-                  {headerTerminalName}
+            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+              <div className="flex min-w-0 items-baseline gap-2">
+                <span className="min-w-0 truncate text-sm font-semibold text-foreground">
+                  {headerTitle}
                 </span>
-              ) : null}
+                {headerTerminalName ? (
+                  <span className="min-w-0 truncate text-xs text-muted-foreground sm:text-sm">
+                    {headerTerminalName}
+                  </span>
+                ) : null}
+              </div>
               {registerSession ? (
-                <>
+                <div className="flex min-w-0 flex-wrap items-center gap-1.5">
                   <Badge
                     className="border-border bg-muted text-muted-foreground"
                     size="sm"
@@ -2109,23 +2268,25 @@ export function RegisterSessionViewContent({
                         : syncStatus.label}
                     </Badge>
                   ) : null}
-                </>
+                </div>
               ) : null}
             </div>
           }
           trailingContent={
-            <div className="flex flex-wrap items-center justify-end gap-2">
+            <div className="flex shrink-0 items-start justify-end">
               {registerSession?.workflowTraceId ? (
                 <Button
                   asChild
-                  className="border-border bg-surface text-muted-foreground hover:bg-muted"
+                  className="h-8 border-border bg-surface px-2.5 text-xs text-muted-foreground hover:bg-muted sm:h-9 sm:px-3 sm:text-sm"
                   size="sm"
                   variant="outline"
                 >
                   <WorkflowTraceRouteLink
+                    className="inline-flex items-center gap-1.5"
                     traceId={registerSession.workflowTraceId}
                   >
-                    View trace
+                    <span aria-hidden="true">Trace</span>
+                    <span className="sr-only">View trace</span>
                   </WorkflowTraceRouteLink>
                 </Button>
               ) : null}
@@ -2248,7 +2409,7 @@ export function RegisterSessionViewContent({
         storeId={(storeId ?? "missing-store") as Id<"store">}
       />
       <FadeIn>
-        <div className="container mx-auto space-y-6 p-6">
+        <div className="container mx-auto space-y-layout-md p-layout-md md:space-y-6 md:p-6">
           {registerSession ? (
             <RegisterSessionSyncNotice
               currency={currency}
@@ -2279,7 +2440,7 @@ export function RegisterSessionViewContent({
               </div>
             ) : (
               <div className="grid gap-0 xl:grid-cols-[380px_minmax(0,1fr)]">
-                <aside className="border-b border-border/80 bg-muted/20 px-layout-lg py-layout-lg xl:border-b-0 xl:border-r">
+                <aside className="border-b border-border/80 bg-muted/20 px-layout-md py-layout-md md:px-layout-lg md:py-layout-lg xl:border-b-0 xl:border-r">
                   <dl className="space-y-layout-md">
                     <div className="rounded-lg border border-border bg-surface-raised p-layout-md">
                       <dt className="text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
@@ -2289,7 +2450,7 @@ export function RegisterSessionViewContent({
                         <span className="block text-xs text-muted-foreground">
                           Expected cash
                         </span>
-                        <span className="block font-numeric tabular-nums text-3xl text-foreground">
+                        <span className="block font-numeric text-2xl tabular-nums text-foreground sm:text-3xl">
                           {formatCurrency(currency, displayedExpectedCash)}
                         </span>
                       </dd>
@@ -2434,7 +2595,7 @@ export function RegisterSessionViewContent({
                   ) : null}
                 </aside>
 
-                <div className="flex flex-col gap-layout-lg px-layout-lg py-layout-lg">
+                <div className="flex flex-col gap-layout-md px-layout-md py-layout-md md:gap-layout-lg md:px-layout-lg md:py-layout-lg">
                   {pendingCloseoutApprovalPanel}
 
                   {shouldShowProminentCorrectionPanel ? (
@@ -2563,8 +2724,9 @@ export function RegisterSessionViewContent({
                             </p>
                           ) : null}
 
-                          <div className="flex flex-wrap items-center gap-3">
+                          <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
                             <LoadingButton
+                              className="w-full sm:w-auto"
                               disabled={isCorrectingOpeningFloat}
                               isLoading={isCorrectingOpeningFloat}
                               onClick={() =>
@@ -2575,6 +2737,7 @@ export function RegisterSessionViewContent({
                               Submit
                             </LoadingButton>
                             <Button
+                              className="w-full sm:w-auto"
                               disabled={isCorrectingOpeningFloat}
                               onClick={() => {
                                 setIsOpeningFloatCorrectionOpen(false);
@@ -2706,7 +2869,7 @@ export function RegisterSessionViewContent({
                   ) : null}
 
                   <div
-                    className={`order-2 flex flex-wrap items-start justify-between gap-layout-sm ${hasPendingCloseoutApproval ? "pt-4" : ""}`}
+                    className={`order-2 flex flex-col items-start gap-layout-sm sm:flex-row sm:justify-between ${hasPendingCloseoutApproval ? "pt-4" : ""}`}
                   >
                     <div className="space-y-1">
                       <h2 className="font-display text-2xl font-semibold text-foreground">
@@ -2736,7 +2899,43 @@ export function RegisterSessionViewContent({
                       />
                     </div>
                   ) : (
-                    <div className="order-2 overflow-hidden rounded-lg border border-border bg-surface-raised">
+                    <>
+                    <div className="order-2 space-y-layout-sm md:hidden">
+                      {previewTransactions.map((transaction) => {
+                        const canOpenTransaction = Boolean(
+                          orgUrlSlug && storeUrlSlug,
+                        );
+                        const transactionRoute = canOpenTransaction
+                          ? {
+                              params: {
+                                orgUrlSlug: orgUrlSlug!,
+                                storeUrlSlug: storeUrlSlug!,
+                                transactionId: transaction._id,
+                              },
+                              search: { o: getOrigin() },
+                              to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId" as const,
+                            }
+                          : null;
+                        const openTransaction = () => {
+                          if (!transactionRoute) {
+                            return;
+                          }
+
+                          navigate(transactionRoute);
+                        };
+
+                        return (
+                          <RegisterSessionTransactionCard
+                            canOpenTransaction={canOpenTransaction}
+                            currency={currency}
+                            key={transaction._id}
+                            onOpen={openTransaction}
+                            transaction={transaction}
+                          />
+                        );
+                      })}
+                    </div>
+                    <div className="order-2 hidden overflow-hidden rounded-lg border border-border bg-surface-raised md:block">
                       <Table>
                         <TableHeader>
                           <TableRow className="border-b border-border hover:bg-transparent">
@@ -2879,39 +3078,45 @@ export function RegisterSessionViewContent({
                           })}
                         </TableBody>
                       </Table>
-                      {hasAdditionalTransactions &&
-                      registerSession &&
-                      orgUrlSlug &&
-                      storeUrlSlug ? (
-                        <div className="flex flex-wrap items-center justify-between gap-layout-sm border-t border-border/70 px-4 py-3">
-                          <p className="text-sm text-muted-foreground">
-                            Showing latest {previewTransactions.length} of{" "}
-                            {transactions.length} linked sales.
-                          </p>
-                          <Button asChild size="sm" variant="outline">
-                            <Link
-                              params={{ orgUrlSlug, storeUrlSlug }}
-                              search={{
-                                o: getOrigin(),
-                                registerSessionId: registerSession._id,
-                              }}
-                              to="/$orgUrlSlug/store/$storeUrlSlug/pos/transactions"
-                            >
-                              View all linked transactions
-                              <ArrowUpRight className="h-3.5 w-3.5" />
-                            </Link>
-                          </Button>
-                        </div>
-                      ) : null}
                     </div>
+                    {hasAdditionalTransactions &&
+                    registerSession &&
+                    orgUrlSlug &&
+                    storeUrlSlug ? (
+                      <div className="order-2 flex flex-col gap-layout-sm rounded-lg border border-border/70 bg-surface-raised px-4 py-3 sm:flex-row sm:items-center sm:justify-between md:rounded-t-none md:border-t-0">
+                        <p className="text-sm text-muted-foreground">
+                          Showing latest {previewTransactions.length} of{" "}
+                          {transactions.length} linked sales.
+                        </p>
+                        <Button
+                          asChild
+                          className="w-full sm:w-auto"
+                          size="sm"
+                          variant="outline"
+                        >
+                          <Link
+                            params={{ orgUrlSlug, storeUrlSlug }}
+                            search={{
+                              o: getOrigin(),
+                              registerSessionId: registerSession._id,
+                            }}
+                            to="/$orgUrlSlug/store/$storeUrlSlug/pos/transactions"
+                          >
+                            View all linked transactions
+                            <ArrowUpRight className="h-3.5 w-3.5" />
+                          </Link>
+                        </Button>
+                      </div>
+                    ) : null}
+                    </>
                   )}
                 </div>
               </div>
             )}
           </section>
 
-          <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_418px]">
-            <section className="rounded-[calc(var(--radius)*1.25)] border border-border bg-surface px-layout-lg py-layout-lg shadow-surface">
+          <div className="grid gap-layout-md md:gap-6 xl:grid-cols-[minmax(0,1fr)_418px]">
+            <section className="rounded-[calc(var(--radius)*1.25)] border border-border bg-surface px-layout-md py-layout-md shadow-surface md:px-layout-lg md:py-layout-lg">
               <div className="space-y-layout-md">
                 <div className="space-y-1">
                   <h2 className="font-display text-2xl font-semibold text-foreground">
@@ -2929,7 +3134,17 @@ export function RegisterSessionViewContent({
                     title="No deposits recorded"
                   />
                 ) : (
-                  <div className="overflow-hidden rounded-lg border border-border bg-surface-raised">
+                  <>
+                  <div className="space-y-layout-sm md:hidden">
+                    {registerSessionSnapshot.deposits.map((deposit) => (
+                      <RegisterSessionDepositCard
+                        currency={currency}
+                        deposit={deposit}
+                        key={deposit._id}
+                      />
+                    ))}
+                  </div>
+                  <div className="hidden overflow-hidden rounded-lg border border-border bg-surface-raised md:block">
                     <Table>
                       <TableHeader>
                         <TableRow className="border-b border-border hover:bg-transparent">
@@ -2976,11 +3191,12 @@ export function RegisterSessionViewContent({
                       </TableBody>
                     </Table>
                   </div>
+                  </>
                 )}
               </div>
             </section>
 
-            <aside className="space-y-6 rounded-[calc(var(--radius)*1.25)] border border-border bg-surface px-layout-lg py-layout-lg shadow-surface">
+            <aside className="space-y-layout-md rounded-[calc(var(--radius)*1.25)] border border-border bg-surface px-layout-md py-layout-md shadow-surface md:space-y-6 md:px-layout-lg md:py-layout-lg">
               {!hasPendingCloseoutApproval ? (
                 <div className="space-y-4">
                   <div className="space-y-2">
@@ -3044,7 +3260,7 @@ export function RegisterSessionViewContent({
                           Closed
                         </Badge>
                       </div>
-                      <dl className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-3">
+                      <dl className="grid gap-3 text-sm sm:grid-cols-3">
                         <div className="space-y-1">
                           <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
                             Expected
@@ -3186,6 +3402,7 @@ export function RegisterSessionViewContent({
                       </label>
 
                       <LoadingButton
+                        className="w-full"
                         disabled={pendingCloseoutAction === "submit"}
                         isLoading={pendingCloseoutAction === "submit"}
                         onClick={() => void handleSubmitCloseout()}
@@ -3273,6 +3490,7 @@ export function RegisterSessionViewContent({
                   ) : null}
 
                   <LoadingButton
+                    className="w-full"
                     disabled={isRecordingDeposit}
                     isLoading={isRecordingDeposit}
                     onClick={() => void handleRecordDeposit()}

--- a/packages/athena-webapp/src/components/common/PageLevelHeader.test.tsx
+++ b/packages/athena-webapp/src/components/common/PageLevelHeader.test.tsx
@@ -64,13 +64,15 @@ describe("PageLevelHeader", () => {
     );
 
     expect(screen.getByText("Main work").parentElement).toHaveClass(
-      "space-y-layout-3xl",
+      "space-y-layout-xl",
+      "md:space-y-layout-3xl",
     );
     expect(screen.getByText("Side rail").parentElement).toHaveClass(
-      "gap-layout-lg",
+      "gap-layout-md",
+      "md:gap-layout-lg",
     );
     expect(
       screen.getByText("Main work").parentElement?.parentElement,
-    ).toHaveClass("gap-layout-2xl");
+    ).toHaveClass("gap-layout-xl", "lg:gap-layout-2xl");
   });
 });

--- a/packages/athena-webapp/src/components/common/PageLevelHeader.tsx
+++ b/packages/athena-webapp/src/components/common/PageLevelHeader.tsx
@@ -35,11 +35,11 @@ export function PageLevelHeader({
         </p>
       ) : null}
       <div className="space-y-3">
-        <h1 className="font-display text-[clamp(2.75rem,4.6vw,4.75rem)] leading-[0.95] tracking-[-0.05em] text-foreground">
+        <h1 className="font-display text-4xl leading-tight tracking-normal text-foreground sm:text-[clamp(2.75rem,4.6vw,4.75rem)] sm:leading-[0.95] sm:tracking-[-0.05em]">
           {title}
         </h1>
         {description ? (
-          <p className="max-w-3xl text-base leading-7 text-muted-foreground md:text-lg">
+          <p className="max-w-3xl text-sm leading-6 text-muted-foreground md:text-lg md:leading-7">
             {description}
           </p>
         ) : null}
@@ -60,7 +60,9 @@ export function PageWorkspace({
   className,
 }: PageWorkspaceProps) {
   return (
-    <Component className={cn("min-w-0 space-y-layout-2xl", className)}>
+    <Component
+      className={cn("min-w-0 space-y-layout-xl md:space-y-layout-2xl", className)}
+    >
       {children}
     </Component>
   );
@@ -78,7 +80,7 @@ export function PageWorkspaceGrid({
   return (
     <div
       className={cn(
-        "grid gap-layout-2xl xl:grid-cols-[minmax(0,1fr)_320px]",
+        "grid gap-layout-xl lg:gap-layout-2xl xl:grid-cols-[minmax(0,1fr)_320px]",
         className,
       )}
     >
@@ -99,7 +101,9 @@ export function PageWorkspaceMain({
   className,
 }: PageWorkspaceStackProps) {
   return (
-    <Component className={cn("min-w-0 space-y-layout-3xl", className)}>
+    <Component
+      className={cn("min-w-0 space-y-layout-xl md:space-y-layout-3xl", className)}
+    >
       {children}
     </Component>
   );
@@ -111,7 +115,9 @@ export function PageWorkspaceRail({
   className,
 }: PageWorkspaceStackProps) {
   return (
-    <Component className={cn("flex flex-col gap-layout-lg", className)}>
+    <Component
+      className={cn("flex flex-col gap-layout-md md:gap-layout-lg", className)}
+    >
       {children}
     </Component>
   );

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -377,8 +377,7 @@ const posSyncedSaleTimelineSnapshot: DailyOperationsSnapshot = {
     {
       createdAt: Date.UTC(2026, 4, 8, 18),
       id: "event-pos-sale-synced",
-      message:
-        "Offline POS sale 946956 synced: 3 sale lines, GH₵1,039, cash.",
+      message: "Sale 946956 synced: 3 sale lines, GH₵1,039, cash.",
       subject: {
         id: "txn-946956",
         type: "posTransaction",
@@ -1012,7 +1011,7 @@ describe("DailyOperationsViewContent", () => {
       screen.getByText((content, node) => {
         return (
           node?.textContent ===
-          "Offline POS sale #946956 synced: 3 sale lines, GH₵1,039, cash."
+          "Sale #946956 synced: 3 sale lines, GH₵1,039, cash."
         );
       }),
     ).toBeInTheDocument();

--- a/packages/athena-webapp/src/components/organization-switcher.tsx
+++ b/packages/athena-webapp/src/components/organization-switcher.tsx
@@ -12,17 +12,13 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { Icons } from "./ui/icons";
-import { OverlayModal } from "./ui/modals/overlay-modal";
 import { useNavigate, useParams } from "@tanstack/react-router";
+import type { ComponentPropsWithoutRef } from "react";
 import { useEffect, useState } from "react";
-import { useOrganizationModal } from "@/hooks/useOrganizationModal";
-import { Organization } from "~/types";
+import type { Organization } from "~/types";
 import { useGetStores } from "../hooks/useGetActiveStore";
 
-type PopoverTriggerProps = React.ComponentPropsWithoutRef<
-  typeof PopoverTrigger
->;
+type PopoverTriggerProps = ComponentPropsWithoutRef<typeof PopoverTrigger>;
 
 interface OrganizationSwitcherProps extends PopoverTriggerProps {
   items: Organization[];
@@ -38,9 +34,6 @@ export default function OrganizationSwitcher({
   className,
   items = [],
 }: OrganizationSwitcherProps) {
-  const organizationModal = useOrganizationModal();
-
-  const [isSwitching, setIsSwitching] = useState(false);
   const [selectedOrganization, setSelectedOrganization] =
     useState<OrganizationSelectItem | null>(null);
   const [open, setOpen] = useState(false);
@@ -86,7 +79,7 @@ export default function OrganizationSwitcher({
         });
       }
     }
-  }, [selectedOrganization, stores]);
+  }, [navigate, selectedOrganization, stores]);
 
   const onOrganizationSelect = async (organization: OrganizationSelectItem) => {
     setSelectedOrganization(organization);
@@ -95,20 +88,6 @@ export default function OrganizationSwitcher({
 
   return (
     <>
-      <OverlayModal
-        isOpen={isSwitching}
-        title={""}
-        description={""}
-        onClose={() => console.log("nay")}
-        withoutHeader={true}
-      >
-        <div className="flex justify-center items-center">
-          <Icons.spinner className="mr-2 h-4 w-4 text-muted-foreground animate-spin" />
-          <p className="text-sm text-center text-muted-foreground">
-            Switching organizations..
-          </p>
-        </div>
-      </OverlayModal>
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <Button
@@ -117,10 +96,12 @@ export default function OrganizationSwitcher({
             role="combobox"
             aria-expanded={open}
             aria-label="Select an organization"
-            className={cn("justify-between", className)}
+            className={cn("min-w-0 justify-between", className)}
           >
             <Building2 className="mr-2 h-4 w-4" />
-            {currentOrganization?.label}
+            <span className="min-w-0 truncate">
+              {currentOrganization?.label}
+            </span>
             <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>

--- a/packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.test.tsx
@@ -1,10 +1,26 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ExpenseReportsView } from "./ExpenseReportsView";
 
 const getActiveStoreMock = vi.fn();
 const useQueryMock = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    children,
+    "aria-label": ariaLabel,
+    className,
+  }: {
+    children?: React.ReactNode;
+    "aria-label"?: string;
+    className?: string;
+  }) => (
+    <a aria-label={ariaLabel} className={className} href="#">
+      {children}
+    </a>
+  ),
+}));
 
 vi.mock("convex/react", () => ({
   useQuery: (...args: unknown[]) => useQueryMock(...args),
@@ -95,5 +111,41 @@ describe("ExpenseReportsView", () => {
     expect(screen.getByText("Point of sale")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Go back" })).toBeInTheDocument();
     expect(screen.getByText("EXP-123456")).toBeInTheDocument();
+  });
+
+  it("renders expense reports as scan-friendly mobile cards", () => {
+    useQueryMock.mockReturnValue([
+      {
+        _id: "expense-mobile",
+        transactionNumber: "EXP-MOBILE",
+        totalValue: 19800,
+        staffProfileName: "Ada L.",
+        itemCount: 2,
+        completedAt: Date.now(),
+        notes: "Restock drawer supplies.",
+      },
+    ]);
+
+    render(<ExpenseReportsView />);
+
+    const card = screen.getByRole("link", {
+      name: "Open expense report #EXP-MOBILE",
+    });
+
+    expect(card).toHaveClass("rounded-lg", "p-layout-md");
+    expect(within(card).getByText("#EXP-MOBILE")).toBeInTheDocument();
+    expect(within(card).getByText("2 items")).toBeInTheDocument();
+    expect(within(card).getByText("Cashier")).toHaveClass(
+      "text-xs",
+      "tracking-[0.12em]",
+    );
+    expect(within(card).getByText("Ada L.")).toHaveClass("text-sm");
+    expect(within(card).getByText("Notes")).toHaveClass(
+      "text-xs",
+      "tracking-[0.12em]",
+    );
+    expect(within(card).getByText("Restock drawer supplies.")).toHaveClass(
+      "text-sm",
+    );
   });
 });

--- a/packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx
+++ b/packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
+import { Link } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
-import { Receipt } from "lucide-react";
+import { ArrowUpRight, Receipt } from "lucide-react";
 
 import View from "../../View";
 import { FadeIn } from "../../common/FadeIn";
@@ -16,6 +17,8 @@ import { currencyFormatter } from "~/convex/utils";
 import { expenseReportColumns, ExpenseReportRow } from "./expenseReportColumns";
 import { toExpenseReportRows } from "./expenseReportRows";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { getOrigin } from "~/src/lib/navigationUtils";
+import { getRelativeTime } from "~/src/lib/utils";
 
 // Helper to check if timestamp is today
 const isToday = (timestamp: number) => {
@@ -23,6 +26,71 @@ const isToday = (timestamp: number) => {
   const today = new Date();
   return date.toDateString() === today.toDateString();
 };
+
+function ExpenseReportMobileCard({ report }: { report: ExpenseReportRow }) {
+  const itemLabel = `${report.itemCount} ${
+    report.itemCount === 1 ? "item" : "items"
+  }`;
+
+  return (
+    <Link
+      to="/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports/$reportId"
+      params={(prev) => ({
+        ...prev,
+        orgUrlSlug: prev.orgUrlSlug!,
+        storeUrlSlug: prev.storeUrlSlug!,
+        reportId: report._id,
+      })}
+      search={{ o: getOrigin() }}
+      aria-label={`Open expense report #${report.transactionNumber}`}
+      className="block rounded-lg border border-border/70 bg-surface-raised p-layout-md shadow-sm transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <div className="flex items-start justify-between gap-layout-md">
+        <div className="min-w-0 space-y-1">
+          <p className="flex min-w-0 items-center gap-1 text-lg font-semibold leading-6 text-foreground">
+            <span className="truncate">#{report.transactionNumber}</span>
+            <ArrowUpRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+          </p>
+          <p className="text-xs leading-5 text-muted-foreground">
+            {itemLabel}
+          </p>
+        </div>
+        <p className="shrink-0 text-right text-lg font-semibold leading-6 text-foreground">
+          {report.formattedTotal}
+        </p>
+      </div>
+
+      <dl className="mt-layout-md grid gap-layout-sm border-t border-border/70 pt-layout-sm">
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-layout-sm">
+          <dt className="text-xs font-medium uppercase leading-5 tracking-[0.12em] text-muted-foreground">
+            Cashier
+          </dt>
+          <dd className="min-w-0 truncate text-right text-sm leading-5 text-foreground">
+            {report.cashierName ?? "N/A"}
+          </dd>
+        </div>
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-layout-sm">
+          <dt className="text-xs font-medium uppercase leading-5 tracking-[0.12em] text-muted-foreground">
+            Completed
+          </dt>
+          <dd className="min-w-0 truncate text-right text-sm leading-5 text-foreground">
+            {getRelativeTime(report.completedAt)}
+          </dd>
+        </div>
+        {report.notes ? (
+          <div className="space-y-1">
+            <dt className="text-xs font-medium uppercase leading-5 tracking-[0.12em] text-muted-foreground">
+              Notes
+            </dt>
+            <dd className="text-sm leading-5 text-foreground">
+              {report.notes}
+            </dd>
+          </div>
+        ) : null}
+      </dl>
+    </Link>
+  );
+}
 
 export function ExpenseReportsView() {
   const { activeStore } = useGetActiveStore();
@@ -65,36 +133,47 @@ export function ExpenseReportsView() {
           />
 
           <section className="space-y-layout-md">
-          <Tabs
-            value={filter}
-            onValueChange={(v) => setFilter(v as "today" | "all")}
-          >
-            <TabsList>
-              <TabsTrigger value="today">Today</TabsTrigger>
-              <TabsTrigger value="all">All Time</TabsTrigger>
-            </TabsList>
-          </Tabs>
+            <Tabs
+              value={filter}
+              onValueChange={(v) => setFilter(v as "today" | "all")}
+            >
+              <TabsList>
+                <TabsTrigger value="today">Today</TabsTrigger>
+                <TabsTrigger value="all">All Time</TabsTrigger>
+              </TabsList>
+            </Tabs>
 
-          {hasReports ? (
-            <GenericDataTable
-              data={filteredData}
-              columns={expenseReportColumns}
-              tableId="pos-expense-reports"
-            />
-          ) : (
-            <div className="flex items-center justify-center min-h-[50vh]">
-              <EmptyState
-                icon={<Receipt className="w-16 h-16 text-muted-foreground" />}
-                title={
-                  <p className="text-muted-foreground">
-                    {filter === "today"
-                      ? "No expense reports today"
-                      : "No expense reports"}
-                  </p>
-                }
-              />
-            </div>
-          )}
+            {hasReports ? (
+              <>
+                <div className="grid gap-layout-sm md:hidden">
+                  {filteredData.map((report) => (
+                    <ExpenseReportMobileCard key={report._id} report={report} />
+                  ))}
+                </div>
+                <div className="hidden md:block">
+                  <GenericDataTable
+                    data={filteredData}
+                    columns={expenseReportColumns}
+                    tableId="pos-expense-reports"
+                  />
+                </div>
+              </>
+            ) : (
+              <div className="flex min-h-[50vh] items-center justify-center">
+                <EmptyState
+                  icon={
+                    <Receipt className="h-16 w-16 text-muted-foreground" />
+                  }
+                  title={
+                    <p className="text-muted-foreground">
+                      {filter === "today"
+                        ? "No expense reports today"
+                        : "No expense reports"}
+                    </p>
+                  }
+                />
+              </div>
+            )}
           </section>
         </PageWorkspace>
       </FadeIn>

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionsView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { TransactionsView } from "./TransactionsView";
@@ -8,6 +8,19 @@ const getActiveStoreMock = vi.fn();
 const useSearchMock = vi.fn();
 
 vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    children,
+    "aria-label": ariaLabel,
+    className,
+  }: {
+    children?: React.ReactNode;
+    "aria-label"?: string;
+    className?: string;
+  }) => (
+    <a aria-label={ariaLabel} className={className} href="#">
+      {children}
+    </a>
+  ),
   useSearch: () => useSearchMock(),
 }));
 
@@ -173,7 +186,51 @@ describe("TransactionsView", () => {
     render(<TransactionsView />);
 
     expect(screen.getByText("POS-VOID")).toBeInTheDocument();
-    expect(screen.getByText("Voided")).toBeInTheDocument();
+    expect(screen.getAllByText("Voided").length).toBeGreaterThan(0);
+  });
+
+  it("renders completed transactions as scan-friendly mobile cards", () => {
+    getActiveStoreMock.mockReturnValue({
+      activeStore: {
+        _id: "store-1",
+        currency: "GHS",
+      },
+    });
+    useQueryMock.mockReturnValue([
+      {
+        _id: "txn-mobile",
+        transactionNumber: "POS-MOBILE",
+        total: 1000,
+        paymentMethod: "cash",
+        paymentMethods: ["cash"],
+        cashierName: "Ada L.",
+        customerName: "Walk-in",
+        itemCount: 1,
+        completedAt: Date.now(),
+        hasTrace: false,
+        sessionTraceId: null,
+      },
+    ]);
+
+    render(<TransactionsView />);
+
+    const card = screen.getByRole("link", {
+      name: "Open transaction #POS-MOBILE",
+    });
+
+    expect(card).toHaveClass("rounded-lg", "p-layout-md");
+    expect(within(card).getByText("#POS-MOBILE")).toBeInTheDocument();
+    expect(within(card).getByText("1 item - Walk-in")).toBeInTheDocument();
+    expect(within(card).getByText("Payment")).toHaveClass(
+      "text-xs",
+      "tracking-[0.12em]",
+    );
+    expect(within(card).getByText("Cash")).toHaveClass("text-sm");
+    expect(within(card).getByText("Cashier")).toHaveClass(
+      "text-xs",
+      "tracking-[0.12em]",
+    );
+    expect(within(card).getByText("Ada L.")).toHaveClass("text-sm");
   });
 
   it("includes service lines in completed transaction item counts", () => {
@@ -203,7 +260,7 @@ describe("TransactionsView", () => {
     render(<TransactionsView />);
 
     expect(screen.getByText("POS-SERVICE-COUNT")).toBeInTheDocument();
-    expect(screen.getByText("3 items")).toBeInTheDocument();
+    expect(screen.getAllByText("3 items").length).toBeGreaterThan(0);
   });
 
   it("passes the register session filter to the completed transactions query", () => {

--- a/packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx
+++ b/packages/athena-webapp/src/components/pos/transactions/TransactionsView.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useMemo, useState } from "react";
-import { useSearch } from "@tanstack/react-router";
+import { Link, useSearch } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
-import { Receipt } from "lucide-react";
+import {
+  ArrowUpRight,
+  Banknote,
+  CreditCardIcon,
+  Receipt,
+  Smartphone,
+  WalletCards,
+} from "lucide-react";
 
 import View from "../../View";
 import { FadeIn } from "../../common/FadeIn";
@@ -20,6 +27,8 @@ import {
 } from "./transactionColumns";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { formatStoredAmount } from "~/src/lib/pos/displayAmounts";
+import { getOrigin } from "~/src/lib/navigationUtils";
+import { getRelativeTime } from "~/src/lib/utils";
 import type { Id } from "~/convex/_generated/dataModel";
 
 function formatPaymentMethod(method: string | null) {
@@ -81,6 +90,116 @@ type CompletedTransaction = {
   voidedAt?: number | null;
   voidReason?: string | null;
 };
+
+function getPaymentMethodIcon({
+  paymentMethod,
+  hasMultipleMethods,
+}: {
+  paymentMethod: string;
+  hasMultipleMethods?: boolean;
+}) {
+  if (hasMultipleMethods) return <WalletCards className="h-4 w-4" />;
+
+  switch (paymentMethod) {
+    case "cash":
+      return <Banknote className="h-4 w-4" />;
+    case "card":
+      return <CreditCardIcon className="h-4 w-4" />;
+    case "mobile_money":
+      return <Smartphone className="h-4 w-4" />;
+    default:
+      return null;
+  }
+}
+
+function TransactionMobileCard({
+  transaction,
+}: {
+  transaction: CompletedTransactionRow;
+}) {
+  const isVoided = transaction.status === "void";
+  const itemLabel = `${transaction.itemCount} ${
+    transaction.itemCount === 1 ? "item" : "items"
+  }`;
+
+  return (
+    <Link
+      to="/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId"
+      params={(prev) => ({
+        ...prev,
+        orgUrlSlug: prev.orgUrlSlug!,
+        storeUrlSlug: prev.storeUrlSlug!,
+        transactionId: transaction._id,
+      })}
+      search={{ o: getOrigin() }}
+      aria-label={`Open transaction #${transaction.transactionNumber}`}
+      className="block rounded-lg border border-border/70 bg-surface-raised p-layout-md shadow-sm transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <div className="flex items-start justify-between gap-layout-md">
+        <div className="min-w-0 space-y-1">
+          <p className="flex min-w-0 items-center gap-1 text-lg font-semibold leading-6 text-foreground">
+            <span className="truncate">#{transaction.transactionNumber}</span>
+            <ArrowUpRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+          </p>
+          <p className="text-xs leading-5 text-muted-foreground">
+            {transaction.customerName
+              ? `${itemLabel} - ${transaction.customerName}`
+              : itemLabel}
+          </p>
+        </div>
+        <div className="shrink-0 text-right">
+          <p
+            className={`text-lg font-semibold leading-6 text-foreground ${
+              isVoided ? "line-through" : ""
+            }`}
+          >
+            {transaction.formattedTotal}
+          </p>
+          {isVoided ? (
+            <span className="mt-1 inline-flex rounded-sm border border-destructive/30 bg-destructive/10 px-1.5 py-0.5 text-xs font-medium leading-4 text-destructive">
+              Voided
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      <dl className="mt-layout-md grid gap-layout-sm border-t border-border/70 pt-layout-sm">
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-layout-sm">
+          <dt className="text-xs font-medium uppercase leading-5 tracking-[0.12em] text-muted-foreground">
+            Payment
+          </dt>
+          <dd className="flex min-w-0 items-center justify-end gap-2 text-right text-sm leading-5 text-foreground">
+            <span className="text-muted-foreground">
+              {getPaymentMethodIcon({
+                paymentMethod: transaction.paymentMethod,
+                hasMultipleMethods: transaction.hasMultiplePaymentMethods,
+              })}
+            </span>
+            <span className="truncate text-sm leading-5">
+              {transaction.paymentMethodLabel}
+            </span>
+          </dd>
+        </div>
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-layout-sm">
+          <dt className="text-xs font-medium uppercase leading-5 tracking-[0.12em] text-muted-foreground">
+            Cashier
+          </dt>
+          <dd className="min-w-0 truncate text-right text-sm leading-5 text-foreground">
+            {transaction.cashierName ?? "N/A"}
+          </dd>
+        </div>
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-layout-sm">
+          <dt className="text-xs font-medium uppercase leading-5 tracking-[0.12em] text-muted-foreground">
+            Completed
+          </dt>
+          <dd className="min-w-0 truncate text-right text-sm leading-5 text-foreground">
+            {getRelativeTime(transaction.completedAt)}
+          </dd>
+        </div>
+      </dl>
+    </Link>
+  );
+}
 
 export function TransactionsView() {
   const { activeStore } = useGetActiveStore();
@@ -218,51 +337,67 @@ export function TransactionsView() {
           />
 
           <section className="space-y-layout-md">
-          {activeFilterSummary ? (
-            <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
-              Showing {activeFilterSummary}
-            </div>
-          ) : null}
+            {activeFilterSummary ? (
+              <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+                Showing {activeFilterSummary}
+              </div>
+            ) : null}
 
-          <Tabs
-            value={filter}
-            onValueChange={(v) => setFilter(v as "today" | "fromDate" | "all")}
-          >
-            <TabsList>
-              <TabsTrigger value="today">Today</TabsTrigger>
-              {operatingDate && operatingDateStartAt !== null ? (
-                <TabsTrigger value="fromDate">
-                  From {formatOperatingDateFilterLabel(operatingDate)}
-                </TabsTrigger>
-              ) : null}
-              <TabsTrigger value="all">All Time</TabsTrigger>
-            </TabsList>
-          </Tabs>
+            <Tabs
+              value={filter}
+              onValueChange={(v) =>
+                setFilter(v as "today" | "fromDate" | "all")
+              }
+            >
+              <TabsList>
+                <TabsTrigger value="today">Today</TabsTrigger>
+                {operatingDate && operatingDateStartAt !== null ? (
+                  <TabsTrigger value="fromDate">
+                    From {formatOperatingDateFilterLabel(operatingDate)}
+                  </TabsTrigger>
+                ) : null}
+                <TabsTrigger value="all">All Time</TabsTrigger>
+              </TabsList>
+            </Tabs>
 
-          {hasTransactions ? (
-            <GenericDataTable
-              data={filteredData}
-              columns={transactionColumns}
-              tableId="pos-completed-transactions"
-            />
-          ) : (
-            <div className="flex items-center justify-center min-h-[50vh]">
-              <EmptyState
-                icon={<Receipt className="w-16 h-16 text-muted-foreground" />}
-                title={
-                  <p className="text-muted-foreground">
-                    {filter === "today"
-                      ? "No completed transactions today"
-                      : filter === "fromDate" && operatingDate
-                        ? `No completed transactions from ${formatOperatingDateFilterLabel(operatingDate)}`
-                      : registerSessionId
-                        ? `No transactions for ${registerFilterLabel}`
-                        : "No completed transactions"}
-                  </p>
-                }
-              />
-            </div>
-          )}
+            {hasTransactions ? (
+              <>
+                <div className="grid gap-layout-sm md:hidden">
+                  {filteredData.map((transaction) => (
+                    <TransactionMobileCard
+                      key={transaction._id}
+                      transaction={transaction}
+                    />
+                  ))}
+                </div>
+                <div className="hidden md:block">
+                  <GenericDataTable
+                    data={filteredData}
+                    columns={transactionColumns}
+                    tableId="pos-completed-transactions"
+                  />
+                </div>
+              </>
+            ) : (
+              <div className="flex min-h-[50vh] items-center justify-center">
+                <EmptyState
+                  icon={
+                    <Receipt className="h-16 w-16 text-muted-foreground" />
+                  }
+                  title={
+                    <p className="text-muted-foreground">
+                      {filter === "today"
+                        ? "No completed transactions today"
+                        : filter === "fromDate" && operatingDate
+                          ? `No completed transactions from ${formatOperatingDateFilterLabel(operatingDate)}`
+                          : registerSessionId
+                            ? `No transactions for ${registerFilterLabel}`
+                            : "No completed transactions"}
+                    </p>
+                  }
+                />
+              </div>
+            )}
           </section>
         </PageWorkspace>
       </FadeIn>

--- a/packages/athena-webapp/src/routes/_authed.test.tsx
+++ b/packages/athena-webapp/src/routes/_authed.test.tsx
@@ -16,6 +16,7 @@ const mocked = vi.hoisted(() => ({
   signOut: vi.fn().mockResolvedValue(undefined),
   startManagerElevation: vi.fn(),
   endManagerElevation: vi.fn(),
+  setOpenMobile: vi.fn(),
   useAuth: vi.fn(),
   useLocalPosEntryContext: vi.fn(),
   useManagerElevation: vi.fn(),
@@ -23,6 +24,7 @@ const mocked = vi.hoisted(() => ({
   usePosTerminalAppSessionRecovery: vi.fn(),
   readStoredPosAppAccountId: vi.fn(),
   SidebarProvider: vi.fn(),
+  useSidebar: vi.fn(),
   useRouterState: vi.fn(),
 }));
 
@@ -99,7 +101,7 @@ vi.mock("../components/ui/sidebar", () => ({
       {children}
     </button>
   ),
-  useSidebar: () => ({ state: "expanded" }),
+  useSidebar: mocked.useSidebar,
 }));
 
 vi.mock("../components/app-sidebar", () => ({
@@ -193,6 +195,7 @@ describe("Authed layout", () => {
     mocked.signOut.mockClear();
     mocked.startManagerElevation.mockReset();
     mocked.endManagerElevation.mockReset();
+    mocked.setOpenMobile.mockReset();
     mocked.useAuth.mockReset();
     mocked.useLocalPosEntryContext.mockReset();
     mocked.useLocalPosEntryContext.mockReturnValue({ status: "missing_seed" });
@@ -203,6 +206,12 @@ describe("Authed layout", () => {
     mocked.readStoredPosAppAccountId.mockReset();
     mocked.readStoredPosAppAccountId.mockReturnValue("stored-app-user-1");
     mocked.SidebarProvider.mockReset();
+    mocked.useSidebar.mockReset();
+    mocked.useSidebar.mockReturnValue({
+      isMobile: false,
+      setOpenMobile: mocked.setOpenMobile,
+      state: "expanded",
+    });
     mocked.useManagerElevation.mockReturnValue({
       activeElevation: null,
       endManagerElevation: mocked.endManagerElevation,
@@ -521,6 +530,69 @@ describe("Authed layout", () => {
     expect(screen.getByTestId("store-modal")).toBeInTheDocument();
     expect(screen.getByTestId("organization-modal")).toBeInTheDocument();
     expect(screen.getByTestId("authed-outlet")).toBeInTheDocument();
+  });
+
+  it("does not dismiss the mobile sidebar on the initial authed shell render", () => {
+    mocked.useAuth.mockReturnValue({
+      user: { _id: "user-1" },
+      isLoading: false,
+    });
+    mocked.useSidebar.mockReturnValue({
+      isMobile: true,
+      setOpenMobile: mocked.setOpenMobile,
+      state: "expanded",
+    });
+
+    render(<Layout />);
+
+    expect(mocked.setOpenMobile).not.toHaveBeenCalled();
+  });
+
+  it("dismisses the mobile sidebar after the route changes", () => {
+    mocked.useAuth.mockReturnValue({
+      user: { _id: "user-1" },
+      isLoading: false,
+    });
+    mocked.useSidebar.mockReturnValue({
+      isMobile: true,
+      setOpenMobile: mocked.setOpenMobile,
+      state: "expanded",
+    });
+    let pathname = "/wigclub/store/wigclub/products";
+    mocked.useRouterState.mockImplementation(({ select }) =>
+      select({ location: { pathname } }),
+    );
+
+    const { rerender } = render(<Layout />);
+    expect(mocked.setOpenMobile).not.toHaveBeenCalled();
+
+    pathname = "/wigclub/store/wigclub/operations";
+    rerender(<Layout />);
+
+    expect(mocked.setOpenMobile).toHaveBeenCalledWith(false);
+  });
+
+  it("leaves the desktop sidebar state alone after the route changes", () => {
+    mocked.useAuth.mockReturnValue({
+      user: { _id: "user-1" },
+      isLoading: false,
+    });
+    mocked.useSidebar.mockReturnValue({
+      isMobile: false,
+      setOpenMobile: mocked.setOpenMobile,
+      state: "expanded",
+    });
+    let pathname = "/wigclub/store/wigclub/products";
+    mocked.useRouterState.mockImplementation(({ select }) =>
+      select({ location: { pathname } }),
+    );
+
+    const { rerender } = render(<Layout />);
+
+    pathname = "/wigclub/store/wigclub/operations";
+    rerender(<Layout />);
+
+    expect(mocked.setOpenMobile).not.toHaveBeenCalled();
   });
 
   it("mounts the signed-in POS register through the POS-only shell when a terminal seed is ready", () => {

--- a/packages/athena-webapp/src/routes/_authed.tsx
+++ b/packages/athena-webapp/src/routes/_authed.tsx
@@ -12,6 +12,7 @@ import {
   type ReactNode,
   type SetStateAction,
   useEffect,
+  useRef,
   useState,
 } from "react";
 import {
@@ -324,17 +325,18 @@ function UserMenu({ userEmail }: { userEmail: string }) {
       <DropdownMenuTrigger asChild>
         <button
           type="button"
+          aria-label={`Open account menu for ${userEmail}`}
           className="flex min-w-0 items-center gap-layout-xs rounded-md px-layout-xs py-layout-2xs text-sm text-foreground transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           <UserCircle className="h-4 w-4 shrink-0 text-muted-foreground" />
-          <span className="max-w-[18rem] truncate font-medium">
+          <span className="hidden max-w-[18rem] truncate font-medium sm:block">
             {userEmail}
           </span>
           {activeElevation ? (
             <Badge
               variant="outline"
               size="sm"
-              className="max-w-fit shrink-0 border-action-workflow-border bg-action-workflow-soft text-action-workflow gap-1"
+              className="hidden max-w-fit shrink-0 gap-1 border-action-workflow-border bg-action-workflow-soft text-action-workflow md:inline-flex"
             >
               <ShieldCheck aria-hidden="true" className="h-3 w-3 shrink-0" />
               <span className="truncate">
@@ -404,6 +406,25 @@ function TopBar({ userEmail }: { userEmail: string }) {
   );
 }
 
+function MobileSidebarRouteDismiss({ routeKey }: { routeKey: string }) {
+  const { isMobile, setOpenMobile } = useSidebar();
+  const previousRouteKeyRef = useRef(routeKey);
+
+  useEffect(() => {
+    if (previousRouteKeyRef.current === routeKey) {
+      return;
+    }
+
+    previousRouteKeyRef.current = routeKey;
+
+    if (isMobile) {
+      setOpenMobile(false);
+    }
+  }, [isMobile, routeKey, setOpenMobile]);
+
+  return null;
+}
+
 export default function Layout() {
   const [defaultOpen] = useState<boolean | null>(true);
   const [fullscreenOverride, setFullscreenOverride] = useState<
@@ -412,6 +433,12 @@ export default function Layout() {
   const navigate = useNavigate();
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
+  });
+  const routeKey = useRouterState({
+    select: (state) =>
+      "href" in state.location && typeof state.location.href === "string"
+        ? state.location.href
+        : state.location.pathname,
   });
   const { isLoading, user } = useAuth();
   const browserPathname = getBrowserPathname();
@@ -612,6 +639,7 @@ export default function Layout() {
             className="fixed inset-0 h-svh !min-h-0 flex-col overflow-hidden"
             defaultOpen={defaultOpen}
           >
+            <MobileSidebarRouteDismiss routeKey={routeKey} />
             {isFullscreenActive ? null : <TopBar userEmail={userEmail} />}
             <div
               className={cn(

--- a/packages/athena-webapp/src/tests/prod/posFlow.prod.spec.ts
+++ b/packages/athena-webapp/src/tests/prod/posFlow.prod.spec.ts
@@ -1,0 +1,160 @@
+import { expect, test, type Page } from "@playwright/test";
+import { ConvexHttpClient } from "convex/browser";
+
+import { api } from "../../../convex/_generated/api";
+import type { Id } from "../../../convex/_generated/dataModel";
+
+const prodConvexUrl =
+  process.env.ATHENA_PROD_CONVEX_URL ||
+  "https://colorless-cardinal-870.convex.cloud";
+const prodStoreId = (process.env.ATHENA_PROD_POS_STORE_ID ||
+  "nn7byz68a3j4tfjvgdf9evpt3n78kk38") as Id<"store">;
+const prodPosRecoveryCode = process.env.ATHENA_PROD_POS_RECOVERY_CODE;
+const posHubPath =
+  process.env.ATHENA_PROD_POS_HUB_PATH || "/wigclub/store/wigclub/pos";
+const posBasePath = posHubPath.replace(/\/$/, "");
+const posRegisterPath = `${posBasePath}/register`;
+const posLoginRecoveryPath = `/login?redirectTo=${encodeURIComponent(posRegisterPath)}`;
+
+const publicPosEntryRoutes = [
+  {
+    label: "POS hub",
+    path: posBasePath,
+    expectedText: /POS|Point of Sale|terminal|sign in|recovery/i,
+  },
+  {
+    label: "register",
+    path: `${posBasePath}/register`,
+    expectedText: /checkout|register|drawer|terminal|sign in|recovery|POS/i,
+  },
+] as const;
+
+function collectProdRuntimeSignals(page: Page) {
+  const pageErrors: Array<string> = [];
+  const consoleErrors: Array<string> = [];
+  const failedResponses: Array<string> = [];
+
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      consoleErrors.push(message.text());
+    }
+  });
+  page.on("response", (response) => {
+    if (response.status() >= 500) {
+      failedResponses.push(`${response.status()} ${response.url()}`);
+    }
+  });
+
+  return {
+    assertClean(label: string) {
+      const criticalConsoleErrors = consoleErrors.filter(
+        (message) =>
+          /CONVEX Q|Server Error|Unhandled Runtime Error|Application error|ChunkLoadError/i.test(
+            message,
+          ) &&
+          !message.includes("installHook.js"),
+      );
+
+      expect(pageErrors, `${label} page errors`).toEqual([]);
+      expect(criticalConsoleErrors, `${label} console errors`).toEqual([]);
+      expect(failedResponses, `${label} 5xx responses`).toEqual([]);
+    },
+  };
+}
+
+async function openPosRecoveryForm(page: Page) {
+  await page.goto(posLoginRecoveryPath, {
+    waitUntil: "domcontentloaded",
+  });
+
+  await expect(page.getByRole("heading", { name: /log in/i })).toBeVisible();
+  await page.getByRole("button", { name: /pos sign in/i }).click();
+  await expect(page.getByRole("heading", { name: /pos recovery/i })).toBeVisible();
+  await expect(page.getByLabel(/pos account/i)).toBeVisible();
+  await expect(page.getByLabel(/recovery code/i)).toBeVisible();
+}
+
+test.describe("production POS flow", () => {
+  test("keeps public POS entry routes renderable", async ({ page }) => {
+    const runtimeSignals = collectProdRuntimeSignals(page);
+
+    for (const route of publicPosEntryRoutes) {
+      await test.step(route.label, async () => {
+        const response = await page.goto(route.path, {
+          waitUntil: "domcontentloaded",
+        });
+
+        expect(response?.ok(), `${route.label} navigation`).toBe(true);
+        await expect(page.locator("#app"), `${route.label} app root`).not.toBeEmpty({
+          timeout: 30_000,
+        });
+        await expect(page.locator("body"), route.label).toContainText(
+          route.expectedText,
+          { timeout: 30_000 },
+        );
+        await expect(page.locator("body"), route.label).not.toContainText(
+          /Server Error|CONVEX Q|Unhandled Runtime Error|Application error/i,
+        );
+        await page.waitForTimeout(2_000);
+        runtimeSignals.assertClean(route.label);
+      });
+    }
+  });
+
+  test("keeps POS recovery sign-in entry available without submitting", async ({
+    page,
+  }) => {
+    const runtimeSignals = collectProdRuntimeSignals(page);
+    await openPosRecoveryForm(page);
+    await expect(page.getByRole("button", { name: /^continue$/i })).toBeDisabled();
+    await expect(page.locator("body")).not.toContainText(
+      /Server Error|CONVEX Q|Unhandled Runtime Error|Application error/i,
+    );
+    runtimeSignals.assertClean("POS recovery sign-in");
+  });
+
+  test("authenticates through POS recovery and reaches register entry", async ({
+    page,
+  }) => {
+    test.skip(
+      !prodPosRecoveryCode,
+      "ATHENA_PROD_POS_RECOVERY_CODE is required for authenticated POS E2E.",
+    );
+
+    const runtimeSignals = collectProdRuntimeSignals(page);
+
+    await openPosRecoveryForm(page);
+    await page.getByLabel(/recovery code/i).fill(prodPosRecoveryCode ?? "");
+    await page.getByRole("button", { name: /^continue$/i }).click();
+
+    await expect(page).toHaveURL(new RegExp(`${posRegisterPath}/?$`), {
+      timeout: 30_000,
+    });
+    await expect(page.locator("#app")).not.toBeEmpty({ timeout: 30_000 });
+    await expect(page.locator("body")).toContainText(
+      /checkout|register|drawer|terminal|recovery|POS/i,
+      { timeout: 30_000 },
+    );
+    await expect(page.locator("body")).not.toContainText(
+      /Server Error|CONVEX Q|Unhandled Runtime Error|Application error/i,
+    );
+    await page.waitForTimeout(3_000);
+    runtimeSignals.assertClean("authenticated POS register entry");
+  });
+
+  test("serves the live register catalog snapshot used by POS prewarm", async () => {
+    const client = new ConvexHttpClient(prodConvexUrl);
+
+    const rows = await client.query(
+      api.pos.public.catalog.listRegisterCatalogSnapshot,
+      { storeId: prodStoreId },
+    );
+
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows[0]).toMatchObject({
+      productSkuId: expect.any(String),
+      name: expect.any(String),
+    });
+  });
+});

--- a/scripts/harness-app-registry.test.ts
+++ b/scripts/harness-app-registry.test.ts
@@ -879,6 +879,7 @@ describe("HARNESS_APP_REGISTRY", () => {
     expect(offlineRouteScenario?.touchedPaths).toEqual([
       "public/pos-app-shell-sw.js",
       "playwright.config.ts",
+      "playwright.prod.config.ts",
       "src/main.tsx",
       "src/offline",
       "src/routes/_authed.tsx",
@@ -891,6 +892,7 @@ describe("HARNESS_APP_REGISTRY", () => {
       "src/lib/pos/presentation/register",
       "src/tests/pos/offlineRouteAccess.spec.ts",
       "src/tests/pos/offlineSalesContinuity.spec.ts",
+      "src/tests/prod/posFlow.prod.spec.ts",
     ]);
     expect(offlineRouteScenario?.commands).toEqual([
       {
@@ -902,6 +904,11 @@ describe("HARNESS_APP_REGISTRY", () => {
         kind: "raw",
         command:
           "bun run --filter '@athena/webapp' test:e2e -- src/tests/pos/offlineRouteAccess.spec.ts src/tests/pos/offlineSalesContinuity.spec.ts",
+      },
+      {
+        kind: "raw",
+        command:
+          "bun run --filter '@athena/webapp' test:e2e:prod:pos",
       },
       {
         kind: "raw",

--- a/scripts/harness-app-registry.ts
+++ b/scripts/harness-app-registry.ts
@@ -706,6 +706,7 @@ export const HARNESS_APP_REGISTRY = [
         touchedPaths: [
           "public/pos-app-shell-sw.js",
           "playwright.config.ts",
+          "playwright.prod.config.ts",
           "src/main.tsx",
           "src/offline",
           "src/routes/_authed.tsx",
@@ -718,6 +719,7 @@ export const HARNESS_APP_REGISTRY = [
           "src/lib/pos/presentation/register",
           "src/tests/pos/offlineRouteAccess.spec.ts",
           "src/tests/pos/offlineSalesContinuity.spec.ts",
+          "src/tests/prod/posFlow.prod.spec.ts",
         ],
         commands: [
           {
@@ -729,6 +731,11 @@ export const HARNESS_APP_REGISTRY = [
             kind: "raw",
             command:
               "bun run --filter '@athena/webapp' test:e2e -- src/tests/pos/offlineRouteAccess.spec.ts src/tests/pos/offlineSalesContinuity.spec.ts",
+          },
+          {
+            kind: "raw",
+            command:
+              "bun run --filter '@athena/webapp' test:e2e:prod:pos",
           },
           {
             kind: "raw",

--- a/scripts/harness-audit.test.ts
+++ b/scripts/harness-audit.test.ts
@@ -170,6 +170,7 @@ async function createFixtureRepo() {
   await write("packages/athena-webapp/tailwind.config.js", "export default {};\n", rootDir);
   await write("packages/athena-webapp/postcss.config.js", "export default {};\n", rootDir);
   await write("packages/athena-webapp/playwright.config.ts", "export default {};\n", rootDir);
+  await write("packages/athena-webapp/playwright.prod.config.ts", "export default {};\n", rootDir);
   await write(
     "packages/athena-webapp/src/design-system-build-config.test.ts",
     "export {};\n",
@@ -1097,6 +1098,11 @@ async function createFixtureRepo() {
   );
   await write(
     "packages/athena-webapp/src/tests/pos/offlineSalesContinuity.spec.ts",
+    "export {};\n",
+    rootDir
+  );
+  await write(
+    "packages/athena-webapp/src/tests/prod/posFlow.prod.spec.ts",
     "export {};\n",
     rootDir
   );


### PR DESCRIPTION
## Summary
- add a production-backend POS Playwright config that runs against the candidate build in CI
- cover desktop and mobile POS entry, POS recovery entry, authenticated recovery-to-register when the CI secret is present, and the live Wigclub catalog snapshot query that crashed prod
- wire the POS E2E guard into the PR workflow with timeout, concurrency, and fail-fast secret validation

## Validation
- bun run workflow:check
- bun run harness:check
- bun run graphify:rebuild && bun run graphify:check
- bun run harness:test
- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json
- bun run --filter '@athena/webapp' test:e2e:prod:pos
- ATHENA_POS_E2E_RUN_LOCAL_BUILD=1 bun run --filter '@athena/webapp' test:e2e:prod:pos
- pre-push hook passed all configured checks

Note: local prod POS E2E skips the recovery-code submission when ATHENA_PROD_POS_RECOVERY_CODE is not present; CI requires that secret before running.