### PR TITLE
feat(pos): deliver provisional import checkout availability

### DIFF
--- a/docs/solutions/architecture/athena-pos-provisional-import-availability-2026-06-11.md
+++ b/docs/solutions/architecture/athena-pos-provisional-import-availability-2026-06-11.md
@@ -1,0 +1,106 @@
+---
+title: Athena POS Provisional Import Availability Keeps Sale Flow Separate From Count Finalization
+date: 2026-06-11
+category: architecture
+module: athena-webapp
+problem_type: provisional_import_pos_availability
+component: pos
+symptoms:
+  - "Imported legacy inventory needs to be searchable in POS before final Athena counts are trusted"
+  - "Trusted stock mismatches can block checkout even when field reality says the product is being sold"
+  - "Inventory import review decisions can accidentally look like they mutate existing Athena SKUs"
+root_cause: provisional_inventory_was_modeled_like_final_trusted_stock
+resolution_type: provisional_catalog_projection_with_reviewable_stock_exceptions
+severity: high
+tags:
+  - pos
+  - inventory-import
+  - provisional-stock
+  - local-first
+  - reconciliation
+---
+
+# Athena POS Provisional Import Availability Keeps Sale Flow Separate From Count Finalization
+
+## Problem
+
+During legacy inventory migration, cashiers need imported products available in
+checkout before every physical count is finalized. Treating those imported rows
+as normal trusted stock creates two bad outcomes:
+
+- provisional products disappear or show as unavailable while the count is
+  intentionally pending;
+- trusted-stock mismatches can hard-block a real sale that should complete and
+  become review evidence.
+
+Import review decisions also need to stay attached to the provisional SKU
+projection. They should not silently rewrite existing Athena SKUs while the
+import remains staged.
+
+## Solution
+
+Model provisional import availability as a checkout projection, not as final
+inventory truth:
+
+- Store staged imported rows in the provisional import table and project them
+  into POS catalog search with generated Athena SKU values.
+- Preserve the import review decision as the source of the provisional SKU's
+  fields until finalization. Decisions remain draftable and restageable before
+  the import is finalized.
+- Keep existing Athena SKUs intact. The staging flow can create or update the
+  provisional projection, but final inventory replacement is a later explicit
+  finalization step.
+- Let POS add known provisional items without enforcing `quantityAvailable`.
+  Surface `Count pending` instead of `0 available` for provisional and pending
+  checkout rows whose counts are not trusted yet.
+- Let trusted-stock mismatches complete the local sale. Cloud sync should mark
+  the sale event for review with inventory mismatch evidence, not write drawer
+  authority blocks or force the cashier into the drawer gate.
+- Keep product lookup deduplicated when the same generated Athena SKU appears
+  through both trusted catalog and provisional projections. Prefer trusted count
+  copy when the trusted catalog row is the source of truth, and only use
+  provisional availability copy when the row is actually provisional.
+
+## Prevention
+
+- Do not use imported legacy SKU text as the Athena SKU when creating
+  provisional products. Generate Athena SKUs so staging is idempotent and does
+  not collide with old-system identifiers.
+- Do not show raw placeholder values such as `NULL` in POS cards or cart rows.
+  Omit absent variant/category values instead.
+- Do not cap checkout quantity controls for known provisional or trusted rows
+  solely because `quantityAvailable` is zero. Unknown availability may still
+  block because the register lacks a product identity to reconcile.
+- Do not classify `transaction.completed` sync review as drawer lifecycle
+  review. Drawer authority blocks are for register lifecycle events such as
+  open, closeout, and reopen.
+- Do not let provisional rows duplicate trusted catalog rows in search results.
+  Deduplicate by product/SKU identity at the query boundary and cover both
+  provisional-first and trusted-first ordering in tests.
+
+## Validation
+
+Use this focused slice when changing provisional import POS availability:
+
+- `convex/inventory/catalogImport.test.ts`
+- `convex/pos/application/queries/listRegisterCatalog.test.ts`
+- `convex/pos/application/queries/searchCatalog.test.ts`
+- `convex/pos/public/sync.test.ts`
+- `src/components/operations/InventoryImportView.test.tsx`
+- `src/components/pos/SearchResultsSection.test.tsx`
+- `src/components/pos/CartItems.test.tsx`
+- `src/components/products/ProductsListView.test.ts`
+- `src/lib/pos/infrastructure/local/localCommandGateway.test.ts`
+- `src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`
+- `src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+
+Run `bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json` and
+`bun run pr:athena` before delivery. The sync runtime test should include a
+sale inventory review conflict assertion proving no drawer authority block is
+persisted.
+
+## Related
+
+- [Athena POS Provisional Import Trust Boundary](./athena-pos-provisional-import-trust-boundary-2026-06-10.md)
+- [Athena POS Pending Checkout Item Recovery](./athena-pos-pending-checkout-item-recovery-2026-06-06.md)
+- [Athena POS Offline Sales Continuity Separates Local Authority From Cloud Validation](./athena-pos-offline-sales-continuity-2026-06-04.md)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1861 files · ~0 words
+- 1862 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6435 nodes · 7117 edges · 1789 communities detected
+- 6443 nodes · 7127 edges · 1790 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1799,6 +1799,7 @@
 - [[_COMMUNITY_Community 1786|Community 1786]]
 - [[_COMMUNITY_Community 1787|Community 1787]]
 - [[_COMMUNITY_Community 1788|Community 1788]]
+- [[_COMMUNITY_Community 1789|Community 1789]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1875,16 +1876,16 @@ Cohesion: 0.07
 Nodes (20): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+12 more)
 
 ### Community 12 - "Community 12"
+Cohesion: 0.13
+Nodes (35): buildFinalTrustedQuantitiesByRowNumber(), buildProvisionalSkuPatch(), buildSkuInsert(), buildSkuPatch(), finalizeProvisionalImportRowsForAppliedImport(), findExistingSku(), findOrCreateCategory(), findOrCreateProduct() (+27 more)
+
+### Community 13 - "Community 13"
 Cohesion: 0.12
 Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
 
-### Community 13 - "Community 13"
+### Community 14 - "Community 14"
 Cohesion: 0.08
 Nodes (21): formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels(), getSkuDetailEntries() (+13 more)
-
-### Community 14 - "Community 14"
-Cohesion: 0.14
-Nodes (33): buildFinalTrustedQuantitiesByRowNumber(), buildProvisionalSkuPatch(), buildSkuInsert(), buildSkuPatch(), finalizeProvisionalImportRowsForAppliedImport(), findExistingSku(), findOrCreateCategory(), findOrCreateProduct() (+25 more)
 
 ### Community 15 - "Community 15"
 Cohesion: 0.12
@@ -2079,36 +2080,36 @@ Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
 ### Community 63 - "Community 63"
+Cohesion: 0.13
+Nodes (2): handleEnterReviewMode(), saveInventoryImportRouteDraft()
+
+### Community 64 - "Community 64"
 Cohesion: 0.24
 Nodes (12): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), buildValidationMetadataMetrics(), getReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), mapSyncStatus(), normalizeStaffAuthorityStatus() (+4 more)
 
-### Community 64 - "Community 64"
+### Community 65 - "Community 65"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.26
 Nodes (13): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget() (+5 more)
 
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.33
 Nodes (14): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+6 more)
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.17
 Nodes (6): buildServerPricedCheckoutProducts(), calculateItemsSubtotal(), deriveDeliveryOptionFromAddress(), isDeliveryFeeWaived(), normalizeDeliveryOption(), resolveServerDeliveryFee()
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.27
 Nodes (14): cacheAssetRequest(), cacheFirstAsset(), cacheLinkedShellAssets(), cacheModuleDependencies(), isExcluded(), isHtmlResponse(), isJavaScriptLikeResponse(), isPosNavigation() (+6 more)
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.15
 Nodes (4): formatCurrency(), formatFinancialLabel(), formatTimelineRange(), formatTimelineTime()
-
-### Community 70 - "Community 70"
-Cohesion: 0.14
-Nodes (2): handleEnterReviewMode(), saveInventoryImportRouteDraft()
 
 ### Community 71 - "Community 71"
 Cohesion: 0.24
@@ -2611,16 +2612,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 196 - "Community 196"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
-
-### Community 197 - "Community 197"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 198 - "Community 198"
+### Community 197 - "Community 197"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 198 - "Community 198"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 199 - "Community 199"
 Cohesion: 0.43
@@ -2723,12 +2724,12 @@ Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
 ### Community 224 - "Community 224"
-Cohesion: 0.47
-Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
+Cohesion: 0.4
+Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
 
 ### Community 225 - "Community 225"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
 
 ### Community 226 - "Community 226"
 Cohesion: 0.33
@@ -2736,27 +2737,27 @@ Nodes (0):
 
 ### Community 227 - "Community 227"
 Cohesion: 0.33
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 228 - "Community 228"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 229 - "Community 229"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 230 - "Community 230"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 231 - "Community 231"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 232 - "Community 232"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 233 - "Community 233"
 Cohesion: 0.33
@@ -2771,108 +2772,108 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 236 - "Community 236"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 237 - "Community 237"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 238 - "Community 238"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
+
+### Community 239 - "Community 239"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 241 - "Community 241"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 240 - "Community 240"
+### Community 242 - "Community 242"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 241 - "Community 241"
+### Community 243 - "Community 243"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 242 - "Community 242"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 243 - "Community 243"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 244 - "Community 244"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 245 - "Community 245"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 246 - "Community 246"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 245 - "Community 245"
+### Community 247 - "Community 247"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 246 - "Community 246"
+### Community 248 - "Community 248"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
-
-### Community 247 - "Community 247"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 248 - "Community 248"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
 
 ### Community 249 - "Community 249"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 250 - "Community 250"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
 
 ### Community 251 - "Community 251"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 252 - "Community 252"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 252 - "Community 252"
+### Community 253 - "Community 253"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 253 - "Community 253"
+### Community 254 - "Community 254"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 255 - "Community 255"
+### Community 256 - "Community 256"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 0.5
 Nodes (2): createAuthorizedRegisterDepositCtx(), createQueryCtx()
 
-### Community 258 - "Community 258"
+### Community 259 - "Community 259"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 259 - "Community 259"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 260 - "Community 260"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 261 - "Community 261"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 262 - "Community 262"
 Cohesion: 0.7
@@ -3039,96 +3040,96 @@ Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 303 - "Community 303"
-Cohesion: 0.5
-Nodes (3): createVersionChecker(), shouldAutoReloadForCurrentRoute(), shouldAutoReloadForPath()
-
-### Community 304 - "Community 304"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 305 - "Community 305"
+### Community 304 - "Community 304"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 306 - "Community 306"
+### Community 305 - "Community 305"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 307 - "Community 307"
+### Community 306 - "Community 306"
 Cohesion: 0.7
 Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+
+### Community 307 - "Community 307"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 308 - "Community 308"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 309 - "Community 309"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 310 - "Community 310"
 Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 311 - "Community 311"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (3): createVersionChecker(), shouldAutoReloadForCurrentRoute(), shouldAutoReloadForPath()
 
 ### Community 312 - "Community 312"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 313 - "Community 313"
-Cohesion: 0.6
-Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 314 - "Community 314"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 314 - "Community 314"
+Cohesion: 0.6
+Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+
 ### Community 315 - "Community 315"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 316 - "Community 316"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 316 - "Community 316"
+### Community 317 - "Community 317"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 317 - "Community 317"
+### Community 318 - "Community 318"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 318 - "Community 318"
+### Community 319 - "Community 319"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 319 - "Community 319"
+### Community 320 - "Community 320"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 320 - "Community 320"
+### Community 321 - "Community 321"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 321 - "Community 321"
+### Community 322 - "Community 322"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 322 - "Community 322"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 323 - "Community 323"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 324 - "Community 324"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
-
-### Community 325 - "Community 325"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 325 - "Community 325"
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 326 - "Community 326"
 Cohesion: 0.5
@@ -3139,72 +3140,72 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 328 - "Community 328"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 329 - "Community 329"
 Cohesion: 0.67
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 329 - "Community 329"
+### Community 330 - "Community 330"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 330 - "Community 330"
+### Community 331 - "Community 331"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 331 - "Community 331"
+### Community 332 - "Community 332"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 332 - "Community 332"
+### Community 333 - "Community 333"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 333 - "Community 333"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 334 - "Community 334"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 335 - "Community 335"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 336 - "Community 336"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 337 - "Community 337"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 337 - "Community 337"
+### Community 338 - "Community 338"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 338 - "Community 338"
+### Community 339 - "Community 339"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 339 - "Community 339"
+### Community 340 - "Community 340"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 340 - "Community 340"
+### Community 341 - "Community 341"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 341 - "Community 341"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 342 - "Community 342"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 343 - "Community 343"
 Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 344 - "Community 344"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 345 - "Community 345"
 Cohesion: 0.5
@@ -3215,36 +3216,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 347 - "Community 347"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 348 - "Community 348"
 Cohesion: 0.67
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 348 - "Community 348"
+### Community 349 - "Community 349"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 349 - "Community 349"
+### Community 350 - "Community 350"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 350 - "Community 350"
+### Community 351 - "Community 351"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 351 - "Community 351"
+### Community 352 - "Community 352"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 352 - "Community 352"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 353 - "Community 353"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 354 - "Community 354"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 355 - "Community 355"
 Cohesion: 0.5
@@ -3263,20 +3264,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 359 - "Community 359"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 360 - "Community 360"
 Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 361 - "Community 361"
 Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 362 - "Community 362"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 363 - "Community 363"
 Cohesion: 0.5
@@ -3299,12 +3300,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 368 - "Community 368"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
-
-### Community 369 - "Community 369"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 369 - "Community 369"
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 370 - "Community 370"
 Cohesion: 0.67
@@ -3319,12 +3320,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 373 - "Community 373"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 374 - "Community 374"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 374 - "Community 374"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 375 - "Community 375"
 Cohesion: 0.5
@@ -3335,20 +3336,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 377 - "Community 377"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 378 - "Community 378"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 379 - "Community 379"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 380 - "Community 380"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 381 - "Community 381"
 Cohesion: 0.5
@@ -3356,19 +3357,19 @@ Nodes (0):
 
 ### Community 382 - "Community 382"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 383 - "Community 383"
-Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
-
-### Community 384 - "Community 384"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 384 - "Community 384"
+Cohesion: 0.67
+Nodes (2): useGetArchivedProducts(), useGetProducts()
+
 ### Community 385 - "Community 385"
 Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
 
 ### Community 386 - "Community 386"
 Cohesion: 0.5
@@ -3376,23 +3377,23 @@ Nodes (0):
 
 ### Community 387 - "Community 387"
 Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 388 - "Community 388"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 389 - "Community 389"
+Cohesion: 0.67
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
+
+### Community 390 - "Community 390"
 Cohesion: 0.67
 Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
-### Community 389 - "Community 389"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 390 - "Community 390"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 391 - "Community 391"
-Cohesion: 0.67
-Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 392 - "Community 392"
 Cohesion: 0.5
@@ -3400,55 +3401,55 @@ Nodes (0):
 
 ### Community 393 - "Community 393"
 Cohesion: 0.67
-Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
+Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
 ### Community 394 - "Community 394"
-Cohesion: 0.83
-Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
-
-### Community 395 - "Community 395"
-Cohesion: 0.83
-Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
-
-### Community 396 - "Community 396"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 395 - "Community 395"
+Cohesion: 0.67
+Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
+
+### Community 396 - "Community 396"
+Cohesion: 0.83
+Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
+
 ### Community 397 - "Community 397"
 Cohesion: 0.83
-Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
+Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
 ### Community 398 - "Community 398"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 399 - "Community 399"
+Cohesion: 0.83
+Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
+
+### Community 400 - "Community 400"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 401 - "Community 401"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 400 - "Community 400"
+### Community 402 - "Community 402"
 Cohesion: 0.83
 Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
-### Community 401 - "Community 401"
+### Community 403 - "Community 403"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 402 - "Community 402"
+### Community 404 - "Community 404"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 403 - "Community 403"
+### Community 405 - "Community 405"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
-
-### Community 404 - "Community 404"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 405 - "Community 405"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 406 - "Community 406"
 Cohesion: 0.5
@@ -3475,76 +3476,76 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 412 - "Community 412"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 413 - "Community 413"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 414 - "Community 414"
 Cohesion: 0.67
 Nodes (2): useOptionalStoreContext(), useStoreContext()
 
-### Community 413 - "Community 413"
+### Community 415 - "Community 415"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 414 - "Community 414"
+### Community 416 - "Community 416"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 415 - "Community 415"
+### Community 417 - "Community 417"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 416 - "Community 416"
+### Community 418 - "Community 418"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 417 - "Community 417"
+### Community 419 - "Community 419"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 418 - "Community 418"
+### Community 420 - "Community 420"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 419 - "Community 419"
+### Community 421 - "Community 421"
 Cohesion: 0.67
 Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
-### Community 420 - "Community 420"
+### Community 422 - "Community 422"
 Cohesion: 0.67
 Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
-### Community 421 - "Community 421"
+### Community 423 - "Community 423"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 422 - "Community 422"
+### Community 424 - "Community 424"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 423 - "Community 423"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 424 - "Community 424"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 425 - "Community 425"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 426 - "Community 426"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 427 - "Community 427"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 428 - "Community 428"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 429 - "Community 429"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 430 - "Community 430"
 Cohesion: 0.67
@@ -3583,16 +3584,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 439 - "Community 439"
-Cohesion: 1.0
-Nodes (2): buildCtx(), createDb()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 440 - "Community 440"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 441 - "Community 441"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildCtx(), createDb()
 
 ### Community 442 - "Community 442"
 Cohesion: 0.67
@@ -3603,16 +3604,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 444 - "Community 444"
-Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 445 - "Community 445"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 446 - "Community 446"
-Cohesion: 0.67
-Nodes (1): PosServerError
+Cohesion: 1.0
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 447 - "Community 447"
 Cohesion: 0.67
@@ -3620,7 +3621,7 @@ Nodes (0):
 
 ### Community 448 - "Community 448"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 449 - "Community 449"
 Cohesion: 0.67
@@ -3631,32 +3632,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 451 - "Community 451"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 452 - "Community 452"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 453 - "Community 453"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 454 - "Community 454"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 455 - "Community 455"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 456 - "Community 456"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 457 - "Community 457"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 458 - "Community 458"
 Cohesion: 0.67
@@ -3667,44 +3668,44 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 460 - "Community 460"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 461 - "Community 461"
-Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 462 - "Community 462"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 463 - "Community 463"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 464 - "Community 464"
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+
+### Community 465 - "Community 465"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 465 - "Community 465"
+### Community 466 - "Community 466"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 467 - "Community 467"
 Cohesion: 1.0
 Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
-### Community 466 - "Community 466"
+### Community 468 - "Community 468"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 467 - "Community 467"
-Cohesion: 0.67
-Nodes (1): View()
-
-### Community 468 - "Community 468"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 469 - "Community 469"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 470 - "Community 470"
 Cohesion: 0.67
@@ -3715,52 +3716,52 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 472 - "Community 472"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 473 - "Community 473"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 474 - "Community 474"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 475 - "Community 475"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 476 - "Community 476"
-Cohesion: 1.0
-Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 477 - "Community 477"
 Cohesion: 0.67
-Nodes (1): FadeIn()
+Nodes (0):
 
 ### Community 478 - "Community 478"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
 ### Community 479 - "Community 479"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 480 - "Community 480"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 481 - "Community 481"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 482 - "Community 482"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 483 - "Community 483"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 484 - "Community 484"
 Cohesion: 0.67
@@ -8982,6 +8983,10 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1789 - "Community 1789"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -10615,763 +10620,765 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1409`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1410`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1411`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1412`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1413`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1414`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1415`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1416`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1417`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1418`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `data.ts`
+- **Thin community `Community 1419`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1420`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1421`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1422`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1423`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1424`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1425`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1426`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1427`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1428`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1429`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1430`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1431`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `constants.ts`
+- **Thin community `Community 1432`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1433`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1434`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1435`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `data.ts`
+- **Thin community `Community 1436`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `types.ts`
+- **Thin community `Community 1437`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1438`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1439`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1440`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1441`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1442`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `index.tsx`
+- **Thin community `Community 1443`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1444`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1445`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1446`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1447`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1448`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1449`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1450`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1451`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `index.tsx`
+- **Thin community `Community 1452`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1453`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1454`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1455`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `button.tsx`
+- **Thin community `Community 1456`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1457`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `card.tsx`
+- **Thin community `Community 1458`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1459`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1460`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `command.tsx`
+- **Thin community `Community 1461`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1462`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1463`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1464`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `form.tsx`
+- **Thin community `Community 1465`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1466`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1467`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `input.tsx`
+- **Thin community `Community 1468`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1469`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1470`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1471`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1472`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1473`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1474`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `select.tsx`
+- **Thin community `Community 1475`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1476`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1477`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1478`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `table.tsx`
+- **Thin community `Community 1479`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1480`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1481`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1482`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1483`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1484`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1485`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1486`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1487`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `constants.ts`
+- **Thin community `Community 1488`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1489`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1490`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1491`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `data.ts`
+- **Thin community `Community 1492`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1493`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1494`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1495`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1496`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1497`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1498`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1499`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1500`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1501`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1502`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1503`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `index.ts`
+- **Thin community `Community 1504`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1505`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1506`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1507`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1508`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1509`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1510`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1511`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1512`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1513`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1514`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1515`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `aws.ts`
+- **Thin community `Community 1516`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `constants.ts`
+- **Thin community `Community 1517`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `countries.ts`
+- **Thin community `Community 1518`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1519`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1520`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1521`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1522`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1523`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1524`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1525`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `dto.ts`
+- **Thin community `Community 1526`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `ports.ts`
+- **Thin community `Community 1527`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `constants.ts`
+- **Thin community `Community 1528`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1529`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1530`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `index.ts`
+- **Thin community `Community 1531`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1532`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `types.ts`
+- **Thin community `Community 1533`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1534`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1535`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1536`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1537`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1538`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1539`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1540`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1541`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 1542`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1543`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1544`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1545`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `category.ts`
+- **Thin community `Community 1546`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `product.ts`
+- **Thin community `Community 1547`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `store.ts`
+- **Thin community `Community 1548`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1549`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `user.ts`
+- **Thin community `Community 1550`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1551`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1552`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1553`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1554`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1555`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1556`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1557`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1558`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1559`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1560`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `index.tsx`
+- **Thin community `Community 1561`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1562`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1563`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1564`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1565`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1566`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1567`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1568`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `index.tsx`
+- **Thin community `Community 1569`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1570`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1571`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1572`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `home.tsx`
+- **Thin community `Community 1573`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1574`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1575`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1576`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `index.tsx`
+- **Thin community `Community 1577`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `review.tsx`
+- **Thin community `Community 1578`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1579`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1580`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `index.tsx`
+- **Thin community `Community 1581`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1582`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1583`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1584`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `index.tsx`
+- **Thin community `Community 1585`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1586`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1587`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1588`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1589`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1590`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1591`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `index.tsx`
+- **Thin community `Community 1592`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1593`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1594`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1595`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1596`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1597`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1598`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1599`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1600`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1601`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `index.tsx`
+- **Thin community `Community 1602`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1603`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `index.tsx`
+- **Thin community `Community 1604`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `new.tsx`
+- **Thin community `Community 1605`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `index.tsx`
+- **Thin community `Community 1606`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `new.tsx`
+- **Thin community `Community 1607`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1608`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1609`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `index.tsx`
+- **Thin community `Community 1610`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `new.tsx`
+- **Thin community `Community 1611`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `index.tsx`
+- **Thin community `Community 1612`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1613`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1614`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1615`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1616`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `index.tsx`
+- **Thin community `Community 1617`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1618`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1619`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1620`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `index.tsx`
+- **Thin community `Community 1621`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1622`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1623`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1624`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1625`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1626`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1627`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1628`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1629`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1630`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1631`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1632`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1633`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1634`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1635`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1636`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1637`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1638`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1639`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1640`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1641`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1642`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1643`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1644`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1645`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `setup.ts`
+- **Thin community `Community 1646`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1647`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `types.ts`
+- **Thin community `Community 1648`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1649`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1650`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1651`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1652`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1653`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `types.ts`
+- **Thin community `Community 1654`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1655`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1656`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1657`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1658`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1659`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1660`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1661`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1662`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1663`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `schema.ts`
+- **Thin community `Community 1664`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1665`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1666`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1667`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1668`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1669`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1670`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1671`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1672`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1673`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `types.ts`
+- **Thin community `Community 1674`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1675`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1676`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1677`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1678`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1679`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1680`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1681`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `constants.ts`
+- **Thin community `Community 1682`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1683`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `About.tsx`
+- **Thin community `Community 1684`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1685`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1686`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1687`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1688`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1689`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1690`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1691`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1692`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1693`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1694`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `types.ts`
+- **Thin community `Community 1695`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1696`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1697`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1698`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1699`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1700`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1701`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1702`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1703`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1704`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1705`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1706`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `button.tsx`
+- **Thin community `Community 1707`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `card.tsx`
+- **Thin community `Community 1708`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1709`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `command.tsx`
+- **Thin community `Community 1710`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1711`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1712`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1713`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `form.tsx`
+- **Thin community `Community 1714`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1715`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1716`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1717`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1718`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `input.tsx`
+- **Thin community `Community 1719`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `label.tsx`
+- **Thin community `Community 1720`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1721`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1722`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1723`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `index.ts`
+- **Thin community `Community 1724`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `types.ts`
+- **Thin community `Community 1725`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1726`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1727`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1728`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1729`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `select.tsx`
+- **Thin community `Community 1730`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1731`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1732`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `table.tsx`
+- **Thin community `Community 1733`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1734`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1735`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1736`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1737`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1738`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `config.ts`
+- **Thin community `Community 1739`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1740`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1741`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1742`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1743`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `constants.ts`
+- **Thin community `Community 1744`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `countries.ts`
+- **Thin community `Community 1745`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1746`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1747`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1748`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1749`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `index.ts`
+- **Thin community `Community 1750`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `store.ts`
+- **Thin community `Community 1751`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `bag.ts`
+- **Thin community `Community 1752`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1753`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `category.ts`
+- **Thin community `Community 1754`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `organization.ts`
+- **Thin community `Community 1755`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `product.ts`
+- **Thin community `Community 1756`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `store.ts`
+- **Thin community `Community 1757`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1758`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `user.ts`
+- **Thin community `Community 1759`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `states.ts`
+- **Thin community `Community 1760`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1761`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1762`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1763`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1764`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1765`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1766`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1767`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `index.tsx`
+- **Thin community `Community 1768`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1769`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `index.tsx`
+- **Thin community `Community 1770`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1771`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1772`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1773`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1774`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1775`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `index.tsx`
+- **Thin community `Community 1776`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1777`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1778`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1779`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1780`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1781`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `index.js`
+- **Thin community `Community 1782`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1783`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1784`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1785`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1786`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1787`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1788`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1789`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1861
-- Graph nodes: 6435
-- Graph edges: 7117
-- Communities: 1789
+- Code files discovered: 1862
+- Graph nodes: 6443
+- Graph edges: 7127
+- Communities: 1790
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (87 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -20,7 +20,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - `storefrontJourneyEvents.ts` (45 edges, Community 8) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 8) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 43) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `checkoutSession.ts` (14 edges, Community 64) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `checkoutSession.ts` (14 edges, Community 65) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 - `storeConfig.ts` (14 edges, Community 43) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation

