### PR TITLE
Trace pending checkout operational events

### DIFF
--- a/docs/solutions/architecture/athena-pos-pending-checkout-item-recovery-2026-06-06.md
+++ b/docs/solutions/architecture/athena-pos-pending-checkout-item-recovery-2026-06-06.md
@@ -35,6 +35,9 @@ Split checkout recovery from trusted catalog management:
   transaction shape until the item is reviewed.
 - The server records operator-readable operational events for creation, reuse,
   and review decisions, including the actor and sold quantity evidence.
+- POS-authored operational events carry register session, terminal, staff, and
+  local-event trace metadata so Daily Operations can explain where the evidence
+  came from without trusting cashier-created catalog data.
 - Offline terminals record a `pending_checkout_item.defined` local event and sync
   it through the same idempotent POS local event projection as completed sales.
 
@@ -64,3 +67,8 @@ review priority and audit visibility while preserving normal cashier flow.
 - Exclude pending checkout lines from inventory validation, hold consumption,
   SKU decrement, and trusted stock reporting.
 - Keep owner/admin review routes behind `full_admin`.
+- Normalize POS trace fields at the operational-event boundary so quick-add,
+  pending checkout, offline sync, and sale-backed events dedupe on the same
+  register/session/terminal context.
+- Suppress sale-backed pending checkout reuse rows from the Daily Operations
+  timeline when the completed sale already provides the cashier-facing event.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6399 nodes · 7049 edges · 1786 communities detected
+- 6405 nodes · 7060 edges · 1786 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1864,8 +1864,8 @@ Cohesion: 0.09
 Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.09
-Nodes (40): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents(), buildWeekMetricForDate(), buildWeekMetrics(), compareDailyOperationsTimelineEvents() (+32 more)
+Cohesion: 0.08
+Nodes (41): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents(), buildWeekMetricForDate(), buildWeekMetrics(), compareDailyOperationsTimelineEvents() (+33 more)
 
 ### Community 11 - "Community 11"
 Cohesion: 0.07
@@ -2280,316 +2280,316 @@ Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
 ### Community 114 - "Community 114"
-Cohesion: 0.38
-Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
+Cohesion: 0.33
+Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
 ### Community 115 - "Community 115"
 Cohesion: 0.38
