### PR TITLE
fix(pos): clarify pending checkout event quantity

### DIFF
--- a/packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.test.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.test.ts
@@ -235,7 +235,7 @@ describe("createOrReusePendingCheckoutItem", () => {
         actorUserId: "user0001",
         eventType: "pos_pending_checkout_item_created",
         message:
-          "Ama Mensah added pending checkout item Loose wave bundle for 2 sold.",
+          "Ama Mensah added pending checkout item Loose wave bundle. Quantity sold: 2.",
         subjectId: item._id,
         subjectLabel: "Loose wave bundle",
         subjectType: "pos_pending_checkout_item",
@@ -304,6 +304,8 @@ describe("createOrReusePendingCheckoutItem", () => {
       }),
       expect.objectContaining({
         eventType: "pos_pending_checkout_item_reused",
+        message:
+          "Ama Mensah reused pending checkout item Mystery wig. Quantity sold: 3.",
         metadata: expect.objectContaining({
           quantitySold: 3,
           reviewPriority: "high",

--- a/packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.ts
@@ -408,7 +408,7 @@ function buildEventMessage(args: {
 }) {
   const action = args.reused ? "reused" : "added";
 
-  return `${args.actorLabel} ${action} pending checkout item ${args.itemName} for ${args.quantitySold} sold.`;
+  return `${args.actorLabel} ${action} pending checkout item ${args.itemName}. Quantity sold: ${args.quantitySold}.`;
 }
 
 function buildWorkItemPriority(


### PR DESCRIPTION
## Summary
Pending checkout reuse events now read as an operational action followed by the quantity sold, instead of the awkward `for 1 sold` phrasing. Creation and reuse event tests now pin the operator-facing message shape so future audit copy keeps the quantity clear.

## Validation
- `bun test packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.test.ts`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- Pre-push suite: graphify check, architecture check, harness review, Convex audit, changed-file lint, webapp build, full webapp test suite, selected behavior scenarios, inferential review

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)