### PR TITLE
Expose provisional import inventory in POS

### DIFF
--- a/.agents/skills/execute/SKILL.md
+++ b/.agents/skills/execute/SKILL.md
@@ -72,7 +72,7 @@ Use this resolution order before asking the user for context:
 - Prefer the repo's PR-equivalent validation command when one exists; do not assume local `pre-push` hooks cover the full remote CI surface.
 - Default execution posture is `test-first` for new behavior and bug fixes, `characterization-first` for unclear legacy behavior, and `sensor-only` only for pure docs, generated artifacts, configuration, or mechanical changes with no behavior.
 - `auto_review_and_merge = on` unless the user opts out.
-- Merge target `main`; merge method `squash`; review loop cap `3`.
+- Merge target `main`; merge method `squash`; review loops run relevant reviewer subagents until unanimous approval with no numeric cap.
 - Merge is the default delivery posture. Do not stop at an open PR when auto-review and merge are on.
 - After merge, fast-forward the local root checkout to `origin/main`; do not leave the repo on a stale local `main`.
 - In Athena, merge or arm auto-merge with `bun run github:pr-merge -- <pr-number-or-url> --method squash --delete-branch` or `bun run github:pr-merge -- <pr-number-or-url> --auto --method squash` instead of raw `gh pr merge`. The helper uses GitHub APIs directly, so it does not try to check out or update local `main` and is safe when `main` is already checked out in the root worktree.
@@ -197,7 +197,7 @@ After opening the PR:
   - if both are true, do both
 - The follow-up issue should capture the failing remote check, the local validations that passed, the root cause, and the local command, harness mapping, or coverage addition needed so the failure is caught before CI next time.
 - Link that follow-up issue from the current Linear ticket and the PR comment trail when it materially affects the handoff.
-- Iterate up to `3` times by default, but continue autonomously if the next fix is still clear.
+- Keep looping relevant reviewer subagents until unanimous approval: every selected reviewer must report approval/no blocking findings, GitHub feedback must have no unresolved actionable blockers, and checks must be passing or auto-mergeable. There is no numeric iteration cap; stop only when the next fix is not clear, permissions/repo settings block progress, or genuine user input is required.
 - When local gates and review gates pass, mark the PR ready if needed and arm auto-merge with `bun run github:pr-merge -- <pr-number-or-url> --auto --method squash` unless the user explicitly asked you to wait through merge completion or repo settings reject auto-merge.
 - If auto-merge cannot be armed and all PR checks are already green, squash-merge into `main` with `bun run github:pr-merge -- <pr-number-or-url> --method squash --delete-branch`.
 - Treat the merge as incomplete until the remote merge is confirmed and the local root checkout fast-forwards to the merged `origin/main`.

--- a/docs/plans/2026-06-10-001-feat-provisional-import-pos-availability-plan.html
+++ b/docs/plans/2026-06-10-001-feat-provisional-import-pos-availability-plan.html
@@ -1,0 +1,380 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>feat: Add provisional import POS availability</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f8fafc;
+        --paper: #ffffff;
+        --ink: #111827;
+        --muted: #64748b;
+        --line: #dbe3ef;
+        --soft: #eef5ff;
+        --accent: #2454a6;
+        --warn: #8a4b00;
+      }
+
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--ink);
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        line-height: 1.55;
+      }
+
+      main {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 40px 24px 64px;
+      }
+
+      header {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--paper);
+        padding: 28px;
+      }
+
+      h1, h2, h3 {
+        line-height: 1.2;
+        margin: 0;
+      }
+
+      h1 {
+        font-size: clamp(2rem, 4vw, 3.2rem);
+        letter-spacing: 0;
+      }
+
+      h2 {
+        margin-top: 34px;
+        border-top: 1px solid var(--line);
+        padding-top: 26px;
+        font-size: 1.35rem;
+      }
+
+      h3 {
+        margin-top: 22px;
+        font-size: 1rem;
+      }
+
+      p {
+        margin: 10px 0 0;
+      }
+
+      a {
+        color: var(--accent);
+        text-decoration: none;
+      }
+
+      a:hover {
+        text-decoration: underline;
+      }
+
+      .meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin-top: 18px;
+      }
+
+      .pill {
+        border: 1px solid var(--line);
+        border-radius: 999px;
+        background: var(--soft);
+        color: #1f3f73;
+        font-size: 0.82rem;
+        padding: 4px 10px;
+      }
+
+      nav {
+        display: grid;
+        gap: 8px;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        margin: 20px 0 0;
+      }
+
+      nav a {
+        border: 1px solid var(--line);
+        border-radius: 6px;
+        background: var(--paper);
+        padding: 8px 10px;
+        font-size: 0.9rem;
+      }
+
+      section {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--paper);
+        margin-top: 18px;
+        padding: 24px;
+      }
+
+      ul {
+        padding-left: 22px;
+      }
+
+      li + li {
+        margin-top: 8px;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 14px;
+        font-size: 0.92rem;
+      }
+
+      th, td {
+        border: 1px solid var(--line);
+        padding: 10px;
+        text-align: left;
+        vertical-align: top;
+      }
+
+      th {
+        background: #f1f5f9;
+      }
+
+      code {
+        background: #f1f5f9;
+        border-radius: 4px;
+        padding: 2px 5px;
+        font-size: 0.9em;
+      }
+
+      .unit {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        margin-top: 16px;
+        padding: 16px;
+        background: #fbfdff;
+      }
+
+      .unit h3 {
+        margin-top: 0;
+      }
+
+      .callout {
+        border-left: 4px solid var(--accent);
+        background: var(--soft);
+        padding: 12px 14px;
+      }
+
+      .warning {
+        border-left-color: var(--warn);
+        background: #fff7ed;
+      }
+
+      @media (max-width: 720px) {
+        main {
+          padding: 24px 14px 48px;
+        }
+
+        header, section {
+          padding: 18px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>feat: Add provisional import POS availability</h1>
+        <p>Make imported legacy inventory searchable and sellable in POS before trusted Athena counts are finalized, without turning imported quantities into trusted stock.</p>
+        <div class="meta">
+          <span class="pill">Type: feat</span>
+          <span class="pill">Status: active</span>
+          <span class="pill">Date: 2026-06-10</span>
+          <span class="pill">Canonical markdown: <a href="2026-06-10-001-feat-provisional-import-pos-availability-plan.md">plan.md</a></span>
+        </div>
+        <nav aria-label="Plan sections">
+          <a href="#problem">Problem</a>
+          <a href="#requirements">Requirements</a>
+          <a href="#decisions">Key Decisions</a>
+          <a href="#design">Design Shape</a>
+          <a href="#units">Implementation Units</a>
+          <a href="#risks">Risks</a>
+        </nav>
+      </header>
+
+      <section id="problem">
+        <h2>Problem Frame</h2>
+        <p>The store needs old-system inventory available at checkout while operators finish validating Athena counts. Cashiers can physically see the product, so POS should not block on unfinalized quantity; however, imported quantities must stay outside trusted stock until finalization.</p>
+        <div class="callout warning">
+          <strong>Boundary:</strong> POS availability during import is a policy override, not a fake quantity. Do not inflate <code>productSku.quantityAvailable</code>.
+        </div>
+      </section>
+
+      <section id="requirements">
+        <h2>Requirements</h2>
+        <ul>
+          <li>Imported legacy products can be made available to POS lookup before final inventory counts are applied.</li>
+          <li>POS can add and sell active provisional-import SKUs regardless of <code>quantityAvailable</code> or active hold availability.</li>
+          <li>Provisional imported quantities remain separate from trusted <code>productSku.inventoryCount</code> and <code>productSku.quantityAvailable</code> until finalization.</li>
+          <li>POS sale lines preserve enough provisional import metadata to reconcile sold quantities during finalization.</li>
+          <li>Pending checkout items remain the fallback for products not present in Athena and not present in the provisional import.</li>
+          <li>Provisional import rows stay out of storefront and normal trusted catalog stock reporting until finalized.</li>
+          <li>Operators can see which import rows are POS-available, finalize them into trusted stock, or close/reject provisional rows.</li>
+          <li>Offline/local-first POS preserves completed sales and treats provisional-import stock uncertainty as reconciliation context.</li>
+        </ul>
+      </section>
+
+      <section id="decisions">
+        <h2>Key Technical Decisions</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Decision</th>
+              <th>Rationale</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Use a provisional import table</td>
+              <td>Imported counts, POS exposure status, sale evidence, and finalization state need a durable trust boundary outside normal SKU availability.</td>
+            </tr>
+            <tr>
+              <td>Create or link catalog identity early</td>
+              <td>POS needs searchable product/SKU/barcode/price identity while stock trust remains provisional.</td>
+            </tr>
+            <tr>
+              <td>Use availability policy, not fake count</td>
+              <td>Cashiers can sell active provisional imports without leaking fake high quantities into stock ops, dashboards, or storefront.</td>
+            </tr>
+            <tr>
+              <td>Extend pending-checkout bypass shape</td>
+              <td>Session commands and completion already skip holds/decrements for special sale-line classes after server validation.</td>
+            </tr>
+            <tr>
+              <td>Finalization reconciles provisional sales</td>
+              <td>Operators need imported quantity, provisional sold quantity, and final trusted quantity basis before normal enforcement resumes.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="design">
+        <h2>Design Shape</h2>
+        <p>Saved import review rows are staged into <code>inventoryImportProvisionalSku</code> records. Active provisional rows join POS catalog metadata and bounded availability policy so POS can show "Count pending" and allow sale. Sale completion records provisional sale evidence without trusted stock decrement. Finalization applies trusted counts and returns the SKU to normal hold-aware enforcement.</p>
+        <table>
+          <thead>
+            <tr>
+              <th>State</th>
+              <th>POS searchable</th>
+              <th>POS count enforcement</th>
+              <th>Trusted inventory mutation</th>
+              <th>Storefront visible</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Review saved only</td>
+              <td>No</td>
+              <td>N/A</td>
+              <td>No</td>
+              <td>No</td>
+            </tr>
+            <tr>
+              <td>Provisional POS active</td>
+              <td>Yes</td>
+              <td>No</td>
+              <td>No, sale evidence only</td>
+              <td>No for import-created hidden identities</td>
+            </tr>
+            <tr>
+              <td>Finalized</td>
+              <td>Yes</td>
+              <td>Yes</td>
+              <td>Yes</td>
+              <td>Follows normal product visibility</td>
+            </tr>
+            <tr>
+              <td>Rejected/closed</td>
+              <td>No, unless linked to trusted SKU</td>
+              <td>Normal trusted SKU rules only</td>
+              <td>No provisional mutation</td>
+              <td>No provisional exposure</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section id="units">
+        <h2>Implementation Units</h2>
+
+        <article class="unit">
+          <h3>U1. Add provisional import inventory schema</h3>
+          <p>Add <code>inventoryImportProvisionalSku</code>, indexes, and optional POS sale-line references. This establishes the durable trust boundary.</p>
+        </article>
+
+        <article class="unit">
+          <h3>U2. Stage import review rows into provisional POS catalog identity</h3>
+          <p>Add a staging command and import review action that creates hidden provisional SKU anchors without applying trusted counts.</p>
+        </article>
+
+        <article class="unit">
+          <h3>U3. Expose provisional imports through POS catalog and availability policy</h3>
+          <p>Extend register catalog and availability DTOs so active provisional rows are searchable, sellable, and presented without fake numeric availability.</p>
+        </article>
+
+        <article class="unit">
+          <h3>U4. Skip POS hold and count enforcement for provisional import sale lines</h3>
+          <p>Validate provisional line references server-side, skip holds/decrements, and record sale evidence during completion.</p>
+        </article>
+
+        <article class="unit">
+          <h3>U5. Carry provisional import semantics through local-first POS sync</h3>
+          <p>Extend local sync payloads and projection so validated offline completed sales against provisional imports become reconciliation evidence.</p>
+        </article>
+
+        <article class="unit">
+          <h3>U6. Finalize provisional import counts with provisional sale reconciliation</h3>
+          <p>Let operators convert provisional rows to trusted counts while seeing imported quantity, sold quantity during the provisional window, and final count basis.</p>
+        </article>
+
+        <article class="unit">
+          <h3>U7. Update POS and operations presentation copy</h3>
+          <p>Show cashier-facing "Count pending" style copy and operator-facing provisional status/sold evidence without making cashiers adjudicate inventory truth.</p>
+        </article>
+
+        <article class="unit">
+          <h3>U8. Document the provisional import stock boundary</h3>
+          <p>Add a solution note and rebuild graphify after implementation so future work does not reintroduce fake inventory counts.</p>
+        </article>
+      </section>
+
+      <section id="risks">
+        <h2>Risks &amp; Mitigations</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Risk</th>
+              <th>Mitigation</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Provisional rows become storefront-visible</td>
+              <td>Keep POS inclusion in POS catalog queries, not general product visibility; test hidden/POS-only identity behavior.</td>
+            </tr>
+            <tr>
+              <td>Fake availability leaks into stock ops</td>
+              <td>Use provisional rows and availability policy metadata instead of inflated <code>quantityAvailable</code>.</td>
+            </tr>
+            <tr>
+              <td>Sale completion double-decrements after finalization</td>
+              <td>Persist provisional import references on sale lines and skip trusted mutation for those lines.</td>
+            </tr>
+            <tr>
+              <td>Offline sync arrives after provisional status changes</td>
+              <td>Preserve sale facts and route drift to review/conflict rails.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/plans/2026-06-10-001-feat-provisional-import-pos-availability-plan.md
+++ b/docs/plans/2026-06-10-001-feat-provisional-import-pos-availability-plan.md
@@ -1,0 +1,501 @@
+---
+title: "feat: Add provisional import POS availability"
+type: feat
+status: active
+date: 2026-06-10
+---
+
+# feat: Add provisional import POS availability
+
+## Summary
+
+Make imported legacy inventory searchable and sellable in POS before trusted Athena counts are finalized. The plan adds a provisional import stock boundary beside normal catalog inventory: POS can sell matched/imported SKUs without enforcing available quantity, while Athena preserves imported counts and provisional sale evidence for final reconciliation.
+
+---
+
+## Problem Frame
+
+The store needs the old-system inventory available at checkout while operators finish importing and validating true Athena counts. Cashiers can physically see the product in front of them, so blocking checkout on unfinalized or zero Athena quantity creates operational friction; at the same time, the imported quantities must not become trusted stock until the import is finalized.
+
+---
+
+## Requirements
+
+- R1. Imported legacy products can be made available to POS lookup before final inventory counts are applied.
+- R2. POS can add and sell active provisional-import SKUs regardless of `quantityAvailable` or active hold availability.
+- R3. Provisional imported quantities remain separate from trusted `productSku.inventoryCount` and `productSku.quantityAvailable` until finalization.
+- R4. POS sale lines against provisional imports preserve enough metadata to reconcile sold quantities during finalization.
+- R5. Existing pending checkout items remain the fallback for products not present in Athena and not present in the provisional import.
+- R6. Provisional import rows stay out of storefront and normal trusted catalog stock reporting until finalized.
+- R7. Operators can see which import rows are already POS-available, finalize them into trusted stock, or close/reject provisional rows.
+- R8. Offline/local-first POS behavior preserves completed sales and treats provisional-import stock uncertainty as review/reconciliation context, not receipt mutation.
+
+---
+
+## Scope Boundaries
+
+- Do not inflate `productSku.quantityAvailable` with fake values such as `9999`.
+- Do not replace pending checkout items; they remain the path for missing products not covered by the import.
+- Do not make provisional import rows storefront-sellable before finalization.
+- Do not redesign the full inventory import parser or review UI beyond the staging/finalization actions and status needed for this feature.
+- Do not solve cross-terminal oversell prevention for provisional imports; the accepted behavior is sale continuity plus reconciliation.
+- Do not change expense-session inventory enforcement unless shared POS helpers require a compatibility guard.
+
+### Deferred to Follow-Up Work
+
+- Fraud/risk scoring for unusually high provisional-import sale volume.
+- Rich final count variance dashboards beyond the import review/finalization surface.
+- Automated owner notifications when provisional import sales exceed the imported quantity.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/convex/inventory/catalogImport.ts` owns inventory import review versions and the existing trusted import mutation.
+- `packages/athena-webapp/src/components/operations/InventoryImportView.tsx` is the operator-facing review/finalization surface.
+- `packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts` splits stable register catalog metadata from bounded availability overlays.
+- `packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts` already skips inventory holds for pending checkout sale lines after server-side pending-line validation.
+- `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts` already skips trusted stock decrement for pending checkout items and records pending sale evidence instead.
+- `packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts` joins catalog rows and availability rows for online/local register search.
+- `packages/athena-webapp/src/components/pos/ProductCard.tsx`, `packages/athena-webapp/src/components/pos/ProductLookup.tsx`, and `packages/athena-webapp/src/components/pos/types.ts` already support availability messages and optional quantity presentation.
+- `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts` and `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts` preserve local-first POS sale facts and route inventory uncertainty to review/conflict rails.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture/athena-pos-pending-checkout-item-recovery-2026-06-06.md` says cashier continuity should not convert checkout quantities into trusted inventory, holds, or stock movements.
+- `docs/solutions/logic-errors/athena-pos-register-local-catalog-search-2026-05-04.md` says register catalog metadata must stay stable and must not include volatile stock fields.
+- `docs/solutions/performance/athena-pos-cart-latency-foundation-2026-05-05.md` says POS cart operations should use ledger holds and avoid invalidating full-store catalog subscriptions.
+- `docs/solutions/architecture/athena-pos-offline-inventory-snapshot-2026-05-15.md` separates searchable catalog metadata, live availability, and local availability snapshots.
+- `docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md` says completed local sales are customer-facing facts; sync preserves them and creates reconciliation work when cloud stock conflicts.
+
+### External References
+
+- None. The repository has strong local patterns for Convex schemas, POS catalog read models, ledger holds, local sync, and inventory review.
+
+---
+
+## Key Technical Decisions
+
+- **Use a provisional import table for imported stock truth:** Imported counts, row decisions, POS exposure status, sale evidence, and finalization status belong outside trusted `productSku.quantityAvailable` until the operator finalizes them.
+- **Create or link normal catalog identity early, but keep stock untrusted:** POS search needs product/SKU/barcode/price identity. The provisional row owns stock trust and POS availability policy; the SKU remains hidden from storefront or ordinary trusted browse until finalized if it was created only for import staging.
+- **Represent POS availability as a policy, not a fake count:** Active provisional import rows should project an availability policy such as "unbounded provisional import" so POS can add any sale quantity without pretending there are many units available.
+- **Extend the existing pending-checkout bypass shape:** Session commands and completion already know how to skip holds/decrements for pending checkout lines after server-side validation. Provisional import lines should follow the same command-boundary posture with their own identifier and audit path.
+- **Finalization reconciles provisional sales explicitly:** The final trusted count must account for sale evidence recorded while provisional mode was active. Operators should see imported quantity, provisional sold quantity, and the count that will become trusted.
+- **Keep POS catalog metadata stable:** The full register catalog can include active provisional import identities, but volatile availability remains in bounded availability rows and policy flags.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should imported inventory live in a provisional table? Yes. The table is the trust boundary for imported counts and sale evidence.
+- Should POS enforce counts for provisional imports? No. The cashier can sell the item while counts are pending.
+- Should pending checkout items be reused for every imported item? No. Imported rows have identifiers and prices; pending checkout remains the fallback for missing products.
+- Should trusted SKU counts be inflated to make POS work? No. POS availability policy should bypass enforcement without corrupting inventory data.
+
+### Deferred to Implementation
+
+- Exact field names for availability policy/status should be chosen while editing DTO/schema validators so they align with existing naming.
+- Exact finalization copy should be validated against the current import review UI once implementation starts.
+- Whether the first release exposes a bulk "Make all review rows POS-available" action or only stages the current saved review version can be decided while fitting the existing review workflow.
+
+---
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+```mermaid
+flowchart TB
+  ImportReview["Saved import review version"] --> Stage["Stage provisional POS availability"]
+  Stage --> Provisional["inventoryImportProvisionalSku rows"]
+  Stage --> Identity["Catalog product/SKU identity"]
+  Provisional --> Catalog["Register catalog snapshot"]
+  Identity --> Catalog
+  Provisional --> Availability["Bounded POS availability policy"]
+  Availability --> Lookup["POS lookup/card: Count pending"]
+  Lookup --> Cart["Add to POS cart without quantity enforcement"]
+  Cart --> Sale["Complete sale and record provisional import line"]
+  Sale --> Evidence["Provisional sold quantity evidence"]
+  Evidence --> Finalize["Finalize import counts"]
+  ImportReview --> Finalize
+  Finalize --> Trusted["Trusted productSku counts and normal POS enforcement"]
+```
+
+| State | POS searchable | POS count enforcement | Trusted inventory mutation | Storefront visible |
+| --- | --- | --- | --- | --- |
+| Review saved only | No | N/A | No | No |
+| Provisional POS active | Yes | No | No, only sale evidence | No for import-created hidden identities |
+| Finalized | Yes | Yes | Yes | Follows normal product visibility |
+| Rejected/closed | No, unless linked to trusted SKU | Normal for trusted SKU only | No provisional mutation | No provisional exposure |
+
+---
+
+## Implementation Units
+
+- U1. **Add provisional import inventory schema**
+
+**Goal:** Introduce the persistent trust boundary for imported rows that are POS-sellable before final count finalization.
+
+**Requirements:** R1, R3, R4, R6, R7
+
+**Dependencies:** None
+
+**Files:**
+- Create: `packages/athena-webapp/convex/schemas/inventory/inventoryImportProvisionalSku.ts`
+- Modify: `packages/athena-webapp/convex/schemas/inventory/index.ts`
+- Modify: `packages/athena-webapp/convex/schema.ts`
+- Modify: `packages/athena-webapp/convex/schemas/pos/posSessionItem.ts`
+- Modify: `packages/athena-webapp/convex/schemas/pos/posTransactionItem.ts`
+- Test: `packages/athena-webapp/convex/schemas/inventory/inventoryImportProvisionalSku.test.ts`
+
+**Approach:**
+- Add an `inventoryImportProvisionalSku` table keyed by store, import key/review version, row key, product SKU, and status.
+- Store imported row metadata needed for review and reconciliation: imported name/SKU/barcode/price/category, imported quantity, selected row decision, linked product/SKU IDs, POS exposure timestamps, provisional sale totals, and finalization metadata.
+- Add indexes for active rows by store/SKU, store/barcode, store/import key, and store/status.
+- Add optional `inventoryImportProvisionalSkuId` to POS session and transaction items so provisional sale evidence survives receipts, sync, and finalization.
+
+**Execution note:** Implement schema/test coverage first. This feature crosses POS, inventory, and sync boundaries, so stable IDs and status values should exist before command work begins.
+
+**Patterns to follow:**
+- `packages/athena-webapp/convex/schemas/inventory/inventoryImportReviewVersion.ts`
+- `packages/athena-webapp/convex/schemas/pos/posPendingCheckoutItem.ts`
+- `packages/athena-webapp/convex/schema.ts`
+
+**Test scenarios:**
+- Happy path: schema accepts an active provisional row linked to a review version, row key, product SKU, imported quantity, and POS exposure timestamp.
+- Edge case: schema accepts a row with imported SKU but no barcode, while still preserving row key and normalized searchable metadata.
+- Edge case: POS session and transaction item schemas accept an optional provisional import reference without requiring a pending checkout item.
+- Error path: invalid provisional status or finalization state is rejected.
+
+**Verification:**
+- Provisional import rows can represent POS-active, finalized, rejected, and closed import states without changing trusted stock fields.
+
+---
+
+- U2. **Stage import review rows into provisional POS catalog identity**
+
+**Goal:** Let an operator make a saved inventory import available in POS without applying trusted counts.
+
+**Requirements:** R1, R3, R6, R7
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/inventory/catalogImport.ts`
+- Modify: `packages/athena-webapp/src/components/operations/InventoryImportView.tsx`
+- Modify: `packages/athena-webapp/src/components/operations/InventoryImportView.test.tsx`
+- Test: `packages/athena-webapp/convex/inventory/catalogImport.test.ts`
+
+**Approach:**
+- Add a command that stages the latest/specified saved review version into provisional rows.
+- For rows matched to existing Athena SKUs, create a hidden provisional product/SKU anchor instead of linking the provisional row to the trusted `productSkuId`; this keeps trusted inventory semantics isolated while still exposing the imported legacy row in POS.
+- For new import rows, create or reuse hidden/POS-only catalog identity sufficient for register lookup, but keep storefront/trusted catalog visibility disabled until finalization.
+- Record operational events for staging, including row counts and actor/store context.
+- Add import review UI status and an action such as "Make available in POS" or "Stage for POS" after the review draft is saved.
+
+**Patterns to follow:**
+- `saveInventoryImportReviewVersionWithCtx` and `importInventoryRowsWithCtx` in `packages/athena-webapp/convex/inventory/catalogImport.ts`
+- Existing manager elevation access checks in `packages/athena-webapp/convex/inventory/catalogImport.ts`
+- `OperationsSummaryMetric` and restrained operation copy in `packages/athena-webapp/src/components/operations/InventoryImportView.tsx`
+
+**Test scenarios:**
+- Happy path: staging a saved review version creates active provisional rows and gives matched rows hidden provisional SKU anchors.
+- Happy path: staging a new import row creates POS-searchable catalog identity and an active provisional row without applying imported quantity to trusted stock.
+- Edge case: staging is idempotent for the same import key and row key; repeated staging updates metadata but does not duplicate provisional rows.
+- Edge case: rows marked "skip" are not made POS-active.
+- Error path: non-admin/non-elevated users cannot stage provisional import availability.
+- Integration: staging writes an operational event with row counts, import key, version id, and actor.
+
+**Verification:**
+- Operators can explicitly make import review rows available to POS while trusted SKU counts remain unchanged.
+
+---
+
+- U3. **Expose provisional imports through POS catalog and availability policy**
+
+**Goal:** Make active provisional import rows searchable in POS and present them as sellable without showing fake available counts.
+
+**Requirements:** R1, R2, R3, R5, R6
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/catalog.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/application/dto.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts`
+- Modify: `packages/athena-webapp/src/components/pos/types.ts`
+- Test: `packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts`
+- Test: `packages/athena-webapp/convex/pos/public/catalog.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.test.ts`
+
+**Approach:**
+- Extend the register catalog scope to include active provisional import rows linked to product/SKU identity, even when the identity would otherwise be hidden from storefront/trusted browse.
+- Extend catalog/availability DTOs with an availability policy/status for provisional imports.
+- Return active provisional import rows as `inStock: true` for POS selection while avoiding a misleading trusted `quantityAvailable` display.
+- Make bounded availability and full availability snapshot reads return policy metadata so online and local-first POS surfaces behave consistently.
+- Keep normal trusted SKUs on the existing hold-aware availability path.
+
+**Patterns to follow:**
+- Metadata/availability split in `packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts`
+- Local catalog gateway overlay in `packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts`
+- Existing `availabilityMessage` and `availabilityStatus` fields in `packages/athena-webapp/src/components/pos/types.ts`
+
+**Test scenarios:**
+- Happy path: active provisional import SKU appears in `listRegisterCatalog` even if its product/SKU is POS-only or hidden from storefront.
+- Happy path: bounded availability returns active provisional import rows as sellable with policy/status metadata and no fake count requirement.
+- Edge case: finalized or rejected provisional rows no longer override normal trusted catalog behavior.
+- Edge case: trusted out-of-stock SKU still appears/behaves according to existing exact-match rules and is not made sellable unless it has an active provisional import row.
+- Error path: provisional rows from another store are ignored.
+- Integration: local catalog gateway maps policy metadata to product cards/search results without losing SKU/barcode/product IDs.
+
+**Verification:**
+- POS lookup can find active provisional imported products and show them as sellable while preserving the existing catalog metadata/availability split.
+
+---
+
+- U4. **Skip POS hold and count enforcement for provisional import sale lines**
+
+**Goal:** Let cashiers add and complete provisional import items without inventory conflicts, while preserving sale evidence for reconciliation.
+
+**Requirements:** R2, R4, R5, R8
+
+**Dependencies:** U1, U3
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts`
+- Modify: `packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/transactions.ts`
+- Test: `packages/athena-webapp/convex/pos/application/sessionCommands.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/completeTransaction.test.ts`
+- Test: `packages/athena-webapp/convex/pos/public/transactions.test.ts`
+
+**Approach:**
+- Add server-side validation that a provisional import sale line references an active provisional row for the same store/product/SKU.
+- Skip hold acquisition/adjustment for active provisional import lines, mirroring the pending checkout bypass but using `inventoryImportProvisionalSkuId`.
+- During sale completion, skip trusted `quantityAvailable` and `inventoryCount` decrement for provisional import lines.
+- Persist transaction item references and update provisional row sale evidence counters/timestamps.
+- Keep pending checkout behavior unchanged and ensure normal trusted catalog lines still enforce inventory.
+
+**Patterns to follow:**
+- Pending checkout validation and hold bypass in `packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts`
+- Pending checkout sale evidence branch in `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts`
+- Inventory hold gateway tests in `packages/athena-webapp/convex/pos/infrastructure/integrations/inventoryHoldGateway.test.ts`
+
+**Test scenarios:**
+- Happy path: adding an active provisional import SKU to a POS session does not call hold acquisition and creates a session item with provisional import reference.
+- Happy path: updating quantity for a provisional import line does not call hold adjustment.
+- Happy path: completing a sale with a provisional import line creates the transaction item, updates provisional sale evidence, and does not decrement trusted SKU inventory.
+- Edge case: a cart containing normal SKU plus provisional import SKU enforces holds/counts only for the normal SKU.
+- Error path: client-supplied provisional import ID from another store or mismatched SKU is rejected.
+- Error path: finalized/rejected provisional import rows cannot bypass inventory enforcement.
+
+**Verification:**
+- POS can complete provisional import sales regardless of current stock count, and the system records sale evidence without corrupting trusted inventory.
+
+---
+
+- U5. **Carry provisional import semantics through local-first POS sync**
+
+**Goal:** Preserve offline/provisioned terminal sales against provisional imported SKUs and project them into cloud evidence without treating local availability as trusted inventory.
+
+**Requirements:** R2, R4, R8
+
+**Dependencies:** U1, U3, U4
+
+**Files:**
+- Modify: `packages/shared/posLocalSyncContract.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/types.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`
+- Modify: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts`
+- Test: `packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts`
+- Test: `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts`
+
+**Approach:**
+- Extend local sale item payloads with provisional import references and availability policy metadata.
+- Ensure local command validation treats active provisional imports as locally sellable without requiring a trusted availability snapshot count.
+- During sync, validate the cloud provisional row and map/sanitize IDs as needed before projecting the completed sale.
+- Block projection when a provisional row changed after an offline sale so a stale provisional reference cannot be trusted as sale evidence.
+- Do not project local provisional sales into trusted SKU counts until finalization.
+
+**Patterns to follow:**
+- Pending checkout local event payloads in `packages/shared/posLocalSyncContract.ts`
+- Local pending checkout projection in `packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`
+- Offline inventory conflict posture in `docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md`
+
+**Test scenarios:**
+- Happy path: local completed sale containing a provisional import line syncs and updates provisional sale evidence.
+- Edge case: provisional import sale syncs after the row was finalized; sync preserves the sale and records evidence without double-decrementing stock.
+- Edge case: provisional row is unavailable during sync; projection is blocked with a conflict review context.
+- Error path: malformed provisional import IDs in uploaded events are rejected during ingestion.
+- Integration: mixed local sale with normal, pending checkout, service, and provisional import lines preserves each line's existing projection semantics.
+
+**Verification:**
+- Offline provisional import sales with active validated references survive sync and become reconciliation evidence rather than trusted inventory mutation.
+
+---
+
+- U6. **Finalize provisional import counts with provisional sale reconciliation**
+
+**Goal:** Convert provisional imported rows into trusted Athena stock only when operators finalize counts, with provisional sales accounted for explicitly.
+
+**Requirements:** R3, R4, R7
+
+**Dependencies:** U1, U2, U4
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/inventory/catalogImport.ts`
+- Modify: `packages/athena-webapp/src/components/operations/InventoryImportView.tsx`
+- Modify: `packages/athena-webapp/src/components/operations/InventoryImportView.test.tsx`
+- Test: `packages/athena-webapp/convex/inventory/catalogImport.test.ts`
+
+**Approach:**
+- Add a finalization command that transitions active provisional rows to finalized/trusted state.
+- Show imported quantity, provisional sold quantity, and final trusted quantity basis in the import review/finalization surface.
+- Apply trusted `inventoryCount` and `quantityAvailable` according to an explicit finalization rule selected in the UI: physical count now, or imported baseline adjusted by provisional sales.
+- Record operational events for finalization and skipped/rejected provisional rows.
+- Remove provisional POS availability policy once rows are finalized so normal POS inventory enforcement resumes.
+
+**Patterns to follow:**
+- Trusted `importInventoryRowsWithCtx` path in `packages/athena-webapp/convex/inventory/catalogImport.ts`
+- Draft/save/finalization affordances in `packages/athena-webapp/src/components/operations/InventoryImportView.tsx`
+- Product copy tone in `docs/product-copy-tone.md`
+
+**Test scenarios:**
+- Happy path: finalizing a provisional row applies trusted counts and marks the row finalized.
+- Happy path: finalization displays and accounts for provisional sold quantity.
+- Edge case: row with provisional sold quantity greater than imported quantity requires operator-visible variance handling rather than silently writing negative availability.
+- Edge case: finalizing a row already linked to an existing SKU updates that SKU rather than creating duplicate catalog identity.
+- Error path: non-admin/non-elevated users cannot finalize provisional import counts.
+- Integration: after finalization, POS availability for that SKU uses normal hold-aware enforcement.
+
+**Verification:**
+- Operators can close the provisional window and return affected SKUs to normal trusted inventory enforcement.
+
+---
+
+- U7. **Update POS and operations presentation copy**
+
+**Goal:** Make provisional import availability understandable to cashiers and operators without implying trusted stock.
+
+**Requirements:** R2, R5, R6, R7
+
+**Dependencies:** U3, U4, U6
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/pos/ProductCard.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/ProductLookup.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/ProductEntry.tsx`
+- Modify: `packages/athena-webapp/src/components/operations/InventoryImportView.tsx`
+- Test: `packages/athena-webapp/src/components/pos/ProductCard.test.tsx`
+- Test: `packages/athena-webapp/src/components/pos/ProductEntry.test.tsx`
+- Test: `packages/athena-webapp/src/components/operations/InventoryImportView.test.tsx`
+
+**Approach:**
+- Show active provisional import items as selectable with copy such as "Count pending" or "Import count pending" instead of "0 available."
+- Keep cashier workflow normal: no manager prompt, no warning that asks the cashier to adjudicate inventory trust.
+- Make operator review rows show provisional POS status and provisional sold count.
+- Keep no-result behavior routed to pending checkout item creation when neither trusted catalog nor provisional import matches.
+
+**Patterns to follow:**
+- Existing `availabilityMessage` handling in `packages/athena-webapp/src/components/pos/ProductCard.tsx`
+- Pending checkout UX in `packages/athena-webapp/src/components/pos/ProductEntry.tsx`
+- Calm operator copy from `docs/product-copy-tone.md`
+
+**Test scenarios:**
+- Happy path: provisional import product card is enabled and displays count-pending copy without a numeric available quantity.
+- Happy path: exact lookup for a provisional import barcode adds the item without showing no-result/pending checkout prompts.
+- Edge case: trusted out-of-stock products still render out-of-stock behavior unless an active provisional import row applies.
+- Edge case: no trusted/provisional match still offers pending checkout item recovery.
+- Integration: import review surface shows staged/finalized/rejected provisional status and sold evidence.
+
+**Verification:**
+- Cashiers can identify and add provisional imported items quickly, and operators can see the provisional status during review/finalization.
+
+---
+
+- U8. **Document the provisional import stock boundary**
+
+**Goal:** Preserve the architectural rule so future POS/import changes do not reintroduce fake inventory counts.
+
+**Requirements:** R2, R3, R5, R8
+
+**Dependencies:** U1-U7
+
+**Files:**
+- Create: `docs/solutions/architecture/athena-pos-provisional-import-trust-boundary-2026-06-10.md`
+- Modify: `graphify-out/graph.json`
+- Modify: `graphify-out/GRAPH_REPORT.md`
+- Modify: `graphify-out/wiki/index.md`
+
+**Approach:**
+- Add a solution note explaining why provisional import rows are POS-sellable but not trusted inventory.
+- Call out the anti-patterns: fake high `quantityAvailable`, storefront exposure before finalization, and treating provisional sales as inventory adjustments before finalization.
+- Rebuild graphify after implementation changes so repository navigation stays current.
+
+**Patterns to follow:**
+- `docs/solutions/architecture/athena-pos-pending-checkout-item-recovery-2026-06-06.md`
+- `docs/solutions/architecture/athena-pos-offline-inventory-snapshot-2026-05-15.md`
+
+**Test scenarios:**
+- Test expectation: none -- documentation and generated graph artifacts only.
+
+**Verification:**
+- The solution note explains the boundary and graphify artifacts reflect the changed code graph.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Inventory import review/staging feeds provisional rows; POS catalog reads join active provisional rows; POS session/transaction commands validate and record provisional sale evidence; finalization returns rows to trusted stock behavior.
+- **Error propagation:** Staging/finalization failures should use existing command result patterns. POS add/complete failures should distinguish invalid provisional references from ordinary stock conflicts.
+- **State lifecycle risks:** Rows can move from saved review to provisional active to finalized/rejected/closed. Sale evidence can arrive before or after finalization because of local-first sync.
+- **API surface parity:** Public POS catalog validators, DTOs, local sync contracts, session commands, direct transaction paths, and UI product types need the same provisional fields.
+- **Integration coverage:** Unit tests alone are not enough; integration-style tests must cover staging to POS lookup, cart add to completion, offline sync projection, and finalization after provisional sales.
+- **Unchanged invariants:** Normal trusted SKU inventory enforcement remains hold-aware. Pending checkout items remain distinct from imported provisional SKUs. Storefront catalog visibility remains governed by normal product/SKU visibility and must not include provisional POS-only identities.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| Provisional import rows accidentally become storefront-visible | Keep POS inclusion in POS catalog queries, not general product visibility; test hidden/POS-only identity behavior. |
+| Fake availability leaks into analytics or stock ops | Store provisional imported counts in the provisional table and use policy metadata instead of inflated `quantityAvailable`. |
+| Sale completion double-decrements inventory after finalization | Persist provisional import references on sale lines and skip trusted mutation for lines sold during the provisional window. |
+| Offline sales sync after provisional status changes | Preserve sale facts and route drift to review/conflict rails; do not rewrite receipts. |
+| Final counts are ambiguous when provisional sales occurred | Finalization UI must show provisional sold quantity and make the count basis explicit. |
+| Broad POS DTO changes regress trusted catalog behavior | Add focused tests for normal trusted in-stock/out-of-stock rows alongside provisional rows. |
+
+---
+
+## Documentation / Operational Notes
+
+- This is an operational bridge for import finalization, not a permanent alternative inventory model.
+- Operators should stage provisional POS availability only from a saved review version so import content, decisions, and actor metadata are durable.
+- Support/debugging should inspect provisional rows and sale evidence before trusted inventory when explaining why POS allowed a sale with zero Athena availability.
+- The implementation should add/update a `docs/solutions/` note because this crosses POS, import, inventory, and local-sync boundaries.
+
+---
+
+## Sources & References
+
+- Related plan: `docs/plans/2026-06-06-001-feat-pos-pending-checkout-items-plan.md`
+- Related plan: `docs/plans/2026-05-15-001-feat-pos-offline-inventory-snapshot-plan.md`
+- Related code: `packages/athena-webapp/convex/inventory/catalogImport.ts`
+- Related code: `packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts`
+- Related code: `packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts`
+- Related code: `packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts`
+- Related code: `packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts`
+- Institutional learning: `docs/solutions/architecture/athena-pos-pending-checkout-item-recovery-2026-06-06.md`
+- Institutional learning: `docs/solutions/logic-errors/athena-pos-register-local-catalog-search-2026-05-04.md`
+- Institutional learning: `docs/solutions/performance/athena-pos-cart-latency-foundation-2026-05-05.md`
+- Institutional learning: `docs/solutions/architecture/athena-pos-offline-inventory-snapshot-2026-05-15.md`

--- a/docs/solutions/architecture/athena-pos-provisional-import-trust-boundary-2026-06-10.md
+++ b/docs/solutions/architecture/athena-pos-provisional-import-trust-boundary-2026-06-10.md
@@ -1,0 +1,75 @@
+---
+title: "Athena POS Provisional Import Trust Boundary"
+date: 2026-06-10
+category: architecture
+module: athena-webapp
+problem_type: provisional_inventory_import
+component: pos
+resolution_type: sale_evidence_without_trusted_stock
+severity: high
+tags:
+  - pos
+  - inventory-import
+  - local-sync
+  - audit
+---
+
+# Athena POS Provisional Import Trust Boundary
+
+## Problem
+
+Legacy inventory imports can identify real products that cashiers need to sell
+before Athena has finalized trusted stock counts. Blocking checkout on zero
+Athena `quantityAvailable` creates avoidable sale friction, but inflating SKU
+counts with imported quantities would make unreviewed legacy data look trusted.
+
+## Solution
+
+Treat active provisional import rows as POS sale evidence, not trusted
+inventory:
+
+- POS sale item payloads may carry `inventoryImportProvisionalSkuId` beside the
+  product and SKU identity used on the receipt.
+- Local sync preserves that reference through upload, ingestion, session items,
+  and transaction items.
+- Projection records completed sale evidence back to the provisional import row.
+- Provisional import sale lines bypass inventory holds, stock decrement, and
+  trusted inventory movement creation while the row is active.
+- Normal product/SKU validation still runs so the receipt points at a real
+  store-owned catalog identity.
+
+This mirrors the pending checkout item boundary, but uses the import row as the
+reconciliation anchor instead of a cashier-created pending item.
+
+## Boundaries
+
+Do not copy imported quantities into `productSku.inventoryCount` or
+`productSku.quantityAvailable` to make POS availability work. The provisional
+row owns imported quantity and provisional sold quantity until an operator
+finalizes the import.
+
+Do not let finalized, rejected, or closed provisional rows bypass stock
+enforcement. Once the provisional row is no longer active, POS must use normal
+trusted inventory rules or another explicit review path.
+
+Do not skip catalog identity validation. The provisional row reference explains
+why stock enforcement is bypassed; it does not make arbitrary product/SKU ids
+safe.
+
+## Integration Notes
+
+The local sync slice assumes the schema/main integration provides an
+`inventoryImportProvisionalSku` table and optional
+`inventoryImportProvisionalSkuId` fields on POS session and transaction items.
+If generated Convex types are stale, keep adapter casts narrow and regenerate
+the Convex client/types as part of the schema integration work.
+
+## Prevention
+
+- Add focused local-sync tests whenever provisional import payload fields change.
+- Keep provisional import rows out of general storefront and trusted stock
+  reporting queries until finalization.
+- Record sale evidence with transaction id, quantity sold, and timestamp so
+  finalization can reconcile imported quantity against actual POS sales.
+- Preserve pending checkout items as the fallback for products absent from both
+  Athena catalog and the provisional import.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1859 files · ~0 words
+- 1861 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6406 nodes · 7054 edges · 1787 communities detected
+- 6435 nodes · 7117 edges · 1789 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1797,6 +1797,8 @@
 - [[_COMMUNITY_Community 1784|Community 1784]]
 - [[_COMMUNITY_Community 1785|Community 1785]]
 - [[_COMMUNITY_Community 1786|Community 1786]]
+- [[_COMMUNITY_Community 1787|Community 1787]]
+- [[_COMMUNITY_Community 1788|Community 1788]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1807,8 +1809,8 @@
 6. `getStoreConfigV2()` - 17 edges
 7. `DataTableViewOptions()` - 16 edges
 8. `createConflict()` - 15 edges
-9. `validatePendingCheckoutItemDefinedPayload()` - 14 edges
-10. `projectSaleCompleted()` - 14 edges
+9. `importInventoryRowsWithCtx()` - 14 edges
+10. `validatePendingCheckoutItemDefinedPayload()` - 14 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `getAmountPaidForOrder()` --calls--> `getDiscountValue()`  [EXTRACTED]
@@ -1829,8 +1831,8 @@ Cohesion: 0.04
 Nodes (51): buildDailyCloseTransactionSearch(), canReopenDailyClose(), cn(), formatDailyCloseMoney(), formatMetadataDisplayValue(), formatMetadataValue(), formatTimestampMetadata(), getBucketConfigs() (+43 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.05
-Nodes (39): addLocalAvailabilityConsumption(), addLocalAvailabilityDeltaConsumption(), asCloudOperableSession(), buildCompletedSalePayload(), buildLocalAvailabilityEventIndex(), cartItemsFromLocalRegisterModel(), completedCustomerInfo(), countPendingSyncableLocalEventsForStaff() (+31 more)
+Cohesion: 0.04
+Nodes (42): addLocalAvailabilityConsumption(), addLocalAvailabilityDeltaConsumption(), asCloudOperableSession(), buildCompletedSalePayload(), buildLocalAvailabilityEventIndex(), cartItemsFromLocalRegisterModel(), cartLineSourceKey(), completedCustomerInfo() (+34 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.06
@@ -1838,7 +1840,7 @@ Nodes (56): adjustmentSalesDelta(), adjustmentSettlementAmount(), approvalBelong
 
 ### Community 3 - "Community 3"
 Cohesion: 0.11
-Nodes (49): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(), canMapExistingCloudRegisterSession(), collectExistingSaleMappings(), collectSaleSkuQuantities(), conflictResult(), createConflict() (+41 more)
+Nodes (50): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(), canMapExistingCloudRegisterSession(), collectExistingSaleMappings(), collectSaleSkuQuantities(), conflictResult(), createConflict() (+42 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.06
@@ -1873,120 +1875,120 @@ Cohesion: 0.07
 Nodes (20): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+12 more)
 
 ### Community 12 - "Community 12"
-Cohesion: 0.13
-Nodes (29): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+21 more)
+Cohesion: 0.12
+Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
 
 ### Community 13 - "Community 13"
 Cohesion: 0.08
 Nodes (21): formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels(), getSkuDetailEntries() (+13 more)
 
 ### Community 14 - "Community 14"
+Cohesion: 0.14
+Nodes (33): buildFinalTrustedQuantitiesByRowNumber(), buildProvisionalSkuPatch(), buildSkuInsert(), buildSkuPatch(), finalizeProvisionalImportRowsForAppliedImport(), findExistingSku(), findOrCreateCategory(), findOrCreateProduct() (+25 more)
+
+### Community 15 - "Community 15"
 Cohesion: 0.12
 Nodes (31): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+23 more)
 
-### Community 15 - "Community 15"
+### Community 16 - "Community 16"
 Cohesion: 0.07
 Nodes (13): formatCompactTextList(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary(), formatReviewReportedSummary(), formatReviewTypeSummary(), formatTimestamp() (+5 more)
 
-### Community 16 - "Community 16"
-Cohesion: 0.16
-Nodes (32): asRecord(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale(), getPhase() (+24 more)
-
 ### Community 17 - "Community 17"
+Cohesion: 0.16
+Nodes (33): asRecord(), cartItemSourceKey(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale() (+25 more)
+
+### Community 18 - "Community 18"
 Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
-### Community 18 - "Community 18"
+### Community 19 - "Community 19"
 Cohesion: 0.12
 Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
 
-### Community 19 - "Community 19"
+### Community 20 - "Community 20"
 Cohesion: 0.15
 Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
 
-### Community 20 - "Community 20"
+### Community 21 - "Community 21"
 Cohesion: 0.14
 Nodes (24): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+16 more)
 
-### Community 21 - "Community 21"
+### Community 22 - "Community 22"
 Cohesion: 0.2
 Nodes (28): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftCreatedMessage(), buildCycleCountDraftSavedMessage(), buildCycleCountDraftSubmissionKey(), buildCycleCountDraftSubmittedMessage(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx() (+20 more)
 
-### Community 22 - "Community 22"
+### Community 23 - "Community 23"
 Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.08
 Nodes (7): buildMissingDraftResult(), getApprovalRequestCopy(), handleDecideApprovalRequest(), handleDiscardCycleCountDraft(), handleRefreshCycleCountDraftLineBaseline(), handleSaveCycleCountDraftLine(), handleSubmitCycleCountDraft()
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
 Cohesion: 0.15
 Nodes (22): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildInferentialSummaryNote(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem() (+14 more)
 
-### Community 25 - "Community 25"
+### Community 26 - "Community 26"
 Cohesion: 0.1
 Nodes (15): cancelItemAdjustmentWorkflow(), exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff() (+7 more)
 
-### Community 26 - "Community 26"
+### Community 27 - "Community 27"
 Cohesion: 0.2
 Nodes (25): asRecord(), buildPosLocalSyncUploadEvents(), customerInfoFromPayload(), getCompletedSaleItems(), getCompletedServiceLines(), hasLaterCompletedSale(), isSyncablePosLocalEvent(), isUploadDeferredByValidation() (+17 more)
 
-### Community 27 - "Community 27"
+### Community 28 - "Community 28"
+Cohesion: 0.16
+Nodes (19): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), pendingCheckoutItemMatchesLine(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding() (+11 more)
+
+### Community 29 - "Community 29"
 Cohesion: 0.16
 Nodes (18): buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsTransactionSearch(), getDailyOperationsMetricLabels(), getLocalDateFromOperatingDate(), getLocalOperatingDate(), getLocalOperatingDateRange(), getLocalOperatingDateRangeFromSearch() (+10 more)
 
-### Community 28 - "Community 28"
+### Community 30 - "Community 30"
 Cohesion: 0.12
 Nodes (18): ancestorChain(), collectRawMoneyParses(), collectRawMoneyParsesFromSource(), collectRawNumericHelperNames(), collectSourceFiles(), collectStorefrontDirectMoneyFormats(), containsDisallowedRawNumericParse(), containsTerm() (+10 more)
 
-### Community 29 - "Community 29"
+### Community 31 - "Community 31"
 Cohesion: 0.19
 Nodes (23): assertCompoundSolutionCheck(), collectChangedFiles(), collectCompoundSolutionFindings(), collectExistingFiles(), collectMarkdownContents(), collectSourceLineChanges(), countFileLines(), extractFrontmatter() (+15 more)
 
-### Community 30 - "Community 30"
+### Community 32 - "Community 32"
 Cohesion: 0.15
 Nodes (19): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), isLocalGeneratedArtifactPath() (+11 more)
 
-### Community 31 - "Community 31"
+### Community 33 - "Community 33"
 Cohesion: 0.13
 Nodes (18): buildCartSummary(), buildSessionOperationsRow(), expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), loadPosSessionItems(), loadSessionCustomer(), loadSessionOperator() (+10 more)
 
-### Community 32 - "Community 32"
+### Community 34 - "Community 34"
 Cohesion: 0.19
 Nodes (23): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+15 more)
 
-### Community 33 - "Community 33"
+### Community 35 - "Community 35"
 Cohesion: 0.15
 Nodes (19): acquireExpenseQuantityPatchHold(), adjustExpenseQuantityPatchHold(), createDefaultExpenseSessionCommandService(), createExpenseInventoryHoldGateway(), createExpenseSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired() (+11 more)
 
-### Community 34 - "Community 34"
+### Community 36 - "Community 36"
 Cohesion: 0.09
 Nodes (2): buildCashControlsDashboardSnapshot(), sumDepositsBySession()
 
-### Community 35 - "Community 35"
+### Community 37 - "Community 37"
 Cohesion: 0.19
 Nodes (22): buildEventMessage(), buildNextEvidence(), buildNextSaleEvidence(), buildReviewPriority(), buildWorkItemPriority(), createOrReusePendingCheckoutItem(), createProvisionalCatalogAnchors(), findMatchingPendingCheckoutItem() (+14 more)
 
-### Community 36 - "Community 36"
-Cohesion: 0.17
-Nodes (18): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), pendingCheckoutItemMatchesLine(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding() (+10 more)
-
-### Community 37 - "Community 37"
+### Community 38 - "Community 38"
 Cohesion: 0.1
 Nodes (4): listCompletedTransactionsForDay(), listSessionItems(), listTransactionItems(), readAllQueryResults()
 
-### Community 38 - "Community 38"
+### Community 39 - "Community 39"
 Cohesion: 0.16
 Nodes (20): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle(), formatSignedQuantity() (+12 more)
 
-### Community 39 - "Community 39"
+### Community 40 - "Community 40"
 Cohesion: 0.15
 Nodes (16): buildGitProcessEnv(), collectCommandsForChangedFiles(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets() (+8 more)
-
-### Community 40 - "Community 40"
-Cohesion: 0.2
-Nodes (21): buildSkuInsert(), buildSkuPatch(), findExistingSku(), findOrCreateCategory(), findOrCreateProduct(), findOrCreateSubcategory(), getActorLabel(), importInventoryCommandWithCtx() (+13 more)
 
 ### Community 41 - "Community 41"
 Cohesion: 0.2
@@ -2105,196 +2107,196 @@ Cohesion: 0.15
 Nodes (4): formatCurrency(), formatFinancialLabel(), formatTimelineRange(), formatTimelineTime()
 
 ### Community 70 - "Community 70"
+Cohesion: 0.14
+Nodes (2): handleEnterReviewMode(), saveInventoryImportRouteDraft()
+
+### Community 71 - "Community 71"
 Cohesion: 0.24
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.18
 Nodes (7): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), useConvexRegisterServiceCatalog(), usePrewarmRegisterCatalogOfflineSnapshots()
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.22
 Nodes (10): extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isBarcodeShapedInput(), normalizeIdentifier(), parseCatalogSearchInput(), searchByText(), searchRegisterCatalog() (+2 more)
 
-### Community 73 - "Community 73"
+### Community 74 - "Community 74"
 Cohesion: 0.14
 Nodes (2): getBlockedPosTerminalShellCopy(), PosTerminalBlockedShell()
 
-### Community 74 - "Community 74"
+### Community 75 - "Community 75"
 Cohesion: 0.22
 Nodes (10): createApp(), createHandlers(), createRedisClient(), createRedisCluster(), deleteKeysIndividually(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline(), scanNodeForPattern() (+2 more)
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.31
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getOperationalWorkItemStatus() (+5 more)
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.19
 Nodes (4): formatQuickAddDialogError(), handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 79 - "Community 79"
+### Community 80 - "Community 80"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.26
 Nodes (12): bestFuzzyTokenScore(), compactSearchText(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreCompactFieldContains(), scoreFuzzySearchEntry() (+4 more)
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.27
 Nodes (11): automationIdempotencyKey(), eodDecision(), getLatestDailyOperationsAutomationStatusWithCtx(), listConfiguredAutomationPolicies(), openingDecision(), prepareDailyCloseAutomationWithCtx(), runConfiguredDailyOperationsAutomationWithCtx(), runDailyOpeningAutomationWithCtx() (+3 more)
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
+Cohesion: 0.31
+Nodes (12): getRegisterCatalogPrice(), isActiveProvisionalImportSkuForStore(), isTrustedRegisterCatalogSku(), listRegisterCatalog(), listRegisterCatalogAvailability(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow() (+4 more)
+
+### Community 86 - "Community 86"
 Cohesion: 0.23
 Nodes (7): buildTerminalHealthSummary(), deriveTerminalHealth(), deriveTerminalHealthAttentionReasons(), getTerminalHealthSummary(), resolveAttentionReasonActionTargets(), resolveCloudRegisterSessionTargets(), stripRuntimeStatusIdentity()
 
-### Community 85 - "Community 85"
+### Community 87 - "Community 87"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 86 - "Community 86"
+### Community 88 - "Community 88"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
 
-### Community 87 - "Community 87"
+### Community 89 - "Community 89"
 Cohesion: 0.15
 Nodes (0):
 
-### Community 88 - "Community 88"
+### Community 90 - "Community 90"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 89 - "Community 89"
+### Community 91 - "Community 91"
 Cohesion: 0.23
 Nodes (8): classifyTerminalHealth(), formatAge(), formatStatusLabel(), getPrimaryTerminalAttentionReason(), getReviewEvidenceCount(), getSnapshotAgeSummary(), getTerminalAttentionReasons(), isAppSessionLocalContinuation()
 
-### Community 90 - "Community 90"
+### Community 92 - "Community 92"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 91 - "Community 91"
+### Community 93 - "Community 93"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 92 - "Community 92"
+### Community 94 - "Community 94"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
 
-### Community 93 - "Community 93"
+### Community 95 - "Community 95"
 Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
 
-### Community 94 - "Community 94"
+### Community 96 - "Community 96"
 Cohesion: 0.31
 Nodes (12): collectFilesUnder(), collectProofSnapshot(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof(), hashValidationWiring(), normalizeRepoPath(), readPrAthenaScript(), recordPrePushValidationProof() (+4 more)
 
-### Community 95 - "Community 95"
+### Community 97 - "Community 97"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 96 - "Community 96"
-Cohesion: 0.18
-Nodes (2): handleEnterReviewMode(), saveInventoryImportRouteDraft()
-
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.2
 Nodes (4): formatProductLineMeta(), formatServiceLabel(), formatServiceLineMeta(), formatStoredAmount()
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.21
 Nodes (5): formatDeposit(), formatMoney(), handleCancelEdit(), handleSaveEdit(), summarizeService()
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.29
 Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 102 - "Community 102"
+### Community 103 - "Community 103"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.22
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.25
 Nodes (5): blocked(), evaluateLocalPosReadiness(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 116 - "Community 116"
-Cohesion: 0.38
-Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
-
 ### Community 117 - "Community 117"
 Cohesion: 0.38
-Nodes (8): getRegisterCatalogPrice(), isTrustedRegisterCatalogSku(), listRegisterCatalog(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow(), readCategoryName(), readColorName()
+Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
 ### Community 118 - "Community 118"
 Cohesion: 0.22
@@ -8972,6 +8974,14 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1787 - "Community 1787"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1788 - "Community 1788"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -10055,1309 +10065,1313 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1134`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1135`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1136`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `organization.ts`
+- **Thin community `Community 1137`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1138`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `product.ts`
+- **Thin community `Community 1139`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1140`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1141`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `store.ts`
+- **Thin community `Community 1142`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1143`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `index.ts`
+- **Thin community `Community 1144`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1145`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1146`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1147`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1148`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1149`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1150`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1151`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `index.ts`
+- **Thin community `Community 1152`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1153`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1154`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1155`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1156`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1157`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1158`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1159`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1160`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1161`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1162`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1163`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `customer.ts`
+- **Thin community `Community 1164`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1165`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1166`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1167`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1168`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `index.ts`
+- **Thin community `Community 1169`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1170`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1171`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1172`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1173`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1174`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1175`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1176`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1177`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1178`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1179`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1180`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1181`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1182`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1183`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1184`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1185`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1186`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1187`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `index.ts`
+- **Thin community `Community 1188`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1189`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1190`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1191`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1192`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1193`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1194`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `index.ts`
+- **Thin community `Community 1195`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1196`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1197`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1198`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1199`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1200`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1201`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `bag.ts`
+- **Thin community `Community 1202`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1203`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1204`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1205`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `guest.ts`
+- **Thin community `Community 1206`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `index.ts`
+- **Thin community `Community 1207`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `offer.ts`
+- **Thin community `Community 1208`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1209`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1210`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `review.ts`
+- **Thin community `Community 1211`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1212`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1213`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1214`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1215`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1216`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1217`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1218`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1219`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1220`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `bag.ts`
+- **Thin community `Community 1221`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1222`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `customer.ts`
+- **Thin community `Community 1223`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `guest.ts`
+- **Thin community `Community 1224`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1225`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1226`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1227`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1228`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `payment.ts`
+- **Thin community `Community 1229`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1230`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1231`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1232`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `users.ts`
+- **Thin community `Community 1233`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `payment.ts`
+- **Thin community `Community 1234`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1235`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1236`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1237`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1238`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1239`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `index.ts`
+- **Thin community `Community 1240`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1241`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1242`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1243`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1244`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `auth.ts`
+- **Thin community `Community 1245`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1246`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1247`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1248`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1249`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1250`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1251`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1252`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1253`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1254`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1255`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1256`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1257`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1258`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1259`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1260`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1261`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `constants.ts`
+- **Thin community `Community 1262`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1263`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1264`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1265`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `types.ts`
+- **Thin community `Community 1266`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1267`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1268`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1269`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1270`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1271`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1272`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1273`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1274`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1275`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1276`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1277`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1278`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1279`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1280`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1281`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1282`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1283`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1284`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1285`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1286`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `constants.ts`
+- **Thin community `Community 1287`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1288`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1289`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1290`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `data.ts`
+- **Thin community `Community 1291`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1292`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1293`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1294`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1295`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1296`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1297`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1298`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1299`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1300`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `constants.ts`
+- **Thin community `Community 1301`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1302`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1303`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1304`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `data.ts`
+- **Thin community `Community 1305`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1306`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1307`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1308`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1309`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1310`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1311`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1312`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1313`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1314`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1315`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1316`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1317`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `constants.ts`
+- **Thin community `Community 1318`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1319`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1320`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1321`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1322`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1323`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1324`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1325`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1326`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1327`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1328`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1329`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1330`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1331`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1332`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1333`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1334`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1335`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1336`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1337`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1338`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1339`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1340`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1341`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1342`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1343`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1344`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1345`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1346`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1347`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1348`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1349`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `constants.ts`
+- **Thin community `Community 1350`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1351`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1352`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1353`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `data.ts`
+- **Thin community `Community 1354`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1355`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1356`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `constants.ts`
+- **Thin community `Community 1357`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1358`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1359`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1360`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1361`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `data.ts`
+- **Thin community `Community 1362`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1363`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `constants.ts`
+- **Thin community `Community 1364`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1365`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1366`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1367`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1368`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `data.ts`
+- **Thin community `Community 1369`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1370`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1371`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1372`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1373`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1374`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1375`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1376`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1377`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1378`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1379`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1380`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1381`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1382`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1383`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1384`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1385`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1386`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1387`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1388`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1389`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1390`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1391`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1392`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1393`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1394`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `POSSettingsView.test.tsx`
+- **Thin community `Community 1395`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1396`** (1 nodes): `POSSettingsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `POSTerminalHealthView.test.tsx`
+- **Thin community `Community 1397`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1398`** (1 nodes): `POSTerminalHealthView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1399`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1400`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `types.ts`
+- **Thin community `Community 1401`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1402`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1403`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1404`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1405`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1406`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1407`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1408`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1409`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1410`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1411`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1412`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1413`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1414`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1415`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1416`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1417`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `data.ts`
+- **Thin community `Community 1418`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1419`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1420`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1421`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1422`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1423`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1424`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1425`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1426`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1427`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1428`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1429`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1430`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `constants.ts`
+- **Thin community `Community 1431`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1432`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1433`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1434`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `data.ts`
+- **Thin community `Community 1435`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `types.ts`
+- **Thin community `Community 1436`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1437`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1438`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1439`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1440`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1441`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `index.tsx`
+- **Thin community `Community 1442`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1443`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1444`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1445`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1446`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1447`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1448`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1449`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1450`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `index.tsx`
+- **Thin community `Community 1451`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1452`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1453`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1454`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `button.tsx`
+- **Thin community `Community 1455`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1456`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `card.tsx`
+- **Thin community `Community 1457`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1458`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1459`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `command.tsx`
+- **Thin community `Community 1460`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1461`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1462`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1463`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `form.tsx`
+- **Thin community `Community 1464`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1465`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1466`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `input.tsx`
+- **Thin community `Community 1467`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1468`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1469`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1470`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1471`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1472`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1473`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `select.tsx`
+- **Thin community `Community 1474`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1475`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1476`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1477`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `table.tsx`
+- **Thin community `Community 1478`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1479`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1480`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1481`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1482`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1483`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1484`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1485`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1486`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `constants.ts`
+- **Thin community `Community 1487`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1488`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1489`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1490`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `data.ts`
+- **Thin community `Community 1491`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1492`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1493`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1494`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1495`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1496`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1497`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1498`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1499`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1500`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1501`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1502`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `index.ts`
+- **Thin community `Community 1503`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1504`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1505`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1506`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1507`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1508`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1509`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1510`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1511`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1512`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1513`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1514`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `aws.ts`
+- **Thin community `Community 1515`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `constants.ts`
+- **Thin community `Community 1516`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `countries.ts`
+- **Thin community `Community 1517`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1518`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1519`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1520`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1521`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1522`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1523`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1524`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `dto.ts`
+- **Thin community `Community 1525`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `ports.ts`
+- **Thin community `Community 1526`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `constants.ts`
+- **Thin community `Community 1527`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1528`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1529`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `index.ts`
+- **Thin community `Community 1530`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1531`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `types.ts`
+- **Thin community `Community 1532`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1533`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1534`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1535`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1536`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1537`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1538`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1539`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1540`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1541`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1542`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1543`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `category.ts`
+- **Thin community `Community 1544`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `product.ts`
+- **Thin community `Community 1545`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `store.ts`
+- **Thin community `Community 1546`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1547`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `user.ts`
+- **Thin community `Community 1548`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1549`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1550`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1551`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1552`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1553`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1554`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1555`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1556`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1557`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1558`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `index.tsx`
+- **Thin community `Community 1559`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `index.tsx`
+- **Thin community `Community 1560`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1561`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1562`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1563`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1564`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1565`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1566`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `index.tsx`
+- **Thin community `Community 1567`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1568`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1569`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1570`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `home.tsx`
+- **Thin community `Community 1571`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1572`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1573`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1574`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `index.tsx`
+- **Thin community `Community 1575`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `review.tsx`
+- **Thin community `Community 1576`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1577`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1578`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `index.tsx`
+- **Thin community `Community 1579`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1580`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1581`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1582`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `index.tsx`
+- **Thin community `Community 1583`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1584`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1585`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1586`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1587`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1588`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1589`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `index.tsx`
+- **Thin community `Community 1590`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1591`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1592`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1593`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1594`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1595`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1596`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1597`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1598`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1599`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `index.tsx`
+- **Thin community `Community 1600`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1601`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1602`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `new.tsx`
+- **Thin community `Community 1603`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1604`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1605`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1606`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1607`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `index.tsx`
+- **Thin community `Community 1608`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `new.tsx`
+- **Thin community `Community 1609`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1610`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1611`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1612`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1613`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1614`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `index.tsx`
+- **Thin community `Community 1615`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1616`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1617`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1618`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `index.tsx`
+- **Thin community `Community 1619`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1620`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1621`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1622`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1623`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1624`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1625`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1626`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1627`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1628`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1629`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1630`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1631`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1632`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1633`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1634`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1635`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1636`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1637`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1638`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1639`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1640`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1641`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1642`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1643`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `setup.ts`
+- **Thin community `Community 1644`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1645`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `types.ts`
+- **Thin community `Community 1646`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1647`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1648`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1649`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1650`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1651`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `types.ts`
+- **Thin community `Community 1652`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1653`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1654`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1655`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1656`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1657`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1658`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1659`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1660`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1661`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `schema.ts`
+- **Thin community `Community 1662`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1663`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1664`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1665`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1666`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1667`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1668`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1669`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1670`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1671`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `types.ts`
+- **Thin community `Community 1672`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1673`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1674`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1675`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1676`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1677`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1678`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1679`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `constants.ts`
+- **Thin community `Community 1680`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1681`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `About.tsx`
+- **Thin community `Community 1682`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1683`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1684`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1685`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1686`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1687`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1688`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1689`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1690`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1691`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1692`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `types.ts`
+- **Thin community `Community 1693`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1694`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1695`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1696`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1697`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1698`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1699`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1700`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1701`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1702`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1703`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1704`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `button.tsx`
+- **Thin community `Community 1705`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `card.tsx`
+- **Thin community `Community 1706`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1707`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `command.tsx`
+- **Thin community `Community 1708`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1709`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1710`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1711`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `form.tsx`
+- **Thin community `Community 1712`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1713`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1714`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1715`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1716`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `input.tsx`
+- **Thin community `Community 1717`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `label.tsx`
+- **Thin community `Community 1718`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1719`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1720`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1721`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `index.ts`
+- **Thin community `Community 1722`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `types.ts`
+- **Thin community `Community 1723`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1724`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1725`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1726`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1727`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `select.tsx`
+- **Thin community `Community 1728`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1729`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1730`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `table.tsx`
+- **Thin community `Community 1731`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1732`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1733`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1734`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1735`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1736`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `config.ts`
+- **Thin community `Community 1737`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1738`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1739`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1740`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1741`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `constants.ts`
+- **Thin community `Community 1742`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `countries.ts`
+- **Thin community `Community 1743`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1744`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1745`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1746`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1747`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `index.ts`
+- **Thin community `Community 1748`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `store.ts`
+- **Thin community `Community 1749`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `bag.ts`
+- **Thin community `Community 1750`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1751`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `category.ts`
+- **Thin community `Community 1752`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `organization.ts`
+- **Thin community `Community 1753`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `product.ts`
+- **Thin community `Community 1754`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `store.ts`
+- **Thin community `Community 1755`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1756`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `user.ts`
+- **Thin community `Community 1757`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `states.ts`
+- **Thin community `Community 1758`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1759`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1760`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1761`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1762`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1763`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1764`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1765`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `index.tsx`
+- **Thin community `Community 1766`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1767`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1768`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1769`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1770`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1771`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1772`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1773`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `index.tsx`
+- **Thin community `Community 1774`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1775`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1776`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1777`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1778`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1779`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `index.js`
+- **Thin community `Community 1780`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1781`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1782`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1783`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1784`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1785`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1786`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1787`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1788`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -11368,7 +11382,7 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 0` be split into smaller, more focused modules?**
   _Cohesion score 0.04 - nodes in this community are weakly interconnected._
 - **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.05 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.04 - nodes in this community are weakly interconnected._
 - **Should `Community 2` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 3` be split into smaller, more focused modules?**

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,16 +7,16 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1859
-- Graph nodes: 6406
-- Graph edges: 7054
-- Communities: 1787
+- Code files discovered: 1861
+- Graph nodes: 6435
+- Graph edges: 7117
+- Communities: 1789
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (87 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `useRegisterViewModel.ts` (68 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
+- `useRegisterViewModel.ts` (72 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `dailyClose.ts` (65 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `projectLocalEvents.ts` (51 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `projectLocalEvents.ts` (52 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `usePosLocalSyncRuntime.ts` (47 edges, Community 5) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
 - `harness-inferential-review.ts` (46 edges, Community 7) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `ingestLocalEvents.ts` (46 edges, Community 6) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -18,9 +18,9 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (87 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
-- `useRegisterViewModel.ts` (68 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
+- `useRegisterViewModel.ts` (72 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `dailyClose.ts` (65 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
-- `projectLocalEvents.ts` (51 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
+- `projectLocalEvents.ts` (52 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `usePosLocalSyncRuntime.ts` (47 edges, Community 5) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
 
 ## Navigation

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -17,11 +17,11 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 - [validation-map.json](../../../packages/valkey-proxy-server/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `app.js` (14 edges, Community 74) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.js` (14 edges, Community 75) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `app.test.js` (6 edges, Community 140) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
-- `createRedisClient()` (4 edges, Community 74) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `createRedisCluster()` (3 edges, Community 74) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `deleteKeysIndividually()` (3 edges, Community 74) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisClient()` (4 edges, Community 75) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisCluster()` (3 edges, Community 75) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `deleteKeysIndividually()` (3 edges, Community 75) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/_generated/api.d.ts
+++ b/packages/athena-webapp/convex/_generated/api.d.ts
@@ -220,6 +220,7 @@ import type * as schemas_inventory_complimentaryProduct from "../schemas/invento
 import type * as schemas_inventory_featuredItem from "../schemas/inventory/featuredItem.js";
 import type * as schemas_inventory_index from "../schemas/inventory/index.js";
 import type * as schemas_inventory_inventoryHold from "../schemas/inventory/inventoryHold.js";
+import type * as schemas_inventory_inventoryImportProvisionalSku from "../schemas/inventory/inventoryImportProvisionalSku.js";
 import type * as schemas_inventory_inventoryImportReviewVersion from "../schemas/inventory/inventoryImportReviewVersion.js";
 import type * as schemas_inventory_inviteCode from "../schemas/inventory/inviteCode.js";
 import type * as schemas_inventory_organization from "../schemas/inventory/organization.js";
@@ -574,6 +575,7 @@ declare const fullApi: ApiFromModules<{
   "schemas/inventory/featuredItem": typeof schemas_inventory_featuredItem;
   "schemas/inventory/index": typeof schemas_inventory_index;
   "schemas/inventory/inventoryHold": typeof schemas_inventory_inventoryHold;
+  "schemas/inventory/inventoryImportProvisionalSku": typeof schemas_inventory_inventoryImportProvisionalSku;
   "schemas/inventory/inventoryImportReviewVersion": typeof schemas_inventory_inventoryImportReviewVersion;
   "schemas/inventory/inviteCode": typeof schemas_inventory_inviteCode;
   "schemas/inventory/organization": typeof schemas_inventory_organization;

--- a/packages/athena-webapp/convex/inventory/catalogImport.test.ts
+++ b/packages/athena-webapp/convex/inventory/catalogImport.test.ts
@@ -5,11 +5,13 @@ import {
   importInventoryRowsWithCtx,
   listInventoryImportReviewSkuContextWithCtx,
   saveInventoryImportReviewVersionWithCtx,
+  stageInventoryImportReviewRowsForPosWithCtx,
 } from "./catalogImport";
 
 type TableName =
   | "athenaUser"
   | "category"
+  | "inventoryImportProvisionalSku"
   | "inventoryImportReviewVersion"
   | "operationalEvent"
   | "product"
@@ -23,6 +25,7 @@ function createMutationCtx(seed: Partial<Record<TableName, Row[]>> = {}) {
   const tables: Record<TableName, Map<string, Row>> = {
     athenaUser: new Map(),
     category: new Map(),
+    inventoryImportProvisionalSku: new Map(),
     inventoryImportReviewVersion: new Map(),
     operationalEvent: new Map(),
     product: new Map(),
@@ -438,5 +441,660 @@ describe("catalog import", () => {
       subjectId: saved._id,
       subjectType: "inventory_import_review_version",
     });
+  });
+
+  it("stages saved review rows as active provisional POS rows without applying trusted counts", async () => {
+    const { ctx, tables } = createMutationCtx({
+      inventoryImportReviewVersion: [
+        {
+          _id: "review-version-1",
+          createdAt: 100,
+          createdByUserId: "user-1",
+          importKey: "legacy-review-1",
+          issueCount: 0,
+          organizationId: "org-1",
+          rawContent: "product_name,sku,price,qty\nBody Wave,BW-18,450,6",
+          rowCount: 1,
+          sourceFormat: "csv",
+          storeId: "store-1",
+          versionNumber: 1,
+        },
+      ],
+      product: [
+        {
+          _id: "product-1",
+          availability: "live",
+          categoryId: "category-1",
+          createdByUserId: "user-1",
+          currency: "GHS",
+          inventoryCount: 2,
+          name: "Body Wave",
+          organizationId: "org-1",
+          quantityAvailable: 2,
+          slug: "body-wave",
+          storeId: "store-1",
+          subcategoryId: "subcategory-1",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku-1",
+          barcode: "123456789012",
+          images: [],
+          inventoryCount: 2,
+          price: 30000,
+          productId: "product-1",
+          productName: "Body Wave",
+          quantityAvailable: 2,
+          sku: "BW-18",
+          storeId: "store-1",
+        },
+      ],
+    });
+
+    const staged = await stageInventoryImportReviewRowsForPosWithCtx(ctx, {
+      importKey: "legacy-review-1",
+      reviewVersionId: "review-version-1" as Id<"inventoryImportReviewVersion">,
+      rows: [
+        {
+          barcode: "123456789012",
+          price: 45000,
+          productId: "product-1" as Id<"product">,
+          productName: "Body Wave imported",
+          productSkuId: "sku-1" as Id<"productSku">,
+          quantity: 6,
+          rowKey: "2:BW-18:123456789012:Body Wave imported",
+          rowNumber: 2,
+          sku: "BW-18",
+        },
+      ],
+      sourceFormat: "csv",
+      storeId: "store-1" as Id<"store">,
+    }, access);
+
+    expect(staged).toMatchObject({
+      alreadyStaged: false,
+      catalogIdentitiesCreated: 0,
+      provisionalRowsCreated: 1,
+      provisionalRowsUpdated: 0,
+      rowsSkipped: 0,
+      trustedStockRowsUpdated: 0,
+    });
+    const provisionalRow = Array.from(tables.inventoryImportProvisionalSku.values())[0];
+    expect(provisionalRow).toMatchObject({
+      importKey: "legacy-review-1",
+      importedBarcode: "123456789012",
+      importedPrice: 45000,
+      importedProductName: "Body Wave imported",
+      importedQuantity: 6,
+      importedSku: "BW-18",
+      posExposureStatus: "available",
+      reviewVersionId: "review-version-1",
+      rowKey: "2:BW-18:123456789012:Body Wave imported",
+      status: "active",
+      storeId: "store-1",
+    });
+    expect(provisionalRow.productId).toBe("product-1");
+    expect(provisionalRow.productSkuId).toBe("sku-1");
+    expect(tables.product.size).toBe(1);
+    expect(tables.productSku.size).toBe(1);
+    expect(tables.productSku.get("sku-1")).toMatchObject({
+      inventoryCount: 2,
+      quantityAvailable: 2,
+    });
+    expect(Array.from(tables.operationalEvent.values())[0]).toMatchObject({
+      eventType: "inventory_import_provisional_pos_staged",
+      subjectId: "review-version-1",
+      subjectType: "inventory_import_review_version",
+    });
+  });
+
+  it("finalizes staged provisional rows when the trusted import is applied", async () => {
+    const { ctx, tables } = createMutationCtx({
+      category: [
+        {
+          _id: "category-1",
+          name: "Hair",
+          slug: "hair",
+          storeId: "store-1",
+        },
+      ],
+      inventoryImportProvisionalSku: [
+        {
+          _id: "provisional-1",
+          createdAt: 100,
+          createdByUserId: "user-1",
+          importKey: "legacy-review-1",
+          importedPrice: 45000,
+          importedProductName: "Body Wave imported",
+          importedQuantity: 6,
+          normalizedImportedProductName: "body wave imported",
+          organizationId: "org-1",
+          posExposureStatus: "available",
+          productId: "product-1",
+          productSkuId: "sku-1",
+          reviewVersionId: "review-version-1",
+          reviewVersionNumber: 1,
+          rowKey: "2:BW-18:123456789012:Body Wave imported",
+          rowNumber: 2,
+          saleEvidence: {
+            saleCount: 1,
+            totalQuantitySold: 2,
+          },
+          sourceFormat: "csv",
+          status: "active",
+          storeId: "store-1",
+          updatedAt: 100,
+        },
+      ],
+      product: [
+        {
+          _id: "product-1",
+          availability: "live",
+          categoryId: "category-1",
+          createdByUserId: "user-1",
+          currency: "GHS",
+          inventoryCount: 2,
+          name: "Body Wave",
+          organizationId: "org-1",
+          quantityAvailable: 2,
+          slug: "body-wave",
+          storeId: "store-1",
+          subcategoryId: "subcategory-1",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku-1",
+          barcode: "123456789012",
+          images: [],
+          inventoryCount: 2,
+          price: 30000,
+          productId: "product-1",
+          productName: "Body Wave",
+          quantityAvailable: 2,
+          sku: "BW-18",
+          storeId: "store-1",
+        },
+      ],
+      subcategory: [
+        {
+          _id: "subcategory-1",
+          categoryId: "category-1",
+          name: "Wigs",
+          slug: "wigs",
+          storeId: "store-1",
+        },
+      ],
+    });
+
+    const summary = await importInventoryRowsWithCtx(
+      ctx,
+      {
+        importKey: "legacy-review-1",
+        rows: [
+          {
+            barcode: "123456789012",
+            category: "Hair",
+            price: 50000,
+            productName: "Body Wave",
+            quantity: 9,
+            rowNumber: 2,
+            sku: "BW-18",
+            subcategory: "Wigs",
+          },
+        ],
+        sourceFormat: "csv",
+        storeId: "store-1" as Id<"store">,
+      },
+      access,
+    );
+
+    expect(summary.skusUpdated).toBe(1);
+    expect(tables.productSku.get("sku-1")).toMatchObject({
+      inventoryCount: 7,
+      quantityAvailable: 7,
+    });
+    expect(tables.inventoryImportProvisionalSku.get("provisional-1")).toMatchObject({
+      finalTrustedQuantity: 7,
+      finalizedByUserId: "user-1",
+      posExposureStatus: "hidden",
+      provisionalSoldQuantityAtFinalization: 2,
+      status: "finalized",
+    });
+  });
+
+  it("rejects trusted import before stock mutation when too many provisional rows must finalize", async () => {
+    const provisionalRows = Array.from({ length: 5001 }, (_, index) => ({
+      _id: `provisional-${index}`,
+      createdAt: 100,
+      createdByUserId: "user-1",
+      importKey: "legacy-review-large",
+      importedPrice: 45000,
+      importedProductName: `Imported row ${index}`,
+      importedQuantity: 1,
+      normalizedImportedProductName: `imported row ${index}`,
+      organizationId: "org-1",
+      posExposureStatus: "available",
+      productId: "product-1",
+      productSkuId: "sku-1",
+      reviewVersionId: "review-version-1",
+      reviewVersionNumber: 1,
+      rowKey: `row-${index}`,
+      rowNumber: index + 2,
+      saleEvidence: {
+        saleCount: 0,
+        totalQuantitySold: 0,
+      },
+      sourceFormat: "csv",
+      status: "active",
+      storeId: "store-1",
+      updatedAt: 100,
+    }));
+    const { ctx, tables } = createMutationCtx({
+      inventoryImportProvisionalSku: provisionalRows,
+      product: [
+        {
+          _id: "product-1",
+          availability: "live",
+          categoryId: "category-1",
+          createdByUserId: "user-1",
+          currency: "GHS",
+          inventoryCount: 2,
+          name: "Body Wave",
+          organizationId: "org-1",
+          quantityAvailable: 2,
+          slug: "body-wave",
+          storeId: "store-1",
+          subcategoryId: "subcategory-1",
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku-1",
+          barcode: "123456789012",
+          images: [],
+          inventoryCount: 2,
+          price: 30000,
+          productId: "product-1",
+          productName: "Body Wave",
+          quantityAvailable: 2,
+          sku: "BW-18",
+          storeId: "store-1",
+        },
+      ],
+    });
+
+    await expect(
+      importInventoryRowsWithCtx(
+        ctx,
+        {
+          importKey: "legacy-review-large",
+          rows: [
+            {
+              barcode: "123456789012",
+              price: 50000,
+              productName: "Body Wave",
+              quantity: 9,
+              rowNumber: 2,
+              sku: "BW-18",
+            },
+          ],
+          sourceFormat: "csv",
+          storeId: "store-1" as Id<"store">,
+        },
+        access,
+      ),
+    ).rejects.toThrow("more than 5000 active provisional POS rows");
+
+    expect(tables.productSku.get("sku-1")).toMatchObject({
+      inventoryCount: 2,
+      quantityAvailable: 2,
+    });
+    expect(tables.operationalEvent.size).toBe(0);
+  });
+
+  it("creates hidden catalog identity for new staged rows while keeping imported counts provisional", async () => {
+    const { ctx, tables } = createMutationCtx({
+      inventoryImportReviewVersion: [
+        {
+          _id: "review-version-1",
+          createdAt: 100,
+          createdByUserId: "user-1",
+          importKey: "legacy-review-1",
+          issueCount: 0,
+          organizationId: "org-1",
+          rawContent: "product_name,sku,price,qty\nComb,COMB-1,25,4",
+          rowCount: 1,
+          sourceFormat: "csv",
+          storeId: "store-1",
+          versionNumber: 1,
+        },
+      ],
+    });
+
+    const staged = await stageInventoryImportReviewRowsForPosWithCtx(ctx, {
+      importKey: "legacy-review-1",
+      reviewVersionId: "review-version-1" as Id<"inventoryImportReviewVersion">,
+      rows: [
+        {
+          category: "Accessories",
+          price: 2500,
+          productName: "Comb",
+          quantity: 4,
+          rowKey: "2:COMB-1::Comb",
+          rowNumber: 2,
+          sku: "COMB-1",
+        },
+      ],
+      sourceFormat: "csv",
+      storeId: "store-1" as Id<"store">,
+    }, access);
+
+    const product = Array.from(tables.product.values())[0];
+    const sku = Array.from(tables.productSku.values())[0];
+
+    expect(staged).toMatchObject({
+      catalogIdentitiesCreated: 1,
+      provisionalRowsCreated: 1,
+      trustedStockRowsUpdated: 0,
+    });
+    expect(product).toMatchObject({
+      availability: "draft",
+      inventoryCount: 0,
+      isVisible: false,
+      name: "Comb",
+      quantityAvailable: 0,
+    });
+    expect(sku).toMatchObject({
+      inventoryCount: 0,
+      isVisible: false,
+      price: 2500,
+      productId: product._id,
+      quantityAvailable: 0,
+      sku: "COMB-1",
+    });
+    expect(Array.from(tables.inventoryImportProvisionalSku.values())[0]).toMatchObject({
+      importedQuantity: 4,
+      importedSku: "COMB-1",
+      productId: product._id,
+      productSkuId: sku._id,
+      status: "active",
+    });
+  });
+
+  it("does not mutate a trusted product when creating a provisional catalog identity with the same name", async () => {
+    const { ctx, tables } = createMutationCtx({
+      category: [
+        {
+          _id: "category-1",
+          name: "Accessories",
+          storeId: "store-1",
+        },
+      ],
+      inventoryImportReviewVersion: [
+        {
+          _id: "review-version-1",
+          createdAt: 100,
+          createdByUserId: "user-1",
+          importKey: "legacy-review-1",
+          issueCount: 0,
+          organizationId: "org-1",
+          rawContent: "product_name,sku,price,qty\nComb,COMB-1,25,4",
+          rowCount: 1,
+          sourceFormat: "csv",
+          storeId: "store-1",
+          versionNumber: 1,
+        },
+      ],
+      product: [
+        {
+          _id: "trusted-product-1",
+          availability: "in_stock",
+          categoryId: "category-1",
+          inventoryCount: 8,
+          isVisible: true,
+          name: "Comb",
+          quantityAvailable: 8,
+          storeId: "store-1",
+          subcategoryId: "subcategory-1",
+        },
+      ],
+      productSku: [
+        {
+          _id: "trusted-sku-1",
+          inventoryCount: 8,
+          isVisible: true,
+          price: 3000,
+          productId: "trusted-product-1",
+          productName: "Comb",
+          quantityAvailable: 8,
+          sku: "TRUSTED-COMB",
+          storeId: "store-1",
+        },
+      ],
+      subcategory: [
+        {
+          _id: "subcategory-1",
+          categoryId: "category-1",
+          name: "General",
+          storeId: "store-1",
+        },
+      ],
+    });
+
+    const staged = await stageInventoryImportReviewRowsForPosWithCtx(ctx, {
+      importKey: "legacy-review-1",
+      reviewVersionId: "review-version-1" as Id<"inventoryImportReviewVersion">,
+      rows: [
+        {
+          category: "Accessories",
+          price: 2500,
+          productName: "Comb",
+          quantity: 4,
+          rowKey: "2:COMB-1::Comb",
+          rowNumber: 2,
+          sku: "COMB-1",
+          subcategory: "General",
+        },
+      ],
+      sourceFormat: "csv",
+      storeId: "store-1" as Id<"store">,
+    }, access);
+
+    expect(staged).toMatchObject({
+      catalogIdentitiesCreated: 1,
+      provisionalRowsCreated: 1,
+      trustedStockRowsUpdated: 0,
+    });
+    expect(tables.product.get("trusted-product-1")).toMatchObject({
+      availability: "in_stock",
+      inventoryCount: 8,
+      isVisible: true,
+      quantityAvailable: 8,
+    });
+    expect(tables.productSku.get("trusted-sku-1")).toMatchObject({
+      inventoryCount: 8,
+      isVisible: true,
+      quantityAvailable: 8,
+    });
+    expect(tables.product.size).toBe(2);
+    const provisionalProduct = Array.from(tables.product.values()).find(
+      (product) => product._id !== "trusted-product-1",
+    );
+    expect(provisionalProduct).toMatchObject({
+      availability: "draft",
+      inventoryCount: 0,
+      isVisible: false,
+      name: "Comb",
+      quantityAvailable: 0,
+    });
+    expect(Array.from(tables.inventoryImportProvisionalSku.values())[0]).toMatchObject({
+      productId: provisionalProduct?._id,
+      status: "active",
+    });
+  });
+
+  it("updates existing provisional rows by store/import row key and skips skipped review rows", async () => {
+    const { ctx, tables } = createMutationCtx({
+      inventoryImportReviewVersion: [
+        {
+          _id: "review-version-1",
+          createdAt: 100,
+          createdByUserId: "user-1",
+          importKey: "legacy-review-1",
+          issueCount: 0,
+          organizationId: "org-1",
+          rawContent: "product_name,sku,price,qty\nComb,COMB-1,25,4",
+          rowCount: 2,
+          sourceFormat: "csv",
+          storeId: "store-1",
+          versionNumber: 1,
+        },
+      ],
+    });
+    const args = {
+      importKey: "legacy-review-1",
+      reviewVersionId: "review-version-1" as Id<"inventoryImportReviewVersion">,
+      rows: [
+        {
+          price: 2500,
+          productName: "Comb",
+          quantity: 4,
+          rowKey: "2:COMB-1::Comb",
+          rowNumber: 2,
+          sku: "COMB-1",
+        },
+        {
+          action: "skip_row" as const,
+          price: 9900,
+          productName: "Skip Me",
+          quantity: 1,
+          rowKey: "3:SKIP::Skip Me",
+          rowNumber: 3,
+          sku: "SKIP",
+        },
+      ],
+      sourceFormat: "csv" as const,
+      storeId: "store-1" as Id<"store">,
+    };
+
+    const first = await stageInventoryImportReviewRowsForPosWithCtx(ctx, args, access);
+    const second = await stageInventoryImportReviewRowsForPosWithCtx(ctx, {
+      ...args,
+      rows: [{ ...args.rows[0], price: 2700, quantity: 5 }, args.rows[1]],
+    }, access);
+
+    expect(first).toMatchObject({
+      provisionalRowsCreated: 1,
+      rowsSkipped: 1,
+    });
+    expect(second).toMatchObject({
+      alreadyStaged: true,
+      provisionalRowsCreated: 0,
+      provisionalRowsUpdated: 1,
+      rowsSkipped: 1,
+    });
+    expect(tables.inventoryImportProvisionalSku.size).toBe(1);
+    expect(Array.from(tables.inventoryImportProvisionalSku.values())[0]).toMatchObject({
+      importedPrice: 2700,
+      importedQuantity: 5,
+      rowKey: "2:COMB-1::Comb",
+    });
+
+    const closed = await stageInventoryImportReviewRowsForPosWithCtx(ctx, {
+      ...args,
+      rows: [{ ...args.rows[0], action: "skip_row" as const }],
+    }, access);
+
+    expect(closed).toMatchObject({
+      alreadyStaged: true,
+      provisionalRowsUpdated: 1,
+      rowsSkipped: 1,
+    });
+    expect(Array.from(tables.inventoryImportProvisionalSku.values())[0]).toMatchObject({
+      posExposureStatus: "hidden",
+      status: "closed",
+    });
+
+    const notReopened = await stageInventoryImportReviewRowsForPosWithCtx(ctx, {
+      ...args,
+      rows: [{ ...args.rows[0], price: 3100, quantity: 9 }],
+    }, access);
+
+    expect(notReopened).toMatchObject({
+      alreadyStaged: true,
+      provisionalRowsUpdated: 0,
+      rowsSkipped: 1,
+    });
+    expect(Array.from(tables.inventoryImportProvisionalSku.values())[0]).toMatchObject({
+      importedPrice: 2700,
+      importedQuantity: 5,
+      status: "closed",
+    });
+  });
+
+  it("requires terminal context when staging with manager elevation", async () => {
+    const { ctx } = createMutationCtx({
+      inventoryImportReviewVersion: [
+        {
+          _id: "review-version-1",
+          createdAt: 100,
+          createdByUserId: "user-1",
+          importKey: "legacy-review-1",
+          issueCount: 0,
+          organizationId: "org-1",
+          rawContent: "product_name,sku,price,qty\nComb,COMB-1,25,4",
+          rowCount: 1,
+          sourceFormat: "csv",
+          storeId: "store-1",
+          versionNumber: 1,
+        },
+      ],
+    });
+
+    await expect(
+      stageInventoryImportReviewRowsForPosWithCtx(ctx, {
+        importKey: "legacy-review-1",
+        managerElevationId: "elevation-1" as Id<"managerElevation">,
+        reviewVersionId:
+          "review-version-1" as Id<"inventoryImportReviewVersion">,
+        rows: [
+          {
+            price: 2500,
+            productName: "Comb",
+            quantity: 4,
+            rowKey: "2:COMB-1::Comb",
+            rowNumber: 2,
+            sku: "COMB-1",
+          },
+        ],
+        sourceFormat: "csv",
+        storeId: "store-1" as Id<"store">,
+      }, access),
+    ).rejects.toThrow("Terminal context is required before using manager elevation.");
+  });
+
+  it("requires terminal context when using manager elevation for import review helpers", async () => {
+    const { ctx } = createMutationCtx();
+
+    await expect(
+      saveInventoryImportReviewVersionWithCtx(ctx, {
+        importKey: "legacy-review-1",
+        issueCount: 0,
+        managerElevationId: "elevation-1" as Id<"managerElevation">,
+        rawContent: "product_name,sku,price,qty\nComb,COMB-1,25,4",
+        rowCount: 1,
+        sourceFormat: "csv",
+        storeId: "store-1" as Id<"store">,
+      }),
+    ).rejects.toThrow("Terminal context is required before using manager elevation.");
+
+    await expect(
+      listInventoryImportReviewSkuContextWithCtx(ctx, {
+        managerElevationId: "elevation-1" as Id<"managerElevation">,
+        storeId: "store-1" as Id<"store">,
+      }),
+    ).rejects.toThrow("Terminal context is required before using manager elevation.");
   });
 });

--- a/packages/athena-webapp/convex/inventory/catalogImport.ts
+++ b/packages/athena-webapp/convex/inventory/catalogImport.ts
@@ -24,6 +24,8 @@ const DEFAULT_CATEGORY_NAME = "Legacy import";
 const DEFAULT_SUBCATEGORY_NAME = "Imported inventory";
 const IMPORT_EVENT_TYPE = "inventory_import_applied";
 const REVIEW_VERSION_EVENT_TYPE = "inventory_import_review_version_saved";
+const PROVISIONAL_STAGE_EVENT_TYPE = "inventory_import_provisional_pos_staged";
+const PROVISIONAL_IMPORT_FINALIZATION_LIMIT = 5000;
 
 const importStatusValidator = v.union(
   v.literal("active"),
@@ -64,6 +66,7 @@ const inventoryImportReviewVersionValidator = v.object({
         action: v.optional(
           v.union(v.literal("create_item"), v.literal("skip_row")),
         ),
+        nameSource: v.optional(v.union(v.literal("import"), v.literal("athena"))),
         priceSource: v.optional(v.union(v.literal("import"), v.literal("athena"))),
         productName: v.string(),
         quantitySource: v.optional(v.union(v.literal("import"), v.literal("athena"))),
@@ -75,6 +78,29 @@ const inventoryImportReviewVersionValidator = v.object({
   rowCount: v.number(),
   sourceFormat: importSourceFormatValidator,
   versionNumber: v.number(),
+});
+
+const provisionalImportStageRowValidator = v.object({
+  action: v.optional(v.union(v.literal("create_item"), v.literal("skip_row"))),
+  barcode: v.optional(v.string()),
+  category: v.optional(v.string()),
+  color: v.optional(v.string()),
+  length: v.optional(v.number()),
+  nameSource: v.optional(v.union(v.literal("import"), v.literal("athena"))),
+  price: v.number(),
+  priceSource: v.optional(v.union(v.literal("import"), v.literal("athena"))),
+  productId: v.optional(v.id("product")),
+  productName: v.string(),
+  productSkuId: v.optional(v.id("productSku")),
+  quantity: v.number(),
+  quantitySource: v.optional(v.union(v.literal("import"), v.literal("athena"))),
+  rowKey: v.string(),
+  rowNumber: v.number(),
+  size: v.optional(v.string()),
+  sku: v.optional(v.string()),
+  subcategory: v.optional(v.string()),
+  unitCost: v.optional(v.number()),
+  weight: v.optional(v.string()),
 });
 
 export type CatalogImportRow = {
@@ -94,6 +120,16 @@ export type CatalogImportRow = {
   status?: "active" | "draft" | "archived";
 };
 
+export type ProvisionalInventoryImportStageRow = CatalogImportRow & {
+  action?: "create_item" | "skip_row";
+  nameSource?: "import" | "athena";
+  priceSource?: "import" | "athena";
+  productId?: Id<"product">;
+  productSkuId?: Id<"productSku">;
+  quantitySource?: "import" | "athena";
+  rowKey: string;
+};
+
 export type CatalogImportSummary = {
   alreadyApplied?: boolean;
   categoriesCreated: number;
@@ -103,6 +139,16 @@ export type CatalogImportSummary = {
   skusCreated: number;
   skusUpdated: number;
   subcategoriesCreated: number;
+};
+
+export type ProvisionalInventoryImportStageSummary = {
+  alreadyStaged: boolean;
+  catalogIdentitiesCreated: number;
+  provisionalRowsCreated: number;
+  provisionalRowsUpdated: number;
+  rowsSkipped: number;
+  rowsStaged: number;
+  trustedStockRowsUpdated: 0;
 };
 
 type ImportAccess = {
@@ -129,6 +175,7 @@ export type InventoryImportReviewVersionSummary = {
 
 export type InventoryImportReviewRowDecision = {
   action?: "create_item" | "skip_row";
+  nameSource?: "import" | "athena";
   priceSource?: "import" | "athena";
   productName: string;
   quantitySource?: "import" | "athena";
@@ -177,6 +224,14 @@ export async function importInventoryRowsWithCtx(
     };
   }
 
+  const activeProvisionalRows = await listActiveProvisionalImportRowsForFinalization(
+    ctx,
+    {
+      importKey: args.importKey,
+      storeId: args.storeId,
+    },
+  );
+
   const summary: MutableSummary = {
     categoriesCreated: 0,
     productsCreated: 0,
@@ -187,8 +242,12 @@ export async function importInventoryRowsWithCtx(
     subcategoriesCreated: 0,
   };
   const touchedProductIds = new Set<Id<"product">>();
+  const finalTrustedQuantitiesByRowNumber =
+    buildFinalTrustedQuantitiesByRowNumber(importRows, activeProvisionalRows);
 
   for (const row of importRows) {
+    const finalTrustedQuantity =
+      finalTrustedQuantitiesByRowNumber.get(row.rowNumber) ?? row.quantity;
     const category = await findOrCreateCategory(ctx, {
       name: row.category,
       storeId: args.storeId,
@@ -218,10 +277,17 @@ export async function importInventoryRowsWithCtx(
     }
 
     if (existingSku) {
-      await ctx.db.patch("productSku", existingSku._id, buildSkuPatch(row, product._id));
+      await ctx.db.patch(
+        "productSku",
+        existingSku._id,
+        buildSkuPatch(row, product._id, finalTrustedQuantity),
+      );
       summary.skusUpdated += 1;
     } else {
-      await ctx.db.insert("productSku", buildSkuInsert(row, product._id, args.storeId));
+      await ctx.db.insert(
+        "productSku",
+        buildSkuInsert(row, product._id, args.storeId, finalTrustedQuantity),
+      );
       summary.skusCreated += 1;
     }
 
@@ -233,6 +299,15 @@ export async function importInventoryRowsWithCtx(
     const didUpdate = await recomputeProductInventory(ctx, productId);
     if (didUpdate) summary.productsUpdated += 1;
   }
+
+  await finalizeProvisionalImportRowsForAppliedImport(ctx, {
+    actorUserId: access.athenaUser._id,
+    importKey: args.importKey,
+    finalTrustedQuantitiesByRowNumber,
+    stagedRows: activeProvisionalRows,
+    rows: importRows,
+    storeId: args.storeId,
+  });
 
   await recordOperationalEventWithCtx(ctx, {
     actorUserId: access.athenaUser._id,
@@ -277,6 +352,7 @@ export async function importInventoryCommandWithCtx(
 
     if (
       message === "Manager elevation is required before importing inventory." ||
+      message === "Terminal context is required before using manager elevation." ||
       message === "You do not have permission to import inventory." ||
       message === "Athena user not found."
     ) {
@@ -326,6 +402,7 @@ export async function saveInventoryImportReviewVersionWithCtx(
   },
   resolvedAccess?: ImportAccess,
 ): Promise<InventoryImportReviewVersionSummary> {
+  requireTerminalContextForManagerElevation(args);
   const access = resolvedAccess ?? await requireInventoryImportAccess(ctx, args);
   const rawContent = args.rawContent.trim();
 
@@ -408,6 +485,7 @@ export async function saveInventoryImportReviewVersionCommandWithCtx(
 
     if (
       message === "Manager elevation is required before importing inventory." ||
+      message === "Terminal context is required before using manager elevation." ||
       message === "You do not have permission to import inventory." ||
       message === "Athena user not found."
     ) {
@@ -439,6 +517,7 @@ export const saveInventoryImportReviewVersion = mutation({
           action: v.optional(
             v.union(v.literal("create_item"), v.literal("skip_row")),
           ),
+          nameSource: v.optional(v.union(v.literal("import"), v.literal("athena"))),
           priceSource: v.optional(v.union(v.literal("import"), v.literal("athena"))),
           productName: v.string(),
           quantitySource: v.optional(v.union(v.literal("import"), v.literal("athena"))),
@@ -455,6 +534,216 @@ export const saveInventoryImportReviewVersion = mutation({
   },
   returns: commandResultValidator(v.any()),
   handler: saveInventoryImportReviewVersionCommandWithCtx,
+});
+
+export async function stageInventoryImportReviewRowsForPosWithCtx(
+  ctx: MutationCtx,
+  args: {
+    importKey: string;
+    managerElevationId?: Id<"managerElevation">;
+    notes?: string;
+    reviewVersionId: Id<"inventoryImportReviewVersion">;
+    rows: ProvisionalInventoryImportStageRow[];
+    sourceFormat: "csv" | "json";
+    storeId: Id<"store">;
+    terminalId?: Id<"posTerminal">;
+  },
+  resolvedAccess?: ImportAccess,
+): Promise<ProvisionalInventoryImportStageSummary> {
+  requireTerminalContextForManagerElevation(args);
+  const access = resolvedAccess ?? await requireInventoryImportAccess(ctx, args);
+  const reviewVersion = await ctx.db.get("inventoryImportReviewVersion", args.reviewVersionId);
+
+  if (!reviewVersion || reviewVersion.storeId !== args.storeId) {
+    throw new Error("Inventory import review version not found.");
+  }
+
+  if (reviewVersion.importKey !== args.importKey) {
+    throw new Error("Import key does not match the saved review version.");
+  }
+
+  const rows = normalizeProvisionalStageRows(args.rows);
+  if (rows.length === 0) {
+    throw new Error("At least one import review row is required before staging POS availability.");
+  }
+
+  const summary: ProvisionalInventoryImportStageSummary = {
+    alreadyStaged: false,
+    catalogIdentitiesCreated: 0,
+    provisionalRowsCreated: 0,
+    provisionalRowsUpdated: 0,
+    rowsSkipped: 0,
+    rowsStaged: 0,
+    trustedStockRowsUpdated: 0,
+  };
+  const stagedIds: Array<Id<"inventoryImportProvisionalSku">> = [];
+
+  for (const row of rows) {
+    const existing = await ctx.db
+      .query("inventoryImportProvisionalSku")
+      .withIndex("by_storeId_importKey_rowKey", (q) =>
+        q
+          .eq("storeId", args.storeId)
+          .eq("importKey", args.importKey)
+          .eq("rowKey", row.rowKey)
+      )
+      .first();
+
+    if (row.action === "skip_row") {
+      summary.rowsSkipped += 1;
+      if (existing?.status === "active") {
+        const now = Date.now();
+        summary.alreadyStaged = true;
+        summary.provisionalRowsUpdated += 1;
+        await ctx.db.patch("inventoryImportProvisionalSku", existing._id, {
+          status: "closed",
+          posExposureStatus: "hidden",
+          hiddenAt: now,
+          closedAt: now,
+          closedByUserId: access.athenaUser._id,
+          updatedAt: now,
+        });
+      }
+      continue;
+    }
+
+    if (existing && existing.status !== "active") {
+      summary.alreadyStaged = true;
+      summary.rowsSkipped += 1;
+      continue;
+    }
+
+    const submittedIdentity = await resolveSubmittedProvisionalImportIdentity(
+      ctx,
+      {
+        row,
+        storeId: args.storeId,
+      },
+    );
+    const identity =
+      submittedIdentity ??
+      (existing?.productId && existing.productSkuId
+        ? {
+            productId: existing.productId,
+            productSkuId: existing.productSkuId,
+          }
+        : await resolveProvisionalImportIdentity(ctx, {
+            access,
+            row,
+            storeId: args.storeId,
+            summary,
+          }));
+    const patch = buildProvisionalSkuPatch({
+      access,
+      identity,
+      reviewVersion,
+      row,
+      sourceFormat: args.sourceFormat,
+      storeId: args.storeId,
+    });
+
+    if (existing) {
+      summary.alreadyStaged = true;
+      summary.provisionalRowsUpdated += 1;
+      await ctx.db.patch("inventoryImportProvisionalSku", existing._id, patch);
+      stagedIds.push(existing._id);
+    } else {
+      const id = await ctx.db.insert("inventoryImportProvisionalSku", {
+        ...patch,
+        createdAt: patch.updatedAt,
+        createdByUserId: access.athenaUser._id,
+        saleEvidence: {
+          saleCount: 0,
+          totalQuantitySold: 0,
+        },
+      });
+      summary.provisionalRowsCreated += 1;
+      stagedIds.push(id);
+    }
+
+    summary.rowsStaged += 1;
+  }
+
+  await recordOperationalEventWithCtx(ctx, {
+    actorUserId: access.athenaUser._id,
+    eventType: PROVISIONAL_STAGE_EVENT_TYPE,
+    message: `${getActorLabel(access.athenaUser)} staged ${summary.rowsStaged} inventory import row${summary.rowsStaged === 1 ? "" : "s"} for POS availability.`,
+    metadata: {
+      alreadyStaged: summary.alreadyStaged,
+      catalogIdentitiesCreated: summary.catalogIdentitiesCreated,
+      importKey: args.importKey,
+      provisionalRowsCreated: summary.provisionalRowsCreated,
+      provisionalRowsUpdated: summary.provisionalRowsUpdated,
+      reviewVersionId: args.reviewVersionId,
+      reviewVersionNumber: reviewVersion.versionNumber,
+      rowsSkipped: summary.rowsSkipped,
+      rowsStaged: summary.rowsStaged,
+      sourceFormat: args.sourceFormat,
+      stagedIds,
+      trustedStockRowsUpdated: summary.trustedStockRowsUpdated,
+    },
+    organizationId: access.store.organizationId,
+    reason: normalizeOptional(args.notes),
+    storeId: args.storeId,
+    subjectId: String(args.reviewVersionId),
+    subjectLabel: `Inventory import review v${reviewVersion.versionNumber}`,
+    subjectType: "inventory_import_review_version",
+  });
+
+  return summary;
+}
+
+export async function stageInventoryImportReviewRowsForPosCommandWithCtx(
+  ctx: MutationCtx,
+  args: Parameters<typeof stageInventoryImportReviewRowsForPosWithCtx>[1],
+): Promise<CommandResult<ProvisionalInventoryImportStageSummary>> {
+  try {
+    return ok(await stageInventoryImportReviewRowsForPosWithCtx(ctx, args));
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Inventory import rows could not be staged.";
+
+    if (message === "Authentication required." || message === "Sign in again to continue.") {
+      return userError({ code: "authentication_failed", message });
+    }
+
+    if (
+      message === "Manager elevation is required before importing inventory." ||
+      message === "Terminal context is required before using manager elevation." ||
+      message === "You do not have permission to import inventory." ||
+      message === "Athena user not found."
+    ) {
+      return userError({ code: "authorization_failed", message });
+    }
+
+    if (message === "Store not found." || message === "Inventory import review version not found.") {
+      return userError({ code: "not_found", message });
+    }
+
+    if (
+      message === "Import key does not match the saved review version." ||
+      message === "At least one import review row is required before staging POS availability."
+    ) {
+      return userError({ code: "validation_failed", message });
+    }
+
+    throw error;
+  }
+}
+
+export const stageInventoryImportReviewRowsForPos = mutation({
+  args: {
+    importKey: v.string(),
+    managerElevationId: v.optional(v.id("managerElevation")),
+    notes: v.optional(v.string()),
+    reviewVersionId: v.id("inventoryImportReviewVersion"),
+    rows: v.array(provisionalImportStageRowValidator),
+    sourceFormat: importSourceFormatValidator,
+    storeId: v.id("store"),
+    terminalId: v.optional(v.id("posTerminal")),
+  },
+  returns: commandResultValidator(v.any()),
+  handler: stageInventoryImportReviewRowsForPosCommandWithCtx,
 });
 
 export const getLatestInventoryImportReviewVersion = query({
@@ -499,6 +788,7 @@ export async function listInventoryImportReviewSkuContextWithCtx(
   },
   resolvedAccess?: ImportAccess,
 ) {
+  requireTerminalContextForManagerElevation(args);
   if (!resolvedAccess) {
     await requireInventoryImportAccess(ctx, args);
   }
@@ -569,6 +859,8 @@ async function requireInventoryImportAccess(
     terminalId?: Id<"posTerminal">;
   },
 ): Promise<ImportAccess> {
+  requireTerminalContextForManagerElevation(args);
+
   const store = await ctx.db.get("store", args.storeId);
 
   if (!store) {
@@ -623,6 +915,15 @@ async function requireInventoryImportAccess(
   }
 
   return { athenaUser, store };
+}
+
+function requireTerminalContextForManagerElevation(args: {
+  managerElevationId?: Id<"managerElevation">;
+  terminalId?: Id<"posTerminal">;
+}) {
+  if (args.managerElevationId && !args.terminalId) {
+    throw new Error("Terminal context is required before using manager elevation.");
+  }
 }
 
 function validateImportRows(rows: CatalogImportRow[]) {
@@ -754,6 +1055,225 @@ async function findExistingSku(
   return null;
 }
 
+async function listActiveProvisionalImportRowsForFinalization(
+  ctx: MutationCtx,
+  args: {
+    importKey: string;
+    storeId: Id<"store">;
+  },
+) {
+  const stagedRows = await ctx.db
+    .query("inventoryImportProvisionalSku")
+    .withIndex("by_storeId_importKey_status", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("importKey", args.importKey)
+        .eq("status", "active")
+    )
+    .take(PROVISIONAL_IMPORT_FINALIZATION_LIMIT + 1);
+
+  if (stagedRows.length > PROVISIONAL_IMPORT_FINALIZATION_LIMIT) {
+    throw new Error(
+      `Inventory import has more than ${PROVISIONAL_IMPORT_FINALIZATION_LIMIT} active provisional POS rows. Finalize provisional POS availability in smaller batches before applying trusted counts.`,
+    );
+  }
+
+  return stagedRows;
+}
+
+function buildFinalTrustedQuantitiesByRowNumber(
+  rows: CatalogImportRow[],
+  stagedRows: Awaited<
+    ReturnType<typeof listActiveProvisionalImportRowsForFinalization>
+  >,
+) {
+  const soldByRowNumber = new Map<number, number>();
+  for (const row of stagedRows) {
+    soldByRowNumber.set(
+      row.rowNumber,
+      (soldByRowNumber.get(row.rowNumber) ?? 0) +
+        row.saleEvidence.totalQuantitySold,
+    );
+  }
+
+  return new Map(
+    rows.map((row) => [
+      row.rowNumber,
+      Math.max(0, row.quantity - (soldByRowNumber.get(row.rowNumber) ?? 0)),
+    ]),
+  );
+}
+
+async function finalizeProvisionalImportRowsForAppliedImport(
+  ctx: MutationCtx,
+  args: {
+    actorUserId: Id<"athenaUser">;
+    finalTrustedQuantitiesByRowNumber: Map<number, number>;
+    importKey: string;
+    rows: CatalogImportRow[];
+    stagedRows: Awaited<
+      ReturnType<typeof listActiveProvisionalImportRowsForFinalization>
+    >;
+    storeId: Id<"store">;
+  },
+) {
+  if (args.stagedRows.length === 0) return;
+
+  const now = Date.now();
+
+  for (const row of args.stagedRows) {
+    const finalTrustedQuantity =
+      args.finalTrustedQuantitiesByRowNumber.get(row.rowNumber) ??
+      row.importedQuantity;
+    await ctx.db.patch("inventoryImportProvisionalSku", row._id, {
+      status: "finalized",
+      posExposureStatus: "hidden",
+      hiddenAt: now,
+      finalizedAt: now,
+      finalizedByUserId: args.actorUserId,
+      finalTrustedQuantity,
+      provisionalSoldQuantityAtFinalization: row.saleEvidence.totalQuantitySold,
+      updatedAt: now,
+    });
+  }
+}
+
+async function resolveSubmittedProvisionalImportIdentity(
+  ctx: MutationCtx,
+  args: {
+    row: ProvisionalInventoryImportStageRow;
+    storeId: Id<"store">;
+  },
+): Promise<{
+  productId: Id<"product">;
+  productSkuId: Id<"productSku">;
+} | null> {
+  if (!args.row.productId && !args.row.productSkuId) return null;
+  if (!args.row.productId || !args.row.productSkuId) {
+    throw new Error(
+      `Row ${args.row.rowNumber}: matched Athena product and SKU are required together.`,
+    );
+  }
+
+  const [product, productSku] = await Promise.all([
+    ctx.db.get("product", args.row.productId),
+    ctx.db.get("productSku", args.row.productSkuId),
+  ]);
+
+  if (
+    !product ||
+    product.storeId !== args.storeId ||
+    !productSku ||
+    productSku.storeId !== args.storeId ||
+    productSku.productId !== product._id
+  ) {
+    throw new Error(
+      `Row ${args.row.rowNumber}: matched Athena product and SKU could not be verified for this store.`,
+    );
+  }
+
+  return {
+    productId: product._id,
+    productSkuId: productSku._id,
+  };
+}
+
+async function resolveProvisionalImportIdentity(
+  ctx: MutationCtx,
+  args: {
+    access: ImportAccess;
+    row: ProvisionalInventoryImportStageRow;
+    storeId: Id<"store">;
+    summary: ProvisionalInventoryImportStageSummary;
+  },
+): Promise<{
+  productId?: Id<"product">;
+  productSkuId?: Id<"productSku">;
+}> {
+  const created = await findOrCreateProvisionalCatalogIdentity(ctx, {
+    access: args.access,
+    row: args.row,
+    storeId: args.storeId,
+  });
+  args.summary.catalogIdentitiesCreated += 1;
+
+  return {
+    productId: created.product._id,
+    productSkuId: created.productSku._id,
+  };
+}
+
+async function findOrCreateProvisionalCatalogIdentity(
+  ctx: MutationCtx,
+  args: {
+    access: ImportAccess;
+    row: ProvisionalInventoryImportStageRow;
+    storeId: Id<"store">;
+  },
+): Promise<{ product: Doc<"product">; productSku: Doc<"productSku"> }> {
+  const summary: MutableSummary = {
+    categoriesCreated: 0,
+    productsCreated: 0,
+    productsUpdated: 0,
+    rowsImported: 0,
+    skusCreated: 0,
+    skusUpdated: 0,
+    subcategoriesCreated: 0,
+  };
+  const category = await findOrCreateCategory(ctx, {
+    name: args.row.category,
+    storeId: args.storeId,
+    summary,
+  });
+  const subcategory = await findOrCreateSubcategory(ctx, {
+    categoryId: category._id,
+    name: args.row.subcategory,
+    storeId: args.storeId,
+    summary,
+  });
+  const productId = await ctx.db.insert("product", {
+    availability: "draft",
+    categoryId: category._id,
+    createdByUserId: args.access.athenaUser._id,
+    currency: "GHS",
+    inventoryCount: 0,
+    isVisible: false,
+    name: args.row.productName.trim(),
+    organizationId: args.access.store.organizationId,
+    quantityAvailable: 0,
+    slug:
+      toSlug(`${args.row.productName}-${args.row.rowKey}`) ||
+      `legacy-provisional-import-${Date.now()}`,
+    storeId: args.storeId,
+    subcategoryId: subcategory._id,
+  });
+  summary.productsCreated += 1;
+  const product = await ctx.db.get("product", productId);
+
+  if (!product) {
+    throw new Error(`Row ${args.row.rowNumber}: product could not be loaded.`);
+  }
+
+  const productSkuId = await ctx.db.insert("productSku", {
+    ...buildSkuInsert({ ...args.row, quantity: 0, status: "draft" }, product._id, args.storeId),
+    attributes: {
+      importedRowNumber: args.row.rowNumber,
+      provisionalImportIdentity: true,
+      provisionalImportRowKey: args.row.rowKey,
+      ...(args.row.color ? { legacyColor: args.row.color } : null),
+    },
+    inventoryCount: 0,
+    isVisible: false,
+    quantityAvailable: 0,
+  });
+  const productSku = await ctx.db.get("productSku", productSkuId);
+  if (!productSku) {
+    throw new Error(`Row ${args.row.rowNumber}: SKU could not be loaded.`);
+  }
+
+  return { product, productSku };
+}
+
 async function findOrCreateProduct(
   ctx: MutationCtx,
   args: {
@@ -802,6 +1322,7 @@ function buildSkuInsert(
   row: CatalogImportRow,
   productId: Id<"product">,
   storeId: Id<"store">,
+  finalTrustedQuantity = row.quantity,
 ) {
   return {
     attributes: {
@@ -811,14 +1332,14 @@ function buildSkuInsert(
     barcode: normalizeOptional(row.barcode),
     barcodeAutoGenerated: false,
     images: [],
-    inventoryCount: row.quantity,
+    inventoryCount: finalTrustedQuantity,
     isVisible: row.status !== "archived",
     length: row.length,
     netPrice: row.price,
     price: row.price,
     productId,
     productName: row.productName.trim(),
-    quantityAvailable: row.quantity,
+    quantityAvailable: finalTrustedQuantity,
     size: normalizeOptional(row.size),
     sku: normalizeOptional(row.sku) ?? normalizeOptional(row.barcode),
     storeId,
@@ -827,21 +1348,25 @@ function buildSkuInsert(
   };
 }
 
-function buildSkuPatch(row: CatalogImportRow, productId: Id<"product">) {
+function buildSkuPatch(
+  row: CatalogImportRow,
+  productId: Id<"product">,
+  finalTrustedQuantity = row.quantity,
+) {
   return {
     attributes: {
       importedRowNumber: row.rowNumber,
       ...(row.color ? { legacyColor: row.color } : null),
     },
     barcode: normalizeOptional(row.barcode),
-    inventoryCount: row.quantity,
+    inventoryCount: finalTrustedQuantity,
     isVisible: row.status !== "archived",
     length: row.length,
     netPrice: row.price,
     price: row.price,
     productId,
     productName: row.productName.trim(),
-    quantityAvailable: row.quantity,
+    quantityAvailable: finalTrustedQuantity,
     size: normalizeOptional(row.size),
     sku: normalizeOptional(row.sku),
     unitCost: row.unitCost,
@@ -892,6 +1417,7 @@ function normalizeReviewRowDecisions(
   return decisions
     .map((decision) => ({
       action: decision.action,
+      nameSource: decision.nameSource,
       priceSource: decision.priceSource,
       productName: normalizeLabel(decision.productName) ?? "",
       quantitySource: decision.quantitySource,
@@ -901,8 +1427,90 @@ function normalizeReviewRowDecisions(
     .filter((decision) => decision.rowKey && decision.productName);
 }
 
+function normalizeProvisionalStageRows(
+  rows: ProvisionalInventoryImportStageRow[],
+): ProvisionalInventoryImportStageRow[] {
+  return rows
+    .map((row) => ({
+      ...normalizeImportRow(row),
+      action: row.action,
+      nameSource: row.nameSource,
+      priceSource: row.priceSource,
+      productId: row.productId,
+      productSkuId: row.productSkuId,
+      quantitySource: row.quantitySource,
+      rowKey: normalizeLabel(row.rowKey) ?? "",
+    }))
+    .filter((row) => row.rowKey);
+}
+
+function buildProvisionalSkuPatch(args: {
+  access: ImportAccess;
+  identity: {
+    productId?: Id<"product">;
+    productSkuId?: Id<"productSku">;
+  };
+  reviewVersion: Doc<"inventoryImportReviewVersion">;
+  row: ProvisionalInventoryImportStageRow;
+  sourceFormat: "csv" | "json";
+  storeId: Id<"store">;
+}) {
+  const now = Date.now();
+  const importedSku = normalizeOptional(args.row.sku);
+  const importedBarcode = normalizeOptional(args.row.barcode);
+
+  return {
+    storeId: args.storeId,
+    organizationId: args.access.store.organizationId,
+    importKey: args.reviewVersion.importKey,
+    reviewVersionId: args.reviewVersion._id,
+    reviewVersionNumber: args.reviewVersion.versionNumber,
+    sourceFormat: args.sourceFormat,
+    rowKey: args.row.rowKey,
+    rowNumber: args.row.rowNumber,
+    productId: args.identity.productId,
+    productSkuId: args.identity.productSkuId,
+    importedProductName: args.row.productName.trim(),
+    normalizedImportedProductName:
+      normalizeSearchValue(args.row.productName) ?? "",
+    importedSku,
+    normalizedImportedSku: normalizeSearchValue(importedSku),
+    importedBarcode,
+    normalizedImportedBarcode: normalizeSearchValue(importedBarcode),
+    importedCategory: normalizeOptional(args.row.category),
+    importedSubcategory: normalizeOptional(args.row.subcategory),
+    importedPrice: args.row.price,
+    importedUnitCost: args.row.unitCost,
+    importedQuantity: args.row.quantity,
+    importedSize: normalizeOptional(args.row.size),
+    importedColor: normalizeOptional(args.row.color),
+    importedLength: args.row.length,
+    importedWeight: normalizeOptional(args.row.weight),
+    rowDecision:
+      args.row.action ||
+      args.row.nameSource ||
+      args.row.priceSource ||
+      args.row.quantitySource
+        ? {
+            action: args.row.action,
+            nameSource: args.row.nameSource,
+            priceSource: args.row.priceSource,
+            quantitySource: args.row.quantitySource,
+          }
+        : undefined,
+    status: "active" as const,
+    posExposureStatus: "available" as const,
+    exposedAt: now,
+    updatedAt: now,
+  };
+}
+
 function isNonNegativeInteger(value: number) {
   return Number.isInteger(value) && value >= 0;
+}
+
+function normalizeSearchValue(value?: string) {
+  return normalizeOptional(value)?.toLowerCase();
 }
 
 function getActorLabel(user: Doc<"athenaUser">) {

--- a/packages/athena-webapp/convex/inventory/posSessionItems.ts
+++ b/packages/athena-webapp/convex/inventory/posSessionItems.ts
@@ -92,6 +92,9 @@ export const getSessionItems = query({
       productId: v.id("product"),
       productSkuId: v.id("productSku"),
       pendingCheckoutItemId: v.optional(v.id("posPendingCheckoutItem")),
+      inventoryImportProvisionalSkuId: v.optional(
+        v.id("inventoryImportProvisionalSku"),
+      ),
       productSku: v.string(),
       barcode: v.optional(v.string()),
       productName: v.string(),
@@ -136,6 +139,9 @@ export const addOrUpdateItem = mutation({
     productId: v.id("product"),
     productSkuId: v.id("productSku"),
     pendingCheckoutItemId: v.optional(v.id("posPendingCheckoutItem")),
+    inventoryImportProvisionalSkuId: v.optional(
+      v.id("inventoryImportProvisionalSku"),
+    ),
     staffProfileId: v.id("staffProfile"),
     productSku: v.string(),
     barcode: v.optional(v.string()),

--- a/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/completeTransaction.ts
@@ -57,6 +57,9 @@ import {
   recordPendingCheckoutItemEvidenceCorrection,
   recordPendingCheckoutItemSaleEvidence,
 } from "./createOrReusePendingCheckoutItem";
+import { readActiveProvisionalImportSkuForStoreSku } from "../queries/listRegisterCatalog";
+
+type InventoryImportProvisionalSkuId = Id<"inventoryImportProvisionalSku">;
 
 type PosPaymentInput = {
   method: string;
@@ -66,12 +69,26 @@ type PosPaymentInput = {
 
 type DirectTransactionItemInput = {
   skuId: Id<"productSku">;
+  inventoryImportProvisionalSkuId?: InventoryImportProvisionalSkuId;
   quantity: number;
   price: number;
   name: string;
   barcode?: string;
   sku: string;
   image?: string;
+};
+
+type ActiveProvisionalImportSaleLine = {
+  _id: InventoryImportProvisionalSkuId;
+  productId: Id<"product">;
+  productSkuId: Id<"productSku">;
+  saleEvidence?: {
+    saleCount?: number;
+    totalQuantitySold?: number;
+    lastSoldAt?: number;
+    lastPosTransactionId?: Id<"posTransaction">;
+    lastRegisterSessionId?: Id<"registerSession">;
+  };
 };
 
 type TransactionTotals = {
@@ -333,6 +350,50 @@ async function recordPosSaleInventoryMovement(
     posTransactionId: args.posTransactionId,
     reasonCode: "pos_sale",
     notes: `POS sale ${args.transactionNumber}`,
+  });
+}
+
+async function recordProvisionalImportSkuSaleEvidence(
+  ctx: MutationCtx,
+  args: {
+    provisionalSku: ActiveProvisionalImportSaleLine;
+    posTransactionId: Id<"posTransaction">;
+    registerSessionId?: Id<"registerSession">;
+    quantitySold: number;
+    timestamp: number;
+  },
+) {
+  const db = ctx.db as unknown as {
+    patch(
+      table: "inventoryImportProvisionalSku",
+      id: InventoryImportProvisionalSkuId,
+      patch: {
+        saleEvidence: {
+          saleCount: number;
+          totalQuantitySold: number;
+          lastSoldAt: number;
+          lastPosTransactionId: Id<"posTransaction">;
+          lastRegisterSessionId?: Id<"registerSession">;
+        };
+        updatedAt: number;
+      },
+    ): Promise<void>;
+  };
+  const previousEvidence = args.provisionalSku.saleEvidence ?? {};
+  const saleEvidence = {
+    saleCount: (previousEvidence.saleCount ?? 0) + 1,
+    totalQuantitySold:
+      (previousEvidence.totalQuantitySold ?? 0) + args.quantitySold,
+    lastSoldAt: args.timestamp,
+    lastPosTransactionId: args.posTransactionId,
+    ...(args.registerSessionId
+      ? { lastRegisterSessionId: args.registerSessionId }
+      : {}),
+  };
+
+  await db.patch("inventoryImportProvisionalSku", args.provisionalSku._id, {
+    saleEvidence,
+    updatedAt: args.timestamp,
   });
 }
 
@@ -602,6 +663,10 @@ export async function completeTransaction(
     Id<"productSku">,
     NonNullable<Awaited<ReturnType<typeof getProductSkuById>>>
   >();
+  const provisionalImportLinesById = new Map<
+    InventoryImportProvisionalSkuId,
+    ActiveProvisionalImportSaleLine
+  >();
 
   for (const item of args.items) {
     skuQuantityMap.set(
@@ -619,6 +684,54 @@ export async function completeTransaction(
       });
     }
     skusById.set(skuId, sku);
+
+    const itemsForSku = args.items.filter((item) => item.skuId === skuId);
+    const hasProvisionalImportLine = itemsForSku.some(
+      (item) => item.inventoryImportProvisionalSkuId,
+    );
+    const hasTrustedInventoryLine = itemsForSku.some(
+      (item) => !item.inventoryImportProvisionalSkuId,
+    );
+    if (hasProvisionalImportLine && hasTrustedInventoryLine) {
+      return userError({
+        code: "validation_failed",
+        message:
+          "This sale mixes provisional import and trusted inventory lines for the same SKU. Remove the item and add it again before continuing.",
+      });
+    }
+
+    const submittedProvisionalSkuIds = Array.from(
+      new Set(
+        itemsForSku
+          .map((item) => item.inventoryImportProvisionalSkuId)
+          .filter(Boolean),
+      ),
+    ) as InventoryImportProvisionalSkuId[];
+    if (submittedProvisionalSkuIds.length > 0) {
+      for (const provisionalSkuId of submittedProvisionalSkuIds) {
+        const provisionalSku = await readActiveProvisionalImportSkuForStoreSku(
+          ctx,
+          {
+            storeId: args.storeId,
+            productId: sku.productId,
+            productSkuId: skuId,
+            provisionalSkuId,
+          },
+        );
+
+        if (!provisionalSku) {
+          return userError({
+            code: "precondition_failed",
+            message:
+              "This provisional import item is no longer active for this sale line. Refresh the register catalog before continuing.",
+          });
+        }
+
+        provisionalImportLinesById.set(provisionalSku._id, provisionalSku);
+      }
+
+      continue;
+    }
 
     if (sku.quantityAvailable < totalQuantity) {
       const itemName =
@@ -757,6 +870,25 @@ export async function completeTransaction(
     throw new Error(completionResult.message);
   }
 
+  const provisionalQuantitiesSold = new Map<
+    InventoryImportProvisionalSkuId,
+    {
+      provisionalSku: ActiveProvisionalImportSaleLine;
+      quantitySold: number;
+    }
+  >();
+  for (const item of args.items) {
+    const provisionalSku = item.inventoryImportProvisionalSkuId
+      ? provisionalImportLinesById.get(item.inventoryImportProvisionalSkuId)
+      : undefined;
+    if (!provisionalSku) continue;
+    const existing = provisionalQuantitiesSold.get(provisionalSku._id);
+    provisionalQuantitiesSold.set(provisionalSku._id, {
+      provisionalSku,
+      quantitySold: (existing?.quantitySold ?? 0) + item.quantity,
+    });
+  }
+
   const transactionItems = await Promise.all(
     args.items.map(async (item) => {
       const sku = await getProductSkuById(ctx, item.skuId);
@@ -767,10 +899,16 @@ export async function completeTransaction(
       }
 
       const image = item.image ?? sku.images?.[0];
+      const provisionalSku = item.inventoryImportProvisionalSkuId
+        ? provisionalImportLinesById.get(item.inventoryImportProvisionalSkuId)
+        : undefined;
       const transactionItemId = await createPosTransactionItem(ctx, {
         transactionId,
         productId: sku.productId,
         productSkuId: item.skuId,
+        ...(provisionalSku
+          ? { inventoryImportProvisionalSkuId: provisionalSku._id }
+          : {}),
         productName: item.name,
         productSku: item.sku,
         barcode: item.barcode,
@@ -780,26 +918,37 @@ export async function completeTransaction(
         totalPrice: item.price * item.quantity,
       });
 
-      await patchProductSku(ctx, item.skuId, {
-        quantityAvailable: sku.quantityAvailable - item.quantity,
-        inventoryCount: Math.max(0, sku.inventoryCount - item.quantity),
-      });
-      await recordPosSaleInventoryMovement(ctx, {
-        storeId: args.storeId,
-        organizationId: store?.organizationId,
-        productId: sku.productId,
-        productSkuId: item.skuId,
-        quantity: item.quantity,
-        posTransactionId: transactionId,
-        registerSessionId: args.registerSessionId,
-        staffProfileId: args.staffProfileId,
-        customerProfileId: args.customerProfileId,
-        transactionNumber,
-      });
+      if (!provisionalSku) {
+        await patchProductSku(ctx, item.skuId, {
+          quantityAvailable: sku.quantityAvailable - item.quantity,
+          inventoryCount: Math.max(0, sku.inventoryCount - item.quantity),
+        });
+        await recordPosSaleInventoryMovement(ctx, {
+          storeId: args.storeId,
+          organizationId: store?.organizationId,
+          productId: sku.productId,
+          productSkuId: item.skuId,
+          quantity: item.quantity,
+          posTransactionId: transactionId,
+          registerSessionId: args.registerSessionId,
+          staffProfileId: args.staffProfileId,
+          customerProfileId: args.customerProfileId,
+          transactionNumber,
+        });
+      }
 
       return transactionItemId;
     }),
   );
+  for (const evidence of provisionalQuantitiesSold.values()) {
+    await recordProvisionalImportSkuSaleEvidence(ctx, {
+      provisionalSku: evidence.provisionalSku,
+      posTransactionId: transactionId,
+      registerSessionId: args.registerSessionId,
+      quantitySold: evidence.quantitySold,
+      timestamp: completedAt,
+    });
+  }
 
   await recordCompletedSaleOperationalEvent(ctx, {
     completedAt,
@@ -1280,7 +1429,7 @@ async function applyApprovedTransactionVoid(
   >();
 
   for (const { item, sku } of args.items) {
-    if (item.pendingCheckoutItemId) {
+    if (item.pendingCheckoutItemId || item.inventoryImportProvisionalSkuId) {
       continue;
     }
 
@@ -1679,6 +1828,11 @@ export async function createTransactionFromSessionHandler(
   }
 
   const skuQuantityMap = new Map<Id<"productSku">, number>();
+  const provisionalImportLinesById = new Map<
+    InventoryImportProvisionalSkuId,
+    ActiveProvisionalImportSaleLine
+  >();
+  const provisionalImportSkuIdsBySkuId = new Set<Id<"productSku">>();
   for (const item of items) {
     if (item.pendingCheckoutItemId) {
       const pendingItem = await ctx.db.get(
@@ -1702,10 +1856,42 @@ export async function createTransactionFromSessionHandler(
       continue;
     }
 
+    if (item.inventoryImportProvisionalSkuId) {
+      const provisionalSku = await readActiveProvisionalImportSkuForStoreSku(ctx, {
+        storeId: session.storeId,
+        productId: item.productId,
+        productSkuId: item.productSkuId,
+        provisionalSkuId: item.inventoryImportProvisionalSkuId,
+      });
+      if (provisionalSku) {
+        provisionalImportLinesById.set(
+          item.inventoryImportProvisionalSkuId,
+          provisionalSku,
+        );
+        provisionalImportSkuIdsBySkuId.add(item.productSkuId);
+        continue;
+      }
+      return userError({
+        code: "conflict",
+        message:
+          "This provisional import item is no longer active for this sale line. Refresh the register catalog before completing the sale.",
+      });
+    }
+
     skuQuantityMap.set(
       item.productSkuId,
       (skuQuantityMap.get(item.productSkuId) || 0) + item.quantity,
     );
+  }
+
+  for (const skuId of skuQuantityMap.keys()) {
+    if (provisionalImportSkuIdsBySkuId.has(skuId)) {
+      return userError({
+        code: "validation_failed",
+        message:
+          "This sale mixes provisional import and trusted inventory lines for the same SKU. Remove the item and add it again before continuing.",
+      });
+    }
   }
 
   for (const [skuId, totalQuantity] of skuQuantityMap) {
@@ -1855,7 +2041,14 @@ export async function createTransactionFromSessionHandler(
   const consumedHoldQuantities = await consumeInventoryHoldsForSession(ctx.db, {
     sessionId: args.sessionId,
     items: items
-      .filter((item) => !item.pendingCheckoutItemId)
+      .filter(
+        (item) =>
+          !item.pendingCheckoutItemId &&
+          !(
+            item.inventoryImportProvisionalSkuId &&
+            provisionalImportLinesById.has(item.inventoryImportProvisionalSkuId)
+          ),
+      )
       .map((item) => ({
         skuId: item.productSkuId,
         quantity: item.quantity,
@@ -1875,6 +2068,25 @@ export async function createTransactionFromSessionHandler(
       recordSkuActivityEventWithCtx(ctx, event)) satisfies SkuActivityRecorder,
   });
 
+  const provisionalQuantitiesSold = new Map<
+    InventoryImportProvisionalSkuId,
+    {
+      provisionalSku: ActiveProvisionalImportSaleLine;
+      quantitySold: number;
+    }
+  >();
+  for (const item of items) {
+    const provisionalSku = item.inventoryImportProvisionalSkuId
+      ? provisionalImportLinesById.get(item.inventoryImportProvisionalSkuId)
+      : undefined;
+    if (!provisionalSku) continue;
+    const existing = provisionalQuantitiesSold.get(provisionalSku._id);
+    provisionalQuantitiesSold.set(provisionalSku._id, {
+      provisionalSku,
+      quantitySold: (existing?.quantitySold ?? 0) + item.quantity,
+    });
+  }
+
   const transactionItems = await Promise.all(
     items.map(async (item) => {
       const sku = await getProductSkuById(ctx, item.productSkuId);
@@ -1885,11 +2097,17 @@ export async function createTransactionFromSessionHandler(
       }
 
       const image = item.image ?? sku.images?.[0];
+      const provisionalSku = item.inventoryImportProvisionalSkuId
+        ? provisionalImportLinesById.get(item.inventoryImportProvisionalSkuId)
+        : undefined;
       const transactionItemId = await createPosTransactionItem(ctx, {
         transactionId,
         productId: item.productId,
         productSkuId: item.productSkuId,
         pendingCheckoutItemId: item.pendingCheckoutItemId,
+        ...(provisionalSku
+          ? { inventoryImportProvisionalSkuId: provisionalSku._id }
+          : {}),
         productName: item.productName,
         productSku: item.productSku ?? "",
         barcode: item.barcode,
@@ -1904,7 +2122,7 @@ export async function createTransactionFromSessionHandler(
       const quantityAvailableToSubtract =
         consumedHoldQuantity >= item.quantity ? item.quantity : 0;
 
-      if (!item.pendingCheckoutItemId) {
+      if (!provisionalSku && !item.pendingCheckoutItemId) {
         await patchProductSku(ctx, item.productSkuId, {
           quantityAvailable: Math.max(
             0,
@@ -1924,7 +2142,7 @@ export async function createTransactionFromSessionHandler(
           customerProfileId: session.customerProfileId,
           transactionNumber,
         });
-      } else {
+      } else if (item.pendingCheckoutItemId) {
         await recordPendingCheckoutItemSaleEvidence(ctx, {
           actorStaffProfileId: session.staffProfileId,
           pendingCheckoutItemId: item.pendingCheckoutItemId,
@@ -1942,6 +2160,15 @@ export async function createTransactionFromSessionHandler(
       return transactionItemId;
     }),
   );
+  for (const evidence of provisionalQuantitiesSold.values()) {
+    await recordProvisionalImportSkuSaleEvidence(ctx, {
+      provisionalSku: evidence.provisionalSku,
+      posTransactionId: transactionId,
+      registerSessionId: resolvedRegisterSessionId.data,
+      quantitySold: evidence.quantitySold,
+      timestamp: completedAt,
+    });
+  }
 
   await patchPosSession(ctx, args.sessionId, {
     transactionId,

--- a/packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/sessionCommands.ts
@@ -20,6 +20,8 @@ import {
 } from "./posSessionTracing";
 import { isPosUsableRegisterSessionStatus } from "../../../../shared/registerSessionStatus";
 
+type InventoryImportProvisionalSkuId = Id<"inventoryImportProvisionalSku">;
+
 type CommandFailureStatus =
   | "cashierMismatch"
   | "inventoryUnavailable"
@@ -31,6 +33,19 @@ type CommandFailureStatus =
 function normalizeRegisterNumber(value?: string): string | undefined {
   const normalized = value?.trim();
   return normalized && normalized.length > 0 ? normalized : undefined;
+}
+
+function sessionItemSourceKey(item: {
+  pendingCheckoutItemId?: Id<"posPendingCheckoutItem">;
+  inventoryImportProvisionalSkuId?: InventoryImportProvisionalSkuId;
+}) {
+  if (item.inventoryImportProvisionalSkuId) {
+    return `provisional_import:${item.inventoryImportProvisionalSkuId}`;
+  }
+  if (item.pendingCheckoutItemId) {
+    return `pending_checkout:${item.pendingCheckoutItemId}`;
+  }
+  return "trusted_inventory";
 }
 
 export type PosSessionCommandOutcome<TData> =
@@ -74,6 +89,7 @@ export interface UpsertSessionItemArgs {
   productId: Id<"product">;
   productSkuId: Id<"productSku">;
   pendingCheckoutItemId?: Id<"posPendingCheckoutItem">;
+  inventoryImportProvisionalSkuId?: InventoryImportProvisionalSkuId;
   staffProfileId: Id<"staffProfile">;
   productSku: string;
   barcode?: string;
@@ -179,6 +195,47 @@ async function validatePendingCheckoutLine(
   }
 
   return success({ isPendingCheckoutLine: true });
+}
+
+async function validateProvisionalImportLine(
+  dependencies: SessionCommandDependencies,
+  args: {
+    inventoryImportProvisionalSkuId?: InventoryImportProvisionalSkuId;
+    productId: Id<"product">;
+    productSkuId: Id<"productSku">;
+    storeId: Id<"store">;
+  },
+): Promise<
+  PosSessionCommandOutcome<{
+    inventoryImportProvisionalSkuId?: InventoryImportProvisionalSkuId;
+    isProvisionalImportLine: boolean;
+  }>
+> {
+  if (!args.inventoryImportProvisionalSkuId) {
+    return success({
+      isProvisionalImportLine: false,
+    });
+  }
+
+  const provisionalSku =
+    await dependencies.repository.getActiveProvisionalImportSkuForStoreSku({
+      storeId: args.storeId,
+      productId: args.productId,
+      productSkuId: args.productSkuId,
+      provisionalSkuId: args.inventoryImportProvisionalSkuId,
+    });
+
+  if (!provisionalSku) {
+    return failure(
+      "validationFailed",
+      "This provisional import item is no longer active for this sale line. Refresh the register catalog before continuing.",
+    );
+  }
+
+  return success({
+    inventoryImportProvisionalSkuId: provisionalSku._id,
+    isProvisionalImportLine: true,
+  });
 }
 
 export function createPosSessionCommandService(
@@ -545,20 +602,13 @@ export function createPosSessionCommandService(
         return drawerValidation;
       }
 
-      const existingItem = await dependencies.repository.findSessionItemBySku({
-        sessionId: args.sessionId,
-        productSkuId: args.productSkuId,
-      });
-      const previousQuantity = existingItem?.quantity;
-      if (
-        existingItem?.pendingCheckoutItemId &&
-        existingItem.pendingCheckoutItemId !== args.pendingCheckoutItemId
-      ) {
+      if (args.pendingCheckoutItemId && args.inventoryImportProvisionalSkuId) {
         return failure(
           "validationFailed",
-          "This pending checkout item no longer matches the sale line. Add it again before continuing.",
+          "This cart line has conflicting inventory sources. Remove the item and add it again before continuing.",
         );
       }
+
       const pendingValidation = await validatePendingCheckoutLine(
         dependencies,
         {
@@ -573,11 +623,61 @@ export function createPosSessionCommandService(
       }
       const isPendingCheckoutLine =
         pendingValidation.data.isPendingCheckoutLine;
+      const provisionalImportValidation = await validateProvisionalImportLine(
+        dependencies,
+        {
+          inventoryImportProvisionalSkuId:
+            args.inventoryImportProvisionalSkuId,
+          productId: args.productId,
+          productSkuId: args.productSkuId,
+          storeId: validation.data.storeId,
+        },
+      );
+      if (provisionalImportValidation.status !== "ok") {
+        return provisionalImportValidation;
+      }
+      const isProvisionalImportLine =
+        provisionalImportValidation.data.isProvisionalImportLine;
+      const nextLineSourceKey = sessionItemSourceKey({
+        inventoryImportProvisionalSkuId:
+          provisionalImportValidation.data.inventoryImportProvisionalSkuId,
+        pendingCheckoutItemId: args.pendingCheckoutItemId,
+      });
+      const sameSkuItems = (await dependencies.repository.listSessionItems(
+        args.sessionId,
+      )).filter((item) => item.productSkuId === args.productSkuId);
+      const existingItem = sameSkuItems.find(
+        (item) =>
+          sessionItemSourceKey(item) === nextLineSourceKey,
+      );
+      const conflictingSourceItem = sameSkuItems.find((item) => {
+        const existingSourceKey = sessionItemSourceKey(item);
+        if (existingSourceKey === nextLineSourceKey) return false;
+        return !(
+          existingSourceKey.startsWith("provisional_import:") &&
+          nextLineSourceKey.startsWith("provisional_import:")
+        );
+      });
+      if (conflictingSourceItem?.pendingCheckoutItemId) {
+        return failure(
+          "validationFailed",
+          "This pending checkout item no longer matches the sale line. Add it again before continuing.",
+        );
+      }
+      if (conflictingSourceItem) {
+        return failure(
+          "validationFailed",
+          "This cart line already uses a different inventory source. Remove the item and add it again before continuing.",
+        );
+      }
+      const previousQuantity = existingItem?.quantity;
 
       let itemId: Id<"posSessionItem">;
       const expiresAt = dependencies.calculateExpiration(now);
       if (existingItem) {
-        if (!isPendingCheckoutLine && !existingItem.pendingCheckoutItemId) {
+        const nextUsesTrustedHold =
+          !isPendingCheckoutLine && !isProvisionalImportLine;
+        if (nextUsesTrustedHold) {
           const adjustResult = await dependencies.inventory.adjustHold({
             storeId: validation.data.storeId,
             sessionId: args.sessionId,
@@ -613,11 +713,13 @@ export function createPosSessionCommandService(
           barcode: args.barcode,
           color: args.color,
           pendingCheckoutItemId: args.pendingCheckoutItemId,
+          inventoryImportProvisionalSkuId:
+            provisionalImportValidation.data.inventoryImportProvisionalSkuId,
           updatedAt: now,
         });
         itemId = existingItem._id;
       } else {
-        if (!isPendingCheckoutLine) {
+        if (!isPendingCheckoutLine && !isProvisionalImportLine) {
           const holdResult = await dependencies.inventory.acquireHold({
             storeId: validation.data.storeId,
             sessionId: args.sessionId,
@@ -649,6 +751,8 @@ export function createPosSessionCommandService(
           productId: args.productId,
           productSkuId: args.productSkuId,
           pendingCheckoutItemId: args.pendingCheckoutItemId,
+          inventoryImportProvisionalSkuId:
+            provisionalImportValidation.data.inventoryImportProvisionalSkuId,
           productSku: args.productSku,
           barcode: args.barcode,
           productName: args.productName,
@@ -724,27 +828,29 @@ export function createPosSessionCommandService(
         );
       }
 
-      const releaseResult = await dependencies.inventory.releaseHold({
-        sessionId: args.sessionId,
-        skuId: item.productSkuId,
-        quantity: item.quantity,
-        now,
-        activityContext: {
-          actorStaffProfileId: args.staffProfileId,
-          posSessionItemId: item._id,
-          registerSessionId: validation.data.registerSessionId,
-          terminalId: validation.data.terminalId,
-          workflowTraceId: validation.data.workflowTraceId,
-          metadata: {
-            productName: item.productName,
+      if (!item.pendingCheckoutItemId && !item.inventoryImportProvisionalSkuId) {
+        const releaseResult = await dependencies.inventory.releaseHold({
+          sessionId: args.sessionId,
+          skuId: item.productSkuId,
+          quantity: item.quantity,
+          now,
+          activityContext: {
+            actorStaffProfileId: args.staffProfileId,
+            posSessionItemId: item._id,
+            registerSessionId: validation.data.registerSessionId,
+            terminalId: validation.data.terminalId,
+            workflowTraceId: validation.data.workflowTraceId,
+            metadata: {
+              productName: item.productName,
+            },
           },
-        },
-      });
-      if (!releaseResult.success) {
-        return failure(
-          "inventoryUnavailable",
-          releaseResult.message || "Failed to release inventory hold",
-        );
+        });
+        if (!releaseResult.success) {
+          return failure(
+            "inventoryUnavailable",
+            releaseResult.message || "Failed to release inventory hold",
+          );
+        }
       }
 
       await dependencies.repository.deleteSessionItem(args.itemId);

--- a/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
+++ b/packages/athena-webapp/convex/pos/application/completeTransaction.test.ts
@@ -606,6 +606,15 @@ describe("voidTransaction", () => {
 	        productSku: "PENDING-1",
 	        quantity: 1,
 	      },
+      {
+        _id: "txn-item-provisional-import",
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        productId: "product-import-1",
+        productSkuId: "sku-import-1",
+        productName: "Imported bundle",
+        productSku: "IMPORT-1",
+        quantity: 2,
+      },
 	    ] as never);
     vi.mocked(getProductSkuById).mockImplementation(async (_ctx, skuId) => {
       if (skuId === "sku-pending-1") {
@@ -615,6 +624,16 @@ describe("voidTransaction", () => {
           productId: "product-pending-1",
           quantityAvailable: 0,
           sku: "PENDING-1",
+          storeId: "store-1",
+        } as never;
+      }
+      if (skuId === "sku-import-1") {
+        return {
+          _id: "sku-import-1",
+          inventoryCount: 0,
+          productId: "product-import-1",
+          quantityAvailable: 0,
+          sku: "IMPORT-1",
           storeId: "store-1",
         } as never;
       }
@@ -661,6 +680,11 @@ describe("voidTransaction", () => {
     expect(patchProductSku).not.toHaveBeenCalledWith(
       expect.anything(),
       "sku-pending-1",
+      expect.anything(),
+    );
+    expect(patchProductSku).not.toHaveBeenCalledWith(
+      expect.anything(),
+      "sku-import-1",
       expect.anything(),
     );
     expect(ctx.db.patch).toHaveBeenCalledWith(
@@ -1345,6 +1369,512 @@ describe("completeTransaction checkout side effects", () => {
         reasonCode: "pos_sale",
       }),
     );
+  });
+
+  it("completes active provisional import direct sales without trusted stock mutation", async () => {
+    const runMutation = vi.fn().mockResolvedValue(undefined);
+    const provisionalImportSku = {
+      _id: "provisional-import-sku-1",
+      storeId: "store-1",
+      status: "active",
+      posExposureStatus: "available",
+      productId: "product-import-1",
+      productSkuId: "sku-import-1",
+      saleEvidence: {
+        saleCount: 0,
+        totalQuantitySold: 0,
+      },
+    };
+    const dbPatch = vi.fn(
+      async (_tableName: string, _id: string, patch: object) => {
+        Object.assign(provisionalImportSku, patch);
+      },
+    );
+    const ctx = {
+      db: {
+        get: vi.fn(async (tableName: string, id: string) => {
+          if (tableName === "product" && id === "product-import-1") {
+            return { _id: "product-import-1", storeId: "store-1" };
+          }
+          if (
+            tableName === "inventoryImportProvisionalSku" &&
+            id === "provisional-import-sku-1"
+          ) {
+            return provisionalImportSku;
+          }
+          if (tableName === "staffProfile" && id === "staff-1") {
+            return { _id: "staff-1", status: "active", storeId: "store-1" };
+          }
+          if (tableName === "posTerminal" && id === "terminal-1") {
+            return { _id: "terminal-1", status: "active", storeId: "store-1" };
+          }
+          if (tableName === "registerSession" && id === "register-1") {
+            return {
+              _id: "register-1",
+              openedByStaffProfileId: "staff-1",
+              status: "open",
+              storeId: "store-1",
+              terminalId: "terminal-1",
+            };
+          }
+          return null;
+        }),
+        patch: dbPatch,
+      },
+      runMutation,
+    } as never;
+
+    vi.mocked(getStoreById).mockResolvedValue({
+      _id: "store-1",
+      organizationId: "org-1",
+    } as never);
+    vi.mocked(getProductSkuById).mockResolvedValue({
+      _id: "sku-import-1",
+      images: [],
+      inventoryCount: 0,
+      productId: "product-import-1",
+      quantityAvailable: 0,
+      sku: "LEGACY-1",
+      storeId: "store-1",
+    } as never);
+    vi.mocked(createPosTransaction).mockResolvedValue("txn-1" as never);
+    vi.mocked(recordRetailSalePaymentAllocations).mockResolvedValue(true);
+    vi.mocked(createPosTransactionItem).mockResolvedValue(
+      "txn-item-1" as never,
+    );
+
+    await expect(
+      completeTransaction(ctx, {
+        storeId: "store-1" as Id<"store">,
+        items: [
+          {
+            skuId: "sku-import-1" as Id<"productSku">,
+            inventoryImportProvisionalSkuId:
+              "provisional-import-sku-1" as Id<"inventoryImportProvisionalSku">,
+            quantity: 2,
+            price: 15,
+            name: "Imported bundle",
+            sku: "LEGACY-1",
+          },
+          {
+            skuId: "sku-import-1" as Id<"productSku">,
+            inventoryImportProvisionalSkuId:
+              "provisional-import-sku-1" as Id<"inventoryImportProvisionalSku">,
+            quantity: 3,
+            price: 15,
+            name: "Imported bundle",
+            sku: "LEGACY-1",
+          },
+        ],
+        payments: [{ method: "cash", amount: 75, timestamp: 1 }],
+        subtotal: 75,
+        tax: 0,
+        total: 75,
+        registerNumber: "1",
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        staffProfileId: "staff-1" as Id<"staffProfile">,
+        registerSessionId: "register-1" as Id<"registerSession">,
+      }),
+    ).resolves.toMatchObject({
+      kind: "ok",
+      data: {
+        transactionId: "txn-1",
+      },
+    });
+
+    expect(validateInventoryAvailability).not.toHaveBeenCalled();
+    expect(createPosTransactionItem).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        productId: "product-import-1",
+        productSkuId: "sku-import-1",
+        quantity: 2,
+      }),
+    );
+    expect(dbPatch).toHaveBeenCalledWith(
+      "inventoryImportProvisionalSku",
+      "provisional-import-sku-1",
+      expect.objectContaining({
+        saleEvidence: expect.objectContaining({
+          lastPosTransactionId: "txn-1",
+          lastRegisterSessionId: "register-1",
+          saleCount: 1,
+          totalQuantitySold: 5,
+        }),
+      }),
+    );
+    expect(patchProductSku).not.toHaveBeenCalled();
+    expect(recordInventoryMovementWithCtx).not.toHaveBeenCalled();
+  });
+
+  it("preserves distinct provisional import row evidence for direct sale lines sharing a trusted SKU", async () => {
+    const runMutation = vi.fn().mockResolvedValue(undefined);
+    const provisionalImportSkus = new Map(
+      [
+        {
+          _id: "provisional-import-sku-1",
+          storeId: "store-1",
+          status: "active",
+          posExposureStatus: "available",
+          productId: "product-import-1",
+          productSkuId: "sku-import-1",
+          saleEvidence: {
+            saleCount: 0,
+            totalQuantitySold: 0,
+          },
+        },
+        {
+          _id: "provisional-import-sku-2",
+          storeId: "store-1",
+          status: "active",
+          posExposureStatus: "available",
+          productId: "product-import-1",
+          productSkuId: "sku-import-1",
+          saleEvidence: {
+            saleCount: 0,
+            totalQuantitySold: 0,
+          },
+        },
+      ].map((sku) => [sku._id, sku]),
+    );
+    const dbPatch = vi.fn(async (_tableName: string, id: string, patch: object) => {
+      Object.assign(provisionalImportSkus.get(id)!, patch);
+    });
+    const ctx = {
+      db: {
+        get: vi.fn(async (tableName: string, id: string) => {
+          if (tableName === "product" && id === "product-import-1") {
+            return { _id: "product-import-1", storeId: "store-1" };
+          }
+          if (tableName === "inventoryImportProvisionalSku") {
+            return provisionalImportSkus.get(id) ?? null;
+          }
+          if (tableName === "staffProfile" && id === "staff-1") {
+            return { _id: "staff-1", status: "active", storeId: "store-1" };
+          }
+          if (tableName === "posTerminal" && id === "terminal-1") {
+            return { _id: "terminal-1", status: "active", storeId: "store-1" };
+          }
+          if (tableName === "registerSession" && id === "register-1") {
+            return {
+              _id: "register-1",
+              openedByStaffProfileId: "staff-1",
+              status: "open",
+              storeId: "store-1",
+              terminalId: "terminal-1",
+            };
+          }
+          return null;
+        }),
+        patch: dbPatch,
+      },
+      runMutation,
+    } as never;
+
+    vi.mocked(getStoreById).mockResolvedValue({
+      _id: "store-1",
+      organizationId: "org-1",
+    } as never);
+    vi.mocked(getProductSkuById).mockResolvedValue({
+      _id: "sku-import-1",
+      images: [],
+      inventoryCount: 0,
+      productId: "product-import-1",
+      quantityAvailable: 0,
+      sku: "LEGACY-1",
+      storeId: "store-1",
+    } as never);
+    vi.mocked(createPosTransaction).mockResolvedValue("txn-1" as never);
+    vi.mocked(recordRetailSalePaymentAllocations).mockResolvedValue(true);
+    vi.mocked(createPosTransactionItem)
+      .mockResolvedValueOnce("txn-item-1" as never)
+      .mockResolvedValueOnce("txn-item-2" as never);
+
+    await expect(
+      completeTransaction(ctx, {
+        storeId: "store-1" as Id<"store">,
+        items: [
+          {
+            skuId: "sku-import-1" as Id<"productSku">,
+            inventoryImportProvisionalSkuId:
+              "provisional-import-sku-1" as Id<"inventoryImportProvisionalSku">,
+            quantity: 2,
+            price: 15,
+            name: "Imported bundle",
+            sku: "LEGACY-1",
+          },
+          {
+            skuId: "sku-import-1" as Id<"productSku">,
+            inventoryImportProvisionalSkuId:
+              "provisional-import-sku-2" as Id<"inventoryImportProvisionalSku">,
+            quantity: 3,
+            price: 15,
+            name: "Imported bundle",
+            sku: "LEGACY-1",
+          },
+        ],
+        payments: [{ method: "cash", amount: 75, timestamp: 1 }],
+        subtotal: 75,
+        tax: 0,
+        total: 75,
+        registerNumber: "1",
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        staffProfileId: "staff-1" as Id<"staffProfile">,
+        registerSessionId: "register-1" as Id<"registerSession">,
+      }),
+    ).resolves.toMatchObject({
+      kind: "ok",
+      data: {
+        transactionId: "txn-1",
+        transactionItems: ["txn-item-1", "txn-item-2"],
+      },
+    });
+
+    expect(validateInventoryAvailability).not.toHaveBeenCalled();
+    expect(createPosTransactionItem).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        productSkuId: "sku-import-1",
+        quantity: 2,
+      }),
+    );
+    expect(createPosTransactionItem).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        inventoryImportProvisionalSkuId: "provisional-import-sku-2",
+        productSkuId: "sku-import-1",
+        quantity: 3,
+      }),
+    );
+    expect(dbPatch).toHaveBeenCalledWith(
+      "inventoryImportProvisionalSku",
+      "provisional-import-sku-1",
+      expect.objectContaining({
+        saleEvidence: expect.objectContaining({
+          lastPosTransactionId: "txn-1",
+          lastRegisterSessionId: "register-1",
+          saleCount: 1,
+          totalQuantitySold: 2,
+        }),
+      }),
+    );
+    expect(dbPatch).toHaveBeenCalledWith(
+      "inventoryImportProvisionalSku",
+      "provisional-import-sku-2",
+      expect.objectContaining({
+        saleEvidence: expect.objectContaining({
+          lastPosTransactionId: "txn-1",
+          lastRegisterSessionId: "register-1",
+          saleCount: 1,
+          totalQuantitySold: 3,
+        }),
+      }),
+    );
+    expect(patchProductSku).not.toHaveBeenCalled();
+    expect(recordInventoryMovementWithCtx).not.toHaveBeenCalled();
+  });
+
+  it("rejects hidden provisional import direct sale lines before stock bypass", async () => {
+    const ctx = {
+      db: {
+        get: vi.fn(async (tableName: string, id: string) => {
+          if (
+            tableName === "inventoryImportProvisionalSku" &&
+            id === "provisional-import-sku-1"
+          ) {
+            return {
+              _id: "provisional-import-sku-1",
+              storeId: "store-1",
+              status: "active",
+              posExposureStatus: "hidden",
+              productId: "product-import-1",
+              productSkuId: "sku-import-1",
+            };
+          }
+          return null;
+        }),
+        patch: vi.fn(),
+      },
+      runMutation: vi.fn(),
+    } as never;
+
+    vi.mocked(getProductSkuById).mockResolvedValue({
+      _id: "sku-import-1",
+      images: [],
+      inventoryCount: 0,
+      productId: "product-import-1",
+      quantityAvailable: 0,
+      sku: "LEGACY-1",
+      storeId: "store-1",
+    } as never);
+
+    await expect(
+      completeTransaction(ctx, {
+        storeId: "store-1" as Id<"store">,
+        items: [
+          {
+            skuId: "sku-import-1" as Id<"productSku">,
+            inventoryImportProvisionalSkuId:
+              "provisional-import-sku-1" as Id<"inventoryImportProvisionalSku">,
+            quantity: 2,
+            price: 15,
+            name: "Imported bundle",
+            sku: "LEGACY-1",
+          },
+        ],
+        payments: [{ method: "cash", amount: 30, timestamp: 1 }],
+        subtotal: 30,
+        tax: 0,
+        total: 30,
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+        message:
+          "This provisional import item is no longer active for this sale line. Refresh the register catalog before continuing.",
+      },
+    });
+
+    expect(validateInventoryAvailability).not.toHaveBeenCalled();
+    expect(createPosTransaction).not.toHaveBeenCalled();
+    expect(createPosTransactionItem).not.toHaveBeenCalled();
+    expect(patchProductSku).not.toHaveBeenCalled();
+    expect(recordInventoryMovementWithCtx).not.toHaveBeenCalled();
+  });
+
+  it("rejects mixed trusted and provisional direct sale lines for the same SKU", async () => {
+    const ctx = {
+      db: {
+        get: vi.fn(async (tableName: string, id: string) => {
+          if (
+            tableName === "inventoryImportProvisionalSku" &&
+            id === "provisional-import-sku-1"
+          ) {
+            return {
+              _id: "provisional-import-sku-1",
+              storeId: "store-1",
+              status: "active",
+              productId: "product-import-1",
+              productSkuId: "sku-import-1",
+            };
+          }
+          return null;
+        }),
+        patch: vi.fn(),
+      },
+      runMutation: vi.fn(),
+    } as never;
+
+    vi.mocked(getProductSkuById).mockResolvedValue({
+      _id: "sku-import-1",
+      images: [],
+      inventoryCount: 10,
+      productId: "product-import-1",
+      quantityAvailable: 10,
+      sku: "LEGACY-1",
+      storeId: "store-1",
+    } as never);
+
+    await expect(
+      completeTransaction(ctx, {
+        storeId: "store-1" as Id<"store">,
+        items: [
+          {
+            skuId: "sku-import-1" as Id<"productSku">,
+            inventoryImportProvisionalSkuId:
+              "provisional-import-sku-1" as Id<"inventoryImportProvisionalSku">,
+            quantity: 1,
+            price: 15,
+            name: "Imported bundle",
+            sku: "LEGACY-1",
+          },
+          {
+            skuId: "sku-import-1" as Id<"productSku">,
+            quantity: 3,
+            price: 15,
+            name: "Imported bundle",
+            sku: "LEGACY-1",
+          },
+        ],
+        payments: [{ method: "cash", amount: 60, timestamp: 1 }],
+        subtotal: 60,
+        tax: 0,
+        total: 60,
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "validation_failed",
+      },
+    });
+
+    expectNoCompletionSideEffects();
+  });
+
+  it("rejects stale provisional import direct sale lines before durable sale writes", async () => {
+    const ctx = {
+      db: {
+        get: vi.fn(async (tableName: string, id: string) => {
+          if (
+            tableName === "inventoryImportProvisionalSku" &&
+            id === "provisional-import-sku-1"
+          ) {
+            return {
+              _id: "provisional-import-sku-1",
+              storeId: "store-1",
+              status: "closed",
+              productId: "product-import-1",
+              productSkuId: "sku-import-1",
+            };
+          }
+          return null;
+        }),
+        patch: vi.fn(),
+      },
+      runMutation: vi.fn(),
+    } as never;
+
+    vi.mocked(getProductSkuById).mockResolvedValue({
+      _id: "sku-import-1",
+      images: [],
+      inventoryCount: 0,
+      productId: "product-import-1",
+      quantityAvailable: 0,
+      sku: "LEGACY-1",
+      storeId: "store-1",
+    } as never);
+
+    await expect(
+      completeTransaction(ctx, {
+        storeId: "store-1" as Id<"store">,
+        items: [
+          {
+            skuId: "sku-import-1" as Id<"productSku">,
+            inventoryImportProvisionalSkuId:
+              "provisional-import-sku-1" as Id<"inventoryImportProvisionalSku">,
+            quantity: 1,
+            price: 15,
+            name: "Imported bundle",
+            sku: "LEGACY-1",
+          },
+        ],
+        payments: [{ method: "cash", amount: 15, timestamp: 1 }],
+        subtotal: 15,
+        tax: 0,
+        total: 15,
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "precondition_failed",
+      },
+    });
+
+    expect(validateInventoryAvailability).not.toHaveBeenCalled();
+    expectNoCompletionSideEffects();
   });
 
   it("does not create side effects when payments are empty", async () => {
@@ -2132,6 +2662,532 @@ describe("completeTransaction trace ordering", () => {
     );
     expect(patchProductSku).not.toHaveBeenCalled();
     expect(recordInventoryMovementWithCtx).not.toHaveBeenCalled();
+  });
+
+  it("completes session checkout with active provisional import items without trusted stock mutation", async () => {
+    const runMutation = vi.fn().mockResolvedValue(undefined);
+    const provisionalImportSku = {
+      _id: "provisional-import-sku-1",
+      storeId: "store-1",
+      status: "active",
+      posExposureStatus: "available",
+      productId: "product-import-1",
+      productSkuId: "sku-import-1",
+      saleEvidence: {
+        saleCount: 1,
+        totalQuantitySold: 3,
+      },
+    };
+    const ctx = {
+      db: {
+        get: vi.fn(async (tableName: string, id: string) => {
+          if (
+            tableName === "inventoryImportProvisionalSku" &&
+            id === "provisional-import-sku-1"
+          ) {
+            return provisionalImportSku;
+          }
+
+          return null;
+        }),
+        patch: vi.fn(async (_tableName: string, _id: string, patch: object) => {
+          Object.assign(provisionalImportSku, patch);
+        }),
+      },
+      runMutation,
+    } as never;
+
+    vi.mocked(getStoreById).mockResolvedValue({
+      _id: "store-1",
+      organizationId: "org-1",
+    } as never);
+    vi.mocked(getPosSessionById).mockResolvedValue({
+      _id: "session-1",
+      storeId: "store-1",
+      customerProfileId: "profile-1",
+      staffProfileId: "staff-1",
+      registerNumber: "1",
+      registerSessionId: "register-1",
+      terminalId: "terminal-1",
+    } as never);
+    vi.mocked(getRegisterSessionById).mockResolvedValue({
+      _id: "register-1",
+      storeId: "store-1",
+      status: "open",
+      terminalId: "terminal-1",
+      registerNumber: "1",
+    } as never);
+    vi.mocked(listSessionItems).mockResolvedValue([
+      {
+        _id: "session-item-1",
+        sessionId: "session-1",
+        storeId: "store-1",
+        productId: "product-import-1",
+        productSkuId: "sku-import-1",
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        productSku: "LEGACY-1",
+        productName: "Imported bundle",
+        price: 15,
+        quantity: 2,
+      },
+    ] as never);
+    vi.mocked(getProductSkuById).mockResolvedValue({
+      _id: "sku-import-1",
+      images: [],
+      inventoryCount: 0,
+      productId: "product-import-1",
+      quantityAvailable: 0,
+      sku: "LEGACY-1",
+    } as never);
+    vi.mocked(createPosTransaction).mockResolvedValue("txn-1" as never);
+    vi.mocked(recordRetailSalePaymentAllocations).mockResolvedValue(true);
+    vi.mocked(createPosTransactionItem).mockResolvedValue(
+      "txn-item-1" as never,
+    );
+    vi.mocked(patchPosSession).mockResolvedValue(undefined as never);
+
+    await expect(
+      createTransactionFromSessionHandler(ctx, {
+        sessionId: "session-1" as Id<"posSession">,
+        staffProfileId: "staff-1" as Id<"staffProfile">,
+        payments: [{ method: "cash", amount: 30, timestamp: 1 }],
+      }),
+    ).resolves.toMatchObject({
+      kind: "ok",
+      data: {
+        transactionId: "txn-1",
+      },
+    });
+
+    expect(validateInventoryAvailability).not.toHaveBeenCalled();
+    expect(consumeInventoryHoldsForSession).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        sessionId: "session-1",
+        items: [],
+      }),
+    );
+    expect(createPosTransactionItem).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        productId: "product-import-1",
+        productSkuId: "sku-import-1",
+        quantity: 2,
+        totalPrice: 30,
+      }),
+    );
+    expect(
+      (ctx as unknown as { db: { patch: ReturnType<typeof vi.fn> } }).db.patch,
+    ).toHaveBeenCalledWith(
+      "inventoryImportProvisionalSku",
+      "provisional-import-sku-1",
+      expect.objectContaining({
+        saleEvidence: expect.objectContaining({
+          lastPosTransactionId: "txn-1",
+          lastRegisterSessionId: "register-1",
+          saleCount: 2,
+          totalQuantitySold: 5,
+        }),
+      }),
+    );
+    expect(patchProductSku).not.toHaveBeenCalled();
+    expect(recordInventoryMovementWithCtx).not.toHaveBeenCalled();
+  });
+
+  it("preserves distinct provisional import row evidence for session lines sharing a trusted SKU", async () => {
+    const runMutation = vi.fn().mockResolvedValue(undefined);
+    const provisionalImportSkus = new Map([
+      [
+        "provisional-import-sku-1",
+        {
+          _id: "provisional-import-sku-1",
+          storeId: "store-1",
+          status: "active",
+          posExposureStatus: "available",
+          productId: "product-import-1",
+          productSkuId: "sku-import-1",
+          saleEvidence: {
+            saleCount: 0,
+            totalQuantitySold: 0,
+          },
+        },
+      ],
+      [
+        "provisional-import-sku-2",
+        {
+          _id: "provisional-import-sku-2",
+          storeId: "store-1",
+          status: "active",
+          posExposureStatus: "available",
+          productId: "product-import-1",
+          productSkuId: "sku-import-1",
+          saleEvidence: {
+            saleCount: 1,
+            totalQuantitySold: 4,
+          },
+        },
+      ],
+    ]);
+    const ctx = {
+      db: {
+        get: vi.fn(async (tableName: string, id: string) => {
+          if (tableName === "inventoryImportProvisionalSku") {
+            return provisionalImportSkus.get(id) ?? null;
+          }
+
+          return null;
+        }),
+        patch: vi.fn(async (_tableName: string, id: string, patch: object) => {
+          Object.assign(provisionalImportSkus.get(id) ?? {}, patch);
+        }),
+      },
+      runMutation,
+    } as never;
+
+    vi.mocked(getStoreById).mockResolvedValue({
+      _id: "store-1",
+      organizationId: "org-1",
+    } as never);
+    vi.mocked(getPosSessionById).mockResolvedValue({
+      _id: "session-1",
+      storeId: "store-1",
+      customerProfileId: "profile-1",
+      staffProfileId: "staff-1",
+      registerNumber: "1",
+      registerSessionId: "register-1",
+      terminalId: "terminal-1",
+    } as never);
+    vi.mocked(getRegisterSessionById).mockResolvedValue({
+      _id: "register-1",
+      storeId: "store-1",
+      status: "open",
+      terminalId: "terminal-1",
+      registerNumber: "1",
+    } as never);
+    vi.mocked(listSessionItems).mockResolvedValue([
+      {
+        _id: "session-item-1",
+        sessionId: "session-1",
+        storeId: "store-1",
+        productId: "product-import-1",
+        productSkuId: "sku-import-1",
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        productSku: "LEGACY-1",
+        productName: "Imported bundle A",
+        price: 15,
+        quantity: 2,
+      },
+      {
+        _id: "session-item-2",
+        sessionId: "session-1",
+        storeId: "store-1",
+        productId: "product-import-1",
+        productSkuId: "sku-import-1",
+        inventoryImportProvisionalSkuId: "provisional-import-sku-2",
+        productSku: "LEGACY-1",
+        productName: "Imported bundle B",
+        price: 20,
+        quantity: 1,
+      },
+    ] as never);
+    vi.mocked(getProductSkuById).mockResolvedValue({
+      _id: "sku-import-1",
+      images: [],
+      inventoryCount: 0,
+      productId: "product-import-1",
+      quantityAvailable: 0,
+      sku: "LEGACY-1",
+    } as never);
+    vi.mocked(createPosTransaction).mockResolvedValue("txn-1" as never);
+    vi.mocked(recordRetailSalePaymentAllocations).mockResolvedValue(true);
+    vi.mocked(createPosTransactionItem)
+      .mockResolvedValueOnce("txn-item-1" as never)
+      .mockResolvedValueOnce("txn-item-2" as never);
+    vi.mocked(patchPosSession).mockResolvedValue(undefined as never);
+
+    await expect(
+      createTransactionFromSessionHandler(ctx, {
+        sessionId: "session-1" as Id<"posSession">,
+        staffProfileId: "staff-1" as Id<"staffProfile">,
+        payments: [{ method: "cash", amount: 50, timestamp: 1 }],
+      }),
+    ).resolves.toMatchObject({
+      kind: "ok",
+      data: {
+        transactionId: "txn-1",
+      },
+    });
+
+    expect(createPosTransactionItem).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      expect.objectContaining({
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        quantity: 2,
+      }),
+    );
+    expect(createPosTransactionItem).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      expect.objectContaining({
+        inventoryImportProvisionalSkuId: "provisional-import-sku-2",
+        quantity: 1,
+      }),
+    );
+    const db = (ctx as unknown as { db: { patch: ReturnType<typeof vi.fn> } })
+      .db;
+    expect(db.patch).toHaveBeenCalledWith(
+      "inventoryImportProvisionalSku",
+      "provisional-import-sku-1",
+      expect.objectContaining({
+        saleEvidence: expect.objectContaining({
+          saleCount: 1,
+          totalQuantitySold: 2,
+        }),
+      }),
+    );
+    expect(db.patch).toHaveBeenCalledWith(
+      "inventoryImportProvisionalSku",
+      "provisional-import-sku-2",
+      expect.objectContaining({
+        saleEvidence: expect.objectContaining({
+          saleCount: 2,
+          totalQuantitySold: 5,
+        }),
+      }),
+    );
+    expect(patchProductSku).not.toHaveBeenCalled();
+    expect(recordInventoryMovementWithCtx).not.toHaveBeenCalled();
+  });
+
+  it("rejects mixed trusted and provisional session sale lines for the same SKU before durable sale writes", async () => {
+    const ctx = {
+      db: {
+        get: vi.fn(async (tableName: string, id: string) => {
+          if (
+            tableName === "inventoryImportProvisionalSku" &&
+            id === "provisional-import-sku-1"
+          ) {
+            return {
+              _id: "provisional-import-sku-1",
+              storeId: "store-1",
+              status: "active",
+              posExposureStatus: "available",
+              productId: "product-import-1",
+              productSkuId: "sku-import-1",
+            };
+          }
+
+          return null;
+        }),
+        patch: vi.fn(),
+      },
+      runMutation: vi.fn(),
+    } as never;
+
+    vi.mocked(getPosSessionById).mockResolvedValue({
+      _id: "session-1",
+      storeId: "store-1",
+      staffProfileId: "staff-1",
+      registerNumber: "1",
+      registerSessionId: "register-1",
+      terminalId: "terminal-1",
+    } as never);
+    vi.mocked(getRegisterSessionById).mockResolvedValue({
+      _id: "register-1",
+      storeId: "store-1",
+      status: "open",
+      terminalId: "terminal-1",
+      registerNumber: "1",
+    } as never);
+    vi.mocked(listSessionItems).mockResolvedValue([
+      {
+        _id: "session-item-provisional",
+        sessionId: "session-1",
+        storeId: "store-1",
+        productId: "product-import-1",
+        productSkuId: "sku-import-1",
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        productSku: "LEGACY-1",
+        productName: "Imported bundle",
+        price: 15,
+        quantity: 1,
+      },
+      {
+        _id: "session-item-trusted",
+        sessionId: "session-1",
+        storeId: "store-1",
+        productId: "product-import-1",
+        productSkuId: "sku-import-1",
+        productSku: "LEGACY-1",
+        productName: "Imported bundle",
+        price: 15,
+        quantity: 1,
+      },
+    ] as never);
+
+    await expect(
+      createTransactionFromSessionHandler(ctx, {
+        sessionId: "session-1" as Id<"posSession">,
+        staffProfileId: "staff-1" as Id<"staffProfile">,
+        payments: [{ method: "cash", amount: 30, timestamp: 1 }],
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "validation_failed",
+      },
+    });
+
+    expect(validateInventoryAvailability).not.toHaveBeenCalled();
+    expect(consumeInventoryHoldsForSession).not.toHaveBeenCalled();
+    expectNoCompletionSideEffects();
+  });
+
+  it("rejects stale provisional import session sale lines before durable sale writes", async () => {
+    const ctx = {
+      db: {
+        get: vi.fn(async (tableName: string, id: string) => {
+          if (
+            tableName === "inventoryImportProvisionalSku" &&
+            id === "provisional-import-sku-1"
+          ) {
+            return {
+              _id: "provisional-import-sku-1",
+              storeId: "store-1",
+              status: "active",
+              productId: "product-import-1",
+              productSkuId: "sku-other",
+            };
+          }
+
+          return null;
+        }),
+        patch: vi.fn(),
+      },
+      runMutation: vi.fn(),
+    } as never;
+
+    vi.mocked(getPosSessionById).mockResolvedValue({
+      _id: "session-1",
+      storeId: "store-1",
+      staffProfileId: "staff-1",
+      registerNumber: "1",
+      registerSessionId: "register-1",
+      terminalId: "terminal-1",
+    } as never);
+    vi.mocked(getRegisterSessionById).mockResolvedValue({
+      _id: "register-1",
+      storeId: "store-1",
+      status: "open",
+      terminalId: "terminal-1",
+      registerNumber: "1",
+    } as never);
+    vi.mocked(listSessionItems).mockResolvedValue([
+      {
+        _id: "session-item-1",
+        sessionId: "session-1",
+        storeId: "store-1",
+        productId: "product-import-1",
+        productSkuId: "sku-import-1",
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        productSku: "LEGACY-1",
+        productName: "Imported bundle",
+        price: 15,
+        quantity: 2,
+      },
+    ] as never);
+
+    await expect(
+      createTransactionFromSessionHandler(ctx, {
+        sessionId: "session-1" as Id<"posSession">,
+        staffProfileId: "staff-1" as Id<"staffProfile">,
+        payments: [{ method: "cash", amount: 30, timestamp: 1 }],
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "conflict",
+      },
+    });
+
+    expect(validateInventoryAvailability).not.toHaveBeenCalled();
+    expect(consumeInventoryHoldsForSession).not.toHaveBeenCalled();
+    expectNoCompletionSideEffects();
+  });
+
+  it("rejects hidden provisional import session sale lines before durable sale writes", async () => {
+    const ctx = {
+      db: {
+        get: vi.fn(async (tableName: string, id: string) => {
+          if (
+            tableName === "inventoryImportProvisionalSku" &&
+            id === "provisional-import-sku-1"
+          ) {
+            return {
+              _id: "provisional-import-sku-1",
+              storeId: "store-1",
+              status: "active",
+              posExposureStatus: "hidden",
+              productId: "product-import-1",
+              productSkuId: "sku-import-1",
+            };
+          }
+
+          return null;
+        }),
+        patch: vi.fn(),
+      },
+      runMutation: vi.fn(),
+    } as never;
+
+    vi.mocked(getPosSessionById).mockResolvedValue({
+      _id: "session-1",
+      storeId: "store-1",
+      staffProfileId: "staff-1",
+      registerNumber: "1",
+      registerSessionId: "register-1",
+      terminalId: "terminal-1",
+    } as never);
+    vi.mocked(getRegisterSessionById).mockResolvedValue({
+      _id: "register-1",
+      storeId: "store-1",
+      status: "open",
+      terminalId: "terminal-1",
+      registerNumber: "1",
+    } as never);
+    vi.mocked(listSessionItems).mockResolvedValue([
+      {
+        _id: "session-item-1",
+        sessionId: "session-1",
+        storeId: "store-1",
+        productId: "product-import-1",
+        productSkuId: "sku-import-1",
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        productSku: "LEGACY-1",
+        productName: "Imported bundle",
+        price: 15,
+        quantity: 2,
+      },
+    ] as never);
+
+    await expect(
+      createTransactionFromSessionHandler(ctx, {
+        sessionId: "session-1" as Id<"posSession">,
+        staffProfileId: "staff-1" as Id<"staffProfile">,
+        payments: [{ method: "cash", amount: 30, timestamp: 1 }],
+      }),
+    ).resolves.toMatchObject({
+      kind: "user_error",
+      error: {
+        code: "conflict",
+      },
+    });
+
+    expect(validateInventoryAvailability).not.toHaveBeenCalled();
+    expect(consumeInventoryHoldsForSession).not.toHaveBeenCalled();
+    expectNoCompletionSideEffects();
   });
 
   it.each([

--- a/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts
@@ -12,6 +12,7 @@ type TableName =
   | "category"
   | "color"
   | "inventoryHold"
+  | "inventoryImportProvisionalSku"
   | "product"
   | "productSku";
 type Row = Record<string, unknown> & { _id: string };
@@ -28,6 +29,7 @@ function createRegisterCatalogCtx(
     category: new Map(),
     color: new Map(),
     inventoryHold: new Map(),
+    inventoryImportProvisionalSku: new Map(),
     product: new Map(),
     productSku: new Map(),
   };
@@ -35,7 +37,14 @@ function createRegisterCatalogCtx(
   for (const [table, rows] of Object.entries(seed) as Array<
     [TableName, Row[]]
   >) {
-    rows.forEach((row) => tables[table].set(row._id, row));
+    rows.forEach((row) =>
+      tables[table].set(row._id, {
+        ...(table === "inventoryImportProvisionalSku"
+          ? { posExposureStatus: "available" }
+          : {}),
+        ...row,
+      }),
+    );
   }
 
   function createIndexedQuery(
@@ -338,6 +347,7 @@ describe("listRegisterCatalog", () => {
         length: 18,
         color: "Natural black",
         areProcessingFeesAbsorbed: true,
+        availabilityPolicy: "trusted_inventory",
       },
       {
         id: "sku-out",
@@ -355,11 +365,246 @@ describe("listRegisterCatalog", () => {
         length: null,
         color: "",
         areProcessingFeesAbsorbed: false,
+        availabilityPolicy: "trusted_inventory",
       },
     ]);
 
     expect(rows[0]).not.toHaveProperty("inStock");
     expect(rows[0]).not.toHaveProperty("quantityAvailable");
+  });
+
+  it("surfaces active provisional import SKUs as sellable without trusted quantity", async () => {
+    const { ctx } = createRegisterCatalogCtx({
+      category: [
+        {
+          _id: "category-store-a",
+          storeId: "store-a",
+          name: "Imports",
+        },
+      ],
+      inventoryImportProvisionalSku: [
+        {
+          _id: "provisional-matched",
+          storeId: "store-a",
+          status: "active",
+          posExposureStatus: "available",
+          productId: "product-trusted",
+          productSkuId: "sku-trusted",
+          importedProductName: "Matched Imported Closure",
+          importedSku: "LEGACY-CLOSURE",
+          importedBarcode: "123PROV",
+          importedPrice: 83000,
+          importedQuantity: 8,
+          provisionalQuantitySold: 0,
+          provisionalTransactionCount: 0,
+        },
+        {
+          _id: "provisional-sku-1",
+          storeId: "store-a",
+          status: "active",
+          productId: "product-provisional",
+          productSkuId: "sku-provisional",
+          importedProductName: "Imported Closure",
+          importedSku: "LEGACY-CLOSURE",
+          importedBarcode: "123PROV",
+          importedPrice: 85000,
+          importedQuantity: 12,
+          provisionalQuantitySold: 0,
+          provisionalTransactionCount: 0,
+        },
+        {
+          _id: "provisional-finalized",
+          storeId: "store-a",
+          status: "finalized",
+          productId: "product-finalized",
+          productSkuId: "sku-finalized",
+          importedProductName: "Finalized Closure",
+          importedPrice: 85000,
+          importedQuantity: 12,
+        },
+        {
+          _id: "provisional-hidden",
+          storeId: "store-a",
+          status: "active",
+          posExposureStatus: "hidden",
+          productId: "product-hidden",
+          productSkuId: "sku-hidden",
+          importedProductName: "Hidden Closure",
+          importedPrice: 85000,
+          importedQuantity: 12,
+        },
+      ],
+      product: [
+        {
+          _id: "product-trusted",
+          storeId: "store-a",
+          categoryId: "category-store-a",
+          description: "Trusted catalog row",
+          name: "Imported Closure",
+          availability: "active",
+          isVisible: true,
+        },
+        {
+          _id: "product-provisional",
+          storeId: "store-a",
+          categoryId: "category-store-a",
+          description: "Review anchor",
+          name: "Hidden Review Anchor",
+          availability: "draft",
+          isVisible: false,
+        },
+        {
+          _id: "product-finalized",
+          storeId: "store-a",
+          categoryId: "category-store-a",
+          description: "Closed anchor",
+          name: "Closed Anchor",
+          availability: "draft",
+          isVisible: false,
+        },
+        {
+          _id: "product-hidden",
+          storeId: "store-a",
+          categoryId: "category-store-a",
+          description: "Hidden anchor",
+          name: "Hidden Anchor",
+          availability: "draft",
+          isVisible: false,
+        },
+      ],
+      productSku: [
+        {
+          _id: "sku-trusted",
+          storeId: "store-a",
+          productId: "product-trusted",
+          sku: "LEGACY-CLOSURE",
+          barcode: "123PROV",
+          images: [],
+          isVisible: true,
+          price: 85000,
+          quantityAvailable: 0,
+        },
+        {
+          _id: "sku-provisional",
+          storeId: "store-a",
+          productId: "product-provisional",
+          sku: "ANCHOR-CLOSURE",
+          barcode: "",
+          images: [],
+          isVisible: false,
+          price: 0,
+          quantityAvailable: 0,
+        },
+        {
+          _id: "sku-finalized",
+          storeId: "store-a",
+          productId: "product-finalized",
+          sku: "ANCHOR-FINALIZED",
+          barcode: "",
+          images: [],
+          isVisible: false,
+          price: 0,
+          quantityAvailable: 0,
+        },
+        {
+          _id: "sku-hidden",
+          storeId: "store-a",
+          productId: "product-hidden",
+          sku: "ANCHOR-HIDDEN",
+          barcode: "",
+          images: [],
+          isVisible: false,
+          price: 0,
+          quantityAvailable: 0,
+        },
+      ],
+    });
+
+    await expect(
+      listRegisterCatalog(ctx, {
+        storeId: "store-a" as Id<"store">,
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        productSkuId: "sku-trusted",
+        name: "Imported Closure",
+        sku: "LEGACY-CLOSURE",
+        barcode: "123PROV",
+        price: 85000,
+        availabilityPolicy: "trusted_inventory",
+      }),
+      expect.objectContaining({
+        id: "provisional-matched",
+        productSkuId: "sku-trusted",
+        inventoryImportProvisionalSkuId: "provisional-matched",
+        name: "Matched Imported Closure",
+        sku: "LEGACY-CLOSURE",
+        barcode: "123PROV",
+        price: 83000,
+        availabilityPolicy: "active_provisional_import",
+      }),
+      expect.objectContaining({
+        productSkuId: "sku-provisional",
+        inventoryImportProvisionalSkuId: "provisional-sku-1",
+        name: "Imported Closure",
+        sku: "LEGACY-CLOSURE",
+        barcode: "123PROV",
+        price: 85000,
+        availabilityPolicy: "active_provisional_import",
+      }),
+    ]);
+
+    await expect(
+      listRegisterCatalogAvailability(ctx, {
+        storeId: "store-a" as Id<"store">,
+        productSkuIds: ["sku-trusted", "sku-provisional"] as Array<
+          Id<"productSku">
+        >,
+      }),
+    ).resolves.toEqual([
+      {
+        productSkuId: "sku-trusted",
+        skuId: "sku-trusted",
+        inventoryImportProvisionalSkuId: "provisional-matched",
+        inStock: true,
+        quantityAvailable: 0,
+        availabilityPolicy: "active_provisional_import",
+      },
+      {
+        productSkuId: "sku-provisional",
+        skuId: "sku-provisional",
+        inventoryImportProvisionalSkuId: "provisional-sku-1",
+        inStock: true,
+        quantityAvailable: 0,
+        availabilityPolicy: "active_provisional_import",
+      },
+    ]);
+
+    await expect(
+      listRegisterCatalogAvailabilitySnapshot(ctx, {
+        storeId: "store-a" as Id<"store">,
+      }),
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          productSkuId: "sku-trusted",
+          availabilityPolicy: "trusted_inventory",
+          inStock: false,
+        }),
+        expect.objectContaining({
+          productSkuId: "sku-trusted",
+          inventoryImportProvisionalSkuId: "provisional-matched",
+          availabilityPolicy: "active_provisional_import",
+          inStock: true,
+        }),
+        expect.objectContaining({
+          productSkuId: "sku-provisional",
+          inventoryImportProvisionalSkuId: "provisional-sku-1",
+          availabilityPolicy: "active_provisional_import",
+          inStock: true,
+        }),
+      ]),
+    );
   });
 
   it("does not rely on pagination for large register catalog snapshots", async () => {
@@ -425,6 +670,18 @@ describe("listRegisterCatalog", () => {
           updatedAt: 1,
         },
       ],
+      inventoryImportProvisionalSku: [
+        {
+          _id: "provisional-sku-out",
+          storeId: "store-a",
+          status: "active",
+          productId: "product-out",
+          productSkuId: "sku-out",
+          importedProductName: "Out Wig",
+          importedPrice: 100,
+          importedQuantity: 10,
+        },
+      ],
       productSku: [
         {
           _id: "sku-live",
@@ -467,12 +724,15 @@ describe("listRegisterCatalog", () => {
         skuId: "sku-live",
         inStock: true,
         quantityAvailable: 1,
+        availabilityPolicy: "trusted_inventory",
       },
       {
         productSkuId: "sku-out",
         skuId: "sku-out",
-        inStock: false,
+        inventoryImportProvisionalSkuId: "provisional-sku-out",
+        inStock: true,
         quantityAvailable: 0,
+        availabilityPolicy: "active_provisional_import",
       },
     ]);
   });
@@ -500,6 +760,7 @@ describe("listRegisterCatalog", () => {
     expect(rows.at(-1)).toMatchObject({
       productSkuId: "sku-49",
       quantityAvailable: 1,
+      availabilityPolicy: "trusted_inventory",
     });
   });
 
@@ -536,6 +797,18 @@ describe("listRegisterCatalog", () => {
           expiresAt: Date.now() - 60_000,
           createdAt: 1,
           updatedAt: 1,
+        },
+      ],
+      inventoryImportProvisionalSku: [
+        {
+          _id: "provisional-sku-out",
+          storeId: "store-a",
+          status: "active",
+          productId: "product-out",
+          productSkuId: "sku-out",
+          importedProductName: "Out Wig",
+          importedPrice: 100,
+          importedQuantity: 10,
         },
       ],
       product: [
@@ -625,12 +898,22 @@ describe("listRegisterCatalog", () => {
         skuId: "sku-live",
         inStock: true,
         quantityAvailable: 2,
+        availabilityPolicy: "trusted_inventory",
       },
       {
         productSkuId: "sku-out",
         skuId: "sku-out",
         inStock: false,
         quantityAvailable: 0,
+        availabilityPolicy: "trusted_inventory",
+      },
+      {
+        productSkuId: "sku-out",
+        skuId: "sku-out",
+        inventoryImportProvisionalSkuId: "provisional-sku-out",
+        inStock: true,
+        quantityAvailable: 0,
+        availabilityPolicy: "active_provisional_import",
       },
     ]);
   });

--- a/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts
@@ -5,11 +5,14 @@ import {
   validateInventoryAvailability,
 } from "../../../inventory/helpers/inventoryHolds";
 
+type InventoryImportProvisionalSkuId = Id<"inventoryImportProvisionalSku">;
+
 type RegisterCatalogRow = {
-  id: Id<"productSku">;
+  id: Id<"productSku"> | InventoryImportProvisionalSkuId;
   productSkuId: Id<"productSku">;
   skuId: Id<"productSku">;
   productId: Id<"product">;
+  inventoryImportProvisionalSkuId?: InventoryImportProvisionalSkuId;
   name: string;
   sku: string;
   barcode: string;
@@ -21,16 +24,40 @@ type RegisterCatalogRow = {
   length: number | null;
   color: string;
   areProcessingFeesAbsorbed: boolean;
+  availabilityPolicy: RegisterCatalogAvailabilityPolicy;
 };
+
+type RegisterCatalogAvailabilityPolicy =
+  | "trusted_inventory"
+  | "active_provisional_import";
 
 type RegisterCatalogAvailabilityRow = {
   productSkuId: Id<"productSku">;
   skuId: Id<"productSku">;
+  inventoryImportProvisionalSkuId?: InventoryImportProvisionalSkuId;
   inStock: boolean;
   quantityAvailable: number;
+  availabilityPolicy: RegisterCatalogAvailabilityPolicy;
+};
+
+type InventoryImportProvisionalSku = {
+  _id: InventoryImportProvisionalSkuId;
+  storeId: Id<"store">;
+  status: "active" | "finalized" | "rejected" | "closed";
+  posExposureStatus: "available" | "hidden";
+  productId: Id<"product">;
+  productSkuId: Id<"productSku">;
+  importedProductName: string;
+  importedSku?: string;
+  importedBarcode?: string;
+  importedPrice: number;
+  importedQuantity: number;
+  provisionalQuantitySold?: number;
+  provisionalTransactionCount?: number;
 };
 
 export const REGISTER_CATALOG_AVAILABILITY_LIMIT = 50;
+const REGISTER_CATALOG_PROVISIONAL_IMPORT_LIMIT = 5_000;
 
 async function readCategoryName(
   ctx: QueryCtx,
@@ -75,16 +102,20 @@ function mapSkuToRegisterCatalogRow(args: {
   sku: Doc<"productSku">;
   category: string;
   color: string;
+  provisionalSku?: InventoryImportProvisionalSku;
 }): RegisterCatalogRow {
   return {
-    id: args.sku._id,
+    id: args.provisionalSku?._id ?? args.sku._id,
     productSkuId: args.sku._id,
     skuId: args.sku._id,
     productId: args.product._id,
-    name: args.product.name,
-    sku: args.sku.sku ?? "",
-    barcode: args.sku.barcode ?? "",
-    price: getRegisterCatalogPrice(args.sku),
+    ...(args.provisionalSku
+      ? { inventoryImportProvisionalSkuId: args.provisionalSku._id }
+      : {}),
+    name: args.provisionalSku?.importedProductName ?? args.product.name,
+    sku: args.provisionalSku?.importedSku ?? args.sku.sku ?? "",
+    barcode: args.provisionalSku?.importedBarcode ?? args.sku.barcode ?? "",
+    price: args.provisionalSku?.importedPrice ?? getRegisterCatalogPrice(args.sku),
     category: args.category,
     description: args.product.description ?? "",
     image: args.sku.images[0] ?? null,
@@ -92,6 +123,9 @@ function mapSkuToRegisterCatalogRow(args: {
     length: args.sku.length ?? null,
     color: args.color,
     areProcessingFeesAbsorbed: args.product.areProcessingFeesAbsorbed ?? false,
+    availabilityPolicy: args.provisionalSku
+      ? "active_provisional_import"
+      : "trusted_inventory",
   };
 }
 
@@ -152,6 +186,103 @@ async function listScopedRegisterCatalogSkus(
   return rows;
 }
 
+function isActiveProvisionalImportSkuForStore(
+  row: InventoryImportProvisionalSku | null,
+  args: {
+    storeId: Id<"store">;
+    productId?: Id<"product">;
+    productSkuId?: Id<"productSku">;
+  },
+) {
+  return (
+    row?.storeId === args.storeId &&
+    row.status === "active" &&
+    row.posExposureStatus === "available" &&
+    (!args.productId || row.productId === args.productId) &&
+    (!args.productSkuId || row.productSkuId === args.productSkuId)
+  );
+}
+
+async function queryActiveProvisionalImportSkusForStore(
+  ctx: QueryCtx,
+  args: {
+    storeId: Id<"store">;
+  },
+): Promise<InventoryImportProvisionalSku[]> {
+  const db = ctx.db as unknown as {
+    query(table: "inventoryImportProvisionalSku"): {
+      withIndex(
+        index: "by_storeId_status",
+        apply: (q: ProvisionalIndexBuilder<"storeId" | "status">) => unknown,
+      ): {
+        take(limit: number): Promise<InventoryImportProvisionalSku[]>;
+      };
+    };
+  };
+
+  const rows = await db
+    .query("inventoryImportProvisionalSku")
+    .withIndex("by_storeId_status", (q) =>
+      q.eq("storeId", args.storeId).eq("status", "active"),
+    )
+    .take(REGISTER_CATALOG_PROVISIONAL_IMPORT_LIMIT);
+
+  return rows.filter((row) =>
+    isActiveProvisionalImportSkuForStore(row, { storeId: args.storeId }),
+  );
+}
+
+export async function readActiveProvisionalImportSkuForStoreSku(
+  ctx: Pick<QueryCtx, "db">,
+  args: {
+    storeId: Id<"store">;
+    productId?: Id<"product">;
+    productSkuId: Id<"productSku">;
+    provisionalSkuId?: InventoryImportProvisionalSkuId;
+  },
+): Promise<InventoryImportProvisionalSku | null> {
+  const db = ctx.db as unknown as {
+    get(
+      table: "inventoryImportProvisionalSku",
+      id: InventoryImportProvisionalSkuId,
+    ): Promise<InventoryImportProvisionalSku | null>;
+    query(table: "inventoryImportProvisionalSku"): {
+      withIndex(
+        index: "by_storeId_productSkuId_status",
+        apply: (
+          q: ProvisionalIndexBuilder<"storeId" | "productSkuId" | "status">,
+        ) => unknown,
+      ): {
+        first(): Promise<InventoryImportProvisionalSku | null>;
+      };
+    };
+  };
+
+  if (args.provisionalSkuId) {
+    const row = await db.get(
+      "inventoryImportProvisionalSku",
+      args.provisionalSkuId,
+    );
+    return isActiveProvisionalImportSkuForStore(row, args) ? row : null;
+  }
+
+  const row = await db
+    .query("inventoryImportProvisionalSku")
+    .withIndex("by_storeId_productSkuId_status", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("productSkuId", args.productSkuId)
+        .eq("status", "active"),
+    )
+    .first();
+
+  return isActiveProvisionalImportSkuForStore(row, args) ? row : null;
+}
+
+type ProvisionalIndexBuilder<TField extends string> = {
+  eq(field: TField, value: unknown): ProvisionalIndexBuilder<TField>;
+};
+
 export async function listRegisterCatalog(
   ctx: QueryCtx,
   args: {
@@ -161,17 +292,50 @@ export async function listRegisterCatalog(
   const rows: RegisterCatalogRow[] = [];
   const categoryCache = new Map<Id<"category">, string>();
   const colorCache = new Map<Id<"color">, string>();
+  const trustedSkuIds = new Set<Id<"productSku">>();
 
   for (const { product, sku } of await listScopedRegisterCatalogSkus(
     ctx,
     args,
   )) {
+    trustedSkuIds.add(sku._id);
     rows.push(
       mapSkuToRegisterCatalogRow({
         product,
         sku,
         category: await readCategoryName(ctx, categoryCache, product.categoryId),
         color: await readColorName(ctx, colorCache, sku.color),
+      }),
+    );
+  }
+
+  for (const provisionalSku of await queryActiveProvisionalImportSkusForStore(
+    ctx,
+    args,
+  )) {
+    const [product, sku] = await Promise.all([
+      ctx.db.get("product", provisionalSku.productId),
+      ctx.db.get("productSku", provisionalSku.productSkuId),
+    ]);
+
+    if (
+      !product ||
+      !sku ||
+      product.storeId !== args.storeId ||
+      sku.storeId !== args.storeId ||
+      sku.productId !== product._id ||
+      provisionalSku.importedPrice <= 0
+    ) {
+      continue;
+    }
+
+    rows.push(
+      mapSkuToRegisterCatalogRow({
+        product,
+        sku,
+        category: await readCategoryName(ctx, categoryCache, product.categoryId),
+        color: await readColorName(ctx, colorCache, sku.color),
+        provisionalSku,
       }),
     );
   }
@@ -199,6 +363,23 @@ export async function listRegisterCatalogAvailability(
       continue;
     }
 
+    const provisionalSku = await readActiveProvisionalImportSkuForStoreSku(ctx, {
+      storeId: args.storeId,
+      productId: sku.productId,
+      productSkuId: sku._id,
+    });
+    if (provisionalSku) {
+      rows.push({
+        productSkuId: sku._id,
+        skuId: sku._id,
+        inventoryImportProvisionalSkuId: provisionalSku._id,
+        inStock: true,
+        quantityAvailable: 0,
+        availabilityPolicy: "active_provisional_import",
+      });
+      continue;
+    }
+
     const availability = await validateInventoryAvailability(ctx.db, sku._id, 1, {
       storeId: args.storeId,
     });
@@ -209,6 +390,7 @@ export async function listRegisterCatalogAvailability(
       skuId: sku._id,
       inStock: quantityAvailable > 0,
       quantityAvailable,
+      availabilityPolicy: "trusted_inventory",
     });
   }
 
@@ -226,8 +408,12 @@ export async function listRegisterCatalogAvailabilitySnapshot(
     storeId: args.storeId,
     skuIds: catalogSkus.map(({ sku }) => sku._id),
   });
+  const activeProvisionalSkus = await queryActiveProvisionalImportSkusForStore(
+    ctx,
+    args,
+  );
 
-  return catalogSkus.map(({ sku }): RegisterCatalogAvailabilityRow => {
+  const trustedRows = catalogSkus.map(({ sku }): RegisterCatalogAvailabilityRow => {
     const quantityAvailable = Math.max(
       0,
       sku.quantityAvailable - (heldQuantities.get(sku._id) ?? 0),
@@ -238,6 +424,25 @@ export async function listRegisterCatalogAvailabilitySnapshot(
       skuId: sku._id,
       inStock: quantityAvailable > 0,
       quantityAvailable,
+      availabilityPolicy: "trusted_inventory",
     };
   });
+
+  const provisionalRows: RegisterCatalogAvailabilityRow[] = [];
+  for (const provisionalSku of activeProvisionalSkus) {
+    const sku = await ctx.db.get("productSku", provisionalSku.productSkuId);
+    if (!sku || sku.storeId !== args.storeId) {
+      continue;
+    }
+    provisionalRows.push({
+      productSkuId: sku._id,
+      skuId: sku._id,
+      inventoryImportProvisionalSkuId: provisionalSku._id,
+      inStock: true,
+      quantityAvailable: 0,
+      availabilityPolicy: "active_provisional_import",
+    });
+  }
+
+  return trustedRows.concat(provisionalRows);
 }

--- a/packages/athena-webapp/convex/pos/application/sessionCommands.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sessionCommands.test.ts
@@ -33,6 +33,7 @@ type SessionItemRecord = {
   productId: string;
   productSkuId: string;
   pendingCheckoutItemId?: string;
+  inventoryImportProvisionalSkuId?: string;
   productSku: string;
   productName: string;
   price: number;
@@ -47,6 +48,15 @@ type PendingCheckoutItemRecord = {
   status: "pending_review" | "approved" | "rejected" | "flagged";
   provisionalProductId: string;
   provisionalProductSkuId: string;
+};
+
+type ProvisionalImportSkuRecord = {
+  _id: string;
+  storeId: string;
+  status: "active" | "finalized" | "rejected" | "closed";
+  posExposureStatus?: "available" | "hidden";
+  productId: string;
+  productSkuId: string;
 };
 
 type InventoryCall =
@@ -1297,6 +1307,537 @@ describe("createPosSessionCommandService", () => {
     expect(repository.items).toEqual([]);
   });
 
+  it("rejects cart lines with both pending checkout and provisional import sources", async () => {
+    const commandService = await loadCommandService();
+    const repository = createFakeRepository({
+      sessions: [
+        buildSession({
+          _id: "session-5",
+          sessionNumber: "SES-005",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          staffProfileId: "cashier-1",
+          status: "active",
+          registerNumber: "1",
+          registerSessionId: "drawer-1",
+          expiresAt: 8_000,
+          updatedAt: 500,
+        }),
+      ],
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-1",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+    });
+    const inventoryCalls: InventoryCall[] = [];
+
+    const result = await commandService(
+      createDependencies({
+        repository,
+        inventoryCalls,
+        now: 1_000,
+        nextExpiration: 61_000,
+      }),
+    ).upsertSessionItem({
+      sessionId: "session-5",
+      staffProfileId: "cashier-1",
+      productId: "product-1",
+      productSkuId: "sku-1",
+      pendingCheckoutItemId: "pending-item-1",
+      inventoryImportProvisionalSkuId: "provisional-sku-1",
+      productSku: "SKU-1",
+      productName: "Conflicting bundle",
+      price: 15,
+      quantity: 2,
+    });
+
+    expect(result).toEqual({
+      status: "validationFailed",
+      message:
+        "This cart line has conflicting inventory sources. Remove the item and add it again before continuing.",
+    });
+    expect(inventoryCalls).toEqual([]);
+    expect(repository.items).toEqual([]);
+  });
+
+  it("adds an active provisional import cart line without acquiring trusted inventory holds", async () => {
+    const commandService = await loadCommandService();
+    const repository = createFakeRepository({
+      sessions: [
+        buildSession({
+          _id: "session-5",
+          sessionNumber: "SES-005",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          staffProfileId: "cashier-1",
+          status: "active",
+          registerNumber: "1",
+          registerSessionId: "drawer-1",
+          expiresAt: 8_000,
+          updatedAt: 500,
+        }),
+      ],
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-1",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+      provisionalImportSkus: [
+        {
+          _id: "provisional-sku-1",
+          storeId: "store-1",
+          status: "active",
+          productId: "product-import-1",
+          productSkuId: "sku-import-1",
+        },
+      ],
+    });
+    const inventoryCalls: InventoryCall[] = [];
+
+    const result = await commandService(
+      createDependencies({
+        repository,
+        inventoryCalls,
+        now: 1_000,
+        nextExpiration: 61_000,
+      }),
+    ).upsertSessionItem({
+      sessionId: "session-5",
+      staffProfileId: "cashier-1",
+      productId: "product-import-1",
+      productSkuId: "sku-import-1",
+      inventoryImportProvisionalSkuId: "provisional-sku-1",
+      productSku: "LEGACY-1",
+      productName: "Imported bundle",
+      price: 15,
+      quantity: 2,
+    });
+
+    expect(result).toEqual({
+      status: "ok",
+      data: {
+        itemId: "item-1",
+        expiresAt: 61_000,
+      },
+    });
+    expect(inventoryCalls).toEqual([]);
+    expect(repository.items).toContainEqual(
+      expect.objectContaining({
+        _id: "item-1",
+        inventoryImportProvisionalSkuId: "provisional-sku-1",
+        productSkuId: "sku-import-1",
+        quantity: 2,
+      }),
+    );
+  });
+
+  it("rejects changing an existing trusted cart line into a provisional import line", async () => {
+    const commandService = await loadCommandService();
+    const repository = createFakeRepository({
+      sessions: [
+        buildSession({
+          _id: "session-5",
+          sessionNumber: "SES-005",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          staffProfileId: "cashier-1",
+          status: "active",
+          registerNumber: "1",
+          registerSessionId: "drawer-1",
+          expiresAt: 8_000,
+          updatedAt: 500,
+        }),
+      ],
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-1",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+      items: [
+        buildItem({
+          _id: "item-1",
+          sessionId: "session-5",
+          storeId: "store-1",
+          productId: "product-import-1",
+          productSkuId: "sku-import-1",
+          productSku: "LEGACY-1",
+          productName: "Imported bundle",
+          price: 15,
+          quantity: 2,
+        }),
+      ],
+      provisionalImportSkus: [
+        {
+          _id: "provisional-sku-1",
+          storeId: "store-1",
+          status: "active",
+          productId: "product-import-1",
+          productSkuId: "sku-import-1",
+        },
+      ],
+    });
+    const inventoryCalls: InventoryCall[] = [];
+
+    const result = await commandService(
+      createDependencies({
+        repository,
+        inventoryCalls,
+        now: 1_000,
+        nextExpiration: 61_000,
+      }),
+    ).upsertSessionItem({
+      sessionId: "session-5",
+      staffProfileId: "cashier-1",
+      productId: "product-import-1",
+      productSkuId: "sku-import-1",
+      inventoryImportProvisionalSkuId: "provisional-sku-1",
+      productSku: "LEGACY-1",
+      productName: "Imported bundle",
+      price: 15,
+      quantity: 3,
+    });
+
+    expect(result).toEqual({
+      status: "validationFailed",
+      message:
+        "This cart line already uses a different inventory source. Remove the item and add it again before continuing.",
+    });
+    expect(inventoryCalls).toEqual([]);
+    expect(repository.items[0]).toEqual(
+      expect.objectContaining({
+        _id: "item-1",
+        quantity: 2,
+      }),
+    );
+    expect(repository.items[0]).not.toHaveProperty(
+      "inventoryImportProvisionalSkuId",
+    );
+  });
+
+  it("keeps trusted cart adds trusted when a provisional import row exists for the same SKU", async () => {
+    const commandService = await loadCommandService();
+    const repository = createFakeRepository({
+      sessions: [
+        buildSession({
+          _id: "session-5",
+          sessionNumber: "SES-005",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          staffProfileId: "cashier-1",
+          status: "active",
+          registerNumber: "1",
+          registerSessionId: "drawer-1",
+          expiresAt: 8_000,
+          updatedAt: 500,
+        }),
+      ],
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-1",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+      provisionalImportSkus: [
+        {
+          _id: "provisional-sku-1",
+          storeId: "store-1",
+          status: "active",
+          productId: "product-import-1",
+          productSkuId: "sku-import-1",
+        },
+      ],
+    });
+    const inventoryCalls: InventoryCall[] = [];
+
+    const result = await commandService(
+      createDependencies({
+        repository,
+        inventoryCalls,
+        now: 1_000,
+        nextExpiration: 61_000,
+      }),
+    ).upsertSessionItem({
+      sessionId: "session-5",
+      staffProfileId: "cashier-1",
+      productId: "product-import-1",
+      productSkuId: "sku-import-1",
+      productSku: "LEGACY-1",
+      productName: "Imported bundle",
+      price: 15,
+      quantity: 3,
+    });
+
+    expect(result).toEqual({
+      status: "ok",
+      data: {
+        itemId: "item-1",
+        expiresAt: 61_000,
+      },
+    });
+    expect(inventoryCalls).toEqual([
+      { kind: "acquire", skuId: "sku-import-1", quantity: 3 },
+    ]);
+    expect(repository.items[0]).toEqual(
+      expect.objectContaining({
+        _id: "item-1",
+        inventoryImportProvisionalSkuId: undefined,
+        quantity: 3,
+      }),
+    );
+  });
+
+  it("adds a distinct provisional import cart line when another row reuses the same trusted SKU", async () => {
+    const commandService = await loadCommandService();
+    const repository = createFakeRepository({
+      sessions: [
+        buildSession({
+          _id: "session-5",
+          sessionNumber: "SES-005",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          staffProfileId: "cashier-1",
+          status: "active",
+          registerNumber: "1",
+          registerSessionId: "drawer-1",
+          expiresAt: 8_000,
+          updatedAt: 500,
+        }),
+      ],
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-1",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+      items: [
+        buildItem({
+          _id: "item-1",
+          sessionId: "session-5",
+          storeId: "store-1",
+          productId: "product-import-1",
+          productSkuId: "sku-import-1",
+          inventoryImportProvisionalSkuId: "provisional-sku-1",
+          productSku: "LEGACY-1",
+          productName: "Imported bundle",
+          price: 15,
+          quantity: 2,
+        }),
+      ],
+      provisionalImportSkus: [
+        {
+          _id: "provisional-sku-1",
+          storeId: "store-1",
+          status: "active",
+          productId: "product-import-1",
+          productSkuId: "sku-import-1",
+        },
+        {
+          _id: "provisional-sku-2",
+          storeId: "store-1",
+          status: "active",
+          productId: "product-import-1",
+          productSkuId: "sku-import-1",
+        },
+      ],
+    });
+    const inventoryCalls: InventoryCall[] = [];
+
+    const result = await commandService(
+      createDependencies({
+        repository,
+        inventoryCalls,
+        now: 1_000,
+        nextExpiration: 61_000,
+      }),
+    ).upsertSessionItem({
+      sessionId: "session-5",
+      staffProfileId: "cashier-1",
+      productId: "product-import-1",
+      productSkuId: "sku-import-1",
+      inventoryImportProvisionalSkuId: "provisional-sku-2",
+      productSku: "LEGACY-1",
+      productName: "Imported bundle",
+      price: 15,
+      quantity: 3,
+    });
+
+    expect(result).toEqual({
+      status: "ok",
+      data: {
+        itemId: "item-2",
+        expiresAt: 61_000,
+      },
+    });
+    expect(inventoryCalls).toEqual([]);
+    expect(repository.items[0]).toEqual(
+      expect.objectContaining({
+        _id: "item-1",
+        inventoryImportProvisionalSkuId: "provisional-sku-1",
+        quantity: 2,
+      }),
+    );
+    expect(repository.items[1]).toEqual(
+      expect.objectContaining({
+        _id: "item-2",
+        inventoryImportProvisionalSkuId: "provisional-sku-2",
+        productSkuId: "sku-import-1",
+        quantity: 3,
+      }),
+    );
+  });
+
+  it("rejects inactive provisional import IDs before creating a cart line", async () => {
+    const commandService = await loadCommandService();
+    const repository = createFakeRepository({
+      sessions: [
+        buildSession({
+          _id: "session-5",
+          sessionNumber: "SES-005",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          staffProfileId: "cashier-1",
+          status: "active",
+          registerNumber: "1",
+          registerSessionId: "drawer-1",
+          expiresAt: 8_000,
+          updatedAt: 500,
+        }),
+      ],
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-1",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+      provisionalImportSkus: [
+        {
+          _id: "provisional-sku-1",
+          storeId: "store-1",
+          status: "finalized",
+          productId: "product-import-1",
+          productSkuId: "sku-import-1",
+        },
+      ],
+    });
+    const inventoryCalls: InventoryCall[] = [];
+
+    const result = await commandService(
+      createDependencies({
+        repository,
+        inventoryCalls,
+        now: 1_000,
+        nextExpiration: 61_000,
+      }),
+    ).upsertSessionItem({
+      sessionId: "session-5",
+      staffProfileId: "cashier-1",
+      productId: "product-import-1",
+      productSkuId: "sku-import-1",
+      inventoryImportProvisionalSkuId: "provisional-sku-1",
+      productSku: "LEGACY-1",
+      productName: "Imported bundle",
+      price: 15,
+      quantity: 2,
+    });
+
+    expect(result).toEqual({
+      status: "validationFailed",
+      message:
+        "This provisional import item is no longer active for this sale line. Refresh the register catalog before continuing.",
+    });
+    expect(inventoryCalls).toEqual([]);
+    expect(repository.items).toEqual([]);
+  });
+
+  it("rejects hidden provisional import IDs before creating a cart line", async () => {
+    const commandService = await loadCommandService();
+    const repository = createFakeRepository({
+      sessions: [
+        buildSession({
+          _id: "session-5",
+          sessionNumber: "SES-005",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          staffProfileId: "cashier-1",
+          status: "active",
+          registerNumber: "1",
+          registerSessionId: "drawer-1",
+          expiresAt: 8_000,
+          updatedAt: 500,
+        }),
+      ],
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-1",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+      provisionalImportSkus: [
+        {
+          _id: "provisional-sku-1",
+          storeId: "store-1",
+          status: "active",
+          posExposureStatus: "hidden",
+          productId: "product-import-1",
+          productSkuId: "sku-import-1",
+        },
+      ],
+    });
+    const inventoryCalls: InventoryCall[] = [];
+
+    const result = await commandService(
+      createDependencies({
+        repository,
+        inventoryCalls,
+        now: 1_000,
+        nextExpiration: 61_000,
+      }),
+    ).upsertSessionItem({
+      sessionId: "session-5",
+      staffProfileId: "cashier-1",
+      productId: "product-import-1",
+      productSkuId: "sku-import-1",
+      inventoryImportProvisionalSkuId: "provisional-sku-1",
+      productSku: "LEGACY-1",
+      productName: "Imported bundle",
+      price: 15,
+      quantity: 2,
+    });
+
+    expect(result).toEqual({
+      status: "validationFailed",
+      message:
+        "This provisional import item is no longer active for this sale line. Refresh the register catalog before continuing.",
+    });
+    expect(inventoryCalls).toEqual([]);
+    expect(repository.items).toEqual([]);
+  });
+
   it("does not let a cart update clear an existing pending checkout marker", async () => {
     const commandService = await loadCommandService();
     const repository = createFakeRepository({
@@ -2056,6 +2597,82 @@ describe("createPosSessionCommandService", () => {
     ]);
   });
 
+  it("removes a provisional import cart line without releasing a trusted hold", async () => {
+    const commandService = await loadCommandService();
+    const repository = createFakeRepository({
+      sessions: [
+        buildSession({
+          _id: "session-7",
+          sessionNumber: "SES-007",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          staffProfileId: "cashier-1",
+          status: "active",
+          registerNumber: "1",
+          registerSessionId: "drawer-1",
+          expiresAt: 8_000,
+          updatedAt: 500,
+        }),
+      ],
+      registerSessions: [
+        buildRegisterSession({
+          _id: "drawer-1",
+          storeId: "store-1",
+          status: "open",
+          terminalId: "terminal-1",
+          registerNumber: "1",
+        }),
+      ],
+      items: [
+        buildItem({
+          _id: "item-3",
+          sessionId: "session-7",
+          storeId: "store-1",
+          productId: "product-import-1",
+          productSkuId: "sku-import-1",
+          productSku: "LEGACY-1",
+          productName: "Imported bundle",
+          price: 15,
+          quantity: 3,
+          inventoryImportProvisionalSkuId: "provisional-sku-1",
+        }),
+      ],
+    });
+    const inventoryCalls: InventoryCall[] = [];
+    const traceCalls: TraceCall[] = [];
+
+    const result = await commandService(
+      createDependencies({
+        repository,
+        inventoryCalls,
+        traceCalls,
+        now: 1_000,
+        nextExpiration: 61_000,
+      }),
+    ).removeSessionItem({
+      sessionId: "session-7",
+      staffProfileId: "cashier-1",
+      itemId: "item-3",
+    });
+
+    expect(result).toEqual({
+      status: "ok",
+      data: {
+        expiresAt: 61_000,
+      },
+    });
+    expect(inventoryCalls).toEqual([]);
+    expect(repository.getItem("item-3")).toBeNull();
+    expect(repository.getSession("session-7")?.expiresAt).toBe(61_000);
+    expect(traceCalls).toEqual([
+      expect.objectContaining({
+        stage: "itemRemoved",
+        itemName: "Imported bundle",
+        quantity: 3,
+      }),
+    ]);
+  });
+
   it("does not delete a cart line, patch the session, or trace when inventory release fails", async () => {
     const commandService = await loadCommandService();
     const repository = createFakeRepository({
@@ -2520,12 +3137,17 @@ function createFakeRepository(seed?: {
   sessions?: SessionRecord[];
   items?: SessionItemRecord[];
   pendingCheckoutItems?: PendingCheckoutItemRecord[];
+  provisionalImportSkus?: ProvisionalImportSkuRecord[];
   registerSessions?: RegisterSessionRecord[];
 }) {
   const repository = {
     sessions: [...(seed?.sessions ?? [])],
     items: [...(seed?.items ?? [])],
     pendingCheckoutItems: [...(seed?.pendingCheckoutItems ?? [])],
+    provisionalImportSkus: (seed?.provisionalImportSkus ?? []).map((row) => ({
+      posExposureStatus: "available" as const,
+      ...row,
+    })),
     registerSessions: [...(seed?.registerSessions ?? [])],
     sessionPatches: [] as Array<{
       sessionId: string;
@@ -2628,6 +3250,24 @@ function createFakeRepository(seed?: {
         ) ?? null
       );
     },
+    async getActiveProvisionalImportSkuForStoreSku(args: {
+      storeId: string;
+      productId: string;
+      productSkuId: string;
+      provisionalSkuId?: string;
+    }) {
+      return (
+        repository.provisionalImportSkus.find(
+          (item) =>
+            item.storeId === args.storeId &&
+            item.status === "active" &&
+            item.posExposureStatus === "available" &&
+            item.productId === args.productId &&
+            item.productSkuId === args.productSkuId &&
+            (!args.provisionalSkuId || item._id === args.provisionalSkuId),
+        ) ?? null
+      );
+    },
     async createSession(input: Omit<SessionRecord, "_id">) {
       const sessionId = `session-${repository.sessions.length + 1}`;
       repository.sessions.push({ _id: sessionId, ...input });
@@ -2720,6 +3360,7 @@ function createCommandService(
     productId: string;
     productSkuId: string;
     pendingCheckoutItemId?: string;
+    inventoryImportProvisionalSkuId?: string;
     productSku: string;
     productName: string;
     price: number;

--- a/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.test.ts
@@ -1379,6 +1379,51 @@ describe("createLocalSyncIngestionService", () => {
     expect(repository.createdTransactions).toHaveLength(1);
   });
 
+  it("rejects malformed provisional import row ids before projection side effects", async () => {
+    const repository = createFakeSyncRepository();
+    const service = createLocalSyncIngestionService({
+      repository,
+      projectionRepository: repository,
+      now: () => 100,
+    });
+
+    const result = await service.ingestBatch(
+      buildBatch({
+        events: [
+          buildSaleCompletedEvent({ sequence: 1 }),
+          buildSaleCompletedEvent({
+            sequence: 2,
+            payload: {
+              ...buildSaleCompletedEvent({ sequence: 2 }).payload,
+              items: [
+                {
+                  localTransactionItemId: "local-txn-item-1",
+                  productId: "product-1" as never,
+                  productSkuId: "sku-1" as never,
+                  inventoryImportProvisionalSkuId: "",
+                  productName: "Wig Cap",
+                  productSku: "CAP-1",
+                  quantity: 1,
+                  unitPrice: 25,
+                },
+              ],
+            },
+          }),
+        ],
+      }),
+    );
+
+    expect(result.kind).toBe("ok");
+    if (result.kind !== "ok") throw new Error("Expected ok result");
+    expect(result.data.accepted.at(-1)).toEqual(
+      expect.objectContaining({
+        localEventId: "event-sale-completed-2",
+        status: "rejected",
+      }),
+    );
+    expect(repository.createdTransactions).toHaveLength(1);
+  });
+
   it("consumes a rejected expected sequence so later history can sync", async () => {
     const repository = createFakeSyncRepository();
     const service = createLocalSyncIngestionService({
@@ -3316,7 +3361,7 @@ function createFakeSyncRepository(
           } as never)
         : null;
     },
-    async getPendingCheckoutItem(pendingCheckoutItemId) {
+	    async getPendingCheckoutItem(pendingCheckoutItemId) {
       const created = createdPendingCheckoutItems.find(
         (item): item is { _id: string } & Record<string, unknown> =>
           typeof item === "object" &&
@@ -3333,7 +3378,7 @@ function createFakeSyncRepository(
           provisionalProductSkuId: "sku-1",
         } as never;
       }
-      return pendingCheckoutItemId === "pending-checkout-item-1"
+	      return pendingCheckoutItemId === "pending-checkout-item-1"
         ? ({
             _id: "pending-checkout-item-1",
             storeId: "store-1",
@@ -3341,9 +3386,15 @@ function createFakeSyncRepository(
             provisionalProductId: "product-1",
             provisionalProductSkuId: "sku-1",
           } as never)
-        : null;
+	        : null;
+	    },
+    async getInventoryImportProvisionalSku() {
+      return null;
     },
-    async getServiceCatalog(serviceCatalogId) {
+    async recordInventoryImportProvisionalSkuSaleEvidence() {
+      // No-op for ingestion tests that do not seed provisional import rows.
+    },
+	    async getServiceCatalog(serviceCatalogId) {
       return serviceCatalogId === "service-catalog-1"
         ? ({
             _id: "service-catalog-1",

--- a/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts
@@ -646,6 +646,7 @@ function validateLocalSyncEventReferences(
 
     if (
       !isNonEmptyString(item.pendingCheckoutItemId) &&
+      !isNonEmptyString(item.inventoryImportProvisionalSkuId) &&
       isNonEmptyString(item.productId) &&
       !repository.normalizeCloudId("product", item.productId)
     ) {
@@ -654,6 +655,7 @@ function validateLocalSyncEventReferences(
 
     if (
       !isNonEmptyString(item.pendingCheckoutItemId) &&
+      !isNonEmptyString(item.inventoryImportProvisionalSkuId) &&
       isNonEmptyString(item.productSkuId) &&
       !repository.normalizeCloudId("productSku", item.productSkuId)
     ) {
@@ -665,6 +667,13 @@ function validateLocalSyncEventReferences(
       !isOptionalNonEmptyString(item.pendingCheckoutItemId)
     ) {
       return "POS sale pending checkout item reference is invalid.";
+    }
+
+    if (
+      "inventoryImportProvisionalSkuId" in item &&
+      !isOptionalNonEmptyString(item.inventoryImportProvisionalSkuId)
+    ) {
+      return "POS sale provisional import row reference is invalid.";
     }
   }
 
@@ -993,17 +1002,20 @@ function parseSaleCompletedPayload(
     },
     items: (payload.items as Record<string, unknown>[]).map((item) => {
       const pendingCheckoutItemId = optionalString(item.pendingCheckoutItemId);
+      const inventoryImportProvisionalSkuId = optionalString(
+        item.inventoryImportProvisionalSkuId,
+      );
 
       return {
         localTransactionItemId: optionalString(item.localTransactionItemId),
-        productId: pendingCheckoutItemId
+        productId: pendingCheckoutItemId || inventoryImportProvisionalSkuId
           ? (item.productId as string)
           : requireNormalizedCloudId(
               repository,
               "product",
               item.productId as string,
             ),
-        productSkuId: pendingCheckoutItemId
+        productSkuId: pendingCheckoutItemId || inventoryImportProvisionalSkuId
           ? (item.productSkuId as string)
           : requireNormalizedCloudId(
               repository,
@@ -1013,6 +1025,7 @@ function parseSaleCompletedPayload(
         pendingCheckoutItemId: pendingCheckoutItemId as
           | Id<"posPendingCheckoutItem">
           | undefined,
+        inventoryImportProvisionalSkuId,
         productName: item.productName as string,
         productSku: optionalDisplayString(item.productSku),
         barcode: optionalString(item.barcode),

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.test.ts
@@ -335,6 +335,466 @@ describe("projectLocalSyncEvent", () => {
     ]);
   });
 
+  it("preserves provisional import sale evidence without trusted stock movement", async () => {
+    const repository = createProjectionRepository({
+      sku: {
+        _id: "sku-1",
+        storeId: "store-1",
+        productId: "product-1",
+        sku: "IMP-CAP-1",
+        price: 25,
+        quantityAvailable: 0,
+        inventoryCount: 0,
+        images: [],
+      },
+      inventoryImportProvisionalSku: {
+        _id: "provisional-import-sku-1",
+        storeId: "store-1",
+        status: "active",
+        productId: "product-1",
+        productSkuId: "sku-1",
+        importedPrice: 25,
+        importedBarcode: "999888777666",
+      },
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: buildSaleCompletedEvent({
+        payload: {
+          ...buildSaleCompletedEvent().payload,
+          items: [
+            {
+              localTransactionItemId: "local-provisional-import-line-1",
+              productId: "product-1" as never,
+              productSkuId: "sku-1" as never,
+              inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+              productName: "Imported Wig Cap",
+              productSku: "IMP-CAP-1",
+              quantity: 2,
+              unitPrice: 25,
+            },
+          ],
+          totals: {
+            subtotal: 50,
+            tax: 0,
+            total: 50,
+          },
+          payments: [
+            {
+              localPaymentId: "local-payment-1",
+              method: "cash",
+              amount: 50,
+              timestamp: 21,
+            },
+          ],
+        },
+      }),
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("projected");
+    expect(repository.consumedHoldRequests).toEqual([]);
+    expect(repository.productPatches).toEqual([]);
+    expect(repository.recordedSaleInventoryMovements).toEqual([]);
+    expect(repository.createdTransactionItems).toEqual([
+      expect.objectContaining({
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        productId: "product-1",
+        productSkuId: "sku-1",
+        quantity: 2,
+      }),
+    ]);
+    expect(repository.createdPosSessionItems).toEqual([
+      expect.objectContaining({
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        productId: "product-1",
+        productSkuId: "sku-1",
+        quantity: 2,
+      }),
+    ]);
+    expect(repository.recordedInventoryImportProvisionalSkuSaleEvidence).toEqual([
+      {
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        posTransactionId: "transaction-1",
+        quantitySold: 2,
+        registerSessionId: "register-session-1",
+        timestamp: 20,
+      },
+    ]);
+  });
+
+  it("preserves distinct provisional import sale evidence for offline same-SKU rows", async () => {
+    const repository = createProjectionRepository({
+      sku: {
+        _id: "sku-1",
+        storeId: "store-1",
+        productId: "product-1",
+        sku: "IMP-CAP-1",
+        price: 25,
+        quantityAvailable: 0,
+        inventoryCount: 0,
+        images: [],
+      },
+      inventoryImportProvisionalSkus: [
+        {
+          _id: "provisional-import-sku-1",
+          storeId: "store-1",
+          status: "active",
+          productId: "product-1",
+          productSkuId: "sku-1",
+          importedPrice: 25,
+        },
+        {
+          _id: "provisional-import-sku-2",
+          storeId: "store-1",
+          status: "active",
+          productId: "product-1",
+          productSkuId: "sku-1",
+          importedPrice: 25,
+        },
+      ],
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: buildSaleCompletedEvent({
+        payload: {
+          ...buildSaleCompletedEvent().payload,
+          items: [
+            {
+              localTransactionItemId: "local-provisional-import-line-1",
+              productId: "product-1" as never,
+              productSkuId: "sku-1" as never,
+              inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+              productName: "Imported Wig Cap",
+              productSku: "IMP-CAP-1",
+              quantity: 2,
+              unitPrice: 25,
+            },
+            {
+              localTransactionItemId: "local-provisional-import-line-2",
+              productId: "product-1" as never,
+              productSkuId: "sku-1" as never,
+              inventoryImportProvisionalSkuId: "provisional-import-sku-2",
+              productName: "Imported Wig Cap",
+              productSku: "IMP-CAP-1",
+              quantity: 3,
+              unitPrice: 25,
+            },
+          ],
+          totals: {
+            subtotal: 125,
+            tax: 0,
+            total: 125,
+          },
+          payments: [
+            {
+              localPaymentId: "local-payment-1",
+              method: "cash",
+              amount: 125,
+              timestamp: 21,
+            },
+          ],
+        },
+      }),
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("projected");
+    expect(repository.productPatches).toEqual([]);
+    expect(repository.recordedSaleInventoryMovements).toEqual([]);
+    expect(repository.createdTransactionItems).toEqual([
+      expect.objectContaining({
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        productSkuId: "sku-1",
+        quantity: 2,
+      }),
+      expect.objectContaining({
+        inventoryImportProvisionalSkuId: "provisional-import-sku-2",
+        productSkuId: "sku-1",
+        quantity: 3,
+      }),
+    ]);
+    expect(repository.createdPosSessionItems).toEqual([
+      expect.objectContaining({
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        productSkuId: "sku-1",
+        quantity: 2,
+      }),
+      expect.objectContaining({
+        inventoryImportProvisionalSkuId: "provisional-import-sku-2",
+        productSkuId: "sku-1",
+        quantity: 3,
+      }),
+    ]);
+    expect(repository.recordedInventoryImportProvisionalSkuSaleEvidence).toEqual([
+      {
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        posTransactionId: "transaction-1",
+        quantitySold: 2,
+        registerSessionId: "register-session-1",
+        timestamp: 20,
+      },
+      {
+        inventoryImportProvisionalSkuId: "provisional-import-sku-2",
+        posTransactionId: "transaction-1",
+        quantitySold: 3,
+        registerSessionId: "register-session-1",
+        timestamp: 20,
+      },
+    ]);
+  });
+
+  it("blocks offline sale lines with both pending checkout and provisional import sources", async () => {
+    const repository = createProjectionRepository({
+      inventoryImportProvisionalSku: {
+        _id: "provisional-import-sku-1",
+        storeId: "store-1",
+        status: "active",
+        productId: "product-1",
+        productSkuId: "sku-1",
+        importedPrice: 25,
+      },
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: buildSaleCompletedEvent({
+        payload: {
+          ...buildSaleCompletedEvent().payload,
+          items: [
+            {
+              localTransactionItemId: "local-conflicting-line-1",
+              productId: "product-1" as never,
+              productSkuId: "sku-1" as never,
+              pendingCheckoutItemId: "pending-checkout-item-1" as never,
+              inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+              productName: "Imported Wig Cap",
+              productSku: "IMP-CAP-1",
+              quantity: 2,
+              unitPrice: 25,
+            },
+          ],
+        },
+      }),
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("conflicted");
+    expect(result.conflicts).toEqual([
+      expect.objectContaining({
+        conflictType: "inventory",
+        details: expect.objectContaining({
+          blocksProjection: true,
+          localTransactionItemId: "local-conflicting-line-1",
+          pendingCheckoutItemId: "pending-checkout-item-1",
+          inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        }),
+      }),
+    ]);
+    expect(repository.createdTransactions).toEqual([]);
+    expect(repository.createdTransactionItems).toEqual([]);
+    expect(repository.recordedPendingCheckoutItemSaleEvidence).toEqual([]);
+    expect(repository.recordedInventoryImportProvisionalSkuSaleEvidence).toEqual([]);
+  });
+
+  it("blocks offline provisional import sale lines when the row is inactive", async () => {
+    const repository = createProjectionRepository({
+      sku: {
+        _id: "sku-1",
+        storeId: "store-1",
+        productId: "product-1",
+        sku: "IMP-CAP-1",
+        price: 25,
+        quantityAvailable: 0,
+        inventoryCount: 0,
+        images: [],
+      },
+      inventoryImportProvisionalSku: {
+        _id: "provisional-import-sku-1",
+        storeId: "store-1",
+        status: "closed",
+        productId: "product-1",
+        productSkuId: "sku-1",
+        importedPrice: 25,
+      },
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: buildSaleCompletedEvent({
+        payload: {
+          ...buildSaleCompletedEvent().payload,
+          items: [
+            {
+              localTransactionItemId: "local-provisional-import-line-1",
+              productId: "product-1" as never,
+              productSkuId: "sku-1" as never,
+              inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+              productName: "Imported Wig Cap",
+              productSku: "IMP-CAP-1",
+              quantity: 2,
+              unitPrice: 25,
+            },
+          ],
+        },
+      }),
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("conflicted");
+    expect(result.conflicts).toEqual([
+      expect.objectContaining({
+          conflictType: "inventory",
+          details: expect.objectContaining({
+          blocksProjection: true,
+          inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        }),
+      }),
+    ]);
+    expect(repository.createdTransactions).toEqual([]);
+    expect(repository.consumedHoldRequests).toEqual([]);
+    expect(repository.productPatches).toEqual([]);
+    expect(repository.recordedSaleInventoryMovements).toEqual([]);
+    expect(repository.createdTransactionItems).toEqual([]);
+    expect(repository.recordedInventoryImportProvisionalSkuSaleEvidence).toEqual([]);
+  });
+
+  it("blocks offline provisional import sale lines when the row is hidden from POS", async () => {
+    const repository = createProjectionRepository({
+      sku: {
+        _id: "sku-1",
+        storeId: "store-1",
+        productId: "product-1",
+        sku: "IMP-CAP-1",
+        price: 25,
+        quantityAvailable: 0,
+        inventoryCount: 0,
+        images: [],
+      },
+      inventoryImportProvisionalSku: {
+        _id: "provisional-import-sku-1",
+        storeId: "store-1",
+        status: "active",
+        posExposureStatus: "hidden",
+        productId: "product-1",
+        productSkuId: "sku-1",
+        importedPrice: 25,
+      },
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: buildSaleCompletedEvent({
+        payload: {
+          ...buildSaleCompletedEvent().payload,
+          items: [
+            {
+              localTransactionItemId: "local-provisional-import-line-1",
+              productId: "product-1" as never,
+              productSkuId: "sku-1" as never,
+              inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+              productName: "Imported Wig Cap",
+              productSku: "IMP-CAP-1",
+              quantity: 2,
+              unitPrice: 25,
+            },
+          ],
+        },
+      }),
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("conflicted");
+    expect(result.conflicts).toEqual([
+      expect.objectContaining({
+        conflictType: "inventory",
+        details: expect.objectContaining({
+          blocksProjection: true,
+          inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        }),
+      }),
+    ]);
+    expect(repository.createdTransactions).toEqual([]);
+    expect(repository.consumedHoldRequests).toEqual([]);
+    expect(repository.productPatches).toEqual([]);
+    expect(repository.recordedSaleInventoryMovements).toEqual([]);
+    expect(repository.createdTransactionItems).toEqual([]);
+    expect(repository.recordedInventoryImportProvisionalSkuSaleEvidence).toEqual([]);
+  });
+
+  it("blocks offline sales that mix trusted and provisional lines for the same SKU", async () => {
+    const repository = createProjectionRepository({
+      inventoryImportProvisionalSku: {
+        _id: "provisional-import-sku-1",
+        storeId: "store-1",
+        status: "active",
+        productId: "product-1",
+        productSkuId: "sku-1",
+        importedPrice: 25,
+      },
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: buildSaleCompletedEvent({
+        payload: {
+          ...buildSaleCompletedEvent().payload,
+          items: [
+            {
+              localTransactionItemId: "local-provisional-import-line-1",
+              productId: "product-1" as never,
+              productSkuId: "sku-1" as never,
+              inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+              productName: "Imported Wig Cap",
+              productSku: "IMP-CAP-1",
+              quantity: 1,
+              unitPrice: 25,
+            },
+            {
+              localTransactionItemId: "local-trusted-line-1",
+              productId: "product-1" as never,
+              productSkuId: "sku-1" as never,
+              productName: "Imported Wig Cap",
+              productSku: "IMP-CAP-1",
+              quantity: 1,
+              unitPrice: 25,
+            },
+          ],
+        },
+      }),
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("conflicted");
+    expect(result.conflicts).toEqual([
+      expect.objectContaining({
+        conflictType: "inventory",
+        details: expect.objectContaining({
+          blocksProjection: true,
+          productSkuId: "sku-1",
+        }),
+      }),
+    ]);
+    expect(repository.createdTransactions).toEqual([]);
+    expect(repository.createdTransactionItems).toEqual([]);
+    expect(repository.recordedInventoryImportProvisionalSkuSaleEvidence).toEqual([]);
+    expect(repository.recordedSaleInventoryMovements).toEqual([]);
+  });
+
   it("projects a completed local cash sale into transaction, payment, inventory, and trace-like records", async () => {
     const repository = createProjectionRepository();
 
@@ -2217,6 +2677,65 @@ describe("projectLocalSyncEvent", () => {
     );
   });
 
+  it("projects provisional import offline sales using the imported provisional price", async () => {
+    const repository = createProjectionRepository({
+      inventoryImportProvisionalSku: {
+        _id: "provisional-import-sku-1",
+        storeId: "store-1",
+        status: "active",
+        posExposureStatus: "available",
+        productId: "product-1",
+        productSkuId: "sku-1",
+        importedPrice: 10,
+      },
+    });
+
+    const result = await projectLocalSyncEvent(repository, {
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      event: buildSaleCompletedEvent({
+        payload: {
+          ...buildSaleCompletedEvent().payload,
+          totals: { subtotal: 10, tax: 0, total: 10 },
+          items: [
+            {
+              localTransactionItemId: "local-txn-item-1",
+              productId: "product-1" as never,
+              productSkuId: "sku-1" as never,
+              inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+              productName: "Wig Cap",
+              productSku: "CAP-1",
+              quantity: 1,
+              unitPrice: 10,
+            },
+          ],
+          payments: [
+            {
+              localPaymentId: "local-payment-1",
+              method: "cash",
+              amount: 10,
+              timestamp: 21,
+            },
+          ],
+        },
+      }),
+      syncEventId: "sync-event-1",
+      now: 100,
+    });
+
+    expect(result.status).toBe("projected");
+    expect(result.conflicts).toEqual([]);
+    expect(repository.createdTransactionItems).toEqual([
+      expect.objectContaining({
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        productSkuId: "sku-1",
+        unitPrice: 10,
+      }),
+    ]);
+    expect(repository.productPatches).toEqual([]);
+    expect(repository.recordedSaleInventoryMovements).toEqual([]);
+  });
+
   it("projects clear-only cloud-backed local sales into voided POS sessions", async () => {
     const repository = createProjectionRepository({
       existingPosSession: {
@@ -3689,6 +4208,26 @@ function createProjectionRepository(
       provisionalProductId?: string;
       provisionalProductSkuId?: string;
     } | null;
+    inventoryImportProvisionalSku: {
+      _id: string;
+      storeId: string;
+      status: "active" | "finalized" | "rejected" | "closed";
+      posExposureStatus?: "available" | "hidden";
+      productId: string;
+      productSkuId: string;
+      importedBarcode?: string;
+      importedPrice: number;
+    } | null;
+    inventoryImportProvisionalSkus: Array<{
+      _id: string;
+      storeId: string;
+      status: "active" | "finalized" | "rejected" | "closed";
+      posExposureStatus?: "available" | "hidden";
+      productId: string;
+      productSkuId: string;
+      importedBarcode?: string;
+      importedPrice: number;
+    }>;
     activeHeldQuantity: number;
     consumedHoldQuantities: Map<string, number>;
     existingPosSession: {
@@ -3743,6 +4282,7 @@ function createProjectionRepository(
   posSessionPatches: unknown[];
 	  productPatches: unknown[];
 	  recordedPendingCheckoutItemSaleEvidence: unknown[];
+	  recordedInventoryImportProvisionalSkuSaleEvidence: unknown[];
 	  recordedSaleInventoryMovements: unknown[];
 	  recordedPosSessionTraces: unknown[];
   recordedRegisterSessionTraces: unknown[];
@@ -3779,6 +4319,7 @@ function createProjectionRepository(
 	  const posSessionPatches: unknown[] = [];
 	  const productPatches: unknown[] = [];
 	  const recordedPendingCheckoutItemSaleEvidence: unknown[] = [];
+	  const recordedInventoryImportProvisionalSkuSaleEvidence: unknown[] = [];
 	  const recordedSaleInventoryMovements: unknown[] = [];
 	  const recordedPosSessionTraces: unknown[] = [];
   const recordedRegisterSessionTraces: unknown[] = [];
@@ -3848,6 +4389,7 @@ function createProjectionRepository(
     posSessionPatches,
 	    productPatches,
 	    recordedPendingCheckoutItemSaleEvidence,
+	    recordedInventoryImportProvisionalSkuSaleEvidence,
 	    recordedSaleInventoryMovements,
 	    recordedPosSessionTraces,
     recordedRegisterSessionTraces,
@@ -3957,6 +4499,30 @@ function createProjectionRepository(
             provisionalProductSkuId: "sku-1",
           } as never)
         : null;
+    },
+    async getInventoryImportProvisionalSku(inventoryImportProvisionalSkuId) {
+      if (overrides.inventoryImportProvisionalSkus) {
+        const provisionalSku = overrides.inventoryImportProvisionalSkus.find(
+          (row) => row._id === inventoryImportProvisionalSkuId,
+        );
+        return provisionalSku
+          ? ({
+              posExposureStatus: "available",
+              ...provisionalSku,
+            } as never)
+          : null;
+      }
+      if (overrides.inventoryImportProvisionalSku !== undefined) {
+        return overrides.inventoryImportProvisionalSku &&
+          inventoryImportProvisionalSkuId ===
+            overrides.inventoryImportProvisionalSku._id
+          ? ({
+              posExposureStatus: "available",
+              ...overrides.inventoryImportProvisionalSku,
+            } as never)
+          : null;
+      }
+      return null;
     },
     async getServiceCatalog(serviceCatalogId) {
       return serviceCatalog && serviceCatalogId === serviceCatalog._id
@@ -4145,6 +4711,9 @@ function createProjectionRepository(
             },
           } as never)
         : null;
+    },
+    async recordInventoryImportProvisionalSkuSaleEvidence(input) {
+      recordedInventoryImportProvisionalSkuSaleEvidence.push(input);
     },
     async createServiceWorkItem(input) {
       const id = `service-work-item-${createdServiceWorkItems.length + 1}`;

--- a/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts
@@ -1328,6 +1328,10 @@ async function persistSaleItemsAndInventory(
       quantitySold: number;
     }
   >();
+  const provisionalImportEvidenceById = new Map<
+    string,
+    { inventoryImportProvisionalSkuId: string; quantitySold: number }
+  >();
 
   for (const item of payload.items) {
     const productId = item.productId as Id<"product">;
@@ -1344,6 +1348,7 @@ async function persistSaleItemsAndInventory(
         pendingCheckoutItemId: item.pendingCheckoutItemId as
           | Id<"posPendingCheckoutItem">
           | undefined,
+        inventoryImportProvisionalSkuId: item.inventoryImportProvisionalSkuId,
         productSku: canonicalItem?.productSku ?? item.productSku,
         productName: canonicalItem?.productName ?? item.productName,
         barcode: canonicalItem?.barcode,
@@ -1361,6 +1366,7 @@ async function persistSaleItemsAndInventory(
       pendingCheckoutItemId: item.pendingCheckoutItemId as
         | Id<"posPendingCheckoutItem">
         | undefined,
+      inventoryImportProvisionalSkuId: item.inventoryImportProvisionalSkuId,
       productName: canonicalItem?.productName ?? item.productName,
       productSku: canonicalItem?.productSku ?? item.productSku,
       barcode: canonicalItem?.barcode,
@@ -1380,6 +1386,16 @@ async function persistSaleItemsAndInventory(
         lookupCode: existingEvidence?.lookupCode ?? canonicalItem?.barcode,
         pendingCheckoutItemId,
         price: existingEvidence?.price ?? item.unitPrice,
+        quantitySold: (existingEvidence?.quantitySold ?? 0) + item.quantity,
+      });
+    }
+
+    if (item.inventoryImportProvisionalSkuId) {
+      const existingEvidence = provisionalImportEvidenceById.get(
+        item.inventoryImportProvisionalSkuId,
+      );
+      provisionalImportEvidenceById.set(item.inventoryImportProvisionalSkuId, {
+        inventoryImportProvisionalSkuId: item.inventoryImportProvisionalSkuId,
         quantitySold: (existingEvidence?.quantitySold ?? 0) + item.quantity,
       });
     }
@@ -1410,6 +1426,16 @@ async function persistSaleItemsAndInventory(
       source: "offline_sync",
       storeId: args.storeId,
       terminalId: args.terminalId,
+      timestamp: args.event.occurredAt,
+    });
+  }
+
+  for (const evidence of provisionalImportEvidenceById.values()) {
+    await repository.recordInventoryImportProvisionalSkuSaleEvidence({
+      inventoryImportProvisionalSkuId: evidence.inventoryImportProvisionalSkuId,
+      posTransactionId: sale.transactionId,
+      quantitySold: evidence.quantitySold,
+      registerSessionId: sale.registerSessionId,
       timestamp: args.event.occurredAt,
     });
   }
@@ -2003,7 +2029,10 @@ function collectSaleSkuQuantities(payload: PosLocalSalePayload) {
 }
 
 function trustedInventorySaleItems(payload: PosLocalSalePayload) {
-  return payload.items.filter((item) => !item.pendingCheckoutItemId);
+  return payload.items.filter(
+    (item) =>
+      !item.pendingCheckoutItemId && !item.inventoryImportProvisionalSkuId,
+  );
 }
 
 async function validateSaleCustomerReference(
@@ -2074,7 +2103,55 @@ async function validateSaleCatalogReferences(
     }
   >();
   const serviceLinesByLocalId = new Map<string, CanonicalServiceLine>();
+  const provisionalImportSkusByLocalId = new Map<
+    string,
+    NonNullable<
+      Awaited<ReturnType<SyncProjectionRepository["getInventoryImportProvisionalSku"]>>
+    >
+  >();
   let priceConflict: LocalSyncConflictRecord | null = null;
+  const dualSourceItem = payload.items.find(
+    (item) => item.pendingCheckoutItemId && item.inventoryImportProvisionalSkuId,
+  );
+  if (dualSourceItem) {
+    return {
+      conflict: await createConflict(repository, args, {
+        conflictType: "inventory",
+        summary:
+          "Synced sale line has conflicting pending checkout and provisional import sources.",
+        details: {
+          localTransactionId: payload.localTransactionId,
+          localTransactionItemId: dualSourceItem.localTransactionItemId,
+          pendingCheckoutItemId: dualSourceItem.pendingCheckoutItemId,
+          inventoryImportProvisionalSkuId:
+            dualSourceItem.inventoryImportProvisionalSkuId,
+          productSkuId: dualSourceItem.productSkuId,
+          blocksProjection: true,
+        },
+      }),
+      itemsByLocalId,
+      serviceLinesByLocalId,
+    };
+  }
+
+  const mixedInventorySourceSkuId = findMixedTrustedAndProvisionalSkuId(payload);
+  if (mixedInventorySourceSkuId) {
+    return {
+      conflict: await createConflict(repository, args, {
+        conflictType: "inventory",
+        summary:
+          "Synced sale mixes provisional import and trusted inventory lines for the same SKU.",
+        details: {
+          localTransactionId: payload.localTransactionId,
+          productSkuId: mixedInventorySourceSkuId,
+          blocksProjection: true,
+        },
+      }),
+      itemsByLocalId,
+      serviceLinesByLocalId,
+    };
+  }
+
   for (const item of payload.items) {
     if (item.pendingCheckoutItemId) {
       const cloudPendingId =
@@ -2157,6 +2234,43 @@ async function validateSaleCatalogReferences(
       }
     }
 
+    if (item.inventoryImportProvisionalSkuId) {
+      const provisionalImportSku =
+        await repository.getInventoryImportProvisionalSku(
+          item.inventoryImportProvisionalSkuId,
+        );
+      if (
+        !provisionalImportSku ||
+        provisionalImportSku.storeId !== args.storeId ||
+        provisionalImportSku.status !== "active" ||
+        provisionalImportSku.posExposureStatus !== "available" ||
+        provisionalImportSku.productId !== item.productId ||
+        provisionalImportSku.productSkuId !== item.productSkuId
+      ) {
+        return {
+          conflict: await createConflict(repository, args, {
+            conflictType: "inventory",
+            summary:
+              "Provisional import row changed before this offline sale synced.",
+            details: {
+              localTransactionId: payload.localTransactionId,
+              inventoryImportProvisionalSkuId:
+                item.inventoryImportProvisionalSkuId,
+              productId: item.productId,
+              productSkuId: item.productSkuId,
+              blocksProjection: true,
+            },
+          }),
+          itemsByLocalId,
+          serviceLinesByLocalId,
+        };
+      }
+      provisionalImportSkusByLocalId.set(
+        item.localTransactionItemId ?? item.productSkuId,
+        provisionalImportSku,
+      );
+    }
+
     const [product, sku] = await Promise.all([
       repository.getProduct(item.productId as Id<"product">),
       repository.getProductSku(item.productSkuId as Id<"productSku">),
@@ -2189,10 +2303,12 @@ async function validateSaleCatalogReferences(
         serviceLinesByLocalId,
       };
     }
-    if (
-      roundMoney(item.unitPrice) !==
-      roundMoney(typeof sku.netPrice === "number" ? sku.netPrice : sku.price)
-    ) {
+    const expectedUnitPrice =
+      provisionalImportSkusByLocalId.get(
+        item.localTransactionItemId ?? item.productSkuId,
+      )?.importedPrice ??
+      (typeof sku.netPrice === "number" ? sku.netPrice : sku.price);
+    if (roundMoney(item.unitPrice) !== roundMoney(expectedUnitPrice)) {
       priceConflict ??= await createConflict(repository, args, {
         conflictType: "inventory",
         summary: "Product price changed before this offline sale synced.",
@@ -2201,8 +2317,7 @@ async function validateSaleCatalogReferences(
           productId: item.productId,
           productSkuId: item.productSkuId,
           submittedUnitPrice: item.unitPrice,
-          catalogUnitPrice:
-            typeof sku.netPrice === "number" ? sku.netPrice : sku.price,
+          catalogUnitPrice: expectedUnitPrice,
           blocksProjection: false,
         },
       });
@@ -2344,6 +2459,35 @@ async function validateSaleCatalogReferences(
   }
 
   return { conflict: priceConflict, itemsByLocalId, serviceLinesByLocalId };
+}
+
+function findMixedTrustedAndProvisionalSkuId(payload: PosLocalSalePayload) {
+  const sourcesBySkuId = new Map<
+    Id<"productSku">,
+    { hasProvisionalImport: boolean; hasTrustedInventory: boolean }
+  >();
+
+  for (const item of payload.items) {
+    const productSkuId = item.productSkuId as Id<"productSku">;
+    const source = sourcesBySkuId.get(productSkuId) ?? {
+      hasProvisionalImport: false,
+      hasTrustedInventory: false,
+    };
+    if (item.inventoryImportProvisionalSkuId) {
+      source.hasProvisionalImport = true;
+    } else if (!item.pendingCheckoutItemId) {
+      source.hasTrustedInventory = true;
+    }
+    sourcesBySkuId.set(productSkuId, source);
+  }
+
+  for (const [productSkuId, source] of sourcesBySkuId) {
+    if (source.hasProvisionalImport && source.hasTrustedInventory) {
+      return productSkuId;
+    }
+  }
+
+  return null;
 }
 
 async function validateSaleLocalIds(

--- a/packages/athena-webapp/convex/pos/application/sync/types.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/types.ts
@@ -39,6 +39,7 @@ export type PosLocalSaleItemInput = {
   productId: Id<"product"> | string;
   productSkuId: Id<"productSku"> | string;
   pendingCheckoutItemId?: Id<"posPendingCheckoutItem"> | string;
+  inventoryImportProvisionalSkuId?: string;
   productName: string;
   productSku: string;
   barcode?: string;
@@ -264,6 +265,18 @@ export type SyncProjectionRepository = {
   getPendingCheckoutItem(
     pendingCheckoutItemId: Id<"posPendingCheckoutItem">,
   ): Promise<Doc<"posPendingCheckoutItem"> | null>;
+  getInventoryImportProvisionalSku(
+    inventoryImportProvisionalSkuId: string,
+  ): Promise<{
+    _id: string;
+    storeId: Id<"store">;
+    status: "active" | "finalized" | "rejected" | "closed";
+    posExposureStatus?: "available" | "hidden";
+    productId: Id<"product">;
+    productSkuId: Id<"productSku">;
+    importedBarcode?: string;
+    importedPrice: number;
+  } | null>;
   getServiceCatalog(
     serviceCatalogId: Id<"serviceCatalog">,
   ): Promise<Doc<"serviceCatalog"> | null>;
@@ -372,6 +385,7 @@ export type SyncProjectionRepository = {
     productId: Id<"product">;
     productSkuId: Id<"productSku">;
     pendingCheckoutItemId?: Id<"posPendingCheckoutItem">;
+    inventoryImportProvisionalSkuId?: string;
     productSku: string;
     productName: string;
     barcode?: string;
@@ -440,6 +454,7 @@ export type SyncProjectionRepository = {
     productId: Id<"product">;
     productSkuId: Id<"productSku">;
     pendingCheckoutItemId?: Id<"posPendingCheckoutItem">;
+    inventoryImportProvisionalSkuId?: string;
     productName: string;
     productSku: string;
     barcode?: string;
@@ -463,6 +478,13 @@ export type SyncProjectionRepository = {
     source: "offline_sync";
     timestamp: number;
   }): Promise<Doc<"posPendingCheckoutItem"> | null>;
+  recordInventoryImportProvisionalSkuSaleEvidence(input: {
+    inventoryImportProvisionalSkuId: string;
+    quantitySold: number;
+    posTransactionId: Id<"posTransaction">;
+    registerSessionId?: Id<"registerSession">;
+    timestamp: number;
+  }): Promise<void>;
   createOrReusePendingCheckoutItem(input: {
     storeId: Id<"store">;
     createdByUserId?: Id<"athenaUser">;

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/localSyncRepository.ts
@@ -90,6 +90,39 @@ export function createConvexLocalSyncRepository(
     getPendingCheckoutItem(pendingCheckoutItemId) {
       return ctx.db.get("posPendingCheckoutItem", pendingCheckoutItemId);
     },
+    async getInventoryImportProvisionalSku(inventoryImportProvisionalSkuId) {
+      const normalizeId = (
+        ctx.db as unknown as {
+          normalizeId?: (tableName: string, value: string) => unknown;
+        }
+      ).normalizeId;
+      const normalized =
+        typeof normalizeId === "function"
+          ? normalizeId.call(
+              ctx.db,
+              "inventoryImportProvisionalSku",
+              inventoryImportProvisionalSkuId,
+            )
+          : null;
+      if (typeof normalized !== "string") return null;
+
+      const db = ctx.db as unknown as {
+        get(
+          tableName: string,
+          id: string,
+        ): Promise<{
+          _id: string;
+          storeId: Id<"store">;
+          status: "active" | "finalized" | "rejected" | "closed";
+          posExposureStatus?: "available" | "hidden";
+          productId: Id<"product">;
+          productSkuId: Id<"productSku">;
+          importedBarcode?: string;
+          importedPrice: number;
+        } | null>;
+      };
+      return db.get("inventoryImportProvisionalSku", normalized);
+    },
     getServiceCatalog(serviceCatalogId) {
       return ctx.db.get("serviceCatalog", serviceCatalogId);
     },
@@ -444,13 +477,55 @@ export function createConvexLocalSyncRepository(
       await ctx.db.patch("posSession", posSessionId, patch);
     },
     async createPosSessionItem(input) {
-      return ctx.db.insert("posSessionItem", input);
+      return ctx.db.insert("posSessionItem", input as never);
     },
     async createOrReusePendingCheckoutItem(input) {
       return createOrReusePendingCheckoutItem(ctx, input);
     },
     async recordPendingCheckoutItemSaleEvidence(input) {
       return recordPendingCheckoutItemSaleEvidence(ctx, input);
+    },
+    async recordInventoryImportProvisionalSkuSaleEvidence(input) {
+      const db = ctx.db as unknown as {
+        get(tableName: string, id: string): Promise<{
+          saleEvidence?: {
+            saleCount?: number;
+            totalQuantitySold?: number;
+            lastSoldAt?: number;
+            lastPosTransactionId?: Id<"posTransaction">;
+            lastRegisterSessionId?: Id<"registerSession">;
+          };
+        } | null>;
+        patch(
+          tableName: string,
+          id: string,
+          patch: Record<string, unknown>,
+        ): Promise<void>;
+      };
+      const provisionalSku = await db.get(
+        "inventoryImportProvisionalSku",
+        input.inventoryImportProvisionalSkuId,
+      );
+      if (!provisionalSku) return;
+
+      const previousEvidence = provisionalSku.saleEvidence ?? {};
+      await db.patch(
+        "inventoryImportProvisionalSku",
+        input.inventoryImportProvisionalSkuId,
+        {
+          saleEvidence: {
+            saleCount: (previousEvidence.saleCount ?? 0) + 1,
+            totalQuantitySold:
+              (previousEvidence.totalQuantitySold ?? 0) + input.quantitySold,
+            lastSoldAt: input.timestamp,
+            lastPosTransactionId: input.posTransactionId,
+            ...(input.registerSessionId
+              ? { lastRegisterSessionId: input.registerSessionId }
+              : {}),
+          },
+          updatedAt: input.timestamp,
+        },
+      );
     },
     async createServiceWorkItem(input) {
       return ctx.db.insert(
@@ -535,7 +610,7 @@ export function createConvexLocalSyncRepository(
       });
     },
     async createTransactionItem(input) {
-      return ctx.db.insert("posTransactionItem", input);
+      return ctx.db.insert("posTransactionItem", input as never);
     },
     async createTransactionServiceLine(input) {
       return ctx.db.insert("posTransactionServiceLine", input);

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/sessionCommandRepository.ts
@@ -1,6 +1,9 @@
 import type { Doc, Id } from "../../../_generated/dataModel";
 import type { MutationCtx } from "../../../_generated/server";
 import { internal } from "../../../_generated/api";
+import { readActiveProvisionalImportSkuForStoreSku } from "../../application/queries/listRegisterCatalog";
+
+type InventoryImportProvisionalSkuId = Id<"inventoryImportProvisionalSku">;
 
 const ACTIVE_SESSION_CANDIDATE_LIMIT = 100;
 const SESSION_ITEMS_PAGE_SIZE = 200;
@@ -39,6 +42,12 @@ export interface SessionCommandRepository {
   getPendingCheckoutItem(
     pendingCheckoutItemId: Id<"posPendingCheckoutItem">,
   ): Promise<Doc<"posPendingCheckoutItem"> | null>;
+  getActiveProvisionalImportSkuForStoreSku(args: {
+    storeId: Id<"store">;
+    productId: Id<"product">;
+    productSkuId: Id<"productSku">;
+    provisionalSkuId?: InventoryImportProvisionalSkuId;
+  }): Promise<{ _id: InventoryImportProvisionalSkuId } | null>;
   createSession(
     input: Omit<Doc<"posSession">, "_id" | "_creationTime">,
   ): Promise<Id<"posSession">>;
@@ -133,6 +142,9 @@ export function createSessionCommandRepository(
     },
     getPendingCheckoutItem(pendingCheckoutItemId) {
       return ctx.db.get("posPendingCheckoutItem", pendingCheckoutItemId);
+    },
+    getActiveProvisionalImportSkuForStoreSku(args) {
+      return readActiveProvisionalImportSkuForStoreSku(ctx, args);
     },
     createSession(input) {
       return ctx.db.insert("posSession", input);

--- a/packages/athena-webapp/convex/pos/public/catalog.test.ts
+++ b/packages/athena-webapp/convex/pos/public/catalog.test.ts
@@ -64,6 +64,7 @@ vi.mock("../infrastructure/repositories/catalogRepository", () => ({
 import {
   createOrReusePendingCheckoutItemForSale,
   listPendingCheckoutItemsForReview,
+  listRegisterCatalogSnapshot,
   listRegisterCatalogAvailability,
   listRegisterCatalogAvailabilitySnapshot,
   quickAddSku,
@@ -151,6 +152,75 @@ describe("POS public catalog queries", () => {
     );
   });
 
+  it("requires same-organization POS access before returning the full register catalog snapshot", async () => {
+    const readRegisterCatalog = await import(
+      "../application/queries/listRegisterCatalog"
+    );
+    vi.mocked(readRegisterCatalog.listRegisterCatalog).mockResolvedValue([
+      {
+        areProcessingFeesAbsorbed: false,
+        availabilityPolicy: "active_provisional_import",
+        barcode: "123456789012",
+        category: "Import",
+        color: "",
+        description: "",
+        id: "sku-1" as Id<"productSku">,
+        image: null,
+        inventoryImportProvisionalSkuId:
+          "provisional-1" as Id<"inventoryImportProvisionalSku">,
+        length: null,
+        name: "Legacy import",
+        price: 12000,
+        productId: "product-1" as Id<"product">,
+        productSkuId: "sku-1" as Id<"productSku">,
+        size: "",
+        sku: "LEGACY-1",
+        skuId: "sku-1" as Id<"productSku">,
+      },
+    ]);
+    const ctx = buildCtx();
+
+    const rows = await getHandler(listRegisterCatalogSnapshot)(ctx as never, {
+      storeId: "store-1",
+    });
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        availabilityPolicy: "active_provisional_import",
+        inventoryImportProvisionalSkuId: "provisional-1",
+      }),
+    ]);
+    expect(mocks.requireAuthenticatedAthenaUserWithCtx).toHaveBeenCalledWith(ctx);
+    expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(ctx, {
+      allowedRoles: ["full_admin", "pos_only"],
+      failureMessage:
+        "You cannot view register catalog availability for this store.",
+      organizationId: "org-1",
+      userId: "athena-user-1",
+    });
+    expect(readRegisterCatalog.listRegisterCatalog).toHaveBeenCalledWith(ctx, {
+      storeId: "store-1",
+    });
+  });
+
+  it("does not return the register catalog snapshot when the caller is unauthenticated", async () => {
+    const readRegisterCatalog = await import(
+      "../application/queries/listRegisterCatalog"
+    );
+    mocks.requireAuthenticatedAthenaUserWithCtx.mockRejectedValue(
+      new Error("Sign in again to continue."),
+    );
+    const ctx = buildCtx();
+
+    await expect(
+      getHandler(listRegisterCatalogSnapshot)(ctx as never, {
+        storeId: "store-1",
+      }),
+    ).rejects.toThrow("Sign in again to continue.");
+
+    expect(readRegisterCatalog.listRegisterCatalog).not.toHaveBeenCalled();
+  });
+
   it("requires same-organization POS access before returning bounded availability", async () => {
     mocks.listRegisterCatalogAvailabilitySnapshot.mockResolvedValue([]);
     const readRegisterCatalogAvailability = await import(
@@ -164,6 +234,7 @@ describe("POS public catalog queries", () => {
         skuId: "sku-1" as Id<"productSku">,
         inStock: true,
         quantityAvailable: 3,
+        availabilityPolicy: "trusted_inventory",
       },
     ]);
     const ctx = buildCtx();

--- a/packages/athena-webapp/convex/pos/public/catalog.ts
+++ b/packages/athena-webapp/convex/pos/public/catalog.ts
@@ -41,13 +41,22 @@ const catalogResultValidator = v.object({
   productId: v.id("product"),
   skuId: v.id("productSku"),
   areProcessingFeesAbsorbed: v.boolean(),
+  availabilityPolicy: v.optional(
+    v.union(v.literal("trusted_inventory"), v.literal("active_provisional_import")),
+  ),
+  inventoryImportProvisionalSkuId: v.optional(
+    v.id("inventoryImportProvisionalSku"),
+  ),
 });
 
 const registerCatalogRowValidator = v.object({
-  id: v.id("productSku"),
+  id: v.union(v.id("productSku"), v.id("inventoryImportProvisionalSku")),
   productSkuId: v.id("productSku"),
   skuId: v.id("productSku"),
   productId: v.id("product"),
+  inventoryImportProvisionalSkuId: v.optional(
+    v.id("inventoryImportProvisionalSku"),
+  ),
   name: v.string(),
   sku: v.string(),
   barcode: v.string(),
@@ -59,13 +68,24 @@ const registerCatalogRowValidator = v.object({
   length: v.union(v.number(), v.null()),
   color: v.string(),
   areProcessingFeesAbsorbed: v.boolean(),
+  availabilityPolicy: v.union(
+    v.literal("trusted_inventory"),
+    v.literal("active_provisional_import"),
+  ),
 });
 
 const registerCatalogAvailabilityValidator = v.object({
   productSkuId: v.id("productSku"),
   skuId: v.id("productSku"),
+  inventoryImportProvisionalSkuId: v.optional(
+    v.id("inventoryImportProvisionalSku"),
+  ),
   inStock: v.boolean(),
   quantityAvailable: v.number(),
+  availabilityPolicy: v.union(
+    v.literal("trusted_inventory"),
+    v.literal("active_provisional_import"),
+  ),
 });
 
 const pendingCheckoutResultValidator = v.object({
@@ -205,7 +225,11 @@ export const listRegisterCatalogSnapshot = query({
     storeId: v.id("store"),
   },
   returns: v.array(registerCatalogRowValidator),
-  handler: async (ctx, args) => listRegisterCatalog(ctx, args),
+  handler: async (ctx, args) => {
+    await requireRegisterCatalogStoreAccess(ctx, args);
+
+    return listRegisterCatalog(ctx, args);
+  },
 });
 
 export const listRegisterCatalogAvailability = query({

--- a/packages/athena-webapp/convex/pos/public/transactions.ts
+++ b/packages/athena-webapp/convex/pos/public/transactions.ts
@@ -307,6 +307,9 @@ export const completeTransaction = mutation({
     items: v.array(
       v.object({
         skuId: v.id("productSku"),
+        inventoryImportProvisionalSkuId: v.optional(
+          v.id("inventoryImportProvisionalSku"),
+        ),
         quantity: v.number(),
         price: v.number(),
         name: v.string(),
@@ -545,6 +548,9 @@ export const getTransactionById = query({
           productId: v.id("product"),
           productSkuId: v.id("productSku"),
           pendingCheckoutItemId: v.optional(v.id("posPendingCheckoutItem")),
+          inventoryImportProvisionalSkuId: v.optional(
+            v.id("inventoryImportProvisionalSku"),
+          ),
           productName: v.string(),
           productSku: v.string(),
           barcode: v.optional(v.string()),

--- a/packages/athena-webapp/convex/schema.ts
+++ b/packages/athena-webapp/convex/schema.ts
@@ -13,6 +13,7 @@ import {
   organizationMemberSchema,
   organizationSchema,
   inventoryHoldSchema,
+  inventoryImportProvisionalSkuSchema,
   inventoryImportReviewVersionSchema,
   productSchema,
   productSkuSchema,
@@ -278,6 +279,27 @@ const schema = defineSchema({
   inventoryImportReviewVersion: defineTable(inventoryImportReviewVersionSchema)
     .index("by_storeId_createdAt", ["storeId", "createdAt"])
     .index("by_storeId_importKey", ["storeId", "importKey"]),
+  inventoryImportProvisionalSku: defineTable(inventoryImportProvisionalSkuSchema)
+    .index("by_storeId_status", ["storeId", "status"])
+    .index("by_storeId_importKey", ["storeId", "importKey"])
+    .index("by_storeId_importKey_status", ["storeId", "importKey", "status"])
+    .index("by_storeId_productSkuId_status", [
+      "storeId",
+      "productSkuId",
+      "status",
+    ])
+    .index("by_storeId_importKey_rowKey", ["storeId", "importKey", "rowKey"])
+    .index("by_storeId_reviewVersionId", ["storeId", "reviewVersionId"])
+    .index("by_storeId_normalizedImportedBarcode_status", [
+      "storeId",
+      "normalizedImportedBarcode",
+      "status",
+    ])
+    .index("by_storeId_normalizedImportedSku_status", [
+      "storeId",
+      "normalizedImportedSku",
+      "status",
+    ]),
   inventoryMovement: defineTable(inventoryMovementSchema)
     .index("by_storeId", ["storeId"])
     .index("by_storeId_productSkuId", ["storeId", "productSkuId"])

--- a/packages/athena-webapp/convex/schemas/inventory/index.ts
+++ b/packages/athena-webapp/convex/schemas/inventory/index.ts
@@ -16,3 +16,4 @@ export * from "./redeemedPromoCode";
 export * from "./complimentaryProduct";
 export * from "./inventoryHold";
 export * from "./inventoryImportReviewVersion";
+export * from "./inventoryImportProvisionalSku";

--- a/packages/athena-webapp/convex/schemas/inventory/inventoryImportProvisionalSku.ts
+++ b/packages/athena-webapp/convex/schemas/inventory/inventoryImportProvisionalSku.ts
@@ -1,0 +1,78 @@
+import { v } from "convex/values";
+
+export const inventoryImportProvisionalSkuStatusValidator = v.union(
+  v.literal("active"),
+  v.literal("finalized"),
+  v.literal("rejected"),
+  v.literal("closed"),
+);
+
+export const inventoryImportProvisionalSkuExposureStatusValidator = v.union(
+  v.literal("available"),
+  v.literal("hidden"),
+);
+
+export const inventoryImportProvisionalSkuSchema = v.object({
+  storeId: v.id("store"),
+  organizationId: v.id("organization"),
+  importKey: v.string(),
+  reviewVersionId: v.id("inventoryImportReviewVersion"),
+  reviewVersionNumber: v.number(),
+  sourceFormat: v.union(v.literal("csv"), v.literal("json")),
+  rowKey: v.string(),
+  rowNumber: v.number(),
+
+  productId: v.optional(v.id("product")),
+  productSkuId: v.optional(v.id("productSku")),
+
+  importedProductName: v.string(),
+  normalizedImportedProductName: v.string(),
+  importedSku: v.optional(v.string()),
+  normalizedImportedSku: v.optional(v.string()),
+  importedBarcode: v.optional(v.string()),
+  normalizedImportedBarcode: v.optional(v.string()),
+  importedCategory: v.optional(v.string()),
+  importedSubcategory: v.optional(v.string()),
+  importedPrice: v.number(),
+  importedUnitCost: v.optional(v.number()),
+  importedQuantity: v.number(),
+  importedSize: v.optional(v.string()),
+  importedColor: v.optional(v.string()),
+  importedLength: v.optional(v.number()),
+  importedWeight: v.optional(v.string()),
+
+  rowDecision: v.optional(
+    v.object({
+      action: v.optional(v.union(v.literal("create_item"), v.literal("skip_row"))),
+      nameSource: v.optional(v.union(v.literal("import"), v.literal("athena"))),
+      priceSource: v.optional(v.union(v.literal("import"), v.literal("athena"))),
+      quantitySource: v.optional(v.union(v.literal("import"), v.literal("athena"))),
+    }),
+  ),
+
+  status: inventoryImportProvisionalSkuStatusValidator,
+  posExposureStatus: inventoryImportProvisionalSkuExposureStatusValidator,
+  exposedAt: v.optional(v.number()),
+  hiddenAt: v.optional(v.number()),
+
+  saleEvidence: v.object({
+    saleCount: v.number(),
+    totalQuantitySold: v.number(),
+    lastSoldAt: v.optional(v.number()),
+    lastPosTransactionId: v.optional(v.id("posTransaction")),
+    lastRegisterSessionId: v.optional(v.id("registerSession")),
+  }),
+
+  finalizedAt: v.optional(v.number()),
+  finalizedByUserId: v.optional(v.id("athenaUser")),
+  finalTrustedQuantity: v.optional(v.number()),
+  provisionalSoldQuantityAtFinalization: v.optional(v.number()),
+  rejectedAt: v.optional(v.number()),
+  rejectedByUserId: v.optional(v.id("athenaUser")),
+  closedAt: v.optional(v.number()),
+  closedByUserId: v.optional(v.id("athenaUser")),
+
+  createdByUserId: v.id("athenaUser"),
+  createdAt: v.number(),
+  updatedAt: v.number(),
+});

--- a/packages/athena-webapp/convex/schemas/pos/posSessionItem.ts
+++ b/packages/athena-webapp/convex/schemas/pos/posSessionItem.ts
@@ -8,6 +8,7 @@ export const posSessionItemSchema = v.object({
   productId: v.id("product"),
   productSkuId: v.id("productSku"),
   pendingCheckoutItemId: v.optional(v.id("posPendingCheckoutItem")),
+  inventoryImportProvisionalSkuId: v.optional(v.id("inventoryImportProvisionalSku")),
   productSku: v.string(), // human-readable SKU reference
   barcode: v.optional(v.string()),
 

--- a/packages/athena-webapp/convex/schemas/pos/posTransactionItem.ts
+++ b/packages/athena-webapp/convex/schemas/pos/posTransactionItem.ts
@@ -5,6 +5,7 @@ export const posTransactionItemSchema = v.object({
   productId: v.id("product"),
   productSkuId: v.id("productSku"),
   pendingCheckoutItemId: v.optional(v.id("posPendingCheckoutItem")),
+  inventoryImportProvisionalSkuId: v.optional(v.id("inventoryImportProvisionalSku")),
   productName: v.string(),
   productSku: v.string(), // human-readable SKU reference
   barcode: v.optional(v.string()),

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -13,7 +13,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.
 - [`src/hooks`](../../src/hooks) — React hooks that fan out auth, shell, and feature state. Currently 43 file(s); key children: use-image-upload.ts, use-mobile.tsx, use-navigate-back.ts, use-navigation-keyboard-shortcuts.ts, use-pagination-persistence.ts.
 - [`src/contexts`](../../src/contexts) — Context providers for app-wide state and wiring. Currently 8 file(s); key children: AppShellFullscreenContext.tsx, ManagerElevationContext.test.tsx, ManagerElevationContext.tsx, OnlineOrderContext.tsx, PermissionsContext.tsx.
-- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 128 file(s); key children: access, aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts.
+- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 129 file(s); key children: access, aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts.
 - [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 16 file(s); key children: approvalPolicy.ts, auth.ts, commandResult.test.ts, commandResult.ts, currencyFormatter.test.ts.
 - [`src/utils`](../../src/utils) — Cross-cutting browser helpers and lower-level utilities. Currently 4 file(s); key children: formatNumber.ts, index.ts, versionChecker.test.ts, versionChecker.ts.
 
@@ -22,7 +22,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/stockOps`](../../convex/stockOps) — Stock-adjustment, procurement, replenishment, receiving, and vendor flows layered over inventory state. Currently 14 file(s); key children: access.test.ts, access.ts, adjustments.test.ts, adjustments.ts, cycleCountDrafts.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 6 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCases.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 11 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 492 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 493 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 9 file(s); key children: README.md, SUMMARY.md, pos, prod.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -299,6 +299,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.test.ts`](../../src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.test.ts)
 - [`src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts`](../../src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts)
 - [`src/lib/pos/presentation/register/catalogSearch.test.ts`](../../src/lib/pos/presentation/register/catalogSearch.test.ts)
+- [`src/lib/pos/presentation/register/catalogSearchPresentation.test.ts`](../../src/lib/pos/presentation/register/catalogSearchPresentation.test.ts)
 - [`src/lib/pos/presentation/register/useRegisterViewModel.test.ts`](../../src/lib/pos/presentation/register/useRegisterViewModel.test.ts)
 - [`src/lib/pos/presentation/syncStatusPresentation.test.ts`](../../src/lib/pos/presentation/syncStatusPresentation.test.ts)
 - [`src/lib/productUtils.test.ts`](../../src/lib/productUtils.test.ts)

--- a/packages/athena-webapp/shared/posLocalSyncContract.ts
+++ b/packages/athena-webapp/shared/posLocalSyncContract.ts
@@ -57,6 +57,7 @@ export type PosLocalSyncSaleItemPayload = {
   productId: string;
   productSkuId: string;
   pendingCheckoutItemId?: string;
+  inventoryImportProvisionalSkuId?: string;
   productName: string;
   productSku: string;
   barcode?: string;

--- a/packages/athena-webapp/src/components/operations/InventoryImportView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/InventoryImportView.test.tsx
@@ -11,6 +11,7 @@ const mockedHooks = vi.hoisted(() => ({
   latestReviewVersion: null as unknown,
   navigate: vi.fn(),
   saveReviewVersion: vi.fn(),
+  stageReviewRowsForPos: vi.fn(),
   search: {} as Record<string, unknown>,
   useMutation: vi.fn(),
   useQuery: vi.fn(),
@@ -100,13 +101,20 @@ describe("InventoryImportView", () => {
     window.scrollTo = vi.fn();
     window.sessionStorage.clear();
     mockedHooks.saveReviewVersion.mockReset();
+    mockedHooks.stageReviewRowsForPos.mockReset();
     mockedHooks.navigate.mockReset();
     mockedHooks.useMutation.mockReset();
     mockedHooks.useQuery.mockReset();
     mockedHooks.inventorySkuContext = [];
     mockedHooks.latestReviewVersion = null;
     mockedHooks.search = {};
-    mockedHooks.useMutation.mockReturnValue(mockedHooks.saveReviewVersion);
+    let mutationCallIndex = 0;
+    mockedHooks.useMutation.mockImplementation(() => {
+      mutationCallIndex += 1;
+      return mutationCallIndex % 2 === 1
+        ? mockedHooks.saveReviewVersion
+        : mockedHooks.stageReviewRowsForPos;
+    });
     let queryCallIndex = 0;
     mockedHooks.useQuery.mockImplementation(() => {
       queryCallIndex += 1;
@@ -286,6 +294,26 @@ describe("InventoryImportView", () => {
     expect(reviewOverlay.queryByText("New Clip")).not.toBeInTheDocument();
     expect(reviewOverlay.queryByText("Brush")).not.toBeInTheDocument();
 
+    await user.type(
+      screen.getByLabelText("Search import rows by product identifiers"),
+      "333",
+    );
+    expect(getLastNavigateSearch({ filter: "review", retained: "yes" })).toEqual({
+      filter: "review",
+      q: "333",
+      retained: "yes",
+    });
+
+    reviewOverlay = getReviewOverlaySection();
+    let reviewRows = Array.from(getReviewOverlayElement().querySelectorAll("article"));
+    expect(reviewRows.map((row) => row.textContent)).toEqual([
+      expect.stringContaining("New Clip"),
+    ]);
+    expect(
+      reviewOverlay.getByText(/1 match from other statuses included/),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Clear" }));
     await user.click(screen.getByRole("button", { name: "All" }));
     expect(getLastNavigateSearch({ retained: "yes" })).toEqual({
       filter: "all",
@@ -293,7 +321,7 @@ describe("InventoryImportView", () => {
     });
 
     reviewOverlay = getReviewOverlaySection();
-    const reviewRows = Array.from(getReviewOverlayElement().querySelectorAll("article"));
+    reviewRows = Array.from(getReviewOverlayElement().querySelectorAll("article"));
     expect(reviewRows.map((row) => row.textContent)).toEqual([
       expect.stringContaining("Brush"),
       expect.stringContaining("Comb"),
@@ -303,8 +331,30 @@ describe("InventoryImportView", () => {
     expect(reviewOverlay.getByText("New item")).toBeInTheDocument();
     expect(reviewOverlay.getByText("New Clip")).toBeInTheDocument();
 
+    await user.type(
+      screen.getByLabelText("Search import rows by product identifiers"),
+      "333",
+    );
+    expect(getLastNavigateSearch({ filter: "all", retained: "yes" })).toEqual({
+      filter: "all",
+      q: "333",
+      retained: "yes",
+    });
+
+    reviewOverlay = getReviewOverlaySection();
+    const identifierFilteredRows = Array.from(
+      getReviewOverlayElement().querySelectorAll("article"),
+    );
+    expect(identifierFilteredRows.map((row) => row.textContent)).toEqual([
+      expect.stringContaining("New Clip"),
+    ]);
+    expect(reviewOverlay.queryByText("Brush")).not.toBeInTheDocument();
+    expect(reviewOverlay.queryByText("Comb")).not.toBeInTheDocument();
+
     await user.click(screen.getByRole("button", { name: "Back to import" }));
-    expect(getLastNavigateSearch({ filter: "all", page: 2, retained: "yes" })).toEqual({
+    expect(
+      getLastNavigateSearch({ filter: "all", page: 2, q: "333", retained: "yes" }),
+    ).toEqual({
       retained: "yes",
     });
     expect(mockedHooks.navigate.mock.calls.at(-1)?.[0]).toEqual(
@@ -558,6 +608,89 @@ describe("InventoryImportView", () => {
               rowNumber: 3,
             }),
           ],
+        }),
+      );
+    });
+  });
+
+  it("stages reviewed rows for POS availability without applying final counts", async () => {
+    const user = userEvent.setup();
+    mockedHooks.inventorySkuContext = [
+      {
+        barcode: "111",
+        inventoryCount: 3,
+        price: 2500,
+        productAvailability: "live",
+        productId: "product-1",
+        productName: "Pocket Comb",
+        productSkuId: "sku-1",
+        quantityAvailable: 3,
+        sku: "COMB-1",
+      },
+    ];
+    mockedHooks.saveReviewVersion.mockResolvedValue(
+      ok({
+        _id: "review-version-7",
+        createdAt: Date.UTC(2026, 5, 7, 16),
+        fileName: "manual.csv",
+        importKey: "review-key",
+        issueCount: 0,
+        rowCount: 1,
+        sourceFormat: "csv",
+        versionNumber: 7,
+      }),
+    );
+    mockedHooks.stageReviewRowsForPos.mockResolvedValue(
+      ok({
+        alreadyStaged: false,
+        catalogIdentitiesCreated: 0,
+        provisionalRowsCreated: 1,
+        provisionalRowsUpdated: 0,
+        rowsSkipped: 0,
+        rowsStaged: 1,
+        trustedStockRowsUpdated: 0,
+      }),
+    );
+
+    render(<InventoryImportView />);
+
+    fireEvent.change(screen.getByLabelText("Raw export"), {
+      target: {
+        value: [
+          "product_name,sku,barcode,price,qty",
+          "Pocket Comb,COMB-1,111,25,3",
+        ].join("\n"),
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Inventory check" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Review inventory changes" }));
+    await user.click(screen.getByRole("button", { name: "Make available in POS" }));
+
+    await waitFor(() => {
+      expect(mockedHooks.stageReviewRowsForPos).toHaveBeenCalledWith(
+        expect.objectContaining({
+          importKey: expect.any(String),
+          reviewVersionId: "review-version-7",
+          rows: [
+            expect.objectContaining({
+              barcode: "111",
+              price: 2500,
+              productId: "product-1",
+              productName: "Pocket Comb",
+              productSkuId: "sku-1",
+              quantity: 3,
+              rowKey: "2:COMB-1:111:Pocket Comb",
+              rowNumber: 2,
+              sku: "COMB-1",
+            }),
+          ],
+          sourceFormat: "csv",
+          storeId: "store-1",
+          terminalId: "terminal-1",
         }),
       );
     });

--- a/packages/athena-webapp/src/components/operations/InventoryImportView.tsx
+++ b/packages/athena-webapp/src/components/operations/InventoryImportView.tsx
@@ -43,6 +43,10 @@ import {
   type InventoryImportParseResult,
 } from "@/lib/inventory-import/inventoryImportParser";
 import {
+  matchesSkuSearchTerms,
+  normalizeSkuSearchQuery,
+} from "@/lib/stockOps/skuSearch";
+import {
   PageLevelHeader,
   PageWorkspace,
   PageWorkspaceGrid,
@@ -67,6 +71,7 @@ import { Input } from "../ui/input";
 import { Label } from "../ui/label";
 import { LoadingButton } from "../ui/loading-button";
 import { Textarea } from "../ui/textarea";
+import { SkuSearchFilterBar } from "../stock-ops/SkuSearchFilterBar";
 import { OperationsSummaryMetric } from "./OperationsSummaryMetric";
 
 const IMPORT_TABLE_PAGE_SIZE = 10;
@@ -177,11 +182,20 @@ const OVERLAY_FILTERS: Array<{
   { label: "Decided", value: "decided" },
 ];
 
+const OVERLAY_FILTER_SELECT_OPTIONS = OVERLAY_FILTERS.map((filter) => ({
+  ...filter,
+  label: `Status: ${filter.label}`,
+}));
+
 function parseInventoryOverlayFilter(value: unknown): InventoryOverlayFilter | null {
   if (typeof value !== "string") return null;
   return OVERLAY_FILTERS.some((filter) => filter.value === value)
     ? (value as InventoryOverlayFilter)
     : null;
+}
+
+function parseInventoryOverlayQuery(value: unknown) {
+  return typeof value === "string" ? normalizeSkuSearchQuery(value) : "";
 }
 
 function parseInventoryOverlayPage(value: unknown) {
@@ -244,13 +258,18 @@ export function InventoryImportView({
   const search = useSearch({ strict: false }) as {
     filter?: unknown;
     page?: unknown;
+    q?: unknown;
     review?: unknown;
   };
   const overlayFilterFromSearch = parseInventoryOverlayFilter(search.filter);
+  const overlayQueryFromSearch = parseInventoryOverlayQuery(search.q);
   const overlayPageFromSearch = parseInventoryOverlayPage(search.page);
   const isReviewRoute = mode === "review";
   const saveReviewVersion = useMutation(
     api.inventory.catalogImport.saveInventoryImportReviewVersion,
+  );
+  const stageReviewRowsForPos = useMutation(
+    api.inventory.catalogImport.stageInventoryImportReviewRowsForPos,
   );
   const activeManagerElevation = managerElevation?.activeElevation;
   const effectiveManagerElevationId = activeManagerElevation?.elevationId;
@@ -288,11 +307,13 @@ export function InventoryImportView({
   const [rawContent, setRawContent] = useState("");
   const [notes, setNotes] = useState("");
   const [isSavingReviewVersion, setIsSavingReviewVersion] = useState(false);
+  const [isStagingReviewForPos, setIsStagingReviewForPos] = useState(false);
   const [draftAutosaveStatus, setDraftAutosaveStatus] = useState<
     "idle" | "pending" | "saving" | "saved" | "error"
   >("idle");
   const [isSourceExpanded, setIsSourceExpanded] = useState(true);
   const [lastSavedReviewVersion, setLastSavedReviewVersion] = useState<{
+    _id: Id<"inventoryImportReviewVersion">;
     createdAt: number;
     versionNumber: number;
   } | null>(null);
@@ -301,6 +322,7 @@ export function InventoryImportView({
   const [overlayFilter, setOverlayFilterState] = useState<InventoryOverlayFilter>(
     () => overlayFilterFromSearch ?? "all",
   );
+  const [overlayQuery, setOverlayQuery] = useState(() => overlayQueryFromSearch);
   const [rowDraftDecisions, setRowDraftDecisions] = useState<
     Record<string, ImportRowDraftDecision>
   >({});
@@ -317,10 +339,12 @@ export function InventoryImportView({
     ({
       filter,
       page,
+      query,
       review,
     }: {
       filter?: InventoryOverlayFilter | null;
       page?: number | null;
+      query?: string | null;
       review?: boolean;
     }) => {
       void navigate({
@@ -335,6 +359,7 @@ export function InventoryImportView({
               delete nextSearch.review;
               delete nextSearch.filter;
               delete nextSearch.page;
+              delete nextSearch.q;
             }
           }
 
@@ -351,6 +376,15 @@ export function InventoryImportView({
               nextSearch.page = page;
             } else {
               delete nextSearch.page;
+            }
+          }
+
+          if (query !== undefined) {
+            const nextQuery = normalizeSkuSearchQuery(query);
+            if (nextQuery) {
+              nextSearch.q = nextQuery;
+            } else {
+              delete nextSearch.q;
             }
           }
 
@@ -378,6 +412,7 @@ export function InventoryImportView({
             const nextSearch = { ...current };
             delete nextSearch.filter;
             delete nextSearch.page;
+            delete nextSearch.q;
             delete nextSearch.review;
             return nextSearch;
           }) as never,
@@ -386,9 +421,9 @@ export function InventoryImportView({
         return;
       }
 
-      updateReviewSearch({ filter: nextFilter, page: overlayPage });
+      updateReviewSearch({ filter: nextFilter, page: overlayPage, query: overlayQuery });
     },
-    [navigate, overlayFilter, overlayPage, updateReviewSearch],
+    [navigate, overlayFilter, overlayPage, overlayQuery, updateReviewSearch],
   );
 
   const setOverlayFilter = useCallback(
@@ -401,6 +436,26 @@ export function InventoryImportView({
     },
     [isReviewModeState, isReviewRoute, updateReviewSearch],
   );
+
+  const handleOverlayQueryChange = useCallback(
+    (nextQuery: string) => {
+      setOverlayQuery(nextQuery);
+      if (isReviewRoute || isReviewModeState) {
+        setOverlayPage(1);
+        updateReviewSearch({ page: null, query: nextQuery });
+      }
+    },
+    [isReviewModeState, isReviewRoute, updateReviewSearch],
+  );
+
+  const handleClearOverlayFilters = useCallback(() => {
+    setOverlayFilterState("all");
+    setOverlayQuery("");
+    setOverlayPage(1);
+    if (isReviewRoute || isReviewModeState) {
+      updateReviewSearch({ filter: "all", page: null, query: null });
+    }
+  }, [isReviewModeState, isReviewRoute, updateReviewSearch]);
 
   const parseResult = useMemo<InventoryImportParseResult | null>(() => {
     if (!rawContent.trim()) return null;
@@ -435,6 +490,7 @@ export function InventoryImportView({
     [inventorySkuContext, parseResult?.rows],
   );
   const overlaySummary = useMemo(() => summarizeOverlayRows(overlayRows), [overlayRows]);
+  const normalizedOverlayQuery = normalizeSkuSearchQuery(overlayQuery);
   const needsReviewMetricProps =
     overlaySummary.review > 0
       ? {
@@ -443,19 +499,51 @@ export function InventoryImportView({
           valueClassName: "text-action-workflow",
         }
       : {};
+  const matchesOverlayStatusFilter = useCallback(
+    (row: InventoryOverlayRow) =>
+      overlayFilter === "all" ||
+      (overlayFilter === "decided"
+        ? hasDraftDecisionValue(rowDraftDecisions[getOverlayRowKey(row)] ?? {})
+        : row.status === overlayFilter),
+    [overlayFilter, rowDraftDecisions],
+  );
+  const overlayRowsMatchingQuery = useMemo(
+    () =>
+      normalizedOverlayQuery
+        ? overlayRows.filter((row) =>
+            matchesInventoryOverlayRowSearch(row, normalizedOverlayQuery),
+          )
+        : overlayRows,
+    [normalizedOverlayQuery, overlayRows],
+  );
   const filteredOverlayRows = useMemo(
     () =>
-      overlayRows.filter((row) => {
-        if (overlayFilter === "all") return true;
-        if (overlayFilter === "decided") {
-          return hasDraftDecisionValue(
-            rowDraftDecisions[getOverlayRowKey(row)] ?? {},
-          );
-        }
-        return row.status === overlayFilter;
-      }),
-    [overlayFilter, overlayRows, rowDraftDecisions],
+      normalizedOverlayQuery
+        ? overlayRowsMatchingQuery
+        : overlayRows.filter(matchesOverlayStatusFilter),
+    [
+      matchesOverlayStatusFilter,
+      normalizedOverlayQuery,
+      overlayRows,
+      overlayRowsMatchingQuery,
+    ],
   );
+  const selectedStatusQueryHitCount = useMemo(
+    () =>
+      normalizedOverlayQuery
+        ? overlayRowsMatchingQuery.filter(matchesOverlayStatusFilter).length
+        : filteredOverlayRows.length,
+    [
+      filteredOverlayRows.length,
+      matchesOverlayStatusFilter,
+      normalizedOverlayQuery,
+      overlayRowsMatchingQuery,
+    ],
+  );
+  const crossStatusQueryHitCount =
+    normalizedOverlayQuery && overlayFilter !== "all"
+      ? filteredOverlayRows.length - selectedStatusQueryHitCount
+      : 0;
   const overlayPageCount = Math.max(
     1,
     Math.ceil(filteredOverlayRows.length / IMPORT_TABLE_PAGE_SIZE),
@@ -479,6 +567,7 @@ export function InventoryImportView({
     hasDraftDecisionValue(decision),
   ).length;
   const canSaveImportHandoff = hasReviewableContent;
+  const canStageReviewForPos = canSaveImportHandoff && pendingImportActionCount === 0;
   const shouldShowCollapsedSource =
     Boolean(rawContent.trim()) && Boolean(parseResult) && !isSourceExpanded;
   const isReviewMode = (isReviewRoute || isReviewModeState) && Boolean(parseResult);
@@ -496,6 +585,7 @@ export function InventoryImportView({
 
     setPreviewPage(1);
     setOverlayPage(1);
+    setOverlayQuery("");
     setRowDraftDecisions({});
     lastSavedDraftSignatureRef.current = "";
     setDraftAutosaveStatus("idle");
@@ -503,7 +593,7 @@ export function InventoryImportView({
 
   useEffect(() => {
     setOverlayPage(1);
-  }, [overlayFilter]);
+  }, [normalizedOverlayQuery, overlayFilter]);
 
   useEffect(() => {
     if (!isReviewRoute || !parseResult) return;
@@ -514,12 +604,17 @@ export function InventoryImportView({
     if (overlayPageFromSearch !== overlayPage) {
       setOverlayPage(overlayPageFromSearch);
     }
+    if (overlayQueryFromSearch !== overlayQuery) {
+      setOverlayQuery(overlayQueryFromSearch);
+    }
   }, [
     isReviewRoute,
     overlayFilter,
     overlayFilterFromSearch,
     overlayPage,
     overlayPageFromSearch,
+    overlayQuery,
+    overlayQueryFromSearch,
     parseResult,
   ]);
 
@@ -563,6 +658,7 @@ export function InventoryImportView({
     setDraftAutosaveStatus("saved");
     setIsSourceExpanded(false);
     setLastSavedReviewVersion({
+      _id: latestReviewVersion._id,
       createdAt: latestReviewVersion.createdAt,
       versionNumber: latestReviewVersion.versionNumber,
     });
@@ -615,6 +711,7 @@ export function InventoryImportView({
       if (result.kind === "ok") {
         lastSavedDraftSignatureRef.current = draftSignature;
         setLastSavedReviewVersion({
+          _id: result.data._id,
           createdAt: result.data.createdAt,
           versionNumber: result.data.versionNumber,
         });
@@ -624,11 +721,12 @@ export function InventoryImportView({
           setDraftAutosaveStatus("saved");
           toast.success(`Review version ${result.data.versionNumber} saved`);
         }
-        return;
+        return result.data;
       }
 
       if (mode === "auto") setDraftAutosaveStatus("error");
       presentCommandToast(result);
+      return null;
     } finally {
       setIsSavingReviewVersion(false);
     }
@@ -649,6 +747,52 @@ export function InventoryImportView({
 
   const handleSaveReviewVersion = () => {
     void saveReviewDraft("manual");
+  };
+
+  const handleStageReviewRowsForPos = async () => {
+    if (!activeStore?._id || !parseResult || !rawContent.trim()) return;
+
+    setIsStagingReviewForPos(true);
+    try {
+      const rowDecisions = buildSavedRowDraftDecisions({
+        rows: overlayRows,
+        rowDraftDecisions,
+      });
+      const draftSignature = getDraftAutosaveSignature(rowDecisions);
+      const savedVersion =
+        lastSavedReviewVersion?._id &&
+        draftSignature === lastSavedDraftSignatureRef.current
+          ? lastSavedReviewVersion
+          : await saveReviewDraft("manual");
+      if (!savedVersion?._id) return;
+
+      const result = await runCommand(() =>
+        stageReviewRowsForPos({
+          importKey: importKey || reviewVersionKey,
+          managerElevationId: effectiveManagerElevationId,
+          notes: notes.trim() || undefined,
+          reviewVersionId: savedVersion._id,
+          rows: buildProvisionalImportStageRows({
+            rows: overlayRows,
+            rowDraftDecisions,
+          }),
+          sourceFormat: parseResult.format,
+          storeId: activeStore._id as Id<"store">,
+          terminalId: effectiveTerminalId,
+        })
+      );
+
+      if (result.kind === "ok") {
+        toast.success(
+          `${formatCount(result.data.rowsStaged, "row")} available in POS pending final counts`,
+        );
+        return;
+      }
+
+      presentCommandToast(result);
+    } finally {
+      setIsStagingReviewForPos(false);
+    }
   };
 
   useEffect(() => {
@@ -716,6 +860,7 @@ export function InventoryImportView({
     setDraftAutosaveStatus("saved");
     setIsSourceExpanded(false);
     setLastSavedReviewVersion({
+      _id: latestReviewVersion._id,
       createdAt: latestReviewVersion.createdAt,
       versionNumber: latestReviewVersion.versionNumber,
     });
@@ -733,6 +878,7 @@ export function InventoryImportView({
       storeId: activeStore?._id,
     });
     setOverlayFilterState(nextFilter);
+    setOverlayQuery(overlayQueryFromSearch);
     setOverlayPage(1);
     setIsReviewModeState(true);
     void navigate({
@@ -744,7 +890,10 @@ export function InventoryImportView({
         orgUrlSlug: params.orgUrlSlug!,
         storeUrlSlug: params.storeUrlSlug!,
       })) as never,
-      search: { filter: nextFilter },
+      search: {
+        filter: nextFilter,
+        ...(overlayQueryFromSearch ? { q: overlayQueryFromSearch } : {}),
+      },
       to: "/$orgUrlSlug/store/$storeUrlSlug/operations/inventory-import/review",
     });
   };
@@ -871,28 +1020,57 @@ export function InventoryImportView({
               />
             </div>
 
-            <div className="flex flex-wrap gap-2">
-              {OVERLAY_FILTERS.map((filter) => {
-                const isSelected = overlayFilter === filter.value;
-                return (
-                  <Button
-                    aria-pressed={isSelected}
-                    className={cn(
-                      "h-8",
-                      isSelected &&
-                        "border-action-workflow-border bg-action-workflow-soft text-action-workflow hover:bg-action-workflow-soft/80",
-                    )}
-                    key={filter.value}
-                    onClick={() => setOverlayFilter(filter.value)}
-                    size="sm"
-                    type="button"
-                    variant="outline"
-                  >
-                    {filter.label}
-                  </Button>
-                );
-              })}
-            </div>
+            <SkuSearchFilterBar
+              ariaLabel="Inventory import review filters"
+              className="bg-surface/60"
+              filterId="inventory-import-review-status-filter"
+              filterLabel="Review status"
+              filterOptions={OVERLAY_FILTER_SELECT_OPTIONS}
+              filterTriggerClassName="w-[190px]"
+              filterValue={overlayFilter}
+              hasActiveFilters={overlayFilter !== "all" || Boolean(normalizedOverlayQuery)}
+              onClearFilters={handleClearOverlayFilters}
+              onFilterChange={setOverlayFilter}
+              onQueryChange={handleOverlayQueryChange}
+              query={overlayQuery}
+              searchId="inventory-import-review-search"
+              searchLabel="Search import rows by product identifiers"
+              searchPlaceholder="Search name, SKU, barcode, row, category, price, or qty"
+              secondaryFilters={
+                <div className="flex flex-wrap gap-2">
+                  {OVERLAY_FILTERS.map((filter) => {
+                    const isSelected = overlayFilter === filter.value;
+                    return (
+                      <Button
+                        aria-pressed={isSelected}
+                        className={cn(
+                          "h-8",
+                          isSelected &&
+                            "border-action-workflow-border bg-action-workflow-soft text-action-workflow hover:bg-action-workflow-soft/80",
+                        )}
+                        key={filter.value}
+                        onClick={() => setOverlayFilter(filter.value)}
+                        size="sm"
+                        type="button"
+                        variant="outline"
+                      >
+                        {filter.label}
+                      </Button>
+                    );
+                  })}
+                </div>
+              }
+              summary={
+                <>
+                  Showing {filteredOverlayRows.length} of {overlayRows.length} import rows.
+                  {normalizedOverlayQuery
+                    ? crossStatusQueryHitCount > 0
+                      ? ` ${formatCount(crossStatusQueryHitCount, "match")} from other statuses included.`
+                      : " Identifier filters are applied."
+                    : ""}
+                </>
+              }
+            />
 
             <div className="flex flex-wrap items-center justify-between gap-3 border-y border-border bg-surface/60 px-3 py-3">
               {overlaySummary.review > 0 ? (
@@ -968,8 +1146,8 @@ export function InventoryImportView({
                   <div className="min-w-0">
                     <p className="text-sm font-medium">Next action</p>
                     <p className="mt-1 text-sm text-muted-foreground">
-                      Rows are ready for import handoff. Save this draft before applying
-                      catalog or stock changes.
+                      Rows are ready for POS availability. Stage them without applying final
+                      counts.
                     </p>
                   </div>
                   <div className="flex flex-wrap items-center justify-end gap-2 sm:min-w-[28rem]">
@@ -983,6 +1161,23 @@ export function InventoryImportView({
                     >
                       <Save className="h-4 w-4" />
                       Save for import handoff
+                    </LoadingButton>
+                    <LoadingButton
+                      className="w-56 px-4"
+                      disabled={
+                        !canStageReviewForPos ||
+                        isSavingReviewVersion ||
+                        isStagingReviewForPos ||
+                        draftAutosaveStatus === "pending" ||
+                        draftAutosaveStatus === "saving"
+                      }
+                      isLoading={isStagingReviewForPos}
+                      onClick={handleStageReviewRowsForPos}
+                      type="button"
+                      variant="workflow"
+                    >
+                      <UploadCloud className="h-4 w-4" />
+                      Make available in POS
                     </LoadingButton>
                     <DraftAutosaveStatus status={draftAutosaveStatus} />
                   </div>
@@ -1079,7 +1274,11 @@ export function InventoryImportView({
               <EmptyState
                 icon={<FileJson className="h-10 w-10" />}
                 title="No rows in this view"
-                description="Choose another review filter."
+                description={
+                  normalizedOverlayQuery
+                    ? "Clear search or choose another review filter."
+                    : "Choose another review filter."
+                }
               />
             )}
           </section>
@@ -1841,6 +2040,37 @@ function sortInventoryOverlayRows(rows: InventoryOverlayRow[]) {
   });
 }
 
+function matchesInventoryOverlayRowSearch(row: InventoryOverlayRow, query: string) {
+  return matchesSkuSearchTerms(
+    [
+      row.row.productName,
+      row.row.sku,
+      row.row.barcode,
+      row.row.category,
+      row.row.subcategory,
+      row.row.size,
+      row.row.color,
+      row.row.length,
+      row.row.weight,
+      row.row.status,
+      row.row.rowNumber,
+      row.row.price,
+      row.row.unitCost,
+      row.row.quantity,
+      row.athenaMatch?.productName,
+      row.athenaMatch?.sku,
+      row.athenaMatch?.barcode,
+      row.athenaMatch?.productAvailability,
+      row.athenaMatch?.inventoryCount,
+      row.athenaMatch?.price,
+      row.athenaMatch?.quantityAvailable,
+      row.matchLabel,
+      row.statusLabel,
+    ],
+    query,
+  );
+}
+
 function summarizeOverlayRows(rows: InventoryOverlayRow[]) {
   return rows.reduce(
     (summary, row) => ({
@@ -2044,6 +2274,30 @@ function buildSavedRowDraftDecisions({
       };
     })
     .filter((decision): decision is SavedImportRowDraftDecision => Boolean(decision));
+}
+
+function buildProvisionalImportStageRows({
+  rows,
+  rowDraftDecisions,
+}: {
+  rows: InventoryOverlayRow[];
+  rowDraftDecisions: Record<string, ImportRowDraftDecision>;
+}) {
+  return rows.map((row) => {
+    const rowKey = getOverlayRowKey(row);
+    const decision = rowDraftDecisions[rowKey] ?? {};
+
+    return {
+      ...row.row,
+      action: decision.action,
+      nameSource: decision.nameSource,
+      priceSource: decision.priceSource,
+      productId: row.athenaMatch?.productId,
+      productSkuId: row.athenaMatch?.productSkuId,
+      quantitySource: decision.quantitySource,
+      rowKey,
+    };
+  });
 }
 
 function mapSavedRowDraftDecisions(

--- a/packages/athena-webapp/src/components/pos/ProductCard.tsx
+++ b/packages/athena-webapp/src/components/pos/ProductCard.tsx
@@ -40,13 +40,18 @@ export function ProductCard({
   onAfterAdd,
 }: ProductCardProps) {
   const [quantityInput, setQuantityInput] = useState("1");
+  const isProvisionalImport =
+    product.availabilityPolicy === "active_provisional_import";
   const maxQuantity = useMemo(() => {
+    if (isProvisionalImport) {
+      return undefined;
+    }
     if (typeof product.quantityAvailable !== "number") {
       return undefined;
     }
 
     return Math.max(0, Math.trunc(product.quantityAvailable));
-  }, [product.quantityAvailable]);
+  }, [isProvisionalImport, product.quantityAvailable]);
   const selectedQuantity = normalizeQuantity(quantityInput, maxQuantity);
   const isAvailable =
     product.inStock && (maxQuantity === undefined || maxQuantity > 0);
@@ -150,6 +155,8 @@ export function ProductCard({
           <p className="text-xs text-muted-foreground">
             {product.availabilityMessage ? (
               product.availabilityMessage
+            ) : isProvisionalImport ? (
+              "Count pending"
             ) : (
               <>
                 <b>{product.quantityAvailable ?? 0}</b> available

--- a/packages/athena-webapp/src/components/pos/SearchResultsSection.test.tsx
+++ b/packages/athena-webapp/src/components/pos/SearchResultsSection.test.tsx
@@ -202,6 +202,35 @@ describe("SearchResultsSection", () => {
     expect(onClearSearch).toHaveBeenCalled();
   });
 
+  it("allows provisional import results to be added while trusted counts are pending", async () => {
+    const user = userEvent.setup();
+    const product = buildProduct({
+      availabilityMessage: "Count pending",
+      availabilityPolicy: "active_provisional_import",
+      id: "sku-provisional",
+      inventoryImportProvisionalSkuId:
+        "provisional-1" as Product["inventoryImportProvisionalSkuId"],
+      name: "Imported wig",
+      quantityAvailable: 0,
+    });
+    const onAddProduct = vi.fn(async () => true);
+
+    renderSearchResults({
+      products: [product],
+      onAddProduct,
+    });
+
+    expect(screen.getByText("Count pending")).toBeInTheDocument();
+    const quantityInput = screen.getByRole("spinbutton", {
+      name: /quantity for imported wig/i,
+    });
+    await user.clear(quantityInput);
+    await user.type(quantityInput, "3");
+    await user.click(screen.getByRole("button", { name: /add 3/i }));
+
+    expect(onAddProduct).toHaveBeenCalledWith(product, 3);
+  });
+
   it("clamps result quantity entry to available stock", async () => {
     const user = userEvent.setup();
     const product = buildProduct({

--- a/packages/athena-webapp/src/components/pos/types.ts
+++ b/packages/athena-webapp/src/components/pos/types.ts
@@ -48,6 +48,8 @@ export interface Product {
   productId?: Id<"product">;
   skuId?: Id<"productSku">;
   pendingCheckoutItemId?: Id<"posPendingCheckoutItem">;
+  inventoryImportProvisionalSkuId?: Id<"inventoryImportProvisionalSku">;
+  availabilityPolicy?: "trusted_inventory" | "active_provisional_import";
   pendingCheckoutItemLocalDefinition?: PosLocalSyncPendingCheckoutItemDefinedPayload;
   areProcessingFeesAbsorbed?: boolean;
 }

--- a/packages/athena-webapp/src/lib/pos/application/dto.ts
+++ b/packages/athena-webapp/src/lib/pos/application/dto.ts
@@ -134,7 +134,7 @@ export interface PosRegisterBootstrapDto {
 }
 
 export interface PosCatalogItemDto {
-  id: Id<"productSku">;
+  id: Id<"productSku"> | Id<"inventoryImportProvisionalSku">;
   name: string;
   sku: string;
   barcode: string;
@@ -150,13 +150,20 @@ export interface PosCatalogItemDto {
   productId: Id<"product">;
   skuId: Id<"productSku">;
   areProcessingFeesAbsorbed: boolean;
+  availabilityPolicy?: PosRegisterCatalogAvailabilityPolicy;
+  inventoryImportProvisionalSkuId?: Id<"inventoryImportProvisionalSku">;
 }
 
+export type PosRegisterCatalogAvailabilityPolicy =
+  | "trusted_inventory"
+  | "active_provisional_import";
+
 export interface PosRegisterCatalogRowDto {
-  id: Id<"productSku">;
+  id: Id<"productSku"> | Id<"inventoryImportProvisionalSku">;
   productSkuId: Id<"productSku">;
   skuId: Id<"productSku">;
   productId: Id<"product">;
+  inventoryImportProvisionalSkuId?: Id<"inventoryImportProvisionalSku">;
   name: string;
   sku: string;
   barcode: string;
@@ -168,6 +175,7 @@ export interface PosRegisterCatalogRowDto {
   length: number | null;
   color: string;
   areProcessingFeesAbsorbed: boolean;
+  availabilityPolicy?: PosRegisterCatalogAvailabilityPolicy;
 }
 
 export interface PosRegisterCatalogInput {
@@ -227,8 +235,10 @@ export interface PosRegisterCatalogAvailabilityRowDto {
   availabilitySource?: "live" | "local";
   productSkuId: Id<"productSku">;
   skuId: Id<"productSku">;
+  inventoryImportProvisionalSkuId?: Id<"inventoryImportProvisionalSku">;
   inStock: boolean;
   quantityAvailable: number;
+  availabilityPolicy?: PosRegisterCatalogAvailabilityPolicy;
 }
 
 export interface PosRegisterCatalogAvailabilityInput {
@@ -296,6 +306,7 @@ export interface PosAddItemInput {
   sessionId: Id<"posSession">;
   productId: Id<"product">;
   productSkuId: Id<"productSku">;
+  inventoryImportProvisionalSkuId?: Id<"inventoryImportProvisionalSku">;
   staffProfileId: Id<"staffProfile">;
   productSku: string;
   barcode?: string;

--- a/packages/athena-webapp/src/lib/pos/domain/types.ts
+++ b/packages/athena-webapp/src/lib/pos/domain/types.ts
@@ -44,6 +44,7 @@ export interface PosProductCartLineInput {
   productId?: Id<"product">;
   skuId?: Id<"productSku">;
   pendingCheckoutItemId?: Id<"posPendingCheckoutItem">;
+  inventoryImportProvisionalSkuId?: Id<"inventoryImportProvisionalSku">;
   areProcessingFeesAbsorbed?: boolean;
 }
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/convex/catalogGateway.ts
@@ -123,6 +123,7 @@ function mapProductByIdResult(
     productId: productData._id,
     skuId: sku._id,
     areProcessingFeesAbsorbed: productData.areProcessingFeesAbsorbed || false,
+    availabilityPolicy: "trusted_inventory",
   }));
 }
 
@@ -133,7 +134,7 @@ function signatureForAvailabilityRows(
   return `${storeId}|${rows
     .map(
       (row) =>
-        `${String(row.productSkuId)}:${row.quantityAvailable}:${row.inStock ? 1 : 0}`,
+        `${String(row.productSkuId)}:${row.quantityAvailable}:${row.inStock ? 1 : 0}:${row.availabilityPolicy}`,
     )
     .join("|")}`;
 }
@@ -478,7 +479,10 @@ export function useConvexRegisterCatalogAvailabilityState(
   if (liveRows !== undefined) {
     return {
       status: "ready",
-      rows: liveRows.map((row) => ({ ...row, availabilitySource: "live" })),
+      rows: liveRows.map((row: PosRegisterCatalogAvailabilityRowDto) => ({
+        ...row,
+        availabilitySource: "live",
+      })),
       source: "live",
     };
   }

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.test.ts
@@ -174,6 +174,34 @@ describe("localPosReadiness", () => {
     });
   });
 
+  it("shows store-day start readiness before local drawer recovery", () => {
+    expect(
+      evaluateLocalPosReadiness({
+        entryContext,
+        operatingDate: "2026-05-14",
+        localReadiness: {
+          storeId: "store-1",
+          operatingDate: "2026-05-14",
+          status: "not_started",
+          source: "daily_opening",
+          updatedAt: 1_000,
+        },
+        registerReadModel: {
+          canSell: false,
+          closeoutState: {
+            status: "closed_locally",
+            localRegisterSessionId: "local-register-1",
+            updatedAt: 1_100,
+          },
+        } as PosLocalRegisterReadModel,
+      }),
+    ).toMatchObject({
+      status: "blocked",
+      reason: "not_started",
+      canStartLocally: true,
+    });
+  });
+
   it("treats unknown store-day readiness as blocked unless local register state proves selling is open", () => {
     expect(
       evaluateLocalPosReadiness({

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts
@@ -153,6 +153,21 @@ export function evaluateLocalPosReadiness(input: {
     );
   }
 
+  if (localReadiness?.status === "closed") {
+    return blocked(
+      "closed",
+      "Store day closed. Reopen the end of day review before entering POS.",
+    );
+  }
+
+  if (localReadiness?.status === "not_started") {
+    return blocked(
+      "not_started",
+      "Store day not started. Complete Opening Handoff before starting sales.",
+      { canStartLocally: !input.openingSnapshot },
+    );
+  }
+
   if (input.registerReadModel?.closeoutState?.status === "closed_locally") {
     return blocked(
       "local_closeout",
@@ -161,15 +176,6 @@ export function evaluateLocalPosReadiness(input: {
   }
 
   if (input.openingSnapshot?.status === "started" && !input.closeSnapshot) {
-    if (localReadiness?.status === "closed") {
-      return evaluateLocalPosReadiness({
-        entryContext: input.entryContext,
-        localReadiness,
-        operatingDate: input.operatingDate,
-        registerReadModel: input.registerReadModel,
-      });
-    }
-
     return {
       status: "loading",
     };
@@ -202,23 +208,6 @@ export function evaluateLocalPosReadiness(input: {
       "not_started",
       "Store day not started. Complete Opening Handoff before starting sales.",
       { canStartLocally: true },
-    );
-  }
-
-  if (localReadiness?.status === "closed") {
-    return blocked(
-      "closed",
-      "Store day closed. Reopen the end of day review before entering POS.",
-    );
-  }
-
-  if (
-    localReadiness?.status === "not_started"
-  ) {
-    return blocked(
-      "not_started",
-      "Store day not started. Complete Opening Handoff before starting sales.",
-      { canStartLocally: !input.openingSnapshot },
     );
   }
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.test.ts
@@ -288,6 +288,135 @@ describe("projectLocalRegisterReadModel", () => {
     expect(model.activeSale?.total).toBe(0);
   });
 
+  it("does not replace a same-SKU cart line with a different inventory source", () => {
+    const model = projectLocalRegisterReadModel({
+      events: [
+        event({
+          sequence: 1,
+          type: "register.opened",
+          localRegisterSessionId: "local-register-1",
+          payload: { openingFloat: 100 },
+        }),
+        event({
+          sequence: 2,
+          type: "session.started",
+          localRegisterSessionId: "local-register-1",
+          localPosSessionId: "local-sale-1",
+          payload: { localPosSessionId: "local-sale-1", status: "active" },
+        }),
+        event({
+          sequence: 3,
+          type: "cart.item_added",
+          localRegisterSessionId: "local-register-1",
+          localPosSessionId: "local-sale-1",
+          payload: {
+            localItemId: "local-item-trusted",
+            productId: "product-1",
+            productSkuId: "sku-1",
+            productSku: "SKU-1",
+            productName: "Body Wave",
+            price: 75,
+            quantity: 1,
+          },
+        }),
+        event({
+          sequence: 4,
+          type: "cart.item_added",
+          localRegisterSessionId: "local-register-1",
+          localPosSessionId: "local-sale-1",
+          payload: {
+            localItemId: "local-item-provisional",
+            productId: "product-1",
+            productSkuId: "sku-1",
+            inventoryImportProvisionalSkuId: "provisional-sku-1",
+            productSku: "SKU-1",
+            productName: "Body Wave",
+            price: 75,
+            quantity: 2,
+          },
+        }),
+      ],
+    });
+
+    expect(model.activeSale?.items).toEqual([
+      expect.objectContaining({
+        localItemId: "local-item-trusted",
+        productSkuId: "sku-1",
+        quantity: 1,
+      }),
+    ]);
+    expect(model.activeSale?.items[0]?.inventoryImportProvisionalSkuId).toBe(
+      undefined,
+    );
+  });
+
+  it("keeps same-SKU cart lines separate by provisional import row", () => {
+    const model = projectLocalRegisterReadModel({
+      events: [
+        event({
+          sequence: 1,
+          type: "register.opened",
+          localRegisterSessionId: "local-register-1",
+          payload: { openingFloat: 100 },
+        }),
+        event({
+          sequence: 2,
+          type: "session.started",
+          localRegisterSessionId: "local-register-1",
+          localPosSessionId: "local-sale-1",
+          payload: { localPosSessionId: "local-sale-1", status: "active" },
+        }),
+        event({
+          sequence: 3,
+          type: "cart.item_added",
+          localRegisterSessionId: "local-register-1",
+          localPosSessionId: "local-sale-1",
+          payload: {
+            localItemId: "local-item-provisional-1",
+            productId: "product-1",
+            productSkuId: "sku-1",
+            inventoryImportProvisionalSkuId: "provisional-sku-1",
+            productSku: "SKU-1",
+            productName: "Body Wave",
+            price: 75,
+            quantity: 1,
+          },
+        }),
+        event({
+          sequence: 4,
+          type: "cart.item_added",
+          localRegisterSessionId: "local-register-1",
+          localPosSessionId: "local-sale-1",
+          payload: {
+            localItemId: "local-item-provisional-2",
+            productId: "product-1",
+            productSkuId: "sku-1",
+            inventoryImportProvisionalSkuId: "provisional-sku-2",
+            productSku: "SKU-1",
+            productName: "Body Wave",
+            price: 75,
+            quantity: 2,
+          },
+        }),
+      ],
+    });
+
+    expect(model.activeSale?.items).toEqual([
+      expect.objectContaining({
+        inventoryImportProvisionalSkuId: "provisional-sku-1",
+        localItemId: "local-item-provisional-1",
+        productSkuId: "sku-1",
+        quantity: 1,
+      }),
+      expect.objectContaining({
+        inventoryImportProvisionalSkuId: "provisional-sku-2",
+        localItemId: "local-item-provisional-2",
+        productSkuId: "sku-1",
+        quantity: 2,
+      }),
+    ]);
+  });
+
   it("replays local service draft adds and updates into active sale totals", () => {
     const model = projectLocalRegisterReadModel({
       events: [

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/registerReadModel.ts
@@ -36,6 +36,7 @@ export interface PosLocalCartItemReadModel {
   productId: string;
   productSkuId: string;
   pendingCheckoutItemId?: string;
+  inventoryImportProvisionalSkuId?: string;
   productSku: string;
   barcode?: string;
   productName: string;
@@ -703,6 +704,9 @@ function parseCartItemPayload(
     productId: stringField(payload, "productId") ?? "",
     productSkuId,
     pendingCheckoutItemId: optionalString(payload.pendingCheckoutItemId),
+    inventoryImportProvisionalSkuId: optionalString(
+      payload.inventoryImportProvisionalSkuId,
+    ),
     productSku: stringField(payload, "productSku") ?? "",
     barcode: optionalString(payload.barcode),
     productName: stringField(payload, "productName") ?? "",
@@ -817,18 +821,49 @@ function upsertCartItem(
 ) {
   if (item.quantity <= 0) {
     return items.filter(
-      (candidate) => candidate.productSkuId !== item.productSkuId,
+      (candidate) =>
+        candidate.productSkuId !== item.productSkuId ||
+        cartItemSourceKey(candidate) !== cartItemSourceKey(item),
     );
   }
 
   const index = items.findIndex(
-    (candidate) => candidate.productSkuId === item.productSkuId,
+    (candidate) =>
+      candidate.productSkuId === item.productSkuId &&
+      cartItemSourceKey(candidate) === cartItemSourceKey(item),
   );
-  if (index === -1) return [...items, item];
+  if (index === -1) {
+    const itemSourceKey = cartItemSourceKey(item);
+    const sameSkuItems = items.filter(
+      (candidate) => candidate.productSkuId === item.productSkuId,
+    );
+    const canAppendDistinctProvisionalImportRow =
+      itemSourceKey.startsWith("provisional_import:") &&
+      sameSkuItems.every((candidate) =>
+        cartItemSourceKey(candidate).startsWith("provisional_import:"),
+      );
+
+    return sameSkuItems.length === 0 || canAppendDistinctProvisionalImportRow
+      ? [...items, item]
+      : items;
+  }
 
   const next = [...items];
   next[index] = item;
   return next;
+}
+
+function cartItemSourceKey(item: {
+  pendingCheckoutItemId?: string;
+  inventoryImportProvisionalSkuId?: string;
+}) {
+  if (item.inventoryImportProvisionalSkuId) {
+    return `provisional_import:${item.inventoryImportProvisionalSkuId}`;
+  }
+  if (item.pendingCheckoutItemId) {
+    return `pending_checkout:${item.pendingCheckoutItemId}`;
+  }
+  return "trusted_inventory";
 }
 
 function upsertServiceLine(

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.test.ts
@@ -472,6 +472,52 @@ describe("syncContract", () => {
     ]);
   });
 
+  it("preserves provisional import row references in sale uploads", () => {
+    const events: PosLocalEventRecord[] = [
+      buildLocalEvent({
+        localEventId: "event-sale",
+        sequence: 1,
+        type: "transaction.completed",
+        payload: {
+          localPosSessionId: "local-session-1",
+          localTransactionId: "local-txn-1",
+          receiptNumber: "LOCAL-1-000001",
+          subtotal: 25,
+          tax: 0,
+          total: 25,
+          items: [
+            {
+              localItemId: "local-item-1",
+              productId: "product-1",
+              productSkuId: "sku-1",
+              inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+              productName: "Imported Wig Cap",
+              productSku: "IMP-CAP-1",
+              quantity: 1,
+              price: 25,
+            },
+          ],
+          payments: [{ method: "cash", amount: 25, timestamp: 3 }],
+        },
+      }),
+    ];
+
+    expect(buildPosLocalSyncUploadEvents(events, events)).toEqual([
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          items: [
+            expect.objectContaining({
+              localTransactionItemId: "local-item-1",
+              inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+              productSkuId: "sku-1",
+              quantity: 1,
+            }),
+          ],
+        }),
+      }),
+    ]);
+  });
+
   it("embeds completed service lines in the sale upload event", () => {
     const events: PosLocalEventRecord[] = [
       buildLocalEvent({

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.ts
@@ -267,6 +267,9 @@ function toSaleItemPayload(value: unknown) {
     pendingCheckoutItemId: nullableStringToOptional(
       payload.pendingCheckoutItemId,
     ),
+    inventoryImportProvisionalSkuId: nullableStringToOptional(
+      payload.inventoryImportProvisionalSkuId,
+    ),
     productName: stringOrEmpty(payload.productName),
     productSku: stringOrEmpty(payload.productSku),
     barcode: nullableStringToOptional(payload.barcode),

--- a/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts
@@ -11,6 +11,7 @@ import type {
 import type { PosServiceMode } from "@/lib/pos/domain";
 
 export interface RegisterCatalogSearchRow {
+  id?: string;
   productId: string;
   productSkuId: string;
   name: string;
@@ -24,6 +25,8 @@ export interface RegisterCatalogSearchRow {
   color?: string | null;
   image?: string | null;
   areProcessingFeesAbsorbed?: boolean | null;
+  availabilityPolicy?: "trusted_inventory" | "active_provisional_import";
+  inventoryImportProvisionalSkuId?: string | null;
 }
 
 export type RegisterCatalogSearchResult =

--- a/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearchPresentation.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearchPresentation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { mapCatalogRowToProduct } from "./catalogSearchPresentation";
+
+describe("mapCatalogRowToProduct", () => {
+  it("preserves provisional import row identity when availability is keyed by trusted SKU", () => {
+    const product = mapCatalogRowToProduct(
+      {
+        id: "provisional-import-sku-2",
+        productId: "product-1",
+        productSkuId: "sku-1",
+        inventoryImportProvisionalSkuId: "provisional-import-sku-2",
+        availabilityPolicy: "active_provisional_import",
+        name: "Imported bundle B",
+        sku: "LEGACY-1",
+        barcode: "123",
+        price: 20,
+      },
+      {
+        availabilityPolicy: "active_provisional_import",
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1" as never,
+        inStock: true,
+        quantityAvailable: 0,
+      },
+    );
+
+    expect(product).toMatchObject({
+      id: "provisional-import-sku-2",
+      skuId: "sku-1",
+      inventoryImportProvisionalSkuId: "provisional-import-sku-2",
+      availabilityPolicy: "active_provisional_import",
+      availabilityStatus: "available",
+    });
+  });
+});

--- a/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearchPresentation.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearchPresentation.ts
@@ -4,6 +4,8 @@ import type { Id } from "~/convex/_generated/dataModel";
 
 export type RegisterCatalogAvailability = {
   availabilitySource?: "live" | "local";
+  availabilityPolicy?: "trusted_inventory" | "active_provisional_import";
+  inventoryImportProvisionalSkuId?: Id<"inventoryImportProvisionalSku">;
   inStock: boolean;
   quantityAvailable: number;
 };
@@ -22,15 +24,20 @@ export function mapCatalogRowToProduct(
     availability && Number.isFinite(availability.quantityAvailable)
       ? Math.max(0, Math.trunc(availability.quantityAvailable))
       : undefined;
-  const availabilityStatus =
-    quantityAvailable === undefined
+  const availabilityPolicy =
+    row.availabilityPolicy ?? availability?.availabilityPolicy;
+  const isProvisionalImport =
+    availabilityPolicy === "active_provisional_import";
+  const availabilityStatus = isProvisionalImport
+    ? "available"
+    : quantityAvailable === undefined
       ? "unknown"
       : availability?.inStock && quantityAvailable > 0
         ? "available"
         : "out_of_stock";
 
   return {
-    id: row.productSkuId,
+    id: row.id ?? row.productSkuId,
     name: row.name,
     sku: row.sku ?? "",
     barcode: row.barcode ?? "",
@@ -41,7 +48,9 @@ export function mapCatalogRowToProduct(
     inStock: availabilityStatus === "available",
     availabilityStatus,
     availabilityMessage:
-      availabilityStatus === "unknown"
+      isProvisionalImport
+        ? "Count pending"
+        : availabilityStatus === "unknown"
         ? POS_AVAILABILITY_NOT_READY_MESSAGE
         : undefined,
     quantityAvailable,
@@ -55,6 +64,12 @@ export function mapCatalogRowToProduct(
     color: row.color ?? "",
     productId: row.productId as Id<"product">,
     skuId: row.productSkuId as Id<"productSku">,
+    inventoryImportProvisionalSkuId:
+      (row.inventoryImportProvisionalSkuId ??
+        availability?.inventoryImportProvisionalSkuId) as
+        | Id<"inventoryImportProvisionalSku">
+        | undefined,
+    availabilityPolicy,
     areProcessingFeesAbsorbed: Boolean(row.areProcessingFeesAbsorbed),
   };
 }

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -143,6 +143,7 @@ let mockActiveSession:
         quantity: number;
         productId: Id<"product">;
         skuId: Id<"productSku">;
+        inventoryImportProvisionalSkuId?: Id<"inventoryImportProvisionalSku">;
       }>;
       payments?: Array<{
         method: "cash" | "card" | "mobile_money";
@@ -205,6 +206,8 @@ let mockRegisterCatalogRows: Array<{
   length: number | null;
   color: string;
   areProcessingFeesAbsorbed: boolean;
+  inventoryImportProvisionalSkuId?: Id<"inventoryImportProvisionalSku">;
+  availabilityPolicy?: "trusted_inventory" | "active_provisional_import";
 }>;
 let mockRegisterServiceCatalogRows: Array<{
   serviceCatalogId: Id<"serviceCatalog">;
@@ -221,6 +224,8 @@ let mockRegisterCatalogAvailabilityRows: Array<{
   skuId: Id<"productSku">;
   inStock: boolean;
   quantityAvailable: number;
+  inventoryImportProvisionalSkuId?: Id<"inventoryImportProvisionalSku">;
+  availabilityPolicy?: "trusted_inventory" | "active_provisional_import";
 }>;
 
 vi.mock("convex/react", () => ({
@@ -6242,17 +6247,9 @@ describe("useRegisterViewModel", () => {
         },
       ],
     });
-    mockAppendLocalEvent.mockImplementation(async (event) => {
-      if (event?.type === "cart.item_added") {
-        localEvents.push(
-          buildLocalEvent({
-            ...event,
-            sequence: localEvents.length + 1,
-          }),
-        );
-      }
-
-      return { ok: true, value: { localEventId: "local-event-1" } };
+    mockAppendLocalEvent.mockResolvedValue({
+      ok: true,
+      value: { localEventId: "local-event-1" },
     });
 
     const { useRegisterViewModel } = await import("./useRegisterViewModel");
@@ -6285,6 +6282,333 @@ describe("useRegisterViewModel", () => {
     expect(toast.error).toHaveBeenCalledWith(
       "No trusted availability remains for this item on this terminal.",
     );
+  });
+
+  it("does not recheck trusted availability when updating provisional import quantities", async () => {
+    mockRegisterCatalogRows = [
+      buildRegisterCatalogRow({
+        availabilityPolicy: "active_provisional_import",
+        inventoryImportProvisionalSkuId:
+          "provisional-import-sku-1" as Id<"inventoryImportProvisionalSku">,
+      }),
+    ];
+    mockRegisterCatalogAvailabilityRows = [
+      buildRegisterCatalogAvailabilityRow({
+        availabilityPolicy: "active_provisional_import",
+        inventoryImportProvisionalSkuId:
+          "provisional-import-sku-1" as Id<"inventoryImportProvisionalSku">,
+        quantityAvailable: 0,
+      }),
+    ];
+    const localEvents = [
+      buildLocalEvent({
+        sequence: 1,
+        type: "register.opened",
+        payload: {
+          localRegisterSessionId: "drawer-1",
+          openingFloat: 5_000,
+          expectedCash: 5_000,
+          status: "open",
+        },
+        sync: { status: "synced", cloudEventId: "cloud-event-1" },
+      }),
+      buildLocalEvent({
+        sequence: 2,
+        type: "session.started",
+        localPosSessionId: "session-1",
+        payload: { localPosSessionId: "session-1", status: "active" },
+        sync: { status: "synced", cloudEventId: "cloud-event-2" },
+      }),
+      buildLocalEvent({
+        sequence: 3,
+        type: "cart.item_added",
+        localPosSessionId: "session-1",
+        payload: {
+          localItemId: "item-1",
+          productId: "product-2",
+          productSkuId: "sku-2",
+          inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+          productSku: "DW-18",
+          productName: "Deep Wave",
+          price: 100,
+          quantity: 1,
+        },
+        sync: { status: "synced", cloudEventId: "cloud-event-3" },
+      }),
+    ];
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: localEvents,
+    });
+    mockListLocalCloudMappings.mockResolvedValue({
+      ok: true,
+      value: [
+        {
+          entity: "posSession",
+          localId: "session-1",
+          cloudId: "session-1",
+          mappedAt: 1_100,
+        },
+      ],
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    await act(async () => {
+      await result.current.cart.onUpdateQuantity(
+        "item-1" as Id<"posSessionItem">,
+        3,
+      );
+    });
+
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "No trusted availability remains for this item on this terminal.",
+    );
+    expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "cart.item_added",
+        payload: expect.objectContaining({
+          inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+          productSkuId: "sku-2",
+          quantity: 3,
+        }),
+      }),
+    );
+  });
+
+  it("adds distinct provisional import rows that share a trusted SKU", async () => {
+    mockRegisterCatalogRows = [
+      buildRegisterCatalogRow({
+        id: "provisional-import-sku-1" as Id<"productSku">,
+        availabilityPolicy: "active_provisional_import",
+        inventoryImportProvisionalSkuId:
+          "provisional-import-sku-1" as Id<"inventoryImportProvisionalSku">,
+      }),
+      buildRegisterCatalogRow({
+        id: "provisional-import-sku-2" as Id<"productSku">,
+        availabilityPolicy: "active_provisional_import",
+        inventoryImportProvisionalSkuId:
+          "provisional-import-sku-2" as Id<"inventoryImportProvisionalSku">,
+      }),
+    ];
+    mockRegisterCatalogAvailabilityRows = [
+      buildRegisterCatalogAvailabilityRow({
+        availabilityPolicy: "active_provisional_import",
+        inventoryImportProvisionalSkuId:
+          "provisional-import-sku-1" as Id<"inventoryImportProvisionalSku">,
+        quantityAvailable: 0,
+      }),
+    ];
+    const localEvents = [
+      buildLocalEvent({
+        sequence: 1,
+        type: "register.opened",
+        payload: {
+          localRegisterSessionId: "drawer-1",
+          openingFloat: 5_000,
+          expectedCash: 5_000,
+          status: "open",
+        },
+      }),
+      buildLocalEvent({
+        sequence: 2,
+        type: "session.started",
+        localPosSessionId: "session-1",
+        payload: { localPosSessionId: "session-1", status: "active" },
+      }),
+    ];
+    mockListLocalEvents.mockImplementation(async () => ({
+      ok: true,
+      value: [...localEvents],
+    }));
+    mockAppendLocalEvent.mockResolvedValue({
+      ok: true,
+      value: { localEventId: "local-event-1" },
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    const firstProduct = {
+      ...buildRegisterCatalogRow({
+        id: "provisional-import-sku-1" as Id<"productSku">,
+        availabilityPolicy: "active_provisional_import",
+        inventoryImportProvisionalSkuId:
+          "provisional-import-sku-1" as Id<"inventoryImportProvisionalSku">,
+      }),
+      availabilityStatus: "available" as const,
+      inStock: true,
+      quantityAvailable: 0,
+    };
+    const secondProduct = {
+      ...buildRegisterCatalogRow({
+        id: "provisional-import-sku-2" as Id<"productSku">,
+        availabilityPolicy: "active_provisional_import",
+        inventoryImportProvisionalSkuId:
+          "provisional-import-sku-2" as Id<"inventoryImportProvisionalSku">,
+      }),
+      availabilityStatus: "available" as const,
+      inStock: true,
+      quantityAvailable: 0,
+    };
+
+    let firstAdded = false;
+    let secondAdded = false;
+    await act(async () => {
+      firstAdded = await result.current.productEntry.onAddProduct(firstProduct);
+      secondAdded =
+        await result.current.productEntry.onAddProduct(secondProduct);
+    });
+
+    expect(firstAdded).toBe(true);
+    expect(secondAdded).toBe(true);
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "This item is already in the cart from a different inventory source. Remove it and add it again.",
+    );
+    const cartEvents = mockAppendLocalEvent.mock.calls
+      .map(([event]) => event)
+      .filter((event) => event?.type === "cart.item_added");
+    expect(cartEvents).toHaveLength(2);
+    expect(cartEvents[0]?.payload).toEqual(
+      expect.objectContaining({
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        productSkuId: "sku-2",
+        quantity: 1,
+      }),
+    );
+    expect(cartEvents[1]?.payload).toEqual(
+      expect.objectContaining({
+        inventoryImportProvisionalSkuId: "provisional-import-sku-2",
+        productSkuId: "sku-2",
+        quantity: 1,
+      }),
+    );
+    await waitFor(() =>
+      expect(result.current.cart.items).toEqual([
+        expect.objectContaining({
+          inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+          quantity: 1,
+          skuId: "sku-2",
+        }),
+        expect.objectContaining({
+          inventoryImportProvisionalSkuId: "provisional-import-sku-2",
+          quantity: 1,
+          skuId: "sku-2",
+        }),
+      ]),
+    );
+    expect(mockUseConvexRegisterCatalogAvailability).toHaveBeenCalledWith(
+      expect.objectContaining({
+        productSkuIds: expect.arrayContaining(["sku-2"]),
+      }),
+    );
+    const latestAvailabilityInput =
+      mockUseConvexRegisterCatalogAvailability.mock.calls.at(-1)?.[0] as
+        | { productSkuIds?: string[] }
+        | undefined;
+    expect(latestAvailabilityInput?.productSkuIds).not.toContain(
+      "provisional-import-sku-1",
+    );
+    expect(latestAvailabilityInput?.productSkuIds).not.toContain(
+      "provisional-import-sku-2",
+    );
+  });
+
+  it("blocks adding a trusted cart line over a same-SKU provisional import row", async () => {
+    mockRegisterCatalogRows = [
+      buildRegisterCatalogRow({
+        availabilityPolicy: "active_provisional_import",
+        inventoryImportProvisionalSkuId:
+          "provisional-import-sku-1" as Id<"inventoryImportProvisionalSku">,
+      }),
+    ];
+    mockRegisterCatalogAvailabilityRows = [
+      buildRegisterCatalogAvailabilityRow({
+        availabilityPolicy: "active_provisional_import",
+        inventoryImportProvisionalSkuId:
+          "provisional-import-sku-1" as Id<"inventoryImportProvisionalSku">,
+        quantityAvailable: 0,
+      }),
+    ];
+    mockListLocalEvents.mockResolvedValue({
+      ok: true,
+      value: [
+        buildLocalEvent({
+          sequence: 1,
+          type: "register.opened",
+          payload: {
+            localRegisterSessionId: "drawer-1",
+            openingFloat: 5_000,
+            expectedCash: 5_000,
+            status: "open",
+          },
+        }),
+        buildLocalEvent({
+          sequence: 2,
+          type: "session.started",
+          localPosSessionId: "session-1",
+          payload: { localPosSessionId: "session-1", status: "active" },
+        }),
+        buildLocalEvent({
+          sequence: 3,
+          type: "cart.item_added",
+          localPosSessionId: "session-1",
+          payload: {
+            localItemId: "item-provisional-1",
+            productId: "product-2",
+            productSkuId: "sku-2",
+            inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+            productSku: "DW-18",
+            productName: "Deep Wave",
+            price: 10_000,
+            quantity: 1,
+          },
+        }),
+      ],
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    const trustedProduct = {
+      ...buildRegisterCatalogRow(),
+      availabilityStatus: "available" as const,
+      inStock: true,
+      quantityAvailable: 5,
+    };
+    let added = true;
+    await act(async () => {
+      added = await result.current.productEntry.onAddProduct(trustedProduct);
+    });
+
+    expect(added).toBe(false);
+    expect(toast.error).toHaveBeenCalledWith(
+      "This item is already in the cart from a different inventory source. Remove it and add it again.",
+    );
+    expect(
+      mockAppendLocalEvent.mock.calls.filter(
+        ([event]) => event?.type === "cart.item_added",
+      ),
+    ).toHaveLength(0);
   });
 
   it("prioritizes cart item SKUs in the availability request before search results", async () => {
@@ -7620,7 +7944,7 @@ describe("useRegisterViewModel", () => {
     });
 
     await act(async () => {
-      await result.current.checkout.onAddPayment("cash", 100);
+      await result.current.checkout.onAddPayment("cash", 10_000);
     });
     await act(async () => {
       await result.current.checkout.onCompleteTransaction();
@@ -10093,6 +10417,115 @@ describe("useRegisterViewModel", () => {
     expect(mockRemoveItem).not.toHaveBeenCalled();
   });
 
+  it("updates and removes a just-added provisional optimistic row by row identity", async () => {
+    mockActiveSession = null;
+    const localEvents = [
+      buildLocalEvent({
+        sequence: 1,
+        type: "register.opened",
+        payload: {
+          localRegisterSessionId: "drawer-1",
+          openingFloat: 5_000,
+          expectedCash: 5_000,
+          status: "open",
+        },
+      }),
+      buildLocalEvent({
+        sequence: 2,
+        type: "session.started",
+        localPosSessionId: "session-1",
+        payload: { localPosSessionId: "session-1", status: "active" },
+      }),
+    ];
+    mockListLocalEvents.mockImplementation(async () => ({
+      ok: true,
+      value: [...localEvents],
+    }));
+    mockAppendLocalEvent.mockResolvedValue({
+      ok: true,
+      value: { localEventId: "local-event-1" },
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    await act(async () => {
+      await result.current.productEntry.onAddProduct({
+        id: "provisional-import-sku-1",
+        name: "Deep Wave",
+        price: 10_000,
+        barcode: "1234567890123",
+        productId: "product-2" as Id<"product">,
+        skuId: "sku-2" as Id<"productSku">,
+        sku: "DW-18",
+        category: "Hair",
+        description: "Deep wave bundle",
+        image: null,
+        inStock: true,
+        quantityAvailable: 0,
+        availabilityPolicy: "active_provisional_import",
+        inventoryImportProvisionalSkuId:
+          "provisional-import-sku-1" as Id<"inventoryImportProvisionalSku">,
+      });
+    });
+
+    await waitFor(() =>
+      expect(result.current.cart.items).toEqual([
+        expect.objectContaining({
+          id: "optimistic:provisional-import-sku-1",
+          inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+          quantity: 1,
+          skuId: "sku-2",
+        }),
+      ]),
+    );
+
+    await act(async () => {
+      await result.current.cart.onUpdateQuantity(
+        "optimistic:provisional-import-sku-1" as Id<"posSessionItem">,
+        2,
+      );
+    });
+
+    expect(result.current.cart.items).toEqual([
+      expect.objectContaining({
+        id: "optimistic:provisional-import-sku-1",
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        quantity: 2,
+        skuId: "sku-2",
+      }),
+    ]);
+
+    await act(async () => {
+      await result.current.cart.onRemoveItem(
+        "optimistic:provisional-import-sku-1" as Id<"posSessionItem">,
+      );
+    });
+
+    expect(result.current.cart.items).toEqual([]);
+    expect(
+      mockAppendLocalEvent.mock.calls.filter(
+        ([event]) => event?.type === "cart.item_added",
+      ),
+    ).toHaveLength(3);
+    expect(mockAppendLocalEvent.mock.calls.at(-1)?.[0]).toEqual(
+      expect.objectContaining({
+        type: "cart.item_added",
+        payload: expect.objectContaining({
+          inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+          productSkuId: "sku-2",
+          quantity: 0,
+        }),
+      }),
+    );
+  });
+
   it("does not complete with an empty refreshed local cart after a pending removal settles", async () => {
     const pendingRemove = deferred<{
       ok: true;
@@ -10615,6 +11048,16 @@ describe("useRegisterViewModel", () => {
   });
 
   it("rejects payment edits that start while a local completion is in progress", async () => {
+    mockActiveSession = {
+      ...mockActiveSession!,
+      cartItems: [
+        {
+          ...mockActiveSession!.cartItems[0],
+          inventoryImportProvisionalSkuId:
+            "provisional-import-sku-1" as Id<"inventoryImportProvisionalSku">,
+        },
+      ],
+    };
     const pendingCompletion = deferred<{
       ok: true;
       value: { localEventId: string };
@@ -10661,8 +11104,22 @@ describe("useRegisterViewModel", () => {
     });
 
     expect(updated).toBe(false);
-    expect(mockAppendLocalEvent.mock.calls.map(([event]) => event.type)).toEqual(
-      ["session.payments_updated", "transaction.completed"],
+    expect(mockAppendLocalEvent.mock.calls.map(([event]) => event.type)).toEqual([
+      "session.payments_updated",
+      "transaction.completed",
+    ]);
+    expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "transaction.completed",
+        payload: expect.objectContaining({
+          items: [
+            expect.objectContaining({
+              inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+              productSkuId: "sku-1",
+            }),
+          ],
+        }),
+      }),
     );
   });
 

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -718,7 +718,7 @@ function mapProductToOptimisticCartItem(
   quantity: number,
 ): CartItem {
   return {
-    id: `optimistic:${product.skuId ?? product.id}` as Id<"posSessionItem">,
+    id: `optimistic:${product.id}` as Id<"posSessionItem">,
     name: product.name,
     barcode: product.barcode,
     sku: product.sku,
@@ -731,6 +731,7 @@ function mapProductToOptimisticCartItem(
     productId: product.productId,
     skuId: product.skuId,
     pendingCheckoutItemId: product.pendingCheckoutItemId,
+    inventoryImportProvisionalSkuId: product.inventoryImportProvisionalSkuId,
     areProcessingFeesAbsorbed: product.areProcessingFeesAbsorbed,
   };
 }
@@ -746,6 +747,8 @@ function buildLocalCartItemPayload(input: {
     productId: product.productId,
     productSkuId: product.skuId,
     pendingCheckoutItemId: product.pendingCheckoutItemId ?? null,
+    inventoryImportProvisionalSkuId:
+      product.inventoryImportProvisionalSkuId ?? null,
     productSku: product.sku || "",
     barcode: product.barcode || null,
     productName: product.name,
@@ -758,6 +761,46 @@ function buildLocalCartItemPayload(input: {
     color: product.color || null,
     areProcessingFeesAbsorbed: product.areProcessingFeesAbsorbed,
   };
+}
+
+function productCartSourceKey(product: {
+  pendingCheckoutItemId?: string | null;
+  inventoryImportProvisionalSkuId?: string | null;
+}) {
+  if (product.inventoryImportProvisionalSkuId) {
+    return `provisional_import:${product.inventoryImportProvisionalSkuId}`;
+  }
+  if (product.pendingCheckoutItemId) {
+    return `pending_checkout:${product.pendingCheckoutItemId}`;
+  }
+  return "trusted_inventory";
+}
+
+function cartLineSourceKey(item: {
+  pendingCheckoutItemId?: string | null;
+  inventoryImportProvisionalSkuId?: string | null;
+}) {
+  return productCartSourceKey(item);
+}
+
+function renderedCartLineSourceKey(item: CartItem) {
+  return productCartSourceKey({
+    inventoryImportProvisionalSkuId:
+      "inventoryImportProvisionalSkuId" in item
+        ? (item.inventoryImportProvisionalSkuId ?? null)
+        : null,
+    pendingCheckoutItemId:
+      "pendingCheckoutItemId" in item
+        ? (item.pendingCheckoutItemId ?? null)
+        : null,
+  });
+}
+
+function optimisticCartProductKeyFromCartItem(item: CartItem) {
+  const itemId = item.id.toString();
+  return itemId.startsWith("optimistic:")
+    ? itemId.slice("optimistic:".length)
+    : (item.skuId ?? itemId);
 }
 
 function buildLocalCartItemPayloadFromCartItem(input: {
@@ -773,6 +816,10 @@ function buildLocalCartItemPayloadFromCartItem(input: {
     pendingCheckoutItemId:
       "pendingCheckoutItemId" in item
         ? (item.pendingCheckoutItemId ?? null)
+        : null,
+    inventoryImportProvisionalSkuId:
+      "inventoryImportProvisionalSkuId" in item
+        ? (item.inventoryImportProvisionalSkuId ?? null)
         : null,
     productSku: item.sku || "",
     barcode: item.barcode || null,
@@ -836,6 +883,10 @@ function buildCompletedSalePayload(input: {
         "pendingCheckoutItemId" in item
           ? (item.pendingCheckoutItemId ?? null)
           : null,
+      inventoryImportProvisionalSkuId:
+        "inventoryImportProvisionalSkuId" in item
+          ? (item.inventoryImportProvisionalSkuId ?? null)
+          : null,
       productSku: item.sku || "",
       barcode: item.barcode || null,
       productName: item.name,
@@ -885,6 +936,9 @@ function mapLocalCartItemToCartItem(item: PosLocalCartItemReadModel): CartItem {
     skuId: item.productSkuId as Id<"productSku">,
     pendingCheckoutItemId: item.pendingCheckoutItemId as
       | Id<"posPendingCheckoutItem">
+      | undefined,
+    inventoryImportProvisionalSkuId: item.inventoryImportProvisionalSkuId as
+      | Id<"inventoryImportProvisionalSku">
       | undefined,
     areProcessingFeesAbsorbed: item.areProcessingFeesAbsorbed,
   };
@@ -1177,6 +1231,7 @@ function addLocalAvailabilityConsumption(
   item: PosLocalCartItemReadModel,
 ) {
   if (!item.productSkuId) return;
+  if (cartLineSourceKey(item) !== "trusted_inventory") return;
 
   quantities.set(
     item.productSkuId,
@@ -1244,6 +1299,7 @@ function addLocalAvailabilityDeltaConsumption(input: {
 }) {
   for (const item of input.items) {
     if (!item.productSkuId) continue;
+    if (cartLineSourceKey(item) !== "trusted_inventory") continue;
 
     const unsyncedQuantity = Math.max(
       0,
@@ -1742,8 +1798,10 @@ export function useRegisterViewModel(): RegisterViewModel {
       productSkuIds.add(item.productSkuId as Id<"productSku">);
     }
 
-    for (const productSkuId of Object.keys(optimisticCartProducts)) {
-      productSkuIds.add(productSkuId as Id<"productSku">);
+    for (const item of Object.values(optimisticCartProducts)) {
+      if (item.skuId) {
+        productSkuIds.add(item.skuId);
+      }
     }
 
     for (const row of registerMetadataSearchState.results) {
@@ -2563,7 +2621,10 @@ export function useRegisterViewModel(): RegisterViewModel {
       }
 
       const existingIndex = cartItems.findIndex(
-        (item) => item.skuId === optimisticProduct.skuId,
+        (item) =>
+          item.skuId === optimisticProduct.skuId &&
+          renderedCartLineSourceKey(item) ===
+            renderedCartLineSourceKey(optimisticProduct),
       );
       if (existingIndex >= 0) {
         const existingItem = cartItems[existingIndex];
@@ -2585,6 +2646,7 @@ export function useRegisterViewModel(): RegisterViewModel {
 
     for (const product of Object.values(optimisticCartProducts)) {
       if (!product.skuId) continue;
+      if (cartLineSourceKey(product) !== "trusted_inventory") continue;
 
       quantities.set(
         product.skuId,
@@ -2600,13 +2662,18 @@ export function useRegisterViewModel(): RegisterViewModel {
     for (const [productSkuId, availability] of registerCatalogAvailabilityBySkuId) {
       const quantityAvailable = Math.max(
         0,
-        Math.trunc(availability.quantityAvailable) -
-          (localAvailabilityConsumptionBySkuId.get(productSkuId) ?? 0),
+        availability.availabilityPolicy === "active_provisional_import"
+          ? 0
+          : Math.trunc(availability.quantityAvailable) -
+              (localAvailabilityConsumptionBySkuId.get(productSkuId) ?? 0),
       );
 
       adjusted.set(productSkuId, {
         ...availability,
-        inStock: availability.inStock && quantityAvailable > 0,
+        inStock:
+          availability.availabilityPolicy === "active_provisional_import"
+            ? availability.inStock
+            : availability.inStock && quantityAvailable > 0,
         quantityAvailable,
       });
     }
@@ -2648,7 +2715,8 @@ export function useRegisterViewModel(): RegisterViewModel {
       canAutoAdd: Boolean(
         registerMetadataSearchState.exactMatch &&
           exactAvailability &&
-          exactAvailability.quantityAvailable > 0,
+          (exactAvailability.availabilityPolicy === "active_provisional_import" ||
+            exactAvailability.quantityAvailable > 0),
       ),
     };
   }, [
@@ -4869,9 +4937,10 @@ export function useRegisterViewModel(): RegisterViewModel {
       }
 
       if (
-        availabilityStatus !== "available" ||
-        (typeof product.quantityAvailable === "number" &&
-          product.quantityAvailable <= 0)
+        product.availabilityPolicy !== "active_provisional_import" &&
+        (availabilityStatus !== "available" ||
+          (typeof product.quantityAvailable === "number" &&
+            product.quantityAvailable <= 0))
       ) {
         toast.error(POS_NO_TRUSTED_AVAILABILITY_REMAINING_MESSAGE);
         return false;
@@ -4901,26 +4970,57 @@ export function useRegisterViewModel(): RegisterViewModel {
           const isInStock =
             availability !== undefined ? availability.inStock : product.inStock;
 
-          if (quantityAvailable === undefined) {
-            toast.error(POS_AVAILABILITY_NOT_READY_MESSAGE);
-            return false;
-          }
-
           if (
-            !isInStock ||
-            quantityAvailable - localConsumption < requestedQuantity
+            product.availabilityPolicy !== "active_provisional_import" &&
+            availability?.availabilityPolicy !== "active_provisional_import"
           ) {
-            toast.error(POS_NO_TRUSTED_AVAILABILITY_REMAINING_MESSAGE);
-            return false;
+            if (quantityAvailable === undefined) {
+              toast.error(POS_AVAILABILITY_NOT_READY_MESSAGE);
+              return false;
+            }
+
+            if (
+              !isInStock ||
+              quantityAvailable - localConsumption < requestedQuantity
+            ) {
+              toast.error(POS_NO_TRUSTED_AVAILABILITY_REMAINING_MESSAGE);
+              return false;
+            }
           }
         }
 
+        const nextLineSourceKey = productCartSourceKey(product);
         const localSaleItem = queuedReadModel?.activeSale?.items.find(
-          (item) => item.productSkuId === productSkuId,
+          (item) =>
+            item.productSkuId === productSkuId &&
+            cartLineSourceKey(item) === nextLineSourceKey,
         );
         const existingItem = activeCartItems.find(
-          (item) => item.skuId === productSkuId,
+          (item) =>
+            item.skuId === productSkuId &&
+            cartLineSourceKey(item) === nextLineSourceKey,
         );
+        const conflictingItem =
+          queuedReadModel?.activeSale?.items.find(
+            (item) =>
+              item.productSkuId === productSkuId &&
+              cartLineSourceKey(item) !== nextLineSourceKey &&
+              (cartLineSourceKey(item) === "trusted_inventory" ||
+                nextLineSourceKey === "trusted_inventory"),
+          ) ??
+          activeCartItems.find(
+            (item) =>
+              item.skuId === productSkuId &&
+              cartLineSourceKey(item) !== nextLineSourceKey &&
+              (cartLineSourceKey(item) === "trusted_inventory" ||
+                nextLineSourceKey === "trusted_inventory"),
+          );
+        if (conflictingItem) {
+          toast.error(
+            "This item is already in the cart from a different inventory source. Remove it and add it again.",
+          );
+          return false;
+        }
         const nextQuantity =
           (localSaleItem?.quantity ?? existingItem?.quantity ?? 0) +
           requestedQuantity;
@@ -4928,8 +5028,9 @@ export function useRegisterViewModel(): RegisterViewModel {
           localSaleItem?.localItemId ??
           existingItem?.id.toString() ??
           createLocalFallbackId("local-item");
-        const optimisticProductKey = productSkuId;
-        const previousOptimisticProduct = optimisticCartProducts[productSkuId];
+        const optimisticProductKey = product.id.toString();
+        const previousOptimisticProduct =
+          optimisticCartProducts[optimisticProductKey];
         const isExistingOptimisticProduct = existingItem?.id
           .toString()
           .startsWith("optimistic:");
@@ -5083,10 +5184,17 @@ export function useRegisterViewModel(): RegisterViewModel {
             )
           : undefined;
         const currentQuantity = queuedLocalItem?.quantity ?? item.quantity;
+        const isProvisionalImportLine = Boolean(
+          ("inventoryImportProvisionalSkuId" in item
+            ? item.inventoryImportProvisionalSkuId
+            : undefined) ??
+            queuedLocalItem?.inventoryImportProvisionalSkuId,
+        );
 
         if (
           item.skuId &&
           quantity > currentQuantity &&
+          !isProvisionalImportLine &&
           registerCatalogSkuIds.has(item.skuId)
         ) {
           const requestedIncrease = quantity - currentQuantity;
@@ -5130,7 +5238,7 @@ export function useRegisterViewModel(): RegisterViewModel {
           noteLocalRegisterEventChanged();
           setOptimisticCartProducts((current) => {
             const next = { ...current };
-            delete next[item.skuId!];
+            delete next[optimisticCartProductKeyFromCartItem(item)];
             return next;
           });
           return;
@@ -5151,7 +5259,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         noteLocalRegisterEventChanged();
         setOptimisticCartProducts((current) => ({
           ...current,
-          [item.skuId!]: {
+          [optimisticCartProductKeyFromCartItem(item)]: {
             ...item,
             quantity,
           },
@@ -5263,7 +5371,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         noteLocalRegisterEventChanged();
         setOptimisticCartProducts((current) => {
           const next = { ...current };
-          delete next[item.skuId!];
+          delete next[optimisticCartProductKeyFromCartItem(item)];
           return next;
         });
         return;

--- a/scripts/graphify-check.test.ts
+++ b/scripts/graphify-check.test.ts
@@ -142,4 +142,38 @@ describe("runGraphifyCheck", () => {
       })
     ).resolves.toBeUndefined();
   });
+
+  it("ignores generated validation artifacts when preparing graphify check inputs", async () => {
+    const rootDir = await createFixtureRoot();
+    await write(
+      "artifacts/harness-inferential-review/generated.ts",
+      "export const generated = true;\n",
+      rootDir
+    );
+    await write("graphify-out/GRAPH_REPORT.md", "clean report\n", rootDir);
+    await write("graphify-out/graph.json", '{"clean":true}\n', rootDir);
+    await writeGraphifyWikiArtifacts(rootDir, "fresh");
+
+    await expect(
+      runGraphifyCheck(rootDir, {
+        runGraphifyRebuild: async (workspaceRoot) => {
+          const generatedPath = path.join(
+            workspaceRoot,
+            "artifacts/harness-inferential-review/generated.ts"
+          );
+
+          try {
+            await readFile(generatedPath, "utf8");
+            await write("graphify-out/GRAPH_REPORT.md", "generated report\n", workspaceRoot);
+            await write("graphify-out/graph.json", '{"generated":true}\n', workspaceRoot);
+          } catch {
+            await write("graphify-out/GRAPH_REPORT.md", "clean report\n", workspaceRoot);
+            await write("graphify-out/graph.json", '{"clean":true}\n', workspaceRoot);
+          }
+
+          await writeGraphifyWikiArtifacts(workspaceRoot, "fresh");
+        },
+      })
+    ).resolves.toBeUndefined();
+  });
 });

--- a/scripts/graphify-check.ts
+++ b/scripts/graphify-check.ts
@@ -23,6 +23,7 @@ const SKIP_DIRS = new Set([
   "worktrees",
   "graphify-out",
   "__pycache__",
+  "artifacts",
   "coverage",
   "dist",
   "storybook-static",

--- a/scripts/graphify-rebuild.test.ts
+++ b/scripts/graphify-rebuild.test.ts
@@ -42,6 +42,10 @@ describe("runGraphifyRebuild", () => {
     expect(GRAPHIFY_REBUILD_SNIPPET).toContain("'storybook-static'");
   });
 
+  it("skips generated validation artifacts during graph extraction", () => {
+    expect(GRAPHIFY_REBUILD_SNIPPET).toContain("'artifacts'");
+  });
+
   it("normalizes date-bearing report headers for stable freshness checks", () => {
     expect(GRAPHIFY_REBUILD_SNIPPET).toContain("import re");
     expect(GRAPHIFY_REBUILD_SNIPPET).toContain("report_lines[0] = re.sub(");

--- a/scripts/graphify-rebuild.ts
+++ b/scripts/graphify-rebuild.ts
@@ -17,7 +17,7 @@ export const GRAPHIFY_REBUILD_SNIPPET =
     "from graphify.export import to_json",
     "ROOT = Path('.')",
     "EXTENSIONS = {'.py', '.js', '.ts', '.tsx', '.go', '.rs', '.java', '.c', '.h', '.cpp', '.cc', '.cxx', '.hpp', '.rb', '.cs', '.kt', '.kts', '.scala', '.php', '.swift', '.lua', '.toc', '.zig', '.ps1', '.m', '.mm'}",
-    "SKIP_DIRS = {'node_modules', 'worktrees', 'graphify-out', '__pycache__', 'coverage', 'dist', 'storybook-static'}",
+    "SKIP_DIRS = {'node_modules', 'worktrees', 'graphify-out', '__pycache__', 'artifacts', 'coverage', 'dist', 'storybook-static'}",
     "def collect_repo_files(root: Path) -> list[Path]:",
     "    results = []",
     "    for dirpath, dirnames, filenames in os.walk(root):",


### PR DESCRIPTION
## Summary
- add a provisional inventory import table for active import rows that should be sellable in POS before final stock counts are trusted
- expose active provisional import rows through register catalog/search and local/offline availability without enforcing trusted stock counts
- record provisional sale evidence by import row and net those sales out when the import is finalized into trusted Athena inventory
- keep trusted vs provisional checkout paths separated for session carts, direct checkout, offline sync projection, transaction history, and void reversal
- document the trust boundary and update the execute skill review posture to loop relevant reviewer subagents until unanimous approval with no numeric cap

## Validation
- relevant reviewer subagents looped to unanimous approval: correctness, data integrity, testing
- `bun run --filter '@athena/webapp' test -- convex/inventory/catalogImport.test.ts convex/pos/application/sessionCommands.test.ts convex/pos/application/completeTransaction.test.ts convex/pos/application/queries/listRegisterCatalog.test.ts convex/pos/application/sync/projectLocalEvents.test.ts src/lib/pos/infrastructure/local/registerReadModel.test.ts src/lib/pos/presentation/register/catalogSearchPresentation.test.ts src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
- `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json`
- `bun run --filter '@athena/webapp' lint:convex:changed`
- `git diff --check`
- `bun run graphify:rebuild && bun run graphify:check`
- `bun run pr:athena`
- pre-push validation suite reran during `git push` and passed

## Manual validation
Browser/manual visual validation intentionally left to Kwamina.