--- a/packages/athena-webapp/convex/inventory/catalogImport.test.ts
+++ b/packages/athena-webapp/convex/inventory/catalogImport.test.ts
@@ -453,7 +453,7 @@ describe("catalog import", () => {
           importKey: "legacy-review-1",
           issueCount: 0,
           organizationId: "org-1",
-          rawContent: "product_name,sku,price,qty\nBody Wave,BW-18,450,6",
+          rawContent: "product_name,sku,price,qty\nBody Wave,LEGACY-BODY-WAVE,450,6",
           rowCount: 1,
           sourceFormat: "csv",
           storeId: "store-1",
@@ -503,9 +503,9 @@ describe("catalog import", () => {
           productName: "Body Wave imported",
           productSkuId: "sku-1" as Id<"productSku">,
           quantity: 6,
-          rowKey: "2:BW-18:123456789012:Body Wave imported",
+          rowKey: "2:LEGACY-BODY-WAVE:123456789012:Body Wave imported",
           rowNumber: 2,
-          sku: "BW-18",
+          sku: "LEGACY-BODY-WAVE",
         },
       ],
       sourceFormat: "csv",
@@ -530,7 +530,7 @@ describe("catalog import", () => {
       importedSku: "BW-18",
       posExposureStatus: "available",
       reviewVersionId: "review-version-1",
-      rowKey: "2:BW-18:123456789012:Body Wave imported",
+      rowKey: "2:LEGACY-BODY-WAVE:123456789012:Body Wave imported",
       status: "active",
       storeId: "store-1",
     });
@@ -812,11 +812,12 @@ describe("catalog import", () => {
       price: 2500,
       productId: product._id,
       quantityAvailable: 0,
-      sku: "COMB-1",
     });
+    expect(sku.sku).toMatch(/^[A-Z0-9]+-[A-Z0-9]+-[A-Z0-9]+$/);
+    expect(sku.sku).not.toBe("COMB-1");
     expect(Array.from(tables.inventoryImportProvisionalSku.values())[0]).toMatchObject({
       importedQuantity: 4,
-      importedSku: "COMB-1",
+      importedSku: sku.sku,
       productId: product._id,
       productSkuId: sku._id,
       status: "active",

--- a/packages/athena-webapp/convex/inventory/catalogImport.ts
+++ b/packages/athena-webapp/convex/inventory/catalogImport.ts
@@ -27,6 +27,13 @@ const REVIEW_VERSION_EVENT_TYPE = "inventory_import_review_version_saved";
 const PROVISIONAL_STAGE_EVENT_TYPE = "inventory_import_provisional_pos_staged";
 const PROVISIONAL_IMPORT_FINALIZATION_LIMIT = 5000;
 
+type ProvisionalImportIdentity = {
+  productId: Id<"product">;
+  productSkuId: Id<"productSku">;
+  sku?: string;
+  barcode?: string;
+};
+
 const importStatusValidator = v.union(
   v.literal("active"),
   v.literal("draft"),
@@ -623,10 +630,12 @@ export async function stageInventoryImportReviewRowsForPosWithCtx(
     const identity =
       submittedIdentity ??
       (existing?.productId && existing.productSkuId
-        ? {
+        ? await resolveExistingProvisionalImportIdentity(ctx, {
             productId: existing.productId,
             productSkuId: existing.productSkuId,
-          }
+            row,
+            storeId: args.storeId,
+          })
         : await resolveProvisionalImportIdentity(ctx, {
             access,
             row,
@@ -1144,10 +1153,7 @@ async function resolveSubmittedProvisionalImportIdentity(
     row: ProvisionalInventoryImportStageRow;
     storeId: Id<"store">;
   },
-): Promise<{
-  productId: Id<"product">;
-  productSkuId: Id<"productSku">;
-} | null> {
+): Promise<ProvisionalImportIdentity | null> {
   if (!args.row.productId && !args.row.productSkuId) return null;
   if (!args.row.productId || !args.row.productSkuId) {
     throw new Error(
@@ -1175,6 +1181,42 @@ async function resolveSubmittedProvisionalImportIdentity(
   return {
     productId: product._id,
     productSkuId: productSku._id,
+    sku: productSku.sku,
+    barcode: productSku.barcode,
+  };
+}
+
+async function resolveExistingProvisionalImportIdentity(
+  ctx: MutationCtx,
+  args: {
+    productId: Id<"product">;
+    productSkuId: Id<"productSku">;
+    row: ProvisionalInventoryImportStageRow;
+    storeId: Id<"store">;
+  },
+): Promise<ProvisionalImportIdentity> {
+  const [product, productSku] = await Promise.all([
+    ctx.db.get("product", args.productId),
+    ctx.db.get("productSku", args.productSkuId),
+  ]);
+
+  if (
+    !product ||
+    product.storeId !== args.storeId ||
+    !productSku ||
+    productSku.storeId !== args.storeId ||
+    productSku.productId !== product._id
+  ) {
+    throw new Error(
+      `Row ${args.row.rowNumber}: staged Athena product and SKU could not be verified for this store.`,
+    );
+  }
+
+  return {
+    productId: product._id,
+    productSkuId: productSku._id,
+    sku: productSku.sku,
+    barcode: productSku.barcode,
   };
 }
 
@@ -1186,10 +1228,7 @@ async function resolveProvisionalImportIdentity(
     storeId: Id<"store">;
     summary: ProvisionalInventoryImportStageSummary;
   },
-): Promise<{
-  productId?: Id<"product">;
-  productSkuId?: Id<"productSku">;
-}> {
+): Promise<ProvisionalImportIdentity> {
   const created = await findOrCreateProvisionalCatalogIdentity(ctx, {
     access: args.access,
     row: args.row,
@@ -1200,6 +1239,8 @@ async function resolveProvisionalImportIdentity(
   return {
     productId: created.product._id,
     productSkuId: created.productSku._id,
+    sku: created.productSku.sku,
+    barcode: created.productSku.barcode,
   };
 }
 
@@ -1255,7 +1296,17 @@ async function findOrCreateProvisionalCatalogIdentity(
   }
 
   const productSkuId = await ctx.db.insert("productSku", {
-    ...buildSkuInsert({ ...args.row, quantity: 0, status: "draft" }, product._id, args.storeId),
+    ...buildSkuInsert(
+      {
+        ...args.row,
+        barcode: args.row.barcode,
+        quantity: 0,
+        sku: undefined,
+        status: "draft",
+      },
+      product._id,
+      args.storeId,
+    ),
     attributes: {
       importedRowNumber: args.row.rowNumber,
       provisionalImportIdentity: true,
@@ -1265,6 +1316,14 @@ async function findOrCreateProvisionalCatalogIdentity(
     inventoryCount: 0,
     isVisible: false,
     quantityAvailable: 0,
+    sku: "TEMP_SKU",
+  });
+  await ctx.db.patch("productSku", productSkuId, {
+    sku: generateSKU({
+      productId: product._id,
+      skuId: productSkuId,
+      storeId: args.storeId,
+    }),
   });
   const productSku = await ctx.db.get("productSku", productSkuId);
   if (!productSku) {
@@ -1409,6 +1468,27 @@ function normalizeOptional(value?: string) {
   return normalized || undefined;
 }
 
+function generateSKU({
+  storeId,
+  productId,
+  skuId,
+}: {
+  storeId: string;
+  productId: string;
+  skuId: string;
+}) {
+  const encodeBase36 = (id: string, length: number) => {
+    const subset = id.substring(id.length - length);
+    return parseInt(subset, 36).toString(36).toUpperCase();
+  };
+
+  const storeCode = encodeBase36(storeId, 4);
+  const productCode = encodeBase36(productId, 3);
+  const skuCode = encodeBase36(skuId, 3);
+
+  return `${storeCode}-${productCode}-${skuCode}`;
+}
+
 function normalizeReviewRowDecisions(
   decisions?: InventoryImportReviewRowDecision[],
 ): InventoryImportReviewRowDecision[] {
@@ -1446,18 +1526,16 @@ function normalizeProvisionalStageRows(
 
 function buildProvisionalSkuPatch(args: {
   access: ImportAccess;
-  identity: {
-    productId?: Id<"product">;
-    productSkuId?: Id<"productSku">;
-  };
+  identity: ProvisionalImportIdentity;
   reviewVersion: Doc<"inventoryImportReviewVersion">;
   row: ProvisionalInventoryImportStageRow;
   sourceFormat: "csv" | "json";
   storeId: Id<"store">;
 }) {
   const now = Date.now();
-  const importedSku = normalizeOptional(args.row.sku);
-  const importedBarcode = normalizeOptional(args.row.barcode);
+  const importedSku = normalizeOptional(args.identity.sku);
+  const importedBarcode =
+    normalizeOptional(args.identity.barcode) ?? normalizeOptional(args.row.barcode);
 
   return {
     storeId: args.storeId,

--- a/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts
@@ -166,6 +166,18 @@ describe("listRegisterCatalog", () => {
           name: "Accessories",
           slug: "accessories",
         },
+        {
+          _id: "category-pos-quick-add",
+          storeId: "store-a",
+          name: "POS quick add",
+          slug: "pos-quick-add",
+        },
+        {
+          _id: "category-pos-pending-checkout",
+          storeId: "store-a",
+          name: "POS pending checkout",
+          slug: "pos-pending-checkout",
+        },
       ],
       color: [
         {
@@ -227,6 +239,24 @@ describe("listRegisterCatalog", () => {
           categoryId: "category-store-a",
           description: "Hidden product",
           name: "Hidden Product",
+          isVisible: false,
+        },
+        {
+          _id: "product-pos-quick-add",
+          storeId: "store-a",
+          categoryId: "category-pos-quick-add",
+          description: "Cashier recovery item",
+          name: "Quick Added Item",
+          availability: "live",
+          isVisible: false,
+        },
+        {
+          _id: "product-pos-pending-checkout",
+          storeId: "store-a",
+          categoryId: "category-pos-pending-checkout",
+          description: "Reviewable cashier item",
+          name: "Pending Checkout Item",
+          availability: "live",
           isVisible: false,
         },
         {
@@ -313,6 +343,26 @@ describe("listRegisterCatalog", () => {
           quantityAvailable: 3,
         },
         {
+          _id: "sku-pos-quick-add",
+          storeId: "store-a",
+          productId: "product-pos-quick-add",
+          sku: "QUICK-ADD",
+          barcode: "777",
+          images: [],
+          price: 1000,
+          quantityAvailable: 3,
+        },
+        {
+          _id: "sku-pos-pending-checkout",
+          storeId: "store-a",
+          productId: "product-pos-pending-checkout",
+          sku: "PENDING-CHECKOUT",
+          barcode: "111",
+          images: [],
+          price: 1000,
+          quantityAvailable: 3,
+        },
+        {
           _id: "sku-hidden",
           storeId: "store-a",
           productId: "product-hidden-sku",
@@ -367,13 +417,49 @@ describe("listRegisterCatalog", () => {
         areProcessingFeesAbsorbed: false,
         availabilityPolicy: "trusted_inventory",
       },
+      {
+        id: "sku-pos-quick-add",
+        productSkuId: "sku-pos-quick-add",
+        skuId: "sku-pos-quick-add",
+        productId: "product-pos-quick-add",
+        name: "Quick Added Item",
+        sku: "QUICK-ADD",
+        barcode: "777",
+        price: 1000,
+        category: "POS quick add",
+        description: "Cashier recovery item",
+        image: null,
+        size: "",
+        length: null,
+        color: "",
+        areProcessingFeesAbsorbed: false,
+        availabilityPolicy: "trusted_inventory",
+      },
+      {
+        id: "sku-pos-pending-checkout",
+        productSkuId: "sku-pos-pending-checkout",
+        skuId: "sku-pos-pending-checkout",
+        productId: "product-pos-pending-checkout",
+        name: "Pending Checkout Item",
+        sku: "PENDING-CHECKOUT",
+        barcode: "111",
+        price: 1000,
+        category: "POS pending checkout",
+        description: "Reviewable cashier item",
+        image: null,
+        size: "",
+        length: null,
+        color: "",
+        areProcessingFeesAbsorbed: false,
+        availabilityPolicy: "trusted_inventory",
+      },
     ]);
 
     expect(rows[0]).not.toHaveProperty("inStock");
     expect(rows[0]).not.toHaveProperty("quantityAvailable");
   });
 
-  it("surfaces active provisional import SKUs as sellable without trusted quantity", async () => {
+  it("surfaces active provisional import SKUs without shadowing trusted inventory", async () => {
     const { ctx } = createRegisterCatalogCtx({
       category: [
         {
@@ -477,18 +563,18 @@ describe("listRegisterCatalog", () => {
           _id: "sku-trusted",
           storeId: "store-a",
           productId: "product-trusted",
-          sku: "LEGACY-CLOSURE",
+          sku: "ATHENA-CLOSURE",
           barcode: "123PROV",
           images: [],
           isVisible: true,
           price: 85000,
-          quantityAvailable: 0,
+          quantityAvailable: 14,
         },
         {
           _id: "sku-provisional",
           storeId: "store-a",
           productId: "product-provisional",
-          sku: "ANCHOR-CLOSURE",
+          sku: "ATHENA-PROVISIONAL-CLOSURE",
           barcode: "",
           images: [],
           isVisible: false,
@@ -528,26 +614,16 @@ describe("listRegisterCatalog", () => {
       expect.objectContaining({
         productSkuId: "sku-trusted",
         name: "Imported Closure",
-        sku: "LEGACY-CLOSURE",
+        sku: "ATHENA-CLOSURE",
         barcode: "123PROV",
         price: 85000,
         availabilityPolicy: "trusted_inventory",
       }),
       expect.objectContaining({
-        id: "provisional-matched",
-        productSkuId: "sku-trusted",
-        inventoryImportProvisionalSkuId: "provisional-matched",
-        name: "Matched Imported Closure",
-        sku: "LEGACY-CLOSURE",
-        barcode: "123PROV",
-        price: 83000,
-        availabilityPolicy: "active_provisional_import",
-      }),
-      expect.objectContaining({
         productSkuId: "sku-provisional",
         inventoryImportProvisionalSkuId: "provisional-sku-1",
         name: "Imported Closure",
-        sku: "LEGACY-CLOSURE",
+        sku: "ATHENA-PROVISIONAL-CLOSURE",
         barcode: "123PROV",
         price: 85000,
         availabilityPolicy: "active_provisional_import",
@@ -565,10 +641,9 @@ describe("listRegisterCatalog", () => {
       {
         productSkuId: "sku-trusted",
         skuId: "sku-trusted",
-        inventoryImportProvisionalSkuId: "provisional-matched",
         inStock: true,
-        quantityAvailable: 0,
-        availabilityPolicy: "active_provisional_import",
+        quantityAvailable: 14,
+        availabilityPolicy: "trusted_inventory",
       },
       {
         productSkuId: "sku-provisional",
@@ -589,13 +664,8 @@ describe("listRegisterCatalog", () => {
         expect.objectContaining({
           productSkuId: "sku-trusted",
           availabilityPolicy: "trusted_inventory",
-          inStock: false,
-        }),
-        expect.objectContaining({
-          productSkuId: "sku-trusted",
-          inventoryImportProvisionalSkuId: "provisional-matched",
-          availabilityPolicy: "active_provisional_import",
           inStock: true,
+          quantityAvailable: 14,
         }),
         expect.objectContaining({
           productSkuId: "sku-provisional",

--- a/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts
@@ -58,6 +58,10 @@ type InventoryImportProvisionalSku = {
 
 export const REGISTER_CATALOG_AVAILABILITY_LIMIT = 50;
 const REGISTER_CATALOG_PROVISIONAL_IMPORT_LIMIT = 5_000;
+const POS_OPERATIONAL_CATEGORY_SLUGS = new Set([
+  "pos-pending-checkout",
+  "pos-quick-add",
+]);
 
 async function readCategoryName(
   ctx: QueryCtx,
@@ -113,8 +117,8 @@ function mapSkuToRegisterCatalogRow(args: {
       ? { inventoryImportProvisionalSkuId: args.provisionalSku._id }
       : {}),
     name: args.provisionalSku?.importedProductName ?? args.product.name,
-    sku: args.provisionalSku?.importedSku ?? args.sku.sku ?? "",
-    barcode: args.provisionalSku?.importedBarcode ?? args.sku.barcode ?? "",
+    sku: args.sku.sku || args.provisionalSku?.importedSku || "",
+    barcode: args.sku.barcode || args.provisionalSku?.importedBarcode || "",
     price: args.provisionalSku?.importedPrice ?? getRegisterCatalogPrice(args.sku),
     category: args.category,
     description: args.product.description ?? "",
@@ -136,11 +140,16 @@ function getRegisterCatalogPrice(sku: Doc<"productSku">) {
 export function isTrustedRegisterCatalogSku(args: {
   product: Doc<"product">;
   sku: Doc<"productSku">;
+  category?: Doc<"category"> | null;
 }) {
+  const isReservedPosOperationalProduct = args.category?.slug
+    ? POS_OPERATIONAL_CATEGORY_SLUGS.has(args.category.slug)
+    : false;
+
   return (
     args.product.availability !== "archived" &&
     args.product.availability !== "draft" &&
-    args.product.isVisible !== false &&
+    (args.product.isVisible !== false || isReservedPosOperationalProduct) &&
     args.sku.isVisible !== false
   );
 }
@@ -170,9 +179,17 @@ async function listScopedRegisterCatalogSkus(
 
     if (
       !product ||
-      product.storeId !== args.storeId ||
-      !isTrustedRegisterCatalogSku({ product, sku })
+      product.storeId !== args.storeId
     ) {
+      continue;
+    }
+
+    const category =
+      product.isVisible === false
+        ? await ctx.db.get("category", product.categoryId)
+        : null;
+
+    if (!isTrustedRegisterCatalogSku({ product, sku, category })) {
       continue;
     }
 
@@ -292,13 +309,15 @@ export async function listRegisterCatalog(
   const rows: RegisterCatalogRow[] = [];
   const categoryCache = new Map<Id<"category">, string>();
   const colorCache = new Map<Id<"color">, string>();
-  const trustedSkuIds = new Set<Id<"productSku">>();
+  const trustedAvailableSkuIds = new Set<Id<"productSku">>();
 
   for (const { product, sku } of await listScopedRegisterCatalogSkus(
     ctx,
     args,
   )) {
-    trustedSkuIds.add(sku._id);
+    if (sku.quantityAvailable > 0) {
+      trustedAvailableSkuIds.add(sku._id);
+    }
     rows.push(
       mapSkuToRegisterCatalogRow({
         product,
@@ -324,6 +343,7 @@ export async function listRegisterCatalog(
       product.storeId !== args.storeId ||
       sku.storeId !== args.storeId ||
       sku.productId !== product._id ||
+      trustedAvailableSkuIds.has(provisionalSku.productSkuId) ||
       provisionalSku.importedPrice <= 0
     ) {
       continue;
@@ -363,6 +383,22 @@ export async function listRegisterCatalogAvailability(
       continue;
     }
 
+    const availability = await validateInventoryAvailability(ctx.db, sku._id, 1, {
+      storeId: args.storeId,
+    });
+    const quantityAvailable = availability.available ?? 0;
+
+    if (quantityAvailable > 0) {
+      rows.push({
+        productSkuId: sku._id,
+        skuId: sku._id,
+        inStock: true,
+        quantityAvailable,
+        availabilityPolicy: "trusted_inventory",
+      });
+      continue;
+    }
+
     const provisionalSku = await readActiveProvisionalImportSkuForStoreSku(ctx, {
       storeId: args.storeId,
       productId: sku.productId,
@@ -379,11 +415,6 @@ export async function listRegisterCatalogAvailability(
       });
       continue;
     }
-
-    const availability = await validateInventoryAvailability(ctx.db, sku._id, 1, {
-      storeId: args.storeId,
-    });
-    const quantityAvailable = availability.available ?? 0;
 
     rows.push({
       productSkuId: sku._id,
@@ -428,8 +459,17 @@ export async function listRegisterCatalogAvailabilitySnapshot(
     };
   });
 
+  const trustedAvailableSkuIds = new Set(
+    trustedRows
+      .filter((row) => row.quantityAvailable > 0)
+      .map((row) => row.productSkuId),
+  );
   const provisionalRows: RegisterCatalogAvailabilityRow[] = [];
   for (const provisionalSku of activeProvisionalSkus) {
+    if (trustedAvailableSkuIds.has(provisionalSku.productSkuId)) {
+      continue;
+    }
+
     const sku = await ctx.db.get("productSku", provisionalSku.productSkuId);
     if (!sku || sku.storeId !== args.storeId) {
       continue;

--- a/packages/athena-webapp/convex/pos/application/queries/searchCatalog.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/searchCatalog.test.ts
@@ -32,7 +32,9 @@ const storeId = "store-1" as Id<"store">;
 describe("searchCatalog", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    mocks.getCategoryById.mockResolvedValue({ name: "Retail" });
+    mocks.getCategoryById.mockImplementation(async (_ctx, categoryId) =>
+      categoryById[categoryId as keyof typeof categoryById] ?? null,
+    );
     mocks.getColorById.mockResolvedValue({ name: "Black" });
     mocks.isConvexProductId.mockReturnValue(false);
     mocks.findStoreSkuByBarcode.mockResolvedValue(null);
@@ -51,6 +53,14 @@ describe("searchCatalog", () => {
         sku: skuById["sku-hidden-product"],
       },
       {
+        product: productById["product-pos-quick-add"],
+        sku: skuById["sku-pos-quick-add"],
+      },
+      {
+        product: productById["product-pos-pending-checkout"],
+        sku: skuById["sku-pos-pending-checkout"],
+      },
+      {
         product: productById["product-hidden-sku"],
         sku: skuById["sku-hidden"],
       },
@@ -63,6 +73,16 @@ describe("searchCatalog", () => {
         id: "sku-live",
         productId: "product-live",
         skuId: "sku-live",
+      }),
+      expect.objectContaining({
+        id: "sku-pos-quick-add",
+        productId: "product-pos-quick-add",
+        skuId: "sku-pos-quick-add",
+      }),
+      expect.objectContaining({
+        id: "sku-pos-pending-checkout",
+        productId: "product-pos-pending-checkout",
+        skuId: "sku-pos-pending-checkout",
       }),
     ]);
   });
@@ -78,6 +98,38 @@ describe("searchCatalog", () => {
     await expect(
       lookupByBarcode(ctx, { storeId, barcode: "666" }),
     ).resolves.toBeNull();
+  });
+
+  it("includes hidden live products from the reserved POS quick-add category", async () => {
+    mocks.findStoreSkuByBarcode.mockResolvedValueOnce(
+      skuById["sku-pos-quick-add"],
+    );
+
+    await expect(
+      lookupByBarcode(ctx, { storeId, barcode: "777" }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        id: "sku-pos-quick-add",
+        category: "POS quick add",
+        productId: "product-pos-quick-add",
+      }),
+    );
+  });
+
+  it("includes hidden live products from the reserved POS pending-checkout category", async () => {
+    mocks.findStoreSkuByBarcode.mockResolvedValueOnce(
+      skuById["sku-pos-pending-checkout"],
+    );
+
+    await expect(
+      lookupByBarcode(ctx, { storeId, barcode: "888" }),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        id: "sku-pos-pending-checkout",
+        category: "POS pending checkout",
+        productId: "product-pos-pending-checkout",
+      }),
+    );
   });
 
   it("excludes hidden SKUs from exact product-id lookup", async () => {
@@ -126,12 +178,48 @@ const productById = {
     description: "",
     isVisible: false,
   },
+  "product-pos-quick-add": {
+    _id: "product-pos-quick-add",
+    storeId,
+    categoryId: "category-pos-quick-add",
+    name: "Quick Added Item",
+    description: "",
+    availability: "live",
+    isVisible: false,
+  },
+  "product-pos-pending-checkout": {
+    _id: "product-pos-pending-checkout",
+    storeId,
+    categoryId: "category-pos-pending-checkout",
+    name: "Pending Checkout Item",
+    description: "",
+    availability: "live",
+    isVisible: false,
+  },
   "product-hidden-sku": {
     _id: "product-hidden-sku",
     storeId,
     categoryId: "category-1",
     name: "Hidden SKU Product",
     description: "",
+  },
+};
+
+const categoryById = {
+  "category-1": {
+    _id: "category-1",
+    name: "Retail",
+    slug: "retail",
+  },
+  "category-pos-quick-add": {
+    _id: "category-pos-quick-add",
+    name: "POS quick add",
+    slug: "pos-quick-add",
+  },
+  "category-pos-pending-checkout": {
+    _id: "category-pos-pending-checkout",
+    name: "POS pending checkout",
+    slug: "pos-pending-checkout",
   },
 };
 
@@ -165,6 +253,28 @@ const skuById = {
     sku: "HIDDEN-PRODUCT",
     barcode: "555",
     images: [],
+    price: 1000,
+    quantityAvailable: 1,
+  },
+  "sku-pos-quick-add": {
+    _id: "sku-pos-quick-add",
+    storeId,
+    productId: "product-pos-quick-add",
+    sku: "QUICK-ADD",
+    barcode: "777",
+    images: [],
+    netPrice: 1000,
+    price: 1000,
+    quantityAvailable: 1,
+  },
+  "sku-pos-pending-checkout": {
+    _id: "sku-pos-pending-checkout",
+    storeId,
+    productId: "product-pos-pending-checkout",
+    sku: "PENDING-CHECKOUT",
+    barcode: "888",
+    images: [],
+    netPrice: 1000,
     price: 1000,
     quantityAvailable: 1,
   },

--- a/packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts
@@ -31,14 +31,24 @@ type CatalogResult = {
   areProcessingFeesAbsorbed: boolean;
 };
 
+const POS_OPERATIONAL_CATEGORY_SLUGS = new Set([
+  "pos-pending-checkout",
+  "pos-quick-add",
+]);
+
 function isTrustedCatalogResult(args: {
   product: NonNullable<Awaited<ReturnType<typeof getProductById>>>;
   sku: Doc<"productSku">;
+  category?: Awaited<ReturnType<typeof getCategoryById>>;
 }) {
+  const isReservedPosOperationalProduct = args.category?.slug
+    ? POS_OPERATIONAL_CATEGORY_SLUGS.has(args.category.slug)
+    : false;
+
   return (
     args.product.availability !== "archived" &&
     args.product.availability !== "draft" &&
-    args.product.isVisible !== false &&
+    (args.product.isVisible !== false || isReservedPosOperationalProduct) &&
     args.sku.isVisible !== false
   );
 }
@@ -48,21 +58,26 @@ async function mapSkuToCatalogResult(
   args: {
     product: Awaited<ReturnType<typeof getProductById>>;
     sku: Doc<"productSku">;
+    category?: Awaited<ReturnType<typeof getCategoryById>>;
     categoryName?: string;
   },
 ): Promise<CatalogResult | null> {
+  const category =
+    args.category ?? (args.product ? await getCategoryById(ctx, args.product.categoryId) : null);
+
   if (
     !args.product ||
-    !isTrustedCatalogResult({ product: args.product, sku: args.sku }) ||
+    !isTrustedCatalogResult({
+      product: args.product,
+      sku: args.sku,
+      category,
+    }) ||
     !args.sku.netPrice
   ) {
     return null;
   }
 
-  const category =
-    args.categoryName ??
-    (await getCategoryById(ctx, args.product.categoryId))?.name ??
-    "";
+  const categoryName = args.categoryName ?? category?.name ?? "";
   const color = (await getColorById(ctx, args.sku.color))?.name ?? "";
 
   return {
@@ -71,7 +86,7 @@ async function mapSkuToCatalogResult(
     sku: args.sku.sku || "",
     barcode: args.sku.barcode || "",
     price: args.sku.netPrice || args.sku.price,
-    category,
+    category: categoryName,
     description: args.product.description || "",
     inStock: args.sku.quantityAvailable > 0,
     quantityAvailable: args.sku.quantityAvailable,
@@ -100,21 +115,26 @@ export async function searchProducts(
 
   if (isConvexProductId(query)) {
     const product = await getProductById(ctx, query as Id<"product">);
+    const category =
+      product?.storeId === args.storeId
+        ? await getCategoryById(ctx, product.categoryId)
+        : null;
 
     if (
       product?.storeId === args.storeId &&
       product.availability !== "archived" &&
       product.availability !== "draft" &&
-      product.isVisible !== false
+      (product.isVisible !== false ||
+        POS_OPERATIONAL_CATEGORY_SLUGS.has(category?.slug ?? ""))
     ) {
       const productSkus = await listProductSkusByProductId(ctx, product._id);
-      const categoryName =
-        (await getCategoryById(ctx, product.categoryId))?.name || "";
+      const categoryName = category?.name || "";
       const results = await Promise.all(
         productSkus.map((sku) =>
           mapSkuToCatalogResult(ctx, {
             product,
             sku,
+            category,
             categoryName,
           }),
         ),
@@ -164,21 +184,26 @@ export async function lookupByBarcode(
     const product = isConvexProductId(args.barcode)
       ? await getProductById(ctx, args.barcode as Id<"product">)
       : null;
+    const category =
+      product?.storeId === args.storeId
+        ? await getCategoryById(ctx, product.categoryId)
+        : null;
 
     if (
       product?.storeId === args.storeId &&
       product.availability !== "archived" &&
       product.availability !== "draft" &&
-      product.isVisible !== false
+      (product.isVisible !== false ||
+        POS_OPERATIONAL_CATEGORY_SLUGS.has(category?.slug ?? ""))
     ) {
       const allSkus = await listProductSkusByProductId(ctx, product._id);
-      const categoryName =
-        (await getCategoryById(ctx, product.categoryId))?.name || "";
+      const categoryName = category?.name || "";
       const results = await Promise.all(
         allSkus.map((productSku) =>
           mapSkuToCatalogResult(ctx, {
             product,
             sku: productSku,
+            category,
             categoryName,
           }),
         ),
@@ -193,11 +218,16 @@ export async function lookupByBarcode(
   }
 
   const product = await getProductById(ctx, sku.productId);
+  const category =
+    product?.storeId === args.storeId
+      ? await getCategoryById(ctx, product.categoryId)
+      : null;
   if (
     !product ||
     product.availability === "archived" ||
     product.availability === "draft" ||
-    product.isVisible === false
+    (product.isVisible === false &&
+      !POS_OPERATIONAL_CATEGORY_SLUGS.has(category?.slug ?? ""))
   ) {
     return null;
   }
@@ -205,5 +235,6 @@ export async function lookupByBarcode(
   return mapSkuToCatalogResult(ctx, {
     product,
     sku,
+    category,
   });
 }

--- a/packages/athena-webapp/convex/pos/public/sync.test.ts
+++ b/packages/athena-webapp/convex/pos/public/sync.test.ts
@@ -217,6 +217,7 @@ describe("POS local sync public mutation", () => {
     expect(argsValidator).toContain("pending_checkout_item_defined");
     expect(argsValidator).toContain("localPendingCheckoutItemId");
     expect(argsValidator).toContain("pendingCheckoutItemId");
+    expect(argsValidator).toContain("inventoryImportProvisionalSkuId");
     expect(argsValidator).toContain(
       "pos_pending_checkout_item_local_metadata_v1",
     );

--- a/packages/athena-webapp/convex/pos/public/sync.ts
+++ b/packages/athena-webapp/convex/pos/public/sync.ts
@@ -123,6 +123,7 @@ const posLocalSyncUploadEventValidator = v.union(
           productId: v.string(),
           productSkuId: v.string(),
           pendingCheckoutItemId: v.optional(v.string()),
+          inventoryImportProvisionalSkuId: v.optional(v.string()),
           productName: v.string(),
           productSku: v.string(),
           barcode: v.optional(v.string()),

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -7,7 +7,7 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Core app surfaces
 
 - [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 88 file(s); key children: __root.tsx, _authed, _authed.test.tsx, _authed.tsx, index.test.tsx.
-- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 596 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
+- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 597 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
 - [`src/components/traces`](../../src/components/traces) — Shared workflow trace screens, ordered timelines, and trace detail primitives. Currently 3 file(s); key children: WorkflowTraceRouteLink.tsx, WorkflowTraceView.test.tsx, WorkflowTraceView.tsx.
 - [`src/components/operations`](../../src/components/operations) — Manager-queue and stock-adjustment workflows that share approval rails with other operational surfaces. Currently 26 file(s); key children: CommandApprovalDialog.test.tsx, CommandApprovalDialog.tsx, DailyCloseHistoryView.test.tsx, DailyCloseHistoryView.tsx, DailyCloseView.test.tsx.
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -236,6 +236,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/components/product/ProductStatus.test.tsx`](../../src/components/product/ProductStatus.test.tsx)
 - [`src/components/product/QuickAddProductDialog.test.tsx`](../../src/components/product/QuickAddProductDialog.test.tsx)
 - [`src/components/products/Products.test.tsx`](../../src/components/products/Products.test.tsx)
+- [`src/components/products/ProductsListView.test.ts`](../../src/components/products/ProductsListView.test.ts)
 - [`src/components/products/UnresolvedProducts.test.tsx`](../../src/components/products/UnresolvedProducts.test.tsx)
 - [`src/components/promo-codes/PromoCodeHeader.test.tsx`](../../src/components/promo-codes/PromoCodeHeader.test.tsx)
 - [`src/components/promo-codes/PromoCodesView.test.tsx`](../../src/components/promo-codes/PromoCodesView.test.tsx)

--- a/packages/athena-webapp/src/components/operations/InventoryImportView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/InventoryImportView.test.tsx
@@ -275,16 +275,23 @@ describe("InventoryImportView", () => {
     expect(screen.getByText("+12,347")).toBeInTheDocument();
     expect(screen.getByText("Next action")).toBeInTheDocument();
     expect(screen.getByText(/2 rows still need decisions/)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Show review rows" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Show review rows" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save for import handoff" })).toBeInTheDocument();
     expect(
       screen
         .getAllByRole("button")
         .map((button) => button.textContent?.trim())
         .filter((label) =>
-          ["All", "Matched", "Needs review", "New items", "Decided"].includes(label ?? ""),
+          [
+            "All",
+            "Matched",
+            "Needs review",
+            "New items",
+            "Needs decision",
+            "Decided",
+          ].includes(label ?? ""),
         ),
-    ).toEqual(["All", "Matched", "Needs review", "New items", "Decided"]);
+    ).toEqual(["All", "Matched", "Needs review", "New items", "Needs decision", "Decided"]);
     expect(reviewOverlay.getAllByRole("button", { name: "Import" }).length).toBeGreaterThan(0);
     expect(reviewOverlay.getAllByRole("button", { name: "Athena" }).length).toBeGreaterThan(0);
     expect(reviewOverlay.getByText("Name and count")).toBeInTheDocument();
@@ -449,7 +456,7 @@ describe("InventoryImportView", () => {
 
     const importReview = getReviewOverlaySection();
     expect(screen.getByText(/2 rows still need decisions/)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Show review rows" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Show review rows" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save for import handoff" })).toBeInTheDocument();
     expect(importReview.getByText("Close name")).toBeInTheDocument();
     expect(importReview.getByText("Name differs")).toBeInTheDocument();
@@ -564,6 +571,15 @@ describe("InventoryImportView", () => {
 
     await user.click(getReviewOverlaySection().getAllByRole("button", { name: "Import" })[0]);
     await user.click(getReviewOverlaySection().getAllByRole("button", { name: "Import" })[1]);
+    await user.click(screen.getByRole("button", { name: "Needs decision" }));
+
+    expect(getReviewOverlaySection().getByText("New Clip")).toBeInTheDocument();
+    expect(getReviewOverlaySection().queryByText("Comb")).not.toBeInTheDocument();
+    expect(screen.getByText(/1 row still need decisions/)).toBeInTheDocument();
+    expect(screen.getByText(/1 row ready/)).toBeInTheDocument();
+    expect(screen.queryByText(/already have draft choices/)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show needs decision" })).toBeInTheDocument();
+
     await user.click(screen.getByRole("button", { name: "Decided" }));
 
     expect(getReviewOverlaySection().getAllByText("Comb").length).toBeGreaterThan(0);
@@ -585,7 +601,7 @@ describe("InventoryImportView", () => {
     await user.click(screen.getByRole("button", { name: "New items" }));
     await user.click(screen.getByRole("button", { name: "Create item" }));
 
-    await user.click(saveHandoffButton);
+    await user.click(screen.getByRole("button", { name: "Save for import handoff" }));
 
     await waitFor(() => {
       expect(mockedHooks.saveReviewVersion).toHaveBeenCalledWith(
@@ -611,6 +627,105 @@ describe("InventoryImportView", () => {
         }),
       );
     });
+  });
+
+  it("applies a new-item decision to every row in the active review filter", async () => {
+    const user = userEvent.setup();
+    mockedHooks.saveReviewVersion.mockResolvedValue(
+      ok({
+        _id: "review-version-bulk",
+        createdAt: Date.UTC(2026, 5, 7, 17),
+        fileName: "manual.csv",
+        importKey: "review-key",
+        issueCount: 0,
+        rowCount: 12,
+        sourceFormat: "csv",
+        versionNumber: 8,
+      }),
+    );
+
+    render(<InventoryImportView />);
+
+    fireEvent.change(screen.getByLabelText("Raw export"), {
+      target: {
+        value: [
+          "product_name,sku,price,qty",
+          ...Array.from(
+            { length: 12 },
+            (_, index) => `New Product ${index + 1},NEW-${index + 1},${index + 1},1`,
+          ),
+        ].join("\n"),
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Inventory check" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Review inventory changes" }));
+    await user.click(screen.getByRole("button", { name: "Apply to 12" }));
+    await user.click(screen.getByRole("menuitem", { name: "Create 12 new items" }));
+    await user.click(screen.getByRole("button", { name: "Save for import handoff" }));
+
+    await waitFor(() => {
+      expect(mockedHooks.saveReviewVersion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rowDecisions: expect.arrayContaining([
+            expect.objectContaining({
+              action: "create_item",
+              productName: "New Product 1",
+              rowNumber: 2,
+            }),
+            expect.objectContaining({
+              action: "create_item",
+              productName: "New Product 12",
+              rowNumber: 13,
+            }),
+          ]),
+        }),
+      );
+    });
+    const savedRows = mockedHooks.saveReviewVersion.mock.calls.at(-1)?.[0]?.rowDecisions;
+    expect(savedRows).toHaveLength(12);
+  });
+
+  it("surfaces POS staging after review rows receive decisions", async () => {
+    const user = userEvent.setup();
+    mockedHooks.inventorySkuContext = [
+      {
+        barcode: "111",
+        inventoryCount: 3,
+        price: 2500,
+        productAvailability: "live",
+        productId: "product-1",
+        productName: "Comb",
+        productSkuId: "sku-1",
+        quantityAvailable: 3,
+        sku: "COMB-1",
+      },
+    ];
+
+    render(<InventoryImportView />);
+
+    fireEvent.change(screen.getByLabelText("Raw export"), {
+      target: {
+        value: ["product_name,sku,barcode,price,qty", "Comb,COMB-1,111,25,5"].join(
+          "\n",
+        ),
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Inventory check" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Review inventory changes" }));
+    expect(screen.queryByRole("button", { name: "Make available in POS" })).not.toBeInTheDocument();
+
+    await user.click(getReviewOverlaySection().getByRole("button", { name: "Import" }));
+
+    expect(screen.getByText("Rows are ready for POS availability. Stage them without applying final counts.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Make available in POS" })).toBeInTheDocument();
   });
 
   it("stages reviewed rows for POS availability without applying final counts", async () => {
@@ -884,6 +999,45 @@ describe("InventoryImportView", () => {
     );
     expect(importReview.getByText("New Clip")).toBeInTheDocument();
     expect(importReview.queryByText("Comb")).not.toBeInTheDocument();
+  });
+
+  it("rehydrates saved row decisions by row number when the persisted row key drifts", async () => {
+    mockedHooks.search = { filter: "needs_decision" };
+    mockedHooks.latestReviewVersion = {
+      _id: "review-version-row-key-drift",
+      createdAt: Date.UTC(2026, 5, 7, 20),
+      fileName: "manual.csv",
+      importKey: "review-key",
+      issueCount: 0,
+      notes: undefined,
+      rawContent: [
+        "product_name,sku,price,qty",
+        "BLACK RUBBER BANDS SMALL,,5,45",
+      ].join("\n"),
+      rowCount: 1,
+      rowDecisions: [
+        {
+          action: "create_item",
+          productName: "BLACK RUBBER BANDS SMALL",
+          rowKey: "stale-display-derived-row-key",
+          rowNumber: 2,
+        },
+      ],
+      sourceFormat: "csv",
+      versionNumber: 9,
+    };
+
+    render(<InventoryImportView mode="review" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Inventory review" })).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("Rows are ready for POS availability. Stage them without applying final counts."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Make available in POS" })).toBeInTheDocument();
+    expect(screen.getByText("No rows in this view")).toBeInTheDocument();
   });
 
   it("keeps reloads on the review route while the saved import loads", () => {

--- a/packages/athena-webapp/src/components/operations/InventoryImportView.tsx
+++ b/packages/athena-webapp/src/components/operations/InventoryImportView.tsx
@@ -12,6 +12,7 @@ import {
   ArrowUpRight,
   Columns3,
   FileJson,
+  ListChecks,
   Pencil,
   Save,
   UploadCloud,
@@ -63,6 +64,7 @@ import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
+  DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
@@ -132,9 +134,21 @@ const DEFAULT_PREVIEW_COLUMN_VISIBILITY: PreviewColumnVisibility = {
   sku: false,
 };
 
-type InventoryOverlayFilter = "all" | "review" | "new" | "matched" | "decided";
+type InventoryOverlayFilter =
+  | "all"
+  | "review"
+  | "new"
+  | "matched"
+  | "needs_decision"
+  | "decided";
 type ImportDraftSource = "import" | "athena";
 type ImportNewRowAction = "create_item" | "skip_row";
+type BulkImportReviewDecisionAction =
+  | "create_new_items"
+  | "skip_rows"
+  | "use_import_values"
+  | "use_athena_values"
+  | "clear_choices";
 type ImportRowDraftDecision = {
   action?: ImportNewRowAction;
   nameSource?: ImportDraftSource;
@@ -179,6 +193,7 @@ const OVERLAY_FILTERS: Array<{
   { label: "Matched", value: "matched" },
   { label: "Needs review", value: "review" },
   { label: "New items", value: "new" },
+  { label: "Needs decision", value: "needs_decision" },
   { label: "Decided", value: "decided" },
 ];
 
@@ -500,11 +515,17 @@ export function InventoryImportView({
         }
       : {};
   const matchesOverlayStatusFilter = useCallback(
-    (row: InventoryOverlayRow) =>
-      overlayFilter === "all" ||
-      (overlayFilter === "decided"
-        ? hasDraftDecisionValue(rowDraftDecisions[getOverlayRowKey(row)] ?? {})
-        : row.status === overlayFilter),
+    (row: InventoryOverlayRow) => {
+      const decision = rowDraftDecisions[getOverlayDecisionKey(row)];
+
+      if (overlayFilter === "all") return true;
+      if (overlayFilter === "decided") return hasDraftDecisionValue(decision ?? {});
+      if (overlayFilter === "needs_decision") {
+        return !isOverlayRowDecisionComplete(row, decision);
+      }
+
+      return row.status === overlayFilter;
+    },
     [overlayFilter, rowDraftDecisions],
   );
   const overlayRowsMatchingQuery = useMemo(
@@ -553,9 +574,14 @@ export function InventoryImportView({
     (visibleOverlayPage - 1) * IMPORT_TABLE_PAGE_SIZE,
     visibleOverlayPage * IMPORT_TABLE_PAGE_SIZE,
   );
+  const bulkDecisionSummary = useMemo(
+    () => getBulkImportReviewDecisionSummary(filteredOverlayRows),
+    [filteredOverlayRows],
+  );
   const pendingImportActionCount = overlayRows.filter(
-    (row) => !isOverlayRowDecisionComplete(row, rowDraftDecisions[getOverlayRowKey(row)]),
+    (row) => !isOverlayRowDecisionComplete(row, rowDraftDecisions[getOverlayDecisionKey(row)]),
   ).length;
+  const completedImportActionCount = overlayRows.length - pendingImportActionCount;
   const hasValidRows =
     Boolean(parseResult) &&
     parseResult!.rows.length > 0 &&
@@ -563,9 +589,6 @@ export function InventoryImportView({
     Boolean(activeStore?._id);
   const hasReviewableContent =
     Boolean(parseResult) && Boolean(rawContent.trim()) && Boolean(activeStore?._id);
-  const savedDraftDecisionCount = Object.values(rowDraftDecisions).filter((decision) =>
-    hasDraftDecisionValue(decision),
-  ).length;
   const canSaveImportHandoff = hasReviewableContent;
   const canStageReviewForPos = canSaveImportHandoff && pendingImportActionCount === 0;
   const shouldShowCollapsedSource =
@@ -905,6 +928,16 @@ export function InventoryImportView({
     }
   };
 
+  const handleApplyBulkReviewDecision = (action: BulkImportReviewDecisionAction) => {
+    setRowDraftDecisions((current) =>
+      applyBulkImportReviewDecision({
+        action,
+        current,
+        rows: filteredOverlayRows,
+      }),
+    );
+  };
+
   if (adminState.isLoadingAccess) {
     return (
       <View hideBorder hideHeaderBottomBorder>
@@ -1073,75 +1106,7 @@ export function InventoryImportView({
             />
 
             <div className="flex flex-wrap items-center justify-between gap-3 border-y border-border bg-surface/60 px-3 py-3">
-              {overlaySummary.review > 0 ? (
-                <>
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium">Next action</p>
-                    <p className="mt-1 text-sm text-muted-foreground">
-                      {formatCount(pendingImportActionCount, "row")} still need decisions.
-                      {savedDraftDecisionCount > 0
-                        ? ` ${formatCount(savedDraftDecisionCount, "row")} already have draft choices.`
-                        : ""}{" "}
-                      Save a draft any time and resume it later.
-                    </p>
-                  </div>
-                  <div className="flex flex-wrap items-center justify-end gap-2 sm:min-w-[28rem]">
-                    <Button
-                      onClick={() => setOverlayFilter("review")}
-                      type="button"
-                      variant="outline"
-                    >
-                      Show review rows
-                    </Button>
-                    <LoadingButton
-                      className="w-56 px-4"
-                      disabled={!canSaveImportHandoff || isSavingReviewVersion}
-                      isLoading={isSavingReviewVersion}
-                      onClick={handleSaveReviewVersion}
-                      type="button"
-                      variant="workflow"
-                    >
-                      <Save className="h-4 w-4" />
-                      Save for import handoff
-                    </LoadingButton>
-                    <DraftAutosaveStatus status={draftAutosaveStatus} />
-                  </div>
-                </>
-              ) : overlaySummary.new > 0 ? (
-                <>
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium">Next action</p>
-                    <p className="mt-1 text-sm text-muted-foreground">
-                      {formatCount(pendingImportActionCount, "row")} still need decisions.
-                      {savedDraftDecisionCount > 0
-                        ? ` ${formatCount(savedDraftDecisionCount, "row")} already have draft choices.`
-                        : ""}{" "}
-                      Save a draft any time and resume it later.
-                    </p>
-                  </div>
-                  <div className="flex flex-wrap items-center justify-end gap-2 sm:min-w-[28rem]">
-                    <Button
-                      onClick={() => setOverlayFilter("new")}
-                      type="button"
-                      variant="outline"
-                    >
-                      Show new items
-                    </Button>
-                    <LoadingButton
-                      className="w-56 px-4"
-                      disabled={!canSaveImportHandoff || isSavingReviewVersion}
-                      isLoading={isSavingReviewVersion}
-                      onClick={handleSaveReviewVersion}
-                      type="button"
-                      variant="workflow"
-                    >
-                      <Save className="h-4 w-4" />
-                      Save for import handoff
-                    </LoadingButton>
-                    <DraftAutosaveStatus status={draftAutosaveStatus} />
-                  </div>
-                </>
-              ) : (
+              {pendingImportActionCount === 0 ? (
                 <>
                   <div className="min-w-0">
                     <p className="text-sm font-medium">Next action</p>
@@ -1182,7 +1147,83 @@ export function InventoryImportView({
                     <DraftAutosaveStatus status={draftAutosaveStatus} />
                   </div>
                 </>
-              )}
+              ) : overlaySummary.review > 0 ? (
+                <>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium">Next action</p>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {formatCount(pendingImportActionCount, "row")} still need decisions.
+                      {completedImportActionCount > 0
+                        ? ` ${formatCount(completedImportActionCount, "row")} ready.`
+                        : ""}{" "}
+                      Save a draft any time and resume it later.
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap items-center justify-end gap-2 sm:min-w-[28rem]">
+                    <BulkImportReviewDecisionMenu
+                      onApply={handleApplyBulkReviewDecision}
+                      summary={bulkDecisionSummary}
+                    />
+                    <Button
+                      onClick={() => setOverlayFilter("needs_decision")}
+                      type="button"
+                      variant="outline"
+                    >
+                      Show needs decision
+                    </Button>
+                    <LoadingButton
+                      className="w-56 px-4"
+                      disabled={!canSaveImportHandoff || isSavingReviewVersion}
+                      isLoading={isSavingReviewVersion}
+                      onClick={handleSaveReviewVersion}
+                      type="button"
+                      variant="workflow"
+                    >
+                      <Save className="h-4 w-4" />
+                      Save for import handoff
+                    </LoadingButton>
+                    <DraftAutosaveStatus status={draftAutosaveStatus} />
+                  </div>
+                </>
+              ) : overlaySummary.new > 0 ? (
+                <>
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium">Next action</p>
+                    <p className="mt-1 text-sm text-muted-foreground">
+                      {formatCount(pendingImportActionCount, "row")} still need decisions.
+                      {completedImportActionCount > 0
+                        ? ` ${formatCount(completedImportActionCount, "row")} ready.`
+                        : ""}{" "}
+                      Save a draft any time and resume it later.
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap items-center justify-end gap-2 sm:min-w-[28rem]">
+                    <BulkImportReviewDecisionMenu
+                      onApply={handleApplyBulkReviewDecision}
+                      summary={bulkDecisionSummary}
+                    />
+                    <Button
+                      onClick={() => setOverlayFilter("needs_decision")}
+                      type="button"
+                      variant="outline"
+                    >
+                      Show needs decision
+                    </Button>
+                    <LoadingButton
+                      className="w-56 px-4"
+                      disabled={!canSaveImportHandoff || isSavingReviewVersion}
+                      isLoading={isSavingReviewVersion}
+                      onClick={handleSaveReviewVersion}
+                      type="button"
+                      variant="workflow"
+                    >
+                      <Save className="h-4 w-4" />
+                      Save for import handoff
+                    </LoadingButton>
+                    <DraftAutosaveStatus status={draftAutosaveStatus} />
+                  </div>
+                </>
+              ) : null}
             </div>
 
             {visibleOverlayRows.length > 0 ? (
@@ -1246,13 +1287,13 @@ export function InventoryImportView({
                           </span>
                         ) : null}
                         <ImportRowActionControl
-                          decision={rowDraftDecisions[getOverlayRowKey(overlayRow)]}
+                          decision={rowDraftDecisions[getOverlayDecisionKey(overlayRow)]}
                           row={overlayRow}
                           onChange={(decision) =>
                             setRowDraftDecisions((current) => ({
                               ...current,
-                              [getOverlayRowKey(overlayRow)]: {
-                                ...current[getOverlayRowKey(overlayRow)],
+                              [getOverlayDecisionKey(overlayRow)]: {
+                                ...current[getOverlayDecisionKey(overlayRow)],
                                 ...decision,
                               },
                             }))
@@ -1724,6 +1765,56 @@ function ImportRowActionControl({
         }
       />
     </div>
+  );
+}
+
+function BulkImportReviewDecisionMenu({
+  onApply,
+  summary,
+}: {
+  onApply: (action: BulkImportReviewDecisionAction) => void;
+  summary: BulkImportReviewDecisionSummary;
+}) {
+  if (summary.actionableRows === 0) return null;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button className="h-9 px-3" type="button" variant="outline">
+          <ListChecks className="h-4 w-4" />
+          Apply to {summary.actionableRows.toLocaleString()}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-64">
+        <DropdownMenuLabel>Apply decision</DropdownMenuLabel>
+        <div className="px-2 pb-1 text-xs leading-5 text-muted-foreground">
+          Updates all decision rows in the current results.
+        </div>
+        <DropdownMenuSeparator />
+        {summary.newRows > 0 ? (
+          <DropdownMenuItem onSelect={() => onApply("create_new_items")}>
+            Create {formatCount(summary.newRows, "new item")}
+          </DropdownMenuItem>
+        ) : null}
+        {summary.reviewRows > 0 ? (
+          <>
+            <DropdownMenuItem onSelect={() => onApply("use_import_values")}>
+              Use import values for {formatCount(summary.reviewRows, "review row")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={() => onApply("use_athena_values")}>
+              Use Athena values for {formatCount(summary.reviewRows, "review row")}
+            </DropdownMenuItem>
+          </>
+        ) : null}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => onApply("skip_rows")}>
+          Skip {formatCount(summary.actionableRows, "row")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => onApply("clear_choices")}>
+          Clear choices for {formatCount(summary.actionableRows, "row")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -2220,6 +2311,10 @@ function getOverlayRowKey(row: InventoryOverlayRow) {
   ].join(":");
 }
 
+function getOverlayDecisionKey(row: InventoryOverlayRow) {
+  return String(row.row.rowNumber);
+}
+
 function getImportRowActionLabel(action: ImportNewRowAction) {
   switch (action) {
     case "create_item":
@@ -2241,7 +2336,7 @@ function buildReviewNotesWithImportActions({
   const trimmedNotes = notes.trim();
   const decisions = rows
     .map((row) => {
-      const decision = rowDraftDecisions[getOverlayRowKey(row)];
+      const decision = rowDraftDecisions[getOverlayDecisionKey(row)];
       if (!decision || !hasDraftDecisionValue(decision)) return null;
 
       return `Row ${row.row.rowNumber} ${row.row.productName}: ${formatDraftDecision(decision)}`;
@@ -2263,7 +2358,7 @@ function buildSavedRowDraftDecisions({
   return rows
     .map((row) => {
       const rowKey = getOverlayRowKey(row);
-      const decision = rowDraftDecisions[rowKey];
+      const decision = rowDraftDecisions[getOverlayDecisionKey(row)];
       if (!decision || !hasDraftDecisionValue(decision)) return null;
 
       return {
@@ -2276,6 +2371,115 @@ function buildSavedRowDraftDecisions({
     .filter((decision): decision is SavedImportRowDraftDecision => Boolean(decision));
 }
 
+type BulkImportReviewDecisionSummary = {
+  actionableRows: number;
+  newRows: number;
+  reviewRows: number;
+};
+
+function getBulkImportReviewDecisionSummary(
+  rows: InventoryOverlayRow[],
+): BulkImportReviewDecisionSummary {
+  return rows.reduce<BulkImportReviewDecisionSummary>(
+    (summary, row) => {
+      if (row.status === "new") {
+        summary.actionableRows += 1;
+        summary.newRows += 1;
+      } else if (row.status === "review") {
+        summary.actionableRows += 1;
+        summary.reviewRows += 1;
+      }
+
+      return summary;
+    },
+    {
+      actionableRows: 0,
+      newRows: 0,
+      reviewRows: 0,
+    },
+  );
+}
+
+function applyBulkImportReviewDecision({
+  action,
+  current,
+  rows,
+}: {
+  action: BulkImportReviewDecisionAction;
+  current: Record<string, ImportRowDraftDecision>;
+  rows: InventoryOverlayRow[];
+}) {
+  const next = { ...current };
+
+  for (const row of rows) {
+    const key = getOverlayDecisionKey(row);
+    const patch = getBulkImportReviewDecisionPatch(row, action);
+
+    if (action === "clear_choices") {
+      if (patch) delete next[key];
+      continue;
+    }
+
+    if (!patch) continue;
+
+    next[key] = {
+      ...next[key],
+      ...patch,
+    };
+  }
+
+  return next;
+}
+
+function getBulkImportReviewDecisionPatch(
+  row: InventoryOverlayRow,
+  action: BulkImportReviewDecisionAction,
+): ImportRowDraftDecision | null {
+  if (row.status === "matched") return null;
+
+  if (action === "clear_choices") return {};
+
+  if (action === "skip_rows") {
+    return {
+      action: "skip_row",
+      nameSource: undefined,
+      priceSource: undefined,
+      quantitySource: undefined,
+    };
+  }
+
+  if (row.status === "new") {
+    return action === "create_new_items" ? { action: "create_item" } : null;
+  }
+
+  if (row.status !== "review") return null;
+
+  if (action === "use_import_values" || action === "use_athena_values") {
+    return buildBulkReviewSourcePatch(
+      row,
+      action === "use_import_values" ? "import" : "athena",
+    );
+  }
+
+  return null;
+}
+
+function buildBulkReviewSourcePatch(
+  row: InventoryOverlayRow,
+  source: ImportDraftSource,
+): ImportRowDraftDecision {
+  return {
+    action: undefined,
+    ...(doesOverlayRowNeedNameDecision(row.row, row.athenaMatch)
+      ? { nameSource: source }
+      : null),
+    ...(row.delta !== 0 ? { quantitySource: source } : null),
+    ...(row.athenaPrice !== undefined && row.row.price !== row.athenaPrice
+      ? { priceSource: source }
+      : null),
+  };
+}
+
 function buildProvisionalImportStageRows({
   rows,
   rowDraftDecisions,
@@ -2285,7 +2489,7 @@ function buildProvisionalImportStageRows({
 }) {
   return rows.map((row) => {
     const rowKey = getOverlayRowKey(row);
-    const decision = rowDraftDecisions[rowKey] ?? {};
+    const decision = rowDraftDecisions[getOverlayDecisionKey(row)] ?? {};
 
     return {
       ...row.row,
@@ -2304,7 +2508,7 @@ function mapSavedRowDraftDecisions(
   decisions: SavedImportRowDraftDecision[],
 ): Record<string, ImportRowDraftDecision> {
   return decisions.reduce<Record<string, ImportRowDraftDecision>>((mapped, decision) => {
-    mapped[decision.rowKey] = {
+    mapped[String(decision.rowNumber)] = {
       action: decision.action,
       nameSource: decision.nameSource,
       priceSource: decision.priceSource,

--- a/packages/athena-webapp/src/components/pos/CartItems.test.tsx
+++ b/packages/athena-webapp/src/components/pos/CartItems.test.tsx
@@ -80,6 +80,29 @@ describe("CartItems service lines", () => {
     expect(screen.getByText("BW-18")).toBeInTheDocument();
   });
 
+  it("does not render legacy NULL metadata on cart items", () => {
+    render(
+      <CartItems
+        cartItems={[
+          {
+            id: "item-1" as never,
+            barcode: "",
+            color: "NULL",
+            name: "Fluffy Bonnet",
+            price: 3000,
+            quantity: 3,
+            size: "NULL",
+            sku: "6N2Y-2Q6-3KF",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Fluffy Bonnet")).toBeInTheDocument();
+    expect(screen.getByText("6N2Y-2Q6-3KF")).toBeInTheDocument();
+    expect(screen.queryByText("NULL")).not.toBeInTheDocument();
+  });
+
   it("shows service totals without a quantity count", () => {
     render(
       <CartItems

--- a/packages/athena-webapp/src/components/pos/CartItems.tsx
+++ b/packages/athena-webapp/src/components/pos/CartItems.tsx
@@ -48,6 +48,27 @@ function normalizeCartQuantityInput(value: string | number) {
   return Math.max(1, Math.trunc(parsed));
 }
 
+function normalizeCartAttribute(value: string | number | null | undefined) {
+  const normalized = String(value ?? "").trim();
+  if (!normalized || normalized.toLowerCase() === "null") {
+    return undefined;
+  }
+
+  return normalized;
+}
+
+function formatCartAttributeParts(item: CartItem) {
+  const displaySize = normalizeCartAttribute(item.size);
+  const displayLength = normalizeCartAttribute(item.length);
+  const displayColor = normalizeCartAttribute(item.color);
+
+  return [
+    displayLength ? `${displayLength}"` : undefined,
+    displaySize,
+    displayColor ? capitalizeWords(displayColor) : undefined,
+  ].filter(Boolean);
+}
+
 function CartItemQuantityControl({
   isCompact,
   item,
@@ -372,7 +393,10 @@ export function CartItems({
               );
             })}
 
-            {cartItems.map((item) => (
+            {cartItems.map((item) => {
+              const attributeParts = formatCartAttributeParts(item);
+
+              return (
               <div
                 key={item.id}
                 className={cn(
@@ -444,13 +468,9 @@ export function CartItems({
                         )}
                       </div>
 
-                      {(item.size || item.length || item.color) && (
+                      {attributeParts.length > 0 && (
                         <p className="text-xs text-muted-foreground capitalize">
-                          {item.length && `${item.length}"`}
-                          {item.size && item.length && " • "}
-                          {item.size && `${item.size}`}
-                          {item.color && (item.size || item.length) && " • "}
-                          {item.color && capitalizeWords(item.color)}
+                          {attributeParts.join(" • ")}
                         </p>
                       )}
 
@@ -550,7 +570,8 @@ export function CartItems({
                   )}
                 </div>
               </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </div>

--- a/packages/athena-webapp/src/components/pos/ProductCard.tsx
+++ b/packages/athena-webapp/src/components/pos/ProductCard.tsx
@@ -5,7 +5,7 @@ import { Minus, Package, Plus, ShoppingCart } from "lucide-react";
 import { Product } from "./types";
 import { capitalizeWords } from "~/src/lib/utils";
 import { toDisplayAmount } from "~/convex/lib/currency";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 
 interface ProductCardProps {
   product: Product;
@@ -33,6 +33,15 @@ function normalizeQuantity(value: string | number, maxQuantity?: number) {
   return Math.min(quantity, maxQuantity);
 }
 
+function normalizeProductAttribute(value: string | null | undefined) {
+  const normalized = value?.trim();
+  if (!normalized || normalized.toLowerCase() === "null") {
+    return undefined;
+  }
+
+  return normalized;
+}
+
 export function ProductCard({
   product,
   onAddProduct,
@@ -42,19 +51,20 @@ export function ProductCard({
   const [quantityInput, setQuantityInput] = useState("1");
   const isProvisionalImport =
     product.availabilityPolicy === "active_provisional_import";
-  const maxQuantity = useMemo(() => {
-    if (isProvisionalImport) {
-      return undefined;
-    }
-    if (typeof product.quantityAvailable !== "number") {
-      return undefined;
-    }
-
-    return Math.max(0, Math.trunc(product.quantityAvailable));
-  }, [isProvisionalImport, product.quantityAvailable]);
+  const isPendingCheckoutItem = Boolean(product.pendingCheckoutItemId);
+  const usesPendingCount = isProvisionalImport || isPendingCheckoutItem;
+  const maxQuantity = undefined;
   const selectedQuantity = normalizeQuantity(quantityInput, maxQuantity);
+  const displayCategory = normalizeProductAttribute(product.category);
+  const displayColor = normalizeProductAttribute(product.color);
+  const displaySize = normalizeProductAttribute(product.size);
+  const hasKnownAvailability =
+    usesPendingCount ||
+    typeof product.quantityAvailable === "number" ||
+    product.availabilityStatus === "available" ||
+    product.availabilityStatus === "out_of_stock";
   const isAvailable =
-    product.inStock && (maxQuantity === undefined || maxQuantity > 0);
+    product.availabilityStatus !== "unknown" && hasKnownAvailability;
   const canDecreaseQuantity = selectedQuantity > 1;
   const canIncreaseQuantity =
     maxQuantity === undefined || selectedQuantity < maxQuantity;
@@ -104,7 +114,7 @@ export function ProductCard({
             {capitalizeWords(product.name)}
           </h4>
           <div className="flex items-center gap-2 flex-shrink-0">
-            <p className="px-4 font-numeric text-lg font-medium">
+            <p className="rounded-md bg-muted/70 px-3 py-1 font-numeric text-xl font-semibold tabular-nums text-foreground shadow-sm ring-1 ring-border/70">
               {formatter.format(toDisplayAmount(product.price))}
             </p>
           </div>
@@ -113,28 +123,28 @@ export function ProductCard({
         {/* SKU and Barcode */}
         <div className="flex items-center gap-2 mt-1">
           {product.sku && (
-            <span className="rounded bg-muted px-2 py-1 font-mono text-xs text-muted-foreground">
+            <span className="font-mono text-xs text-muted-foreground">
               {product.sku}
             </span>
           )}
           {product.barcode && (
-            <span className="rounded bg-muted px-2 py-1 font-mono text-xs text-muted-foreground">
+            <span className="font-mono text-xs text-muted-foreground">
               {product.barcode}
             </span>
           )}
         </div>
 
         {/* Category, Size, Length */}
-        {(product.size || product.length || product.category) && (
+        {(displaySize || product.length || displayCategory || displayColor) && (
           <div className="flex items-center gap-2 mt-2">
-            {product.color && (
+            {displayColor && (
               <Badge variant="outline" className="text-xs">
-                {capitalizeWords(product.color)}
+                {capitalizeWords(displayColor)}
               </Badge>
             )}
-            {product.category && (
+            {displayCategory && (
               <Badge variant="outline" className="text-xs">
-                {product.category}
+                {displayCategory}
               </Badge>
             )}
             {product.length && (
@@ -142,9 +152,9 @@ export function ProductCard({
                 {product.length}"
               </Badge>
             )}
-            {product.size && (
+            {displaySize && (
               <Badge variant="outline" className="text-xs">
-                {product.size}
+                {displaySize}
               </Badge>
             )}
           </div>
@@ -155,7 +165,7 @@ export function ProductCard({
           <p className="text-xs text-muted-foreground">
             {product.availabilityMessage ? (
               product.availabilityMessage
-            ) : isProvisionalImport ? (
+            ) : usesPendingCount ? (
               "Count pending"
             ) : (
               <>
@@ -214,6 +224,7 @@ export function ProductCard({
             <div className="ml-3 flex border-l border-border/80 pl-3">
               <Button
                 type="button"
+                variant="commit-soft"
                 size="sm"
                 className="h-11 px-4"
                 disabled={!isAvailable}

--- a/packages/athena-webapp/src/components/pos/SearchResultsSection.test.tsx
+++ b/packages/athena-webapp/src/components/pos/SearchResultsSection.test.tsx
@@ -202,6 +202,54 @@ describe("SearchResultsSection", () => {
     expect(onClearSearch).toHaveBeenCalled();
   });
 
+  it("emphasizes the product price without using action styling", () => {
+    renderSearchResults({
+      products: [
+        buildProduct({
+          id: "sku-priced",
+          name: "Eco Gel",
+          price: 9500,
+        }),
+      ],
+    });
+
+    const price = screen.getByText(/95\.00/);
+    expect(price).toHaveClass("text-xl", "font-semibold", "bg-muted/70");
+    expect(price).not.toHaveClass("bg-action-commit");
+  });
+
+  it("uses the soft commit treatment for product add actions", () => {
+    renderSearchResults({
+      products: [
+        buildProduct({
+          id: "sku-add-style",
+          name: "Eco Gel",
+        }),
+      ],
+    });
+
+    expect(screen.getByRole("button", { name: /^add$/i })).toHaveClass(
+      "bg-action-commit-soft",
+      "text-action-commit",
+    );
+  });
+
+  it("renders the SKU as plain metadata on the card surface", () => {
+    renderSearchResults({
+      products: [
+        buildProduct({
+          id: "sku-plain",
+          name: "Eco Gel",
+          sku: "6N2Y-G4V-WDG",
+        }),
+      ],
+    });
+
+    const sku = screen.getByText("6N2Y-G4V-WDG");
+    expect(sku).toHaveClass("font-mono", "text-xs", "text-muted-foreground");
+    expect(sku).not.toHaveClass("bg-muted", "rounded", "px-2", "py-1");
+  });
+
   it("allows provisional import results to be added while trusted counts are pending", async () => {
     const user = userEvent.setup();
     const product = buildProduct({
@@ -231,7 +279,58 @@ describe("SearchResultsSection", () => {
     expect(onAddProduct).toHaveBeenCalledWith(product, 3);
   });
 
-  it("clamps result quantity entry to available stock", async () => {
+  it("does not render legacy NULL metadata on provisional import results", () => {
+    renderSearchResults({
+      products: [
+        buildProduct({
+          availabilityMessage: "Count pending",
+          availabilityPolicy: "active_provisional_import",
+          category: "Legacy import",
+          color: "NULL",
+          id: "sku-provisional",
+          inventoryImportProvisionalSkuId:
+            "provisional-1" as Product["inventoryImportProvisionalSkuId"],
+          name: "Imported wig",
+          quantityAvailable: 0,
+          size: "NULL",
+        }),
+      ],
+    });
+
+    expect(screen.getByText("Legacy import")).toBeInTheDocument();
+    expect(screen.queryByText("NULL")).not.toBeInTheDocument();
+  });
+
+  it("shows count pending for pending checkout results", async () => {
+    const user = userEvent.setup();
+    const product = buildProduct({
+      id: "pending-checkout-1",
+      name: "Ligali",
+      pendingCheckoutItemId:
+        "pending-checkout-1" as Product["pendingCheckoutItemId"],
+      quantityAvailable: 0,
+    });
+    const onAddProduct = vi.fn(async () => true);
+
+    renderSearchResults({
+      products: [product],
+      onAddProduct,
+    });
+
+    expect(screen.getByText("Count pending")).toBeInTheDocument();
+    expect(screen.queryByText("0 available")).not.toBeInTheDocument();
+
+    const quantityInput = screen.getByRole("spinbutton", {
+      name: /quantity for ligali/i,
+    });
+    await user.clear(quantityInput);
+    await user.type(quantityInput, "3");
+    await user.click(screen.getByRole("button", { name: /add 3/i }));
+
+    expect(onAddProduct).toHaveBeenCalledWith(product, 3);
+  });
+
+  it("allows result quantity entry beyond trusted stock", async () => {
     const user = userEvent.setup();
     const product = buildProduct({
       id: "sku-limited",
@@ -250,8 +349,30 @@ describe("SearchResultsSection", () => {
     });
     await user.clear(quantityInput);
     await user.type(quantityInput, "99");
-    await user.click(screen.getByRole("button", { name: /add 4/i }));
+    await user.click(screen.getByRole("button", { name: /add 99/i }));
 
-    expect(onAddProduct).toHaveBeenCalledWith(product, 4);
+    expect(onAddProduct).toHaveBeenCalledWith(product, 99);
+  });
+
+  it("allows known zero-count results to be added for review", async () => {
+    const user = userEvent.setup();
+    const product = buildProduct({
+      availabilityStatus: "out_of_stock",
+      id: "sku-zero",
+      inStock: false,
+      name: "Count mismatch wig",
+      quantityAvailable: 0,
+    });
+    const onAddProduct = vi.fn(async () => true);
+
+    renderSearchResults({
+      products: [product],
+      onAddProduct,
+    });
+
+    expect(screen.getByText("0")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /^add$/i }));
+
+    expect(onAddProduct).toHaveBeenCalledWith(product, 1);
   });
 });

--- a/packages/athena-webapp/src/components/products/ProductsListView.test.ts
+++ b/packages/athena-webapp/src/components/products/ProductsListView.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { getCategoryProductAvailability } from "./ProductsListView";
+
+describe("ProductsListView category query", () => {
+  it("requests live products for the reserved POS quick-add category", () => {
+    expect(getCategoryProductAvailability("pos-quick-add")).toBe("live");
+  });
+
+  it("requests live products for the reserved POS pending-checkout category", () => {
+    expect(getCategoryProductAvailability("pos-pending-checkout")).toBe("live");
+  });
+
+  it("leaves normal category queries on the default visible live-product path", () => {
+    expect(getCategoryProductAvailability("hair")).toBeUndefined();
+    expect(getCategoryProductAvailability(undefined)).toBeUndefined();
+  });
+});

--- a/packages/athena-webapp/src/components/products/ProductsListView.tsx
+++ b/packages/athena-webapp/src/components/products/ProductsListView.tsx
@@ -4,6 +4,7 @@ import {
   useProductsTableState,
 } from "./ProductsTableContext";
 import { useGetProducts } from "~/src/hooks/useGetProducts";
+import type { ProductAvailability } from "~/src/hooks/useGetProducts";
 import { useState, useMemo } from "react";
 import View from "../View";
 import { FadeIn } from "../common/FadeIn";
@@ -20,6 +21,19 @@ import {
   PageWorkspace,
   PageWorkspaceMain,
 } from "../common/PageLevelHeader";
+
+const POS_OPERATIONAL_CATEGORY_SLUGS = new Set([
+  "pos-pending-checkout",
+  "pos-quick-add",
+]);
+
+export function getCategoryProductAvailability(
+  categorySlug: string | undefined,
+): ProductAvailability | undefined {
+  return categorySlug && POS_OPERATIONAL_CATEGORY_SLUGS.has(categorySlug)
+    ? "live"
+    : undefined;
+}
 
 const ProductActionsToggleGroup = ({
   outOfStockProductsCount,
@@ -109,6 +123,7 @@ function Body() {
   const products = useGetProducts({
     subcategorySlug: subcategorySlug ?? undefined,
     categorySlug: categorySlug ?? undefined,
+    availability: getCategoryProductAvailability(categorySlug ?? undefined),
   });
 
   const [selectedProductActions, setSelectedProductActions] = useState<

--- a/packages/athena-webapp/src/components/ui/button.test.tsx
+++ b/packages/athena-webapp/src/components/ui/button.test.tsx
@@ -21,12 +21,17 @@ describe("Button", () => {
   it("renders semantic action variants", () => {
     render(
       <>
+        <Button variant="commit-soft">Add item</Button>
         <Button variant="workflow">Correct</Button>
         <Button variant="workflow-soft">Selected correction</Button>
         <Button variant="utility">View receipt</Button>
       </>
     );
 
+    expect(screen.getByRole("button", { name: "Add item" })).toHaveClass(
+      "bg-action-commit-soft",
+      "text-action-commit",
+    );
     expect(screen.getByRole("button", { name: "Correct" })).toHaveClass(
       "bg-action-workflow",
     );

--- a/packages/athena-webapp/src/components/ui/button.tsx
+++ b/packages/athena-webapp/src/components/ui/button.tsx
@@ -11,6 +11,8 @@ const buttonVariants = cva(
       variant: {
         default:
           "bg-action-commit text-action-commit-foreground hover:bg-action-commit/90",
+        "commit-soft":
+          "border border-action-commit-border bg-action-commit-soft text-action-commit hover:bg-action-commit-soft/75",
         workflow:
           "bg-action-workflow text-action-workflow-foreground hover:bg-action-workflow/90",
         "workflow-soft":

--- a/packages/athena-webapp/src/hooks/useGetProducts.ts
+++ b/packages/athena-webapp/src/hooks/useGetProducts.ts
@@ -1,8 +1,9 @@
 import { useQuery } from "convex/react";
 import useGetActiveStore from "./useGetActiveStore";
 import { api } from "~/convex/_generated/api";
+import type { Product } from "~/types";
 
-type ProductAvailability = "archived" | "draft" | "live";
+export type ProductAvailability = "archived" | "draft" | "live";
 
 export const useGetProducts = ({
   subcategorySlug,
@@ -30,7 +31,9 @@ export const useGetProducts = ({
       : "skip"
   );
 
-  return products?.sort((a: any, b: any) => a.name.localeCompare(b.name));
+  return products?.sort((a: Product, b: Product) =>
+    a.name.localeCompare(b.name),
+  );
 };
 
 export const useGetArchivedProducts = () => {
@@ -53,5 +56,7 @@ export const useGetUnresolvedProducts = () => {
       : "skip"
   );
 
-  return products?.sort((a: any, b: any) => a.name.localeCompare(b.name));
+  return products?.sort((a: Product, b: Product) =>
+    a.name.localeCompare(b.name),
+  );
 };

--- a/packages/athena-webapp/src/index.css
+++ b/packages/athena-webapp/src/index.css
@@ -68,6 +68,8 @@
     --comparison-secondary-border: 201 45% 82%;
     --action-commit: 338 62% 43%;
     --action-commit-foreground: 336 100% 98%;
+    --action-commit-soft: 338 72% 96%;
+    --action-commit-border: 338 42% 82%;
     --action-workflow: 232 42% 45%;
     --action-workflow-foreground: 232 100% 98%;
     --action-workflow-soft: 232 58% 96%;
@@ -159,6 +161,8 @@
     --comparison-secondary-border: 201 41% 36%;
     --action-commit: 336 72% 68%;
     --action-commit-foreground: 222 30% 12%;
+    --action-commit-soft: 336 24% 22%;
+    --action-commit-border: 336 38% 44%;
     --action-workflow: 235 64% 72%;
     --action-workflow-foreground: 222 30% 12%;
     --action-workflow-soft: 232 24% 22%;

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts
@@ -830,6 +830,69 @@ describe("createLocalCommandGateway", () => {
     });
   });
 
+  it("starts a separate active local sale when the signed-in staff changes", async () => {
+    let nextId = 1;
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      clock: () => 10_000 + nextId,
+      createLocalId: (kind) => `local-event-${kind}-${nextId++}`,
+    });
+    const gateway = createLocalCommandGateway({
+      store,
+      clock: () => 20_000 + nextId,
+      createLocalId: (kind) => `${kind}-${nextId++}`,
+    });
+    await store.appendEvent({
+      type: "register.opened",
+      terminalId: "terminal-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      localRegisterSessionId: "local-register-1",
+      staffProfileId: "staff-1",
+      payload: {
+        localRegisterSessionId: "local-register-1",
+        openingFloat: 100,
+      },
+    });
+    const first = await gateway.startSession({
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      staffProfileId: "staff-1" as never,
+      registerNumber: "1",
+      localRegisterSessionId: "local-register-1",
+    });
+    const second = await gateway.startSession({
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      staffProfileId: "staff-2" as never,
+      registerNumber: "1",
+      localRegisterSessionId: "local-register-1",
+    });
+
+    expect(first).toMatchObject({
+      kind: "ok",
+      data: { localPosSessionId: "local-pos-session-2" },
+    });
+    expect(second).toMatchObject({
+      kind: "ok",
+      data: { localPosSessionId: "local-pos-session-4" },
+    });
+    await expect(store.listEvents()).resolves.toMatchObject({
+      ok: true,
+      value: [
+        expect.objectContaining({ type: "register.opened" }),
+        expect.objectContaining({
+          type: "session.started",
+          staffProfileId: "staff-1",
+        }),
+        expect.objectContaining({
+          type: "session.started",
+          staffProfileId: "staff-2",
+        }),
+      ],
+    });
+  });
+
   it("uses the provisioned local terminal id when commands arrive with the cloud terminal id", async () => {
     let nextId = 1;
     const store = createPosLocalStore({

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts
@@ -602,7 +602,9 @@ export function createLocalCommandGateway(
       }
       if (
         model.value.activeSale?.localRegisterSessionId ===
-        localRegisterSessionId
+          localRegisterSessionId &&
+        model.value.activeSale.staffProfileId ===
+          input.staffProfileId?.toString()
       ) {
         return ok({
           localPosSessionId: model.value.activeSale.localPosSessionId,

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -1026,14 +1026,7 @@ describe("usePosLocalSyncRuntimeStatus", () => {
       ),
     );
     expect(store.markEventsSynced).not.toHaveBeenCalled();
-    expect(store.writeDrawerAuthorityState).toHaveBeenCalledWith(
-      expect.objectContaining({
-        localRegisterSessionId: "register-1",
-        reason: "lifecycle_rejected",
-        status: "blocked",
-        storeId: "store-1",
-      }),
-    );
+    expect(store.writeDrawerAuthorityState).not.toHaveBeenCalled();
   });
 
   it("persists terminal integrity instead of marking events for review when sync authorization fails", async () => {
@@ -3505,6 +3498,122 @@ describe("usePosLocalSyncRuntimeStatus", () => {
         status: "needs_review",
       }),
     );
+  });
+
+  it("does not persist drawer authority blocks for sale inventory review conflicts", async () => {
+    mocks.ingestLocalEvents.mockResolvedValue({
+      kind: "ok",
+      data: {
+        accepted: [
+          {
+            localEventId: "event-sale-completed",
+            sequence: 3,
+            status: "conflicted",
+          },
+        ],
+        held: [],
+        mappings: [],
+        conflicts: [
+          {
+            _id: "conflict-1",
+            conflictType: "inventory_mismatch",
+            localEventId: "event-sale-completed",
+            status: "needs_review",
+            summary: "Inventory count mismatch for synced sale.",
+          },
+        ],
+        syncCursor: {
+          localRegisterSessionId: "register-1",
+          acceptedThroughSequence: 3,
+        },
+      },
+    });
+    const store = {
+      clearDrawerAuthorityState: vi.fn(async () => ({ ok: true, value: null })),
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            localEventId: "event-open",
+            sequence: 1,
+            type: "register.opened",
+          }),
+          buildLocalEvent({
+            localEventId: "event-session",
+            localPosSessionId: "session-1",
+            payload: {
+              localPosSessionId: "session-1",
+              status: "active",
+            },
+            sequence: 2,
+            type: "session.started",
+          }),
+          buildLocalEvent({
+            localEventId: "event-sale-completed",
+            localPosSessionId: "session-1",
+            localTransactionId: "local-txn-1",
+            payload: {
+              localPosSessionId: "session-1",
+              localTransactionId: "local-txn-1",
+              receiptNumber: "LOCAL-1-000001",
+              subtotal: 25,
+              tax: 0,
+              total: 25,
+              payments: [{ method: "cash", amount: 25, timestamp: 2 }],
+            },
+            sequence: 3,
+            type: "transaction.completed",
+          }),
+        ],
+      })),
+      markEventsNeedsReview: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      markEventsSynced: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      readDrawerAuthorityState: vi.fn(async () => ({ ok: true, value: null })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+      writeDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
+      writeLocalCloudMapping: vi.fn(async () => ({
+        ok: true,
+        value: {},
+      })),
+    };
+
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        mode: "drain-enabled",
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(store.markEventsNeedsReview).toHaveBeenCalledWith(
+        ["event-sale-completed", "event-session"],
+        "Cloud sync needs review before this local event can finish.",
+        { uploaded: true },
+      ),
+    );
+    expect(store.writeDrawerAuthorityState).not.toHaveBeenCalled();
   });
 
   it("does not present a reopened local closeout as pending reconciliation", () => {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -1582,8 +1582,7 @@ function isDrawerAuthorityLifecycleEvent(event: PosLocalEventRecord) {
   return (
     event.type === "register.opened" ||
     event.type === "register.closeout_started" ||
-    event.type === "register.reopened" ||
-    event.type === "transaction.completed"
+    event.type === "register.reopened"
   );
 }
 

--- a/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearchPresentation.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearchPresentation.ts
@@ -13,9 +13,6 @@ export type RegisterCatalogAvailability = {
 export const POS_AVAILABILITY_NOT_READY_MESSAGE =
   "Availability not ready. Reconnect or refresh this terminal before selling this item.";
 
-export const POS_NO_TRUSTED_AVAILABILITY_REMAINING_MESSAGE =
-  "No trusted availability remains for this item on this terminal.";
-
 export function mapCatalogRowToProduct(
   row: RegisterCatalogSearchRow,
   availability: RegisterCatalogAvailability | undefined,

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -1754,7 +1754,7 @@ describe("useRegisterViewModel", () => {
     );
   });
 
-  it("blocks starting a new sale over another staff member's non-empty local cart", async () => {
+  it("starts a separate sale when another staff member has a hidden non-empty local cart", async () => {
     mockRegisterState = {
       phase: "readyToStart",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -1853,7 +1853,7 @@ describe("useRegisterViewModel", () => {
 
     expect(result.current.cart.items).toEqual([]);
     expect(result.current.checkout.total).toBe(0);
-    expect(result.current.productEntry.disabled).toBe(true);
+    expect(result.current.productEntry.disabled).toBe(false);
     expect(
       mockAppendLocalEvent.mock.calls.filter(
         ([event]) => event.type === "session.started",
@@ -1864,7 +1864,7 @@ describe("useRegisterViewModel", () => {
       await result.current.sessionPanel?.onStartNewSession();
     });
 
-    expect(toast.error).toHaveBeenCalledWith(
+    expect(toast.error).not.toHaveBeenCalledWith(
       "This local sale belongs to another signed-in staff member.",
     );
     expect(
@@ -1872,11 +1872,12 @@ describe("useRegisterViewModel", () => {
         ([event]) => event.type === "cart.cleared",
       ),
     ).toHaveLength(0);
-    expect(
-      mockAppendLocalEvent.mock.calls.filter(
-        ([event]) => event.type === "session.started",
-      ),
-    ).toHaveLength(0);
+    expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "session.started",
+        staffProfileId: "staff-2",
+      }),
+    );
   });
 
   it("replaces another staff member's empty local sale when starting a new sale", async () => {
@@ -1980,7 +1981,7 @@ describe("useRegisterViewModel", () => {
     );
   });
 
-  it("blocks adding a product over another staff member's non-empty local cart", async () => {
+  it("adds a product to a new separate sale when another staff member has a hidden non-empty local cart", async () => {
     mockRegisterState = {
       phase: "readyToStart",
       terminal: { _id: "terminal-1", displayName: "Front Counter" },
@@ -2070,7 +2071,7 @@ describe("useRegisterViewModel", () => {
       );
     });
 
-    let added = true;
+    let added = false;
     await act(async () => {
       added = await result.current.productEntry.onAddProduct({
         id: "sku-2",
@@ -2088,8 +2089,8 @@ describe("useRegisterViewModel", () => {
       });
     });
 
-    expect(added).toBe(false);
-    expect(toast.error).toHaveBeenCalledWith(
+    expect(added).toBe(true);
+    expect(toast.error).not.toHaveBeenCalledWith(
       "This local sale belongs to another signed-in staff member.",
     );
     expect(
@@ -2097,16 +2098,18 @@ describe("useRegisterViewModel", () => {
         ([event]) => event.type === "cart.cleared",
       ),
     ).toHaveLength(0);
-    expect(
-      mockAppendLocalEvent.mock.calls.filter(
-        ([event]) => event.type === "session.started",
-      ),
-    ).toHaveLength(0);
-    expect(
-      mockAppendLocalEvent.mock.calls.filter(
-        ([event]) => event.type === "cart.item_added",
-      ),
-    ).toHaveLength(0);
+    expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "session.started",
+        staffProfileId: "staff-2",
+      }),
+    );
+    expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "cart.item_added",
+        staffProfileId: "staff-2",
+      }),
+    );
   });
 
   it("replaces another staff member's empty local sale before adding a product", async () => {
@@ -5991,16 +5994,22 @@ describe("useRegisterViewModel", () => {
       );
     });
 
-    expect(added).toBe(false);
-    expect(mockAppendLocalEvent).not.toHaveBeenCalledWith(
-      expect.objectContaining({ type: "cart.item_added" }),
+    expect(added).toBe(true);
+    expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "cart.item_added",
+        payload: expect.objectContaining({
+          productSkuId: "sku-1",
+          quantity: 2,
+        }),
+      }),
     );
-    expect(toast.error).toHaveBeenCalledWith(
+    expect(toast.error).not.toHaveBeenCalledWith(
       "No trusted availability remains for this item on this terminal.",
     );
   });
 
-  it("rechecks trusted availability inside the local add queue", async () => {
+  it("allows trusted count mismatches inside the local add queue", async () => {
     mockRegisterCatalogRows = [buildRegisterCatalogRow()];
     mockRegisterCatalogAvailabilityRows = [
       buildRegisterCatalogAvailabilityRow({
@@ -6058,12 +6067,17 @@ describe("useRegisterViewModel", () => {
       ]);
     });
 
-    expect(
-      mockAppendLocalEvent.mock.calls.filter(
-        ([event]) => event?.type === "cart.item_added",
-      ),
-    ).toHaveLength(1);
-    expect(toast.error).toHaveBeenCalledWith(
+    const cartItemAddedEvents = mockAppendLocalEvent.mock.calls
+      .map(([event]) => event)
+      .filter((event) => event?.type === "cart.item_added");
+    expect(cartItemAddedEvents.length).toBeGreaterThanOrEqual(2);
+    expect(cartItemAddedEvents.at(-1)?.payload).toEqual(
+      expect.objectContaining({
+        productSkuId: "sku-2",
+        quantity: 3,
+      }),
+    );
+    expect(toast.error).not.toHaveBeenCalledWith(
       "No trusted availability remains for this item on this terminal.",
     );
   });
@@ -6143,7 +6157,7 @@ describe("useRegisterViewModel", () => {
     );
   });
 
-  it("rejects requested product quantity beyond trusted availability", async () => {
+  it("adds requested product quantity beyond trusted availability", async () => {
     mockRegisterCatalogRows = [buildRegisterCatalogRow()];
     mockRegisterCatalogAvailabilityRows = [
       buildRegisterCatalogAvailabilityRow({
@@ -6175,21 +6189,27 @@ describe("useRegisterViewModel", () => {
       inStock: true,
       quantityAvailable: 2,
     };
-    let added = true;
+    let added = false;
     await act(async () => {
       added = await result.current.productEntry.onAddProduct(product, 3);
     });
 
-    expect(added).toBe(false);
-    expect(mockAppendLocalEvent).not.toHaveBeenCalledWith(
-      expect.objectContaining({ type: "cart.item_added" }),
+    expect(added).toBe(true);
+    expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "cart.item_added",
+        payload: expect.objectContaining({
+          productSkuId: "sku-2",
+          quantity: 3,
+        }),
+      }),
     );
-    expect(toast.error).toHaveBeenCalledWith(
+    expect(toast.error).not.toHaveBeenCalledWith(
       "No trusted availability remains for this item on this terminal.",
     );
   });
 
-  it("rechecks trusted availability inside queued quantity updates", async () => {
+  it("allows trusted count mismatches inside queued quantity updates", async () => {
     mockRegisterCatalogRows = [buildRegisterCatalogRow()];
     mockRegisterCatalogAvailabilityRows = [
       buildRegisterCatalogAvailabilityRow({
@@ -6278,8 +6298,8 @@ describe("useRegisterViewModel", () => {
       mockAppendLocalEvent.mock.calls.filter(
         ([event]) => event?.type === "cart.item_added",
       ),
-    ).toHaveLength(1);
-    expect(toast.error).toHaveBeenCalledWith(
+    ).toHaveLength(2);
+    expect(toast.error).not.toHaveBeenCalledWith(
       "No trusted availability remains for this item on this terminal.",
     );
   });
@@ -6378,6 +6398,198 @@ describe("useRegisterViewModel", () => {
           inventoryImportProvisionalSkuId: "provisional-import-sku-1",
           productSkuId: "sku-2",
           quantity: 3,
+        }),
+      }),
+    );
+  });
+
+  it("updates a newly added provisional import line before the local projection refreshes", async () => {
+    mockActiveSession = {
+      ...mockActiveSession!,
+      cartItems: [],
+    };
+    mockRegisterCatalogRows = [
+      buildRegisterCatalogRow({
+        id: "provisional-import-sku-1" as Id<"productSku">,
+        availabilityPolicy: "active_provisional_import",
+        inventoryImportProvisionalSkuId:
+          "provisional-import-sku-1" as Id<"inventoryImportProvisionalSku">,
+      }),
+    ];
+    mockRegisterCatalogAvailabilityRows = [
+      buildRegisterCatalogAvailabilityRow({
+        availabilityPolicy: "active_provisional_import",
+        inventoryImportProvisionalSkuId:
+          "provisional-import-sku-1" as Id<"inventoryImportProvisionalSku">,
+        quantityAvailable: 0,
+      }),
+    ];
+    mockListLocalEvents.mockResolvedValue({ ok: true, value: [] });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    await act(async () => {
+      await result.current.productEntry.onAddProduct({
+        id: "provisional-import-sku-1",
+        name: "Deep Wave",
+        price: 100,
+        barcode: "1234567890123",
+        productId: "product-2" as Id<"product">,
+        skuId: "sku-2" as Id<"productSku">,
+        sku: "DW-18",
+        category: "Hair",
+        description: "Deep wave bundle",
+        image: null,
+        inStock: true,
+        quantityAvailable: 0,
+        availabilityPolicy: "active_provisional_import",
+        inventoryImportProvisionalSkuId:
+          "provisional-import-sku-1" as Id<"inventoryImportProvisionalSku">,
+      });
+    });
+
+    expect(result.current.cart.items).toEqual([
+      expect.objectContaining({
+        id: "optimistic:provisional-import-sku-1",
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        quantity: 1,
+      }),
+    ]);
+
+    await act(async () => {
+      await result.current.cart.onUpdateQuantity(
+        result.current.cart.items[0].id as Id<"posSessionItem">,
+        2,
+      );
+    });
+
+    expect(result.current.cart.items).toEqual([
+      expect.objectContaining({
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        quantity: 2,
+      }),
+    ]);
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "No trusted availability remains for this item on this terminal.",
+    );
+    expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "cart.item_added",
+        payload: expect.objectContaining({
+          inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+          productSkuId: "sku-2",
+          quantity: 2,
+        }),
+      }),
+    );
+  });
+
+  it("updates a newly added provisional import line after local projection refreshes", async () => {
+    mockActiveSession = {
+      ...mockActiveSession!,
+      cartItems: [],
+    };
+    mockRegisterCatalogRows = [
+      buildRegisterCatalogRow({
+        id: "provisional-import-sku-1" as Id<"productSku">,
+        availabilityPolicy: "active_provisional_import",
+        inventoryImportProvisionalSkuId:
+          "provisional-import-sku-1" as Id<"inventoryImportProvisionalSku">,
+      }),
+    ];
+    mockRegisterCatalogAvailabilityRows = [
+      buildRegisterCatalogAvailabilityRow({
+        availabilityPolicy: "active_provisional_import",
+        inventoryImportProvisionalSkuId:
+          "provisional-import-sku-1" as Id<"inventoryImportProvisionalSku">,
+        quantityAvailable: 0,
+      }),
+    ];
+
+    const localEvents: ReturnType<typeof buildLocalEvent>[] = [];
+    mockListLocalEvents.mockImplementation(async () => ({
+      ok: true,
+      value: localEvents,
+    }));
+    mockAppendLocalEvent.mockImplementation(async (event) => {
+      localEvents.push(
+        buildLocalEvent({
+          ...event,
+          sequence: localEvents.length + 1,
+        }),
+      );
+      return { ok: true, value: { localEventId: `event-${localEvents.length}` } };
+    });
+
+    const { useRegisterViewModel } = await import("./useRegisterViewModel");
+    const { result } = renderHook(() => useRegisterViewModel());
+
+    await act(async () => {
+      result.current.authDialog?.onAuthenticated(
+        "staff-1" as Id<"staffProfile">,
+      );
+    });
+
+    await act(async () => {
+      await result.current.productEntry.onAddProduct({
+        id: "provisional-import-sku-1",
+        name: "Deep Wave",
+        price: 100,
+        barcode: "1234567890123",
+        productId: "product-2" as Id<"product">,
+        skuId: "sku-2" as Id<"productSku">,
+        sku: "DW-18",
+        category: "Hair",
+        description: "Deep wave bundle",
+        image: null,
+        inStock: true,
+        quantityAvailable: 0,
+        availabilityPolicy: "active_provisional_import",
+        inventoryImportProvisionalSkuId:
+          "provisional-import-sku-1" as Id<"inventoryImportProvisionalSku">,
+      });
+    });
+
+    await waitFor(() =>
+      expect(result.current.cart.items[0]).toEqual(
+        expect.objectContaining({
+          id: expect.stringMatching(/^local-item-/),
+          inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+          quantity: 1,
+        }),
+      ),
+    );
+
+    await act(async () => {
+      await result.current.cart.onUpdateQuantity(
+        result.current.cart.items[0].id as Id<"posSessionItem">,
+        2,
+      );
+    });
+
+    expect(result.current.cart.items).toEqual([
+      expect.objectContaining({
+        inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+        quantity: 2,
+      }),
+    ]);
+    expect(toast.error).not.toHaveBeenCalledWith(
+      "No trusted availability remains for this item on this terminal.",
+    );
+    expect(mockAppendLocalEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "cart.item_added",
+        payload: expect.objectContaining({
+          inventoryImportProvisionalSkuId: "provisional-import-sku-1",
+          productSkuId: "sku-2",
+          quantity: 2,
         }),
       }),
     );
@@ -10382,7 +10594,7 @@ describe("useRegisterViewModel", () => {
     );
   });
 
-  it("keeps cart item removals visible until the local write is durable", async () => {
+  it("hides explicit cart item removals while the local write is pending", async () => {
     const pendingAppend = deferred<{
       ok: true;
       value: { localEventId: string };
@@ -10405,8 +10617,8 @@ describe("useRegisterViewModel", () => {
       );
     });
 
-    expect(result.current.cart.items).toHaveLength(1);
-    expect(result.current.checkout.cartItems).toHaveLength(1);
+    expect(result.current.cart.items).toHaveLength(0);
+    expect(result.current.checkout.cartItems).toHaveLength(0);
 
     pendingAppend.resolve({ ok: true, value: { localEventId: "local-event-1" } });
     await act(async () => {
@@ -10646,7 +10858,7 @@ describe("useRegisterViewModel", () => {
     );
   });
 
-  it("keeps cart item removals visible when the local write fails", async () => {
+  it("restores explicit cart item removals when the local write fails", async () => {
     const pendingAppend = deferred<{
       ok: false;
       error: { message: string };
@@ -10669,7 +10881,8 @@ describe("useRegisterViewModel", () => {
       );
     });
 
-    expect(result.current.cart.items).toHaveLength(1);
+    expect(result.current.cart.items).toHaveLength(0);
+    expect(result.current.checkout.cartItems).toHaveLength(0);
 
     pendingAppend.resolve({
       ok: false,

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -101,7 +101,6 @@ import {
   mapCatalogRowToProduct,
   normalizeExactInput,
   POS_AVAILABILITY_NOT_READY_MESSAGE,
-  POS_NO_TRUSTED_AVAILABILITY_REMAINING_MESSAGE,
   type RegisterCatalogAvailability,
 } from "./catalogSearchPresentation";
 import { useRegisterCatalogIndex } from "./useRegisterCatalogIndex";
@@ -1683,6 +1682,13 @@ export function useRegisterViewModel(): RegisterViewModel {
   const seededRegisterSessionIdsRef = useRef<Set<string>>(new Set());
   const persistedDrawerAuthorityBlockRef = useRef<string | null>(null);
   const autoTerminalRepairAttemptRef = useRef<string | null>(null);
+  const activeCartItemsRef = useRef<CartItem[]>([]);
+  const localRegisterReadModelRef = useRef<PosLocalRegisterReadModel | null>(
+    null,
+  );
+  const localAvailabilityConsumptionBySkuIdRef = useRef<Map<string, number>>(
+    new Map(),
+  );
   const [optimisticCartQuantities, setOptimisticCartQuantities] = useState<
     Record<string, number>
   >({});
@@ -1981,9 +1987,9 @@ export function useRegisterViewModel(): RegisterViewModel {
   );
   const isProjectedLocalActiveSaleEmptyShell =
     isEmptyLocalSaleShell(projectedLocalActiveSale);
-  const isProjectedLocalActiveSaleBlockingCurrentStaff = Boolean(
+  const shouldReplaceProjectedLocalActiveSaleForCurrentStaff = Boolean(
     isProjectedLocalActiveSaleLockedToAnotherStaff &&
-      !isProjectedLocalActiveSaleEmptyShell,
+      isProjectedLocalActiveSaleEmptyShell,
   );
   const registerNumber = activeRegisterNumber ?? terminalRegisterNumber ?? "";
   const heldSessions = useConvexHeldSessions({
@@ -2629,10 +2635,15 @@ export function useRegisterViewModel(): RegisterViewModel {
       if (existingIndex >= 0) {
         const existingItem = cartItems[existingIndex];
         const optimisticQuantity = optimisticCartQuantities[existingItem.id];
-        cartItems[existingIndex] =
-          optimisticQuantity === undefined
-            ? { ...existingItem, quantity: optimisticProduct.quantity }
-            : existingItem;
+        const existingItemIsOptimistic = existingItem.id
+          .toString()
+          .startsWith("optimistic:");
+        if (optimisticQuantity === undefined && existingItemIsOptimistic) {
+          cartItems[existingIndex] = {
+            ...existingItem,
+            quantity: optimisticProduct.quantity,
+          };
+        }
       } else {
         cartItems.push(optimisticProduct);
       }
@@ -2640,6 +2651,8 @@ export function useRegisterViewModel(): RegisterViewModel {
 
     return cartItems;
   }, [optimisticCartProducts, optimisticCartQuantities, serverCartItems]);
+  activeCartItemsRef.current = activeCartItems;
+  localRegisterReadModelRef.current = localRegisterReadModel;
   const localAvailabilityConsumptionBySkuId = useMemo(() => {
     const quantities =
       localAvailabilityConsumptionFromReadModel(localRegisterReadModel);
@@ -2656,6 +2669,8 @@ export function useRegisterViewModel(): RegisterViewModel {
 
     return quantities;
   }, [localRegisterReadModel, optimisticCartProducts]);
+  localAvailabilityConsumptionBySkuIdRef.current =
+    localAvailabilityConsumptionBySkuId;
   const localRegisterCatalogAvailabilityBySkuId = useMemo(() => {
     const adjusted = new Map<string, RegisterCatalogAvailability>();
 
@@ -2716,7 +2731,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         registerMetadataSearchState.exactMatch &&
           exactAvailability &&
           (exactAvailability.availabilityPolicy === "active_provisional_import" ||
-            exactAvailability.quantityAvailable > 0),
+            exactAvailability.quantityAvailable >= 0),
       ),
     };
   }, [
@@ -3400,7 +3415,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         return null;
       }
       if (
-        isProjectedLocalActiveSaleLockedToAnotherStaff &&
+        shouldReplaceProjectedLocalActiveSaleForCurrentStaff &&
         !(await clearProjectedLocalSaleForStaff(staffProfileId, {
           requireEmpty: true,
         }))
@@ -3440,7 +3455,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     }
 
     if (
-      isProjectedLocalActiveSaleLockedToAnotherStaff &&
+      shouldReplaceProjectedLocalActiveSaleForCurrentStaff &&
       !(await clearProjectedLocalSaleForStaff(staffProfileId, {
         requireEmpty: true,
       }))
@@ -3492,7 +3507,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     clearProjectedLocalSaleForStaff,
     ensureLocalRegisterSessionReady,
     hasProvisionedLocalSyncSeed,
-    isProjectedLocalActiveSaleLockedToAnotherStaff,
+    shouldReplaceProjectedLocalActiveSaleForCurrentStaff,
     localCommandGateway,
     localSaleValidationMetadata,
     locallyOperableRegisterSession,
@@ -3976,6 +3991,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     if (
       projectedLocalActiveSale &&
       projectedLocalActiveSale.staffProfileId !== actingStaffProfileId &&
+      isEmptyLocalSaleShell(projectedLocalActiveSale) &&
       !(await clearProjectedLocalSaleForStaff(actingStaffProfileId))
     ) {
       toast.error("This local sale belongs to another signed-in staff member.");
@@ -4936,30 +4952,19 @@ export function useRegisterViewModel(): RegisterViewModel {
         return false;
       }
 
-      if (
-        product.availabilityPolicy !== "active_provisional_import" &&
-        (availabilityStatus !== "available" ||
-          (typeof product.quantityAvailable === "number" &&
-            product.quantityAvailable <= 0))
-      ) {
-        toast.error(POS_NO_TRUSTED_AVAILABILITY_REMAINING_MESSAGE);
-        return false;
-      }
-
       return enqueueCartMutation(async () => {
         const localPosSessionId = await ensureLocalPosSessionId();
         if (!localPosSessionId) {
           return false;
         }
 
-        const queuedReadModel = await readCurrentLocalRegisterModel();
+        const fastCartItems = activeCartItemsRef.current;
+        const fastLocalAvailabilityConsumptionBySkuId =
+          localAvailabilityConsumptionBySkuIdRef.current;
+        const queuedReadModel = localRegisterReadModelRef.current;
         if (registerCatalogSkuIds.has(productSkuId)) {
           const availability =
             registerCatalogAvailabilityBySkuId.get(productSkuId);
-          const localConsumption =
-            localAvailabilityConsumptionFromReadModel(queuedReadModel).get(
-              productSkuId,
-            ) ?? 0;
           const quantityAvailable =
             availability !== undefined
               ? Math.trunc(availability.quantityAvailable)
@@ -4967,8 +4972,6 @@ export function useRegisterViewModel(): RegisterViewModel {
                   typeof product.quantityAvailable === "number"
                 ? Math.trunc(product.quantityAvailable)
                 : undefined;
-          const isInStock =
-            availability !== undefined ? availability.inStock : product.inStock;
 
           if (
             product.availabilityPolicy !== "active_provisional_import" &&
@@ -4976,14 +4979,6 @@ export function useRegisterViewModel(): RegisterViewModel {
           ) {
             if (quantityAvailable === undefined) {
               toast.error(POS_AVAILABILITY_NOT_READY_MESSAGE);
-              return false;
-            }
-
-            if (
-              !isInStock ||
-              quantityAvailable - localConsumption < requestedQuantity
-            ) {
-              toast.error(POS_NO_TRUSTED_AVAILABILITY_REMAINING_MESSAGE);
               return false;
             }
           }
@@ -4995,7 +4990,7 @@ export function useRegisterViewModel(): RegisterViewModel {
             item.productSkuId === productSkuId &&
             cartLineSourceKey(item) === nextLineSourceKey,
         );
-        const existingItem = activeCartItems.find(
+        const existingItem = fastCartItems.find(
           (item) =>
             item.skuId === productSkuId &&
             cartLineSourceKey(item) === nextLineSourceKey,
@@ -5008,7 +5003,7 @@ export function useRegisterViewModel(): RegisterViewModel {
               (cartLineSourceKey(item) === "trusted_inventory" ||
                 nextLineSourceKey === "trusted_inventory"),
           ) ??
-          activeCartItems.find(
+          fastCartItems.find(
             (item) =>
               item.skuId === productSkuId &&
               cartLineSourceKey(item) !== nextLineSourceKey &&
@@ -5034,19 +5029,43 @@ export function useRegisterViewModel(): RegisterViewModel {
         const isExistingOptimisticProduct = existingItem?.id
           .toString()
           .startsWith("optimistic:");
+        const previousFastCartItems = activeCartItemsRef.current;
+        const previousFastLocalAvailabilityConsumptionBySkuId =
+          localAvailabilityConsumptionBySkuIdRef.current;
+        const optimisticItem = mapProductToOptimisticCartItem(
+          product,
+          nextQuantity,
+        );
         if (existingItem && !isExistingOptimisticProduct) {
           setOptimisticCartQuantities((current) => ({
             ...current,
             [existingItem.id]: nextQuantity,
           }));
+          activeCartItemsRef.current = fastCartItems.map((item) =>
+            item.id === existingItem.id
+              ? { ...item, quantity: nextQuantity }
+              : item,
+          );
         } else {
           setOptimisticCartProducts((current) => ({
             ...current,
-            [optimisticProductKey]: mapProductToOptimisticCartItem(
-              product,
-              nextQuantity,
-            ),
+            [optimisticProductKey]: optimisticItem,
           }));
+          activeCartItemsRef.current = [
+            ...fastCartItems.filter((item) => item.id !== optimisticItem.id),
+            optimisticItem,
+          ];
+        }
+
+        if (nextLineSourceKey === "trusted_inventory") {
+          const nextConsumption = new Map(
+            fastLocalAvailabilityConsumptionBySkuId,
+          );
+          nextConsumption.set(
+            productSkuId,
+            (nextConsumption.get(productSkuId) ?? 0) + requestedQuantity,
+          );
+          localAvailabilityConsumptionBySkuIdRef.current = nextConsumption;
         }
 
         const pendingDefinitionSaved = await defineLocalPendingCheckoutItem({
@@ -5066,6 +5085,9 @@ export function useRegisterViewModel(): RegisterViewModel {
           }));
 
         if (!savedLocally) {
+          activeCartItemsRef.current = previousFastCartItems;
+          localAvailabilityConsumptionBySkuIdRef.current =
+            previousFastLocalAvailabilityConsumptionBySkuId;
           if (existingItem && !isExistingOptimisticProduct) {
             setOptimisticCartQuantities((current) => {
               const next = { ...current };
@@ -5096,7 +5118,6 @@ export function useRegisterViewModel(): RegisterViewModel {
       });
     },
     [
-      activeCartItems,
       activeSessionHasBlockedRegisterBinding,
       enqueueCartMutation,
       appendLocalCartItem,
@@ -5104,7 +5125,6 @@ export function useRegisterViewModel(): RegisterViewModel {
       ensureLocalPosSessionId,
       noteLocalRegisterEventChanged,
       optimisticCartProducts,
-      readCurrentLocalRegisterModel,
       registerCatalogAvailabilityBySkuId,
       registerCatalogSkuIds,
       staffProfileId,
@@ -5197,24 +5217,8 @@ export function useRegisterViewModel(): RegisterViewModel {
           !isProvisionalImportLine &&
           registerCatalogSkuIds.has(item.skuId)
         ) {
-          const requestedIncrease = quantity - currentQuantity;
-          const availability = registerCatalogAvailabilityBySkuId.get(item.skuId);
-          if (!availability) {
+          if (!registerCatalogAvailabilityBySkuId.has(item.skuId)) {
             toast.error(POS_AVAILABILITY_NOT_READY_MESSAGE);
-            return;
-          }
-
-          const localConsumption =
-            localAvailabilityConsumptionFromReadModel(queuedReadModel).get(
-              item.skuId,
-            ) ?? 0;
-          const trustedQuantityAvailable = Math.max(
-            0,
-            Math.trunc(availability.quantityAvailable) - localConsumption,
-          );
-
-          if (trustedQuantityAvailable < requestedIncrease) {
-            toast.error(POS_NO_TRUSTED_AVAILABILITY_REMAINING_MESSAGE);
             return;
           }
         }
@@ -5348,14 +5352,50 @@ export function useRegisterViewModel(): RegisterViewModel {
         return;
       }
 
-      return enqueueCartMutation(async () => {
       const item = activeCartItems.find((candidate) => candidate.id === itemId);
       if (!item) {
         return;
       }
 
-      if (item?.id.toString().startsWith("optimistic:")) {
-        if (!item.skuId) return;
+      const itemIsLocalOnly = item.id.toString().startsWith("optimistic:");
+      const optimisticProductKey = optimisticCartProductKeyFromCartItem(item);
+
+      if (itemIsLocalOnly) {
+        setOptimisticCartProducts((current) => {
+          const next = { ...current };
+          delete next[optimisticProductKey];
+          return next;
+        });
+      } else {
+        setOptimisticCartQuantities((current) => ({
+          ...current,
+          [itemId]: 0,
+        }));
+      }
+
+      return enqueueCartMutation(async () => {
+        if (itemIsLocalOnly) {
+          if (!item.skuId) return;
+          const savedLocally = await appendLocalCartItem({
+            localPosSessionId: operableActiveSession._id.toString(),
+            payload: buildLocalCartItemPayloadFromCartItem({
+              item,
+              localItemId: itemId.toString(),
+              quantity: 0,
+            }),
+          });
+          if (!savedLocally) {
+            setOptimisticCartProducts((current) => ({
+              ...current,
+              [optimisticProductKey]: item,
+            }));
+            presentOperatorError("Unable to update this sale. Try again.");
+            return;
+          }
+          noteLocalRegisterEventChanged();
+          return;
+        }
+
         const savedLocally = await appendLocalCartItem({
           localPosSessionId: operableActiveSession._id.toString(),
           payload: buildLocalCartItemPayloadFromCartItem({
@@ -5364,38 +5404,18 @@ export function useRegisterViewModel(): RegisterViewModel {
             quantity: 0,
           }),
         });
+
         if (!savedLocally) {
+          setOptimisticCartQuantities((current) => {
+            const next = { ...current };
+            delete next[itemId];
+            return next;
+          });
           presentOperatorError("Unable to update this sale. Try again.");
           return;
         }
+
         noteLocalRegisterEventChanged();
-        setOptimisticCartProducts((current) => {
-          const next = { ...current };
-          delete next[optimisticCartProductKeyFromCartItem(item)];
-          return next;
-        });
-        return;
-      }
-
-      const savedLocally = await appendLocalCartItem({
-        localPosSessionId: operableActiveSession._id.toString(),
-        payload: buildLocalCartItemPayloadFromCartItem({
-          item,
-          localItemId: itemId.toString(),
-          quantity: 0,
-        }),
-      });
-
-      if (!savedLocally) {
-        presentOperatorError("Unable to update this sale. Try again.");
-        return;
-      }
-
-      setOptimisticCartQuantities((current) => ({
-        ...current,
-        [itemId]: 0,
-      }));
-      noteLocalRegisterEventChanged();
       });
     },
     [
@@ -6609,7 +6629,6 @@ export function useRegisterViewModel(): RegisterViewModel {
         !terminal ||
         !staffProfileId ||
         cashierPresenceBlocksSale ||
-        isProjectedLocalActiveSaleBlockingCurrentStaff ||
         shouldShowDrawerGate ||
         cloudRegisterSessionBlocksLocalProjection ||
         activeSessionHasBlockedRegisterBinding ||
@@ -6640,7 +6659,6 @@ export function useRegisterViewModel(): RegisterViewModel {
             !terminal ||
             !staffProfileId ||
             cashierPresenceBlocksSale ||
-            isProjectedLocalActiveSaleBlockingCurrentStaff ||
             shouldShowDrawerGate ||
             cloudRegisterSessionBlocksLocalProjection ||
             activeSessionHasBlockedRegisterBinding ||

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/inventory-import/review.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/inventory-import/review.tsx
@@ -4,7 +4,9 @@ import { z } from "zod";
 import { InventoryImportView } from "~/src/components/operations/InventoryImportView";
 
 const inventoryImportReviewSearchSchema = z.object({
-  filter: z.enum(["all", "review", "new", "matched", "decided"]).optional(),
+  filter: z
+    .enum(["all", "review", "new", "matched", "needs_decision", "decided"])
+    .optional(),
   page: z.coerce.number().int().positive().optional(),
 });
 

--- a/packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx
+++ b/packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx
@@ -63,6 +63,7 @@ describe("AthenaFoundationsPage", () => {
     expect(indexCss).toContain("--border: 220 16% 88%;");
     expect(indexCss).toContain("--input: 220 16% 88%;");
     expect(indexCss).toContain("--action-commit: 338 62% 43%;");
+    expect(indexCss).toContain("--action-commit-soft: 338 72% 96%;");
     expect(indexCss).toContain("--action-workflow: 232 42% 45%;");
     expect(indexCss).toContain("--action-workflow-soft: 232 58% 96%;");
   });

--- a/packages/athena-webapp/src/tests/prod/posFlow.prod.spec.ts
+++ b/packages/athena-webapp/src/tests/prod/posFlow.prod.spec.ts
@@ -10,6 +10,7 @@ const prodConvexUrl =
 const prodStoreId = (process.env.ATHENA_PROD_POS_STORE_ID ||
   "nn7byz68a3j4tfjvgdf9evpt3n78kk38") as Id<"store">;
 const prodPosRecoveryCode = process.env.ATHENA_PROD_POS_RECOVERY_CODE;
+const prodConvexAuthToken = process.env.ATHENA_PROD_CONVEX_AUTH_TOKEN;
 const posHubPath =
   process.env.ATHENA_PROD_POS_HUB_PATH || "/wigclub/store/wigclub/pos";
 const posBasePath = posHubPath.replace(/\/$/, "");
@@ -144,7 +145,13 @@ test.describe("production POS flow", () => {
   });
 
   test("serves the live register catalog snapshot used by POS prewarm", async () => {
+    test.skip(
+      !prodConvexAuthToken,
+      "ATHENA_PROD_CONVEX_AUTH_TOKEN is required for authenticated POS catalog snapshot.",
+    );
+
     const client = new ConvexHttpClient(prodConvexUrl);
+    client.setAuth(prodConvexAuthToken ?? "");
 
     const rows = await client.query(
       api.pos.public.catalog.listRegisterCatalogSnapshot,

--- a/packages/athena-webapp/tailwind.config.js
+++ b/packages/athena-webapp/tailwind.config.js
@@ -107,6 +107,8 @@ export default {
         action: {
           commit: "hsl(var(--action-commit))",
           "commit-foreground": "hsl(var(--action-commit-foreground))",
+          "commit-soft": "hsl(var(--action-commit-soft))",
+          "commit-border": "hsl(var(--action-commit-border))",
           workflow: "hsl(var(--action-workflow))",
           "workflow-foreground": "hsl(var(--action-workflow-foreground))",
           "workflow-soft": "hsl(var(--action-workflow-soft))",


### PR DESCRIPTION
## Summary
- stages imported inventory into provisional POS availability without hard stock blocking
- updates POS search/cart presentation for provisional and pending items
- keeps inventory import review decisions, bulk actions, filters, and generated SKU behavior aligned with the staging flow
- documents the provisional import availability pattern in docs/solutions

## Validation
- bun run --filter '@athena/webapp' test -- src/components/operations/InventoryImportView.test.tsx src/components/pos/SearchResultsSection.test.tsx src/components/pos/CartItems.test.tsx src/components/products/ProductsListView.test.ts src/lib/pos/presentation/register/useRegisterViewModel.test.ts src/lib/pos/infrastructure/local/localCommandGateway.test.ts src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts convex/inventory/catalogImport.test.ts convex/pos/application/queries/listRegisterCatalog.test.ts convex/pos/application/queries/searchCatalog.test.ts convex/pos/public/sync.test.ts\n- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json\n- bun run graphify:rebuild && bun run graphify:check && git diff --check\n- bun run --filter '@athena/webapp' test:e2e:prod:pos\n- bun run pr:athena