-Nodes (8): getRegisterCatalogPrice(), isTrustedRegisterCatalogSku(), listRegisterCatalog(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
+Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
 ### Community 116 - "Community 116"
+Cohesion: 0.38
+Nodes (8): getRegisterCatalogPrice(), isTrustedRegisterCatalogSku(), listRegisterCatalog(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
+
+### Community 117 - "Community 117"
 Cohesion: 0.22
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.31
 Nodes (7): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), parseVariantDisplayMoney(), saveProduct(), updateVariantSku()
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.29
 Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
 
-### Community 120 - "Community 120"
+### Community 121 - "Community 121"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 121 - "Community 121"
+### Community 122 - "Community 122"
 Cohesion: 0.22
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 122 - "Community 122"
+### Community 123 - "Community 123"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 123 - "Community 123"
+### Community 124 - "Community 124"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 124 - "Community 124"
+### Community 125 - "Community 125"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 125 - "Community 125"
+### Community 126 - "Community 126"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 126 - "Community 126"
+### Community 127 - "Community 127"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 127 - "Community 127"
+### Community 128 - "Community 128"
 Cohesion: 0.39
 Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.36
 Nodes (5): getAutomationPolicyWithCtx(), getAutomationRunByIdempotencyKeyWithCtx(), listAutomationPoliciesForStoreActionWithCtx(), listAutomationRunsByIdempotencyKeyWithCtx(), recordAutomationRunWithCtx()
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.43
 Nodes (6): assertActiveTerminal(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 148 - "Community 148"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 149 - "Community 149"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 150 - "Community 150"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 151 - "Community 151"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.25
 Nodes (1): ResizeObserverStub
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 155 - "Community 155"
-Cohesion: 0.29
-Nodes (2): handleKeyDown(), isDebugShortcut()
 
 ### Community 156 - "Community 156"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.29
+Nodes (2): handleKeyDown(), isDebugShortcut()
 
 ### Community 157 - "Community 157"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 158 - "Community 158"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
-
-### Community 159 - "Community 159"
 Cohesion: 0.25
 Nodes (0):
+
+### Community 159 - "Community 159"
+Cohesion: 0.39
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 160 - "Community 160"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 161 - "Community 161"
-Cohesion: 0.46
-Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
-
-### Community 162 - "Community 162"
-Cohesion: 0.43
-Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
-
-### Community 163 - "Community 163"
 Cohesion: 0.25
 Nodes (0):
 
+### Community 162 - "Community 162"
+Cohesion: 0.46
+Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
+
+### Community 163 - "Community 163"
+Cohesion: 0.43
+Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
+
 ### Community 164 - "Community 164"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 165 - "Community 165"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.33
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.33
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 170 - "Community 170"
+### Community 171 - "Community 171"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 171 - "Community 171"
+### Community 172 - "Community 172"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 172 - "Community 172"
+### Community 173 - "Community 173"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 173 - "Community 173"
+### Community 174 - "Community 174"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 175 - "Community 175"
+### Community 176 - "Community 176"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
+Cohesion: 0.43
+Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
+
+### Community 178 - "Community 178"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 177 - "Community 177"
+### Community 179 - "Community 179"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 178 - "Community 178"
+### Community 180 - "Community 180"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 179 - "Community 179"
+### Community 181 - "Community 181"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 180 - "Community 180"
+### Community 182 - "Community 182"
 Cohesion: 0.33
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 181 - "Community 181"
+### Community 183 - "Community 183"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 182 - "Community 182"
+### Community 184 - "Community 184"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
 
-### Community 183 - "Community 183"
+### Community 185 - "Community 185"
 Cohesion: 0.33
 Nodes (2): handlePinChange(), normalizeOtpCode()
 
-### Community 184 - "Community 184"
+### Community 186 - "Community 186"
 Cohesion: 0.33
 Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
-### Community 185 - "Community 185"
+### Community 187 - "Community 187"
 Cohesion: 0.33
 Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
-### Community 186 - "Community 186"
+### Community 188 - "Community 188"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 187 - "Community 187"
+### Community 189 - "Community 189"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 188 - "Community 188"
+### Community 190 - "Community 190"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 189 - "Community 189"
+### Community 191 - "Community 191"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
-
-### Community 190 - "Community 190"
-Cohesion: 0.29
-Nodes (0):
-
-### Community 191 - "Community 191"
-Cohesion: 0.33
-Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
 
 ### Community 192 - "Community 192"
 Cohesion: 0.29
@@ -2597,47 +2597,47 @@ Nodes (0):
 
 ### Community 193 - "Community 193"
 Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
+Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
 
 ### Community 194 - "Community 194"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 195 - "Community 195"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 196 - "Community 196"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 198 - "Community 198"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 197 - "Community 197"
+### Community 199 - "Community 199"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 198 - "Community 198"
+### Community 200 - "Community 200"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 199 - "Community 199"
+### Community 201 - "Community 201"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 200 - "Community 200"
+### Community 202 - "Community 202"
 Cohesion: 0.33
 Nodes (1): ValkeyClient
 
-### Community 201 - "Community 201"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 202 - "Community 202"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 203 - "Community 203"
-Cohesion: 0.47
-Nodes (4): buildOperationalEvent(), matchesExistingEvent(), metadataDedupeKeysMatch(), recordOperationalEventWithCtx()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 204 - "Community 204"
 Cohesion: 0.33
@@ -2649,15 +2649,15 @@ Nodes (0):
 
 ### Community 206 - "Community 206"
 Cohesion: 0.4
-Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
-
-### Community 207 - "Community 207"
-Cohesion: 0.4
 Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
 
+### Community 207 - "Community 207"
+Cohesion: 0.33
+Nodes (0):
+
 ### Community 208 - "Community 208"
-Cohesion: 0.53
-Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
+Cohesion: 0.4
+Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
 ### Community 209 - "Community 209"
 Cohesion: 0.73
@@ -2736,8 +2736,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 228 - "Community 228"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 229 - "Community 229"
 Cohesion: 0.33
@@ -2756,64 +2756,64 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 233 - "Community 233"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 234 - "Community 234"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
+
+### Community 234 - "Community 234"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 235 - "Community 235"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 236 - "Community 236"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 237 - "Community 237"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 238 - "Community 238"
+### Community 237 - "Community 237"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 239 - "Community 239"
+### Community 238 - "Community 238"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 239 - "Community 239"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 240 - "Community 240"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 241 - "Community 241"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 242 - "Community 242"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 243 - "Community 243"
+### Community 242 - "Community 242"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 244 - "Community 244"
+### Community 243 - "Community 243"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 245 - "Community 245"
+### Community 244 - "Community 244"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 246 - "Community 246"
+### Community 245 - "Community 245"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 247 - "Community 247"
+### Community 246 - "Community 246"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 247 - "Community 247"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 248 - "Community 248"
 Cohesion: 0.53
@@ -2856,52 +2856,52 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 258 - "Community 258"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
-
-### Community 259 - "Community 259"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
+
+### Community 259 - "Community 259"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 260 - "Community 260"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 261 - "Community 261"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 262 - "Community 262"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 263 - "Community 263"
+### Community 262 - "Community 262"
 Cohesion: 0.6
 Nodes (3): isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult()
+
+### Community 263 - "Community 263"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 264 - "Community 264"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 265 - "Community 265"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 266 - "Community 266"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 267 - "Community 267"
+### Community 266 - "Community 266"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 268 - "Community 268"
+### Community 267 - "Community 267"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 269 - "Community 269"
+### Community 268 - "Community 268"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+
+### Community 269 - "Community 269"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 270 - "Community 270"
 Cohesion: 0.4
@@ -2916,12 +2916,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 273 - "Community 273"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 274 - "Community 274"
 Cohesion: 0.5
 Nodes (2): handleFileSelect(), validateFile()
+
+### Community 274 - "Community 274"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 275 - "Community 275"
 Cohesion: 0.4
@@ -2940,28 +2940,28 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 279 - "Community 279"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 280 - "Community 280"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
-### Community 281 - "Community 281"
+### Community 280 - "Community 280"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 282 - "Community 282"
+### Community 281 - "Community 281"
 Cohesion: 0.5
 Nodes (2): buildTerminalOfflineReadiness(), getAppSessionReadinessInput()
 
-### Community 283 - "Community 283"
+### Community 282 - "Community 282"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 284 - "Community 284"
+### Community 283 - "Community 283"
 Cohesion: 0.4
 Nodes (1): ResizeObserverStub
+
+### Community 284 - "Community 284"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 285 - "Community 285"
 Cohesion: 0.4
@@ -2972,44 +2972,44 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 287 - "Community 287"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 288 - "Community 288"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 289 - "Community 289"
+### Community 288 - "Community 288"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 290 - "Community 290"
+### Community 289 - "Community 289"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 291 - "Community 291"
+### Community 290 - "Community 290"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 292 - "Community 292"
+### Community 291 - "Community 291"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 293 - "Community 293"
+### Community 292 - "Community 292"
 Cohesion: 0.6
 Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
-### Community 294 - "Community 294"
+### Community 293 - "Community 293"
 Cohesion: 0.6
 Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
-### Community 295 - "Community 295"
+### Community 294 - "Community 294"
 Cohesion: 0.6
 Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
-### Community 296 - "Community 296"
+### Community 295 - "Community 295"
 Cohesion: 0.6
 Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+
+### Community 296 - "Community 296"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 297 - "Community 297"
 Cohesion: 0.4
@@ -3024,40 +3024,40 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 300 - "Community 300"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 301 - "Community 301"
 Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
-### Community 302 - "Community 302"
+### Community 301 - "Community 301"
 Cohesion: 0.5
 Nodes (3): createVersionChecker(), shouldAutoReloadForCurrentRoute(), shouldAutoReloadForPath()
 
-### Community 303 - "Community 303"
+### Community 302 - "Community 302"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 304 - "Community 304"
+### Community 303 - "Community 303"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 305 - "Community 305"
+### Community 304 - "Community 304"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 306 - "Community 306"
+### Community 305 - "Community 305"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 306 - "Community 306"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 307 - "Community 307"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 308 - "Community 308"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 309 - "Community 309"
 Cohesion: 0.7

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1858
-- Graph nodes: 6399
-- Graph edges: 7049
+- Graph nodes: 6405
+- Graph edges: 7060
 - Communities: 1786
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (14 edges, Community 74) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 137) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 138) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 74) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `createRedisCluster()` (3 edges, Community 74) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `deleteKeysIndividually()` (3 edges, Community 74) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/operations/dailyOperations.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.test.ts
@@ -953,6 +953,21 @@ describe("daily operations overview read model", () => {
             subjectType: "product_sku",
           },
           {
+            _id: "event-pending-checkout-item",
+            createdAt: Date.UTC(2026, 4, 8, 13),
+            eventType: "pos_pending_checkout_item_created",
+            message:
+              "Ama Mensah added pending checkout item Loose wave bundle. Quantity entered: 2.",
+            metadata: {
+              provisionalProductId: "product-pending",
+              provisionalProductSkuId: "sku-pending",
+            },
+            storeId: "store-1",
+            subjectId: "pending-item-1",
+            subjectLabel: "Loose wave bundle",
+            subjectType: "pos_pending_checkout_item",
+          },
+          {
             _id: "event-pos-sale-synced",
             createdAt: Date.UTC(2026, 4, 8, 18),
             eventType: "pos_local_sync.sale_projected",
@@ -967,6 +982,23 @@ describe("daily operations overview read model", () => {
             subjectType: "posTransaction",
           },
           {
+            _id: "event-pending-checkout-item-reused",
+            createdAt: Date.UTC(2026, 4, 8, 17),
+            eventType: "pos_pending_checkout_item_reused",
+            message:
+              "Ama Mensah reused pending checkout item Loose wave bundle. Quantity entered: 2.",
+            metadata: {
+              posTransactionId: "txn-946956",
+              provisionalProductId: "product-pending",
+              provisionalProductSkuId: "sku-pending",
+              transactionCount: 1,
+            },
+            storeId: "store-1",
+            subjectId: "pending-item-1",
+            subjectLabel: "Loose wave bundle",
+            subjectType: "pos_pending_checkout_item",
+          },
+          {
             _id: "event-other-day",
             createdAt: Date.UTC(2026, 4, 9, 8),
             eventType: "daily_opening.started",
@@ -974,6 +1006,15 @@ describe("daily operations overview read model", () => {
             storeId: "store-1",
             subjectId: "opening-next",
             subjectType: "daily_opening",
+          },
+        ],
+        productSku: [
+          {
+            _id: "sku-pending",
+            productId: "product-pending",
+            productName: "Loose wave bundle",
+            sku: "ZZZZ-1-1",
+            storeId: "store-1",
           },
         ],
         store: [store],
@@ -989,9 +1030,13 @@ describe("daily operations overview read model", () => {
     expect(snapshot.timeline.map((event) => event.id)).toEqual([
       "event-2",
       "event-pos-sale-synced",
+      "event-pending-checkout-item",
       "event-quick-add",
       "event-1",
     ]);
+    expect(snapshot.timeline.map((event) => event.id)).not.toContain(
+      "event-pending-checkout-item-reused",
+    );
     expect(
       snapshot.timeline.find((event) => event.id === "event-pos-sale-synced")
         ?.message,
@@ -1016,6 +1061,20 @@ describe("daily operations overview read model", () => {
       },
       search: {
         variant: "VITAMILK-001",
+      },
+      to: "/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug",
+    });
+    expect(
+      snapshot.timeline.find(
+        (event) => event.id === "event-pending-checkout-item",
+      )?.productLink,
+    ).toEqual({
+      label: "Loose wave bundle",
+      params: {
+        productSlug: "product-pending",
+      },
+      search: {
+        variant: "ZZZZ-1-1",
       },
       to: "/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug",
     });

--- a/packages/athena-webapp/convex/operations/dailyOperations.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.ts
@@ -527,7 +527,9 @@ async function listTimelineEvents(
     ]);
 
   return [
-    ...operationalTimelineEvents,
+    ...operationalTimelineEvents.filter(
+      (event): event is DailyOperationsTimelineEvent => event !== null,
+    ),
     ...registerCloseoutTimelineEvents,
     ...pendingRegisterCountEvents,
   ]
@@ -679,101 +681,132 @@ async function mapOperationalTimelineEvent(
     subjectLabel?: string;
     subjectType: string;
   },
-): Promise<DailyOperationsTimelineEvent> {
-    const metadata = event.metadata ?? {};
-    const productId =
-      typeof metadata.productId === "string" ? metadata.productId : undefined;
-    const productSkuId =
-      typeof metadata.productSkuId === "string"
-        ? (metadata.productSkuId as Id<"productSku">)
-        : undefined;
-    const productSku = productSkuId
-      ? await ctx.db.get("productSku", productSkuId)
-      : null;
-    const productName =
-      typeof metadata.productName === "string"
-        ? metadata.productName
-        : event.subjectLabel;
-    const productSkuLabel =
-      typeof metadata.productSkuLabel === "string"
-        ? metadata.productSkuLabel
-        : undefined;
-    const sku =
-      typeof metadata.sku === "string"
-        ? metadata.sku
-        : productSku?.sku ?? undefined;
-    const productLinkProductId = productId ?? productSku?.productId;
-    const productLinkLabel =
-      event.subjectType === "product_sku"
-        ? productName
-        : productSkuLabel ||
-          (productSku?.productName && sku
-            ? `${productSku.productName} (${sku})`
-            : productSku?.productName || productName);
-    const canLinkProduct =
-      event.subjectType === "product_sku" || productSkuId !== undefined;
-    const transactionNumber =
-      typeof metadata.transactionNumber === "string"
-        ? metadata.transactionNumber
-        : typeof metadata.receiptNumber === "string"
-          ? metadata.receiptNumber
-          : undefined;
-    const transactionLink =
-      event.subjectType === "posTransaction" && transactionNumber
-        ? {
-            label: `#${transactionNumber}`,
-            params: {
-              transactionId: event.subjectId,
-            },
-            to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId",
-          }
-        : undefined;
-    const productLink =
-      canLinkProduct && productLinkProductId && productLinkLabel
-        ? {
-            label: productLinkLabel,
-            params: {
-              productSlug: productLinkProductId,
-            },
-            search: {
-              ...(sku ? { variant: sku } : {}),
-            },
-            to: "/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug",
-          }
-        : undefined;
-    const registerNumber =
-      typeof metadata.registerNumber === "string"
-        ? metadata.registerNumber
-        : undefined;
-    const registerLabel =
-      event.subjectType === "register_session"
-        ? event.subjectLabel ?? formatRegisterSessionLabel(registerNumber)
-        : undefined;
-    const registerLink =
-      event.subjectType === "register_session"
-        ? {
-            label: registerLabel ?? "Register session",
-            params: {
-              sessionId: event.subjectId,
-            },
-            to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId",
-          }
-        : undefined;
+): Promise<DailyOperationsTimelineEvent | null> {
+  const metadata = event.metadata ?? {};
+  if (isSaleBackedPendingCheckoutReuseEvent(event.eventType, metadata)) {
+    return null;
+  }
 
-    return {
-      createdAt: event.createdAt,
-      id: event._id,
-      message: normalizeTimelineEventMessage(event.message),
-      productLink,
-      registerLink,
-      subject: {
-        id: event.subjectId,
-        label: event.subjectLabel ?? registerLabel,
-        type: event.subjectType,
-      },
-      transactionLink,
-      type: event.eventType,
-    };
+  const productId =
+    typeof metadata.productId === "string"
+      ? metadata.productId
+      : typeof metadata.provisionalProductId === "string"
+        ? metadata.provisionalProductId
+        : undefined;
+  const productSkuId =
+    typeof metadata.productSkuId === "string"
+      ? (metadata.productSkuId as Id<"productSku">)
+      : typeof metadata.provisionalProductSkuId === "string"
+        ? (metadata.provisionalProductSkuId as Id<"productSku">)
+        : undefined;
+  const productSku = productSkuId
+    ? await ctx.db.get("productSku", productSkuId)
+    : null;
+  const productName =
+    typeof metadata.productName === "string"
+      ? metadata.productName
+      : event.subjectLabel;
+  const productSkuLabel =
+    typeof metadata.productSkuLabel === "string"
+      ? metadata.productSkuLabel
+      : undefined;
+  const sku =
+    typeof metadata.sku === "string"
+      ? metadata.sku
+      : productSku?.sku ?? undefined;
+  const isPendingCheckoutItemEvent =
+    event.subjectType === "pos_pending_checkout_item" &&
+    productSkuId !== undefined;
+  const productLinkProductId = productId ?? productSku?.productId;
+  const productSkuDisplayLabel =
+    productSku?.productName && sku
+      ? `${productSku.productName} (${sku})`
+      : productSku?.productName || productName;
+  const productLinkLabel =
+    isPendingCheckoutItemEvent
+      ? productName
+      : event.subjectType === "product_sku"
+        ? productName
+        : productSkuLabel || productSkuDisplayLabel;
+  const canLinkProduct =
+    event.subjectType === "product_sku" ||
+    isPendingCheckoutItemEvent ||
+    productSkuId !== undefined;
+  const transactionNumber =
+    typeof metadata.transactionNumber === "string"
+      ? metadata.transactionNumber
+      : typeof metadata.receiptNumber === "string"
+        ? metadata.receiptNumber
+        : undefined;
+  const transactionLink =
+    event.subjectType === "posTransaction" && transactionNumber
+      ? {
+          label: `#${transactionNumber}`,
+          params: {
+            transactionId: event.subjectId,
+          },
+          to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions/$transactionId",
+        }
+      : undefined;
+  const productLink =
+    canLinkProduct && productLinkProductId && productLinkLabel
+      ? {
+          label: productLinkLabel,
+          params: {
+            productSlug: productLinkProductId,
+          },
+          search: {
+            ...(sku ? { variant: sku } : {}),
+          },
+          to: "/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug",
+        }
+      : undefined;
+  const registerNumber =
+    typeof metadata.registerNumber === "string"
+      ? metadata.registerNumber
+      : undefined;
+  const registerLabel =
+    event.subjectType === "register_session"
+      ? event.subjectLabel ?? formatRegisterSessionLabel(registerNumber)
+      : undefined;
+  const registerLink =
+    event.subjectType === "register_session"
+      ? {
+          label: registerLabel ?? "Register session",
+          params: {
+            sessionId: event.subjectId,
+          },
+          to: "/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId",
+        }
+      : undefined;
+
+  return {
+    createdAt: event.createdAt,
+    id: event._id,
+    message: normalizeTimelineEventMessage(event.message),
+    productLink,
+    registerLink,
+    subject: {
+      id: event.subjectId,
+      label: event.subjectLabel ?? registerLabel,
+      type: event.subjectType,
+    },
+    transactionLink,
+    type: event.eventType,
+  };
+}
+
+function isSaleBackedPendingCheckoutReuseEvent(
+  eventType: string,
+  metadata: Record<string, unknown>,
+) {
+  if (eventType !== "pos_pending_checkout_item_reused") return false;
+
+  return (
+    typeof metadata.posTransactionId === "string" ||
+    (typeof metadata.transactionCount === "number" &&
+      metadata.transactionCount > 0)
+  );
 }
 
 function normalizeTimelineEventMessage(message: string) {

--- a/packages/athena-webapp/convex/operations/operationalEvents.test.ts
+++ b/packages/athena-webapp/convex/operations/operationalEvents.test.ts
@@ -210,6 +210,59 @@ describe("operational events", () => {
     ]);
   });
 
+  it("normalizes POS trace fields into top-level fields and metadata", async () => {
+    const ctx = createCtx({});
+
+    await recordOperationalEventWithCtx(ctx as unknown as MutationCtx, {
+      actorStaffProfileId: "staff-1" as Id<"staffProfile">,
+      eventType: "pos_quick_add_product_created",
+      localEventId: "event-local-1",
+      message: "Quick add recorded.",
+      metadata: {
+        productSkuId: "sku-1",
+      },
+      posTransactionId: "transaction-1" as Id<"posTransaction">,
+      registerSessionId: "register-session-1" as Id<"registerSession">,
+      storeId: "store-1" as Id<"store">,
+      subjectId: "sku-1",
+      subjectType: "product_sku",
+      terminalId: "terminal-1" as Id<"posTerminal">,
+    });
+
+    const events = await ctx.db
+      .query("operationalEvent")
+      .withIndex("by_storeId_subject", (q) =>
+        q
+          .eq("storeId", "store-1" as Id<"store">)
+          .eq("subjectType", "product_sku")
+          .eq("subjectId", "sku-1"),
+      )
+      .take(10);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      actorStaffProfileId: "staff-1",
+      localEventId: "event-local-1",
+      posTransactionId: "transaction-1",
+      registerSessionId: "register-session-1",
+      terminalId: "terminal-1",
+      metadata: {
+        localEventId: "event-local-1",
+        productSkuId: "sku-1",
+        posTrace: {
+          actorStaffProfileId: "staff-1",
+          localEventId: "event-local-1",
+          posTransactionId: "transaction-1",
+          registerSessionId: "register-session-1",
+          terminalId: "terminal-1",
+        },
+        posTransactionId: "transaction-1",
+        registerSessionId: "register-session-1",
+        terminalId: "terminal-1",
+      },
+    });
+  });
+
   it("records Athena-authored operational events without staff impersonation", async () => {
     const ctx = createCtx({});
     const baseEvent = {

--- a/packages/athena-webapp/convex/operations/operationalEvents.ts
+++ b/packages/athena-webapp/convex/operations/operationalEvents.ts
@@ -31,6 +31,8 @@ export type RecordOperationalEventArgs = {
   customerProfileId?: Id<"customerProfile">;
   workItemId?: Id<"operationalWorkItem">;
   registerSessionId?: Id<"registerSession">;
+  terminalId?: Id<"posTerminal">;
+  localEventId?: string;
   approvalRequestId?: Id<"approvalRequest">;
   inventoryMovementId?: Id<"inventoryMovement">;
   paymentAllocationId?: Id<"paymentAllocation">;
@@ -40,8 +42,10 @@ export type RecordOperationalEventArgs = {
 
 export function buildOperationalEvent(args: RecordOperationalEventArgs) {
   const { metadataDedupeKeys: _metadataDedupeKeys, ...eventArgs } = args;
+  const normalizedArgs = normalizeOperationalEventTraceFields(eventArgs);
+
   return {
-    ...eventArgs,
+    ...normalizedArgs,
     message:
       args.message ??
       buildOperationalEventMessage({
@@ -51,6 +55,95 @@ export function buildOperationalEvent(args: RecordOperationalEventArgs) {
       }),
     createdAt: Date.now(),
   };
+}
+
+export function normalizeOperationalEventTraceFields<
+  EventArgs extends Omit<RecordOperationalEventArgs, "metadataDedupeKeys">,
+>(args: EventArgs): EventArgs {
+  const traceMetadata = buildTraceMetadata(args);
+  if (!traceMetadata) return args;
+
+  const metadata = args.metadata ?? {};
+
+  return {
+    ...args,
+    metadata: {
+      ...metadata,
+      ...(traceMetadata.localEventId !== undefined &&
+      metadata.localEventId === undefined
+        ? { localEventId: traceMetadata.localEventId }
+        : {}),
+      ...(traceMetadata.posTransactionId !== undefined &&
+      metadata.posTransactionId === undefined
+        ? { posTransactionId: traceMetadata.posTransactionId }
+        : {}),
+      ...(traceMetadata.registerSessionId !== undefined &&
+      metadata.registerSessionId === undefined
+        ? { registerSessionId: traceMetadata.registerSessionId }
+        : {}),
+      ...(traceMetadata.terminalId !== undefined &&
+      metadata.terminalId === undefined
+        ? { terminalId: traceMetadata.terminalId }
+        : {}),
+      posTrace: {
+        ...(isRecord(metadata.posTrace) ? metadata.posTrace : {}),
+        ...traceMetadata,
+      },
+    },
+  } as EventArgs;
+}
+
+function buildTraceMetadata(
+  args: Omit<RecordOperationalEventArgs, "metadataDedupeKeys">
+) {
+  if (!shouldNormalizePosTrace(args)) return null;
+
+  const traceMetadata = {
+    actorStaffProfileId: args.actorStaffProfileId,
+    actorUserId: args.actorUserId,
+    localEventId: args.localEventId,
+    posTransactionId: args.posTransactionId,
+    registerSessionId: args.registerSessionId,
+    terminalId: args.terminalId,
+  };
+  const compactTraceMetadata = Object.fromEntries(
+    Object.entries(traceMetadata).filter(([, value]) => value !== undefined)
+  );
+
+  return Object.keys(compactTraceMetadata).length > 0
+    ? compactTraceMetadata
+    : null;
+}
+
+function shouldNormalizePosTrace(
+  args: Omit<RecordOperationalEventArgs, "metadataDedupeKeys">
+) {
+  if (
+    args.localEventId ||
+    args.posTransactionId ||
+    args.registerSessionId ||
+    args.terminalId
+  ) {
+    return true;
+  }
+
+  return (
+    args.eventType.startsWith("pos_") ||
+    args.eventType.startsWith("manager_elevation.") ||
+    [
+      "managerElevation",
+      "posRecoveryCredential",
+      "posTerminal",
+      "posTransaction",
+      "pos_transaction",
+      "registerSession",
+      "register_session",
+    ].includes(args.subjectType)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function matchesExistingEvent(
@@ -72,6 +165,8 @@ function matchesExistingEvent(
     paymentAllocationId?: Id<"paymentAllocation">;
     posTransactionId?: Id<"posTransaction">;
     registerSessionId?: Id<"registerSession">;
+    terminalId?: Id<"posTerminal">;
+    localEventId?: string;
     workItemId?: Id<"operationalWorkItem">;
     metadata?: Record<string, unknown>;
   },
@@ -96,6 +191,8 @@ function matchesExistingEvent(
     existingEvent.paymentAllocationId === args.paymentAllocationId &&
     existingEvent.posTransactionId === args.posTransactionId &&
     existingEvent.registerSessionId === args.registerSessionId &&
+    existingEvent.terminalId === args.terminalId &&
+    existingEvent.localEventId === args.localEventId &&
     existingEvent.workItemId === args.workItemId &&
     metadataDedupeKeysMatch(
       existingEvent.metadata,
@@ -234,6 +331,8 @@ export const recordOperationalEvent = internalMutation({
     customerProfileId: v.optional(v.id("customerProfile")),
     workItemId: v.optional(v.id("operationalWorkItem")),
     registerSessionId: v.optional(v.id("registerSession")),
+    terminalId: v.optional(v.id("posTerminal")),
+    localEventId: v.optional(v.string()),
     approvalRequestId: v.optional(v.id("approvalRequest")),
     inventoryMovementId: v.optional(v.id("inventoryMovement")),
     paymentAllocationId: v.optional(v.id("paymentAllocation")),

--- a/packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts
+++ b/packages/athena-webapp/convex/operations/operationsQueryIndexes.test.ts
@@ -135,6 +135,16 @@ describe("operations query indexing", () => {
         fields: ["storeId", "createdAt"],
       },
       {
+        table: "operationalEvent",
+        descriptor: "by_terminalId",
+        fields: ["terminalId"],
+      },
+      {
+        table: "operationalEvent",
+        descriptor: "by_localEventId",
+        fields: ["localEventId"],
+      },
+      {
         table: "inventoryMovement",
         descriptor: "by_storeId_productSkuId",
         fields: ["storeId", "productSkuId"],

--- a/packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.test.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.test.ts
@@ -235,7 +235,7 @@ describe("createOrReusePendingCheckoutItem", () => {
         actorUserId: "user0001",
         eventType: "pos_pending_checkout_item_created",
         message:
-          "Ama Mensah added pending checkout item Loose wave bundle. Quantity sold: 2.",
+          "Ama Mensah added pending checkout item Loose wave bundle. Quantity entered: 2.",
         subjectId: item._id,
         subjectLabel: "Loose wave bundle",
         subjectType: "pos_pending_checkout_item",
@@ -305,7 +305,7 @@ describe("createOrReusePendingCheckoutItem", () => {
       expect.objectContaining({
         eventType: "pos_pending_checkout_item_reused",
         message:
-          "Ama Mensah reused pending checkout item Mystery wig. Quantity sold: 3.",
+          "Ama Mensah reused pending checkout item Mystery wig. Quantity entered: 3.",
         metadata: expect.objectContaining({
           quantitySold: 3,
           reviewPriority: "high",
@@ -499,30 +499,37 @@ describe("createOrReusePendingCheckoutItem", () => {
 
     const result = await createOrReusePendingCheckoutItem(ctx, {
       createdByUserId: "user0001" as Id<"athenaUser">,
+      createdByStaffProfileId: "staff0001" as Id<"staffProfile">,
       lookupCode: "556677",
+      localEventId: "define-event-1",
       name: "Committed pending item",
       price: 30000,
       quantitySold: 2,
+      registerSessionId: "register-session-1" as Id<"registerSession">,
       storeId: "storezzzz" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
       timestamp: 1_000,
     });
 
     await recordPendingCheckoutItemSaleEvidence(ctx, {
+      actorStaffProfileId: "staff0001" as Id<"staffProfile">,
       actorUserId: "user0001" as Id<"athenaUser">,
       localEventId: "sale-event-1",
       pendingCheckoutItemId: result.pendingCheckoutItemId,
       posTransactionId: "txn001" as Id<"posTransaction">,
       price: 30000,
       quantitySold: 2,
+      registerSessionId: "register-session-1" as Id<"registerSession">,
       source: "offline_sync",
       storeId: "storezzzz" as Id<"store">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
       timestamp: 2_000,
     });
 
     const item = Array.from(tables.posPendingCheckoutItem.values())[0];
     expect(item.evidence).toMatchObject({
       lastPosTransactionId: "txn001",
-      localEventIds: ["sale-event-1"],
+      localEventIds: ["define-event-1", "sale-event-1"],
       offlineSaleCount: 1,
       totalQuantitySold: 2,
       transactionCount: 1,
@@ -533,6 +540,34 @@ describe("createOrReusePendingCheckoutItem", () => {
         transactionCount: 1,
       }),
     });
+    expect(Array.from(tables.operationalEvent.values())).toEqual([
+      expect.objectContaining({
+        actorStaffProfileId: "staff0001",
+        actorUserId: "user0001",
+        eventType: "pos_pending_checkout_item_created",
+        registerSessionId: "register-session-1",
+        metadata: expect.objectContaining({
+          localEventId: "define-event-1",
+          registerSessionId: "register-session-1",
+          terminalId: "terminal-1",
+          transactionCount: 0,
+        }),
+      }),
+      expect.objectContaining({
+        actorStaffProfileId: "staff0001",
+        actorUserId: "user0001",
+        eventType: "pos_pending_checkout_item_reused",
+        posTransactionId: "txn001",
+        registerSessionId: "register-session-1",
+        metadata: expect.objectContaining({
+          localEventId: "sale-event-1",
+          posTransactionId: "txn001",
+          registerSessionId: "register-session-1",
+          terminalId: "terminal-1",
+          transactionCount: 1,
+        }),
+      }),
+    ]);
   });
 
   it("does not double-count sale evidence when an offline local event is replayed", async () => {

--- a/packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/createOrReusePendingCheckoutItem.ts
@@ -408,7 +408,7 @@ function buildEventMessage(args: {
 }) {
   const action = args.reused ? "reused" : "added";
 
-  return `${args.actorLabel} ${action} pending checkout item ${args.itemName}. Quantity sold: ${args.quantitySold}.`;
+  return `${args.actorLabel} ${action} pending checkout item ${args.itemName}. Quantity entered: ${args.quantitySold}.`;
 }
 
 function buildWorkItemPriority(
@@ -455,10 +455,15 @@ async function recordPendingCheckoutOperationalEvent(
   ctx: MutationCtx,
   args: {
     actorUserId?: Id<"athenaUser">;
+    actorStaffProfileId?: Id<"staffProfile">;
     item: Doc<"posPendingCheckoutItem">;
+    localEventId?: string;
+    posTransactionId?: Id<"posTransaction">;
     quantitySold: number;
+    registerSessionId?: Id<"registerSession">;
     reused: boolean;
     source: "online" | "offline_sync";
+    terminalId?: Id<"posTerminal">;
   },
 ) {
   const actor = args.actorUserId
@@ -470,6 +475,7 @@ async function recordPendingCheckoutOperationalEvent(
     : "pos_pending_checkout_item_created";
 
   await recordOperationalEventWithCtx(ctx, {
+    actorStaffProfileId: args.actorStaffProfileId,
     actorUserId: args.actorUserId,
     eventType,
     message: buildEventMessage({
@@ -480,20 +486,26 @@ async function recordPendingCheckoutOperationalEvent(
     }),
     metadata: {
       actorLabel,
+      localEventId: args.localEventId,
       lookupCode: args.item.lookupCode,
       pendingCheckoutItemId: args.item._id,
+      posTransactionId: args.posTransactionId,
       price: args.item.provisionalPrice,
       provisionalProductId: args.item.provisionalProductId,
       provisionalProductSkuId: args.item.provisionalProductSkuId,
       quantitySold: args.quantitySold,
+      registerSessionId: args.registerSessionId,
       reviewPriority: args.item.reviewPriority,
       source: args.source,
       status: args.item.status,
+      terminalId: args.terminalId,
       totalQuantitySold: args.item.evidence.totalQuantitySold,
       transactionCount: args.item.evidence.transactionCount,
     },
     metadataDedupeKeys: ["source", "transactionCount", "totalQuantitySold"],
     organizationId: args.item.organizationId,
+    posTransactionId: args.posTransactionId,
+    registerSessionId: args.registerSessionId,
     storeId: args.item.storeId,
     subjectId: String(args.item._id),
     subjectLabel: args.item.name,
@@ -563,11 +575,16 @@ export async function recordPendingCheckoutItemSaleEvidence(
   const updatedItem = (await ctx.db.get("posPendingCheckoutItem", item._id))!;
   await syncPendingCheckoutWorkItem(ctx, updatedItem);
   await recordPendingCheckoutOperationalEvent(ctx, {
+    actorStaffProfileId: args.actorStaffProfileId,
     actorUserId: args.actorUserId,
     item: updatedItem,
+    localEventId: args.localEventId,
+    posTransactionId: args.posTransactionId,
     quantitySold: Math.trunc(args.quantitySold),
+    registerSessionId: args.registerSessionId,
     reused: true,
     source: args.source,
+    terminalId: args.terminalId,
   });
 
   return updatedItem;
@@ -746,11 +763,15 @@ export async function createOrReusePendingCheckoutItem(
     const item = (await ctx.db.get("posPendingCheckoutItem", existing._id))!;
     await syncPendingCheckoutWorkItem(ctx, item);
     await recordPendingCheckoutOperationalEvent(ctx, {
+      actorStaffProfileId: args.createdByStaffProfileId,
       actorUserId: args.createdByUserId,
       item,
+      localEventId: args.localEventId,
       quantitySold,
+      registerSessionId: args.registerSessionId,
       reused: true,
       source,
+      terminalId: args.terminalId,
     });
 
     return {
@@ -842,11 +863,15 @@ export async function createOrReusePendingCheckoutItem(
     pendingCheckoutItemId,
   ))!;
   await recordPendingCheckoutOperationalEvent(ctx, {
+    actorStaffProfileId: args.createdByStaffProfileId,
     actorUserId: args.createdByUserId,
     item: itemWithWork,
+    localEventId: args.localEventId,
     quantitySold,
+    registerSessionId: args.registerSessionId,
     reused: false,
     source,
+    terminalId: args.terminalId,
   });
 
   return {

--- a/packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.test.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.test.ts
@@ -150,10 +150,13 @@ describe("quickAddCatalogItem", () => {
     const result = await quickAddCatalogItem(ctx, {
       storeId: "storezzzz" as Id<"store">,
       createdByUserId: "user0001" as Id<"athenaUser">,
+      createdByStaffProfileId: "staff0001" as Id<"staffProfile">,
       name: "",
       lookupCode: "123456789012",
       price: 115000,
       quantityAvailable: 2.7,
+      registerSessionId: "register-session-1" as Id<"registerSession">,
+      terminalId: "terminal-1" as Id<"posTerminal">,
     });
 
     const product = Array.from(tables.product.values())[0];
@@ -182,19 +185,30 @@ describe("quickAddCatalogItem", () => {
     expect(Array.from(tables.operationalEvent.values())).toEqual([
       expect.objectContaining({
         actorUserId: "user0001",
+        actorStaffProfileId: "staff0001",
         eventType: "pos_quick_add_product_created",
         organizationId: "org0001",
+        registerSessionId: "register-session-1",
         storeId: "storezzzz",
         subjectId: sku._id,
         subjectLabel: "123456789012",
         subjectType: "product_sku",
+        terminalId: "terminal-1",
         message: "Kwamina Nuh quick added 123456789012 with quantity 2.",
         metadata: expect.objectContaining({
           barcode: "123456789012",
+          posTrace: {
+            actorStaffProfileId: "staff0001",
+            actorUserId: "user0001",
+            registerSessionId: "register-session-1",
+            terminalId: "terminal-1",
+          },
           productId: product._id,
           productSkuId: sku._id,
           quantityAvailable: 2,
+          registerSessionId: "register-session-1",
           sku: sku.sku,
+          terminalId: "terminal-1",
         }),
       }),
     ]);

--- a/packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/quickAddCatalogItem.ts
@@ -202,6 +202,7 @@ function buildQuickAddEventMessage(args: {
 async function recordQuickAddOperationalEvent(
   ctx: MutationCtx,
   args: {
+    actorStaffProfileId?: Id<"staffProfile">;
     actorUserId: Id<"athenaUser">;
     eventType:
       | "pos_quick_add_barcode_attached"
@@ -209,14 +210,17 @@ async function recordQuickAddOperationalEvent(
       | "pos_quick_add_variant_created";
     organizationId: Id<"organization">;
     product: Doc<"product">;
+    registerSessionId?: Id<"registerSession">;
     sku: Doc<"productSku">;
     storeId: Id<"store">;
+    terminalId?: Id<"posTerminal">;
   },
 ) {
   const actor = await ctx.db.get("athenaUser", args.actorUserId);
   const actorLabel = getActorLabel(actor, String(args.actorUserId));
 
   await recordOperationalEventWithCtx(ctx, {
+    actorStaffProfileId: args.actorStaffProfileId,
     actorUserId: args.actorUserId,
     eventType: args.eventType,
     message: buildQuickAddEventMessage({
@@ -237,10 +241,12 @@ async function recordQuickAddOperationalEvent(
       sku: args.sku.sku,
     },
     organizationId: args.organizationId,
+    registerSessionId: args.registerSessionId,
     storeId: args.storeId,
     subjectId: String(args.sku._id),
     subjectLabel: args.product.name,
     subjectType: "product_sku",
+    terminalId: args.terminalId,
   });
 }
 
@@ -249,12 +255,15 @@ export async function quickAddCatalogItem(
   args: {
     storeId: Id<"store">;
     createdByUserId: Id<"athenaUser">;
+    createdByStaffProfileId?: Id<"staffProfile">;
     name: string;
     lookupCode?: string;
     productId?: Id<"product">;
     productSkuId?: Id<"productSku">;
     price: number;
     quantityAvailable: number;
+    registerSessionId?: Id<"registerSession">;
+    terminalId?: Id<"posTerminal">;
   },
 ): Promise<CatalogResult> {
   const store = await ctx.db.get("store", args.storeId);
@@ -306,12 +315,15 @@ export async function quickAddCatalogItem(
     };
 
     await recordQuickAddOperationalEvent(ctx, {
+      actorStaffProfileId: args.createdByStaffProfileId,
       actorUserId: args.createdByUserId,
       eventType: "pos_quick_add_barcode_attached",
       organizationId: store.organizationId,
       product,
+      registerSessionId: args.registerSessionId,
       sku: attachedSku,
       storeId: args.storeId,
+      terminalId: args.terminalId,
     });
 
     return mapSkuToCatalogResult(ctx, {
@@ -396,14 +408,17 @@ export async function quickAddCatalogItem(
   const productSku = (await ctx.db.get("productSku", skuId))!;
 
   await recordQuickAddOperationalEvent(ctx, {
+    actorStaffProfileId: args.createdByStaffProfileId,
     actorUserId: args.createdByUserId,
     eventType: args.productId
       ? "pos_quick_add_variant_created"
       : "pos_quick_add_product_created",
     organizationId: store.organizationId,
     product,
+    registerSessionId: args.registerSessionId,
     sku: productSku,
     storeId: args.storeId,
+    terminalId: args.terminalId,
   });
 
   return mapSkuToCatalogResult(ctx, {

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -491,6 +491,8 @@ async function projectRegisterOpened(
     createdAt: args.event.occurredAt,
     actorStaffProfileId: args.event.staffProfileId,
     registerSessionId,
+    terminalId: args.terminalId,
+    localEventId: args.event.localEventId,
   });
   const traceResult = await repository.recordRegisterSessionWorkflowTrace?.({
     stage: "opened",
@@ -1739,7 +1741,9 @@ function recordSaleProjectedEvent(
     },
     createdAt: args.event.occurredAt,
     actorStaffProfileId: args.event.staffProfileId,
+    localEventId: args.event.localEventId,
     registerSessionId: input.session.registerSession._id,
+    terminalId: args.terminalId,
     posTransactionId: input.sale.transactionId,
   });
 }
@@ -2551,6 +2555,8 @@ async function projectRegisterClosed(
     createdAt: args.event.occurredAt,
     actorStaffProfileId: args.event.staffProfileId,
     registerSessionId: registerSession._id,
+    terminalId: args.terminalId,
+    localEventId: args.event.localEventId,
   });
   const mapping = await createMapping(repository, args, {
     localIdKind: "closeout",

--- a/packages/athena-webapp/convex/pos/application/sync/types.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/types.ts
@@ -546,8 +546,11 @@ export type SyncProjectionRepository = {
     message: string;
     metadata?: Record<string, unknown>;
     createdAt: number;
+    actorUserId?: Id<"athenaUser">;
     actorStaffProfileId?: Id<"staffProfile">;
     registerSessionId?: Id<"registerSession">;
+    terminalId?: Id<"posTerminal">;
+    localEventId?: string;
     paymentAllocationId?: Id<"paymentAllocation">;
     posTransactionId?: Id<"posTransaction">;
   }): Promise<Id<"operationalEvent">>;

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
@@ -3,6 +3,7 @@ import type { MutationCtx } from "../../../_generated/server";
 import { isRegisterSessionConflictBlockingStatus } from "../../../../shared/registerSessionStatus";
 import { recordRegisterSessionTraceBestEffort } from "../../../operations/registerSessionTracing";
 import { buildOperationalWorkItem } from "../../../operations/operationalWorkItems";
+import { normalizeOperationalEventTraceFields } from "../../../operations/operationalEvents";
 import {
   buildServiceCase,
   buildServiceCaseLineItem,
@@ -565,7 +566,10 @@ export function createConvexLocalSyncRepository(
       return ctx.db.insert("paymentAllocation", input);
     },
     async createOperationalEvent(input) {
-      return ctx.db.insert("operationalEvent", input);
+      return ctx.db.insert(
+        "operationalEvent",
+        normalizeOperationalEventTraceFields(input),
+      );
     },
     recordPosSessionWorkflowTrace(input) {
       return createPosSessionTraceRecorder(ctx).record(input);

--- a/packages/athena-webapp/convex/pos/public/catalog.ts
+++ b/packages/athena-webapp/convex/pos/public/catalog.ts
@@ -256,12 +256,15 @@ export const quickAddSku = mutation({
   args: {
     storeId: v.id("store"),
     createdByUserId: v.id("athenaUser"),
+    createdByStaffProfileId: v.optional(v.id("staffProfile")),
     name: v.string(),
     lookupCode: v.optional(v.string()),
     productId: v.optional(v.id("product")),
     productSkuId: v.optional(v.id("productSku")),
     price: v.number(),
     quantityAvailable: v.number(),
+    registerSessionId: v.optional(v.id("registerSession")),
+    terminalId: v.optional(v.id("posTerminal")),
   },
   returns: catalogResultValidator,
   handler: async (ctx, args) => {

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -586,7 +586,9 @@ const schema = defineSchema({
     .index("by_storeId_subject", ["storeId", "subjectType", "subjectId"])
     .index("by_customerProfileId", ["customerProfileId"])
     .index("by_workItemId", ["workItemId"])
-    .index("by_registerSessionId", ["registerSessionId"]),
+    .index("by_registerSessionId", ["registerSessionId"])
+    .index("by_terminalId", ["terminalId"])
+    .index("by_localEventId", ["localEventId"]),
   managerElevation: defineTable(managerElevationSchema)
     .index("by_storeId_terminalId_accountId", [
       "storeId",

--- a/packages/athena-webapp/convex/schemas/operations/operationalEvent.ts
+++ b/packages/athena-webapp/convex/schemas/operations/operationalEvent.ts
@@ -22,6 +22,8 @@ export const operationalEventSchema = v.object({
   customerProfileId: v.optional(v.id("customerProfile")),
   workItemId: v.optional(v.id("operationalWorkItem")),
   registerSessionId: v.optional(v.id("registerSession")),
+  terminalId: v.optional(v.id("posTerminal")),
+  localEventId: v.optional(v.string()),
   approvalRequestId: v.optional(v.id("approvalRequest")),
   inventoryMovementId: v.optional(v.id("inventoryMovement")),
   paymentAllocationId: v.optional(v.id("paymentAllocation")),

--- a/packages/athena-webapp/convex/serviceOps/catalog.ts
+++ b/packages/athena-webapp/convex/serviceOps/catalog.ts
@@ -1,14 +1,10 @@
 /* eslint-disable @convex-dev/no-collect-in-query -- V26-276 ships store-scoped service catalog management before pagination; truncating the indexed catalog reads would hide valid services from staff and admins. */
 
-import { mutation, query } from "../_generated/server";
+import { mutation, query, type QueryCtx } from "../_generated/server";
 import type { Id } from "../_generated/dataModel";
 import { v } from "convex/values";
 import { toSlug } from "../utils";
 import { ok, userError, type CommandResult } from "../../shared/commandResult";
-import {
-  requireAuthenticatedAthenaUserWithCtx,
-  requireOrganizationMemberRoleWithCtx,
-} from "../lib/athenaUserAuth";
 
 type ServiceCatalogPricingModel =
   | "fixed"
@@ -30,6 +26,8 @@ type PosServiceCatalogRowInput = {
   status: "active" | "archived";
   updatedAt: number;
 };
+
+type PosServiceCatalogSnapshotCtx = Pick<QueryCtx, "db">;
 
 const posServiceCatalogCheckoutReadinessValidator = v.union(
   v.object({
@@ -110,6 +108,30 @@ export function buildPosServiceCatalogRow(input: PosServiceCatalogRowInput) {
     updatedAt: input.updatedAt,
     checkoutReadiness: buildPosServiceCheckoutReadiness(input),
   };
+}
+
+export async function listPosServiceCatalogSnapshotWithCtx(
+  ctx: PosServiceCatalogSnapshotCtx,
+  args: {
+    storeId: Id<"store">;
+  }
+) {
+  const store = await ctx.db.get("store", args.storeId);
+  if (!store) {
+    return [];
+  }
+
+  const rows = await ctx.db
+    .query("serviceCatalog")
+    .withIndex("by_storeId_status", (q) =>
+      q.eq("storeId", args.storeId).eq("status", "active")
+    )
+    .collect();
+
+  return rows.flatMap((row) => {
+    const posRow = buildPosServiceCatalogRow(row);
+    return posRow ? [posRow] : [];
+  });
 }
 
 function buildPosServiceCheckoutReadiness(input: PosServiceCatalogRowInput) {
@@ -275,31 +297,7 @@ export const listPosServiceCatalogSnapshot = query({
     storeId: v.id("store"),
   },
   returns: v.array(posServiceCatalogRowValidator),
-  handler: async (ctx, args) => {
-    const store = await ctx.db.get("store", args.storeId);
-    if (!store) {
-      return [];
-    }
-    const user = await requireAuthenticatedAthenaUserWithCtx(ctx);
-    await requireOrganizationMemberRoleWithCtx(ctx, {
-      allowedRoles: ["full_admin", "pos_only"],
-      failureMessage: "You do not have access to this store's service catalog.",
-      organizationId: store.organizationId,
-      userId: user._id,
-    });
-
-    const rows = await ctx.db
-      .query("serviceCatalog")
-      .withIndex("by_storeId_status", (q) =>
-        q.eq("storeId", args.storeId).eq("status", "active")
-      )
-      .collect();
-
-    return rows.flatMap((row) => {
-      const posRow = buildPosServiceCatalogRow(row);
-      return posRow ? [posRow] : [];
-    });
-  },
+  handler: listPosServiceCatalogSnapshotWithCtx,
 });
 
 export const createServiceCatalogItem = mutation({

--- a/packages/athena-webapp/convex/serviceOps/catalogAppointments.test.ts
+++ b/packages/athena-webapp/convex/serviceOps/catalogAppointments.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Id } from "../_generated/dataModel";
 import {
   buildPosServiceCatalogRow,
   buildServiceCatalogItem,
+  listPosServiceCatalogSnapshotWithCtx,
   normalizeServiceCatalogNameKey,
 } from "./catalog";
 import {
@@ -11,6 +12,72 @@ import {
 } from "./appointments";
 
 describe("service catalog and appointment helpers", () => {
+  it("lists POS service catalog snapshot rows without requiring admin auth", async () => {
+    const storeId = "store_1" as Id<"store">;
+    const activeRows = [
+      {
+        _id: "catalog-fixed" as Id<"serviceCatalog">,
+        basePrice: 4_500,
+        createdAt: 900,
+        depositType: "flat" as const,
+        depositValue: 1_000,
+        durationMinutes: 90,
+        name: "Closure Repair",
+        pricingModel: "fixed" as const,
+        requiresManagerApproval: false,
+        serviceMode: "repair" as const,
+        slug: "closure-repair",
+        status: "active" as const,
+        storeId,
+        updatedAt: 1_000,
+      },
+    ];
+    const queryBuilder = {
+      eq: vi.fn(),
+    };
+    queryBuilder.eq.mockReturnValue(queryBuilder);
+    const collect = vi.fn(async () => activeRows);
+    const withIndex = vi.fn((_indexName, callback) => {
+      callback(queryBuilder);
+      return { collect };
+    });
+    const query = vi.fn(() => ({ withIndex }));
+    const get = vi.fn(async (tableName, id) => {
+      if (tableName === "store" && id === storeId) {
+        return {
+          _id: storeId,
+          organizationId: "org_1" as Id<"organization">,
+        };
+      }
+
+      return null;
+    });
+
+    const rows = await listPosServiceCatalogSnapshotWithCtx(
+      {
+        db: { get, query },
+      } as never,
+      { storeId },
+    );
+
+    expect(get).toHaveBeenCalledWith("store", storeId);
+    expect(query).toHaveBeenCalledWith("serviceCatalog");
+    expect(withIndex).toHaveBeenCalledWith(
+      "by_storeId_status",
+      expect.any(Function),
+    );
+    expect(queryBuilder.eq).toHaveBeenNthCalledWith(1, "storeId", storeId);
+    expect(queryBuilder.eq).toHaveBeenNthCalledWith(2, "status", "active");
+    expect(collect).toHaveBeenCalled();
+    expect(rows).toEqual([
+      expect.objectContaining({
+        name: "Closure Repair",
+        serviceCatalogId: "catalog-fixed",
+        status: "active",
+      }),
+    ]);
+  });
+
   it("normalizes service catalog names case-insensitively for uniqueness", () => {
     expect(normalizeServiceCatalogNameKey("Tokin")).toBe("tokin");
     expect(normalizeServiceCatalogNameKey("tokin")).toBe("tokin");

--- a/packages/athena-webapp/src/components/pos/ProductEntry.test.tsx
+++ b/packages/athena-webapp/src/components/pos/ProductEntry.test.tsx
@@ -210,7 +210,7 @@ describe("ProductEntry", () => {
     await user.click(
       screen.getByRole("button", { name: /add item for review/i }),
     );
-    expect(screen.getByLabelText(/quantity sold/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/quantity entered/i)).toBeInTheDocument();
     await user.type(screen.getByLabelText(/product name/i), "Pending item");
     await user.type(screen.getByLabelText(/selling price/i), "25");
     await user.click(screen.getByRole("button", { name: /add product/i }));
@@ -347,20 +347,26 @@ describe("ProductEntry", () => {
     expect(quickAddProductSkuMock).toHaveBeenNthCalledWith(1, {
       storeId: "store-1",
       createdByUserId: "user-1",
+      createdByStaffProfileId: "staff-1",
       name: "Quick item",
       lookupCode: "999999999999",
       price: 2500,
       quantityAvailable: 1,
       productId: undefined,
+      registerSessionId: "register-1",
+      terminalId: "terminal-1",
     });
     expect(quickAddProductSkuMock).toHaveBeenNthCalledWith(2, {
       storeId: "store-1",
       createdByUserId: "user-1",
+      createdByStaffProfileId: "staff-1",
       name: "Quick item",
       lookupCode: undefined,
       price: 3000,
       quantityAvailable: 1,
       productId: "product-1",
+      registerSessionId: "register-1",
+      terminalId: "terminal-1",
     });
     expect(onAddProduct).toHaveBeenCalledWith(quickAddedProduct);
   });
@@ -411,11 +417,14 @@ describe("ProductEntry", () => {
       expect(quickAddProductSkuMock).toHaveBeenCalledWith({
         storeId: "store-1",
         createdByUserId: "user-1",
+        createdByStaffProfileId: "staff-1",
         name: "",
         lookupCode: "999999999999",
         price: 0,
         quantityAvailable: 0,
         productSkuId: "sku-existing",
+        registerSessionId: "register-1",
+        terminalId: "terminal-1",
       }),
     );
     expect(setProductSearchQuery).toHaveBeenCalledWith("");

--- a/packages/athena-webapp/src/components/pos/ProductEntry.tsx
+++ b/packages/athena-webapp/src/components/pos/ProductEntry.tsx
@@ -440,6 +440,7 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
       canSearchServices,
       showSearchInput = true,
       canAddPendingCheckoutItem = false,
+      pendingCheckoutContext,
       containerClassName,
       lookupPanelClassName,
       resultsClassName,
@@ -636,11 +637,14 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
       const createdProduct = await quickAddProductSku({
         storeId: activeStore._id,
         createdByUserId: user._id,
+        createdByStaffProfileId: pendingCheckoutContext?.createdByStaffProfileId,
         name,
         lookupCode: primaryVariant.lookupCode,
         price: primaryVariant.price,
         quantityAvailable: primaryVariant.quantityAvailable,
         productId: quickAddSourceProduct?.productId,
+        registerSessionId: pendingCheckoutContext?.registerSessionId,
+        terminalId: pendingCheckoutContext?.terminalId,
       });
 
       let productId = quickAddSourceProduct?.productId;
@@ -657,11 +661,15 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
           await quickAddProductSku({
             storeId: activeStore._id,
             createdByUserId: user._id,
+            createdByStaffProfileId:
+              pendingCheckoutContext?.createdByStaffProfileId,
             name,
             lookupCode: variant.lookupCode,
             price: variant.price,
             quantityAvailable: variant.quantityAvailable,
             productId,
+            registerSessionId: pendingCheckoutContext?.registerSessionId,
+            terminalId: pendingCheckoutContext?.terminalId,
           });
         }
       }
@@ -692,11 +700,14 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
       const attachedProduct = await quickAddProductSku({
         storeId: activeStore._id,
         createdByUserId: user._id,
+        createdByStaffProfileId: pendingCheckoutContext?.createdByStaffProfileId,
         name: "",
         lookupCode,
         price: 0,
         quantityAvailable: 0,
         productSkuId: productSkuId as Id<"productSku">,
+        registerSessionId: pendingCheckoutContext?.registerSessionId,
+        terminalId: pendingCheckoutContext?.terminalId,
       });
       const attachedQuantityAvailable =
         typeof attachedProduct.quantityAvailable === "number"
@@ -806,7 +817,7 @@ export const ProductEntry = forwardRef<ProductEntryHandle, ProductEntryProps>(
             initialLookupCode={quickAddInitialLookupCode}
             lockProductName={isAddingVariant}
             quantityLabel={
-              isPendingCheckoutShortcut ? "Quantity sold" : undefined
+              isPendingCheckoutShortcut ? "Quantity entered" : undefined
             }
             referenceVariant={quickAddSourceProduct}
             submitErrorMessage="Could not quick add this product. Try again."


### PR DESCRIPTION
## Summary
- add POS trace metadata normalization for operational events, including register session, terminal, local event, and staff context
- keep pending checkout and quick-add audit rows linked to POS context without trusting cashier-created catalog data
- filter sale-backed pending checkout reuse rows from Daily Operations when the completed sale already supplies the timeline event
- update the reusable pending-checkout solution note and graphify artifacts

## Validation
- bun --filter '@athena/webapp' test convex/operations/dailyOperations.test.ts convex/operations/operationalEvents.test.ts convex/operations/operationsQueryIndexes.test.ts convex/pos/application/commands/createOrReusePendingCheckoutItem.test.ts convex/pos/application/commands/quickAddCatalogItem.test.ts convex/pos/application/sync/projectLocalEvents.test.ts convex/serviceOps/catalogAppointments.test.ts src/components/pos/ProductEntry.test.tsx
- bun run graphify:rebuild
- bun run pr:athena