### PR TITLE
fix(pos): keep terminal-local review out of register resolver

### DIFF
--- a/docs/solutions/architecture/athena-pos-terminal-runtime-review-actions-2026-05-28.md
+++ b/docs/solutions/architecture/athena-pos-terminal-runtime-review-actions-2026-05-28.md
@@ -69,6 +69,27 @@ The POS debug strip can show check-in publish status, reason, timestamps, and a
 short note. That copy is diagnostic. Operator-facing review copy should still
 come from shared sync review state and conflict evidence.
 
+## Inline Review Resolution Update
+
+Remote terminal health can own the control plane without becoming a second
+manager-review system. The terminal detail page may run the existing audited
+register-session sync review resolver inline when the attention reason is
+cloud/server review evidence and the backend has mapped that evidence to a real
+Cash Controls register session.
+
+Do not show that resolver for `local_runtime` review reasons. A terminal-local
+review counter can remain after the server-side register review has already
+settled. Routing that row through the register-session resolver produces an
+`already_resolved` result but does not make the terminal healthy, because the
+remaining evidence must come from the checkout browser retrying or reconciling
+its local review events and publishing a fresh terminal check-in.
+
+For terminal-local review, keep the page on terminal-side guidance or a
+terminal-command path. If a future command can safely ask the browser to retry
+uploaded review events, that command should report fresh runtime evidence back
+through terminal health instead of patching the local review count from the
+server.
+
 ## Regression Targets
 
 - `convex/pos/application/terminals.test.ts` should prove attention reasons
@@ -85,6 +106,9 @@ come from shared sync review state and conflict evidence.
 - `POSTerminalDetailView.test.tsx` and `POSRegisterView.test.tsx` should prove
   the support actions and debug fields render without exposing terminal secrets
   or raw backend conflict language.
+- Terminal detail tests should prove cloud/server review can resolve inline,
+  while local-runtime review remains terminal-side guidance even when review
+  evidence has a register-session id.
 
 ## Prevention
 
@@ -92,6 +116,8 @@ come from shared sync review state and conflict evidence.
 - Do not infer Cash Controls links from arbitrary local ids; require a
   `posLocalSyncMapping` register-session mapping or a normalized cloud
   `registerSession` id that belongs to the same store and terminal.
+- Do not show a register-session resolver for terminal-local review counters.
+  The server may already be settled while the browser still needs to check in.
 - Do not treat runtime check-in failures as cashier command failures.
 - Do not expose sync secrets, secret hashes, staff proof tokens, or raw local
   payload bodies in terminal health detail.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6546 nodes · 7302 edges · 1802 communities detected
+- 6548 nodes · 7304 edges · 1802 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2388,232 +2388,232 @@ Cohesion: 0.22
 Nodes (0):
 
 ### Community 137 - "Community 137"
+Cohesion: 0.22
+Nodes (0):
+
+### Community 138 - "Community 138"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 138 - "Community 138"
+### Community 139 - "Community 139"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 139 - "Community 139"
+### Community 140 - "Community 140"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 140 - "Community 140"
+### Community 141 - "Community 141"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 141 - "Community 141"
+### Community 142 - "Community 142"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 142 - "Community 142"
+### Community 143 - "Community 143"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.36
 Nodes (5): getAutomationPolicyWithCtx(), getAutomationRunByIdempotencyKeyWithCtx(), listAutomationPoliciesForStoreActionWithCtx(), listAutomationRunsByIdempotencyKeyWithCtx(), recordAutomationRunWithCtx()
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 153 - "Community 153"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 154 - "Community 154"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 155 - "Community 155"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 156 - "Community 156"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.25
 Nodes (1): ResizeObserverStub
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 160 - "Community 160"
-Cohesion: 0.29
-Nodes (2): handleKeyDown(), isDebugShortcut()
 
 ### Community 161 - "Community 161"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.29
+Nodes (2): handleKeyDown(), isDebugShortcut()
 
 ### Community 162 - "Community 162"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 163 - "Community 163"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
-
-### Community 164 - "Community 164"
 Cohesion: 0.25
 Nodes (0):
+
+### Community 164 - "Community 164"
+Cohesion: 0.39
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 165 - "Community 165"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 166 - "Community 166"
-Cohesion: 0.46
-Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
-
-### Community 167 - "Community 167"
-Cohesion: 0.43
-Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
-
-### Community 168 - "Community 168"
 Cohesion: 0.25
 Nodes (0):
 
+### Community 167 - "Community 167"
+Cohesion: 0.46
+Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
+
+### Community 168 - "Community 168"
+Cohesion: 0.43
+Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
+
 ### Community 169 - "Community 169"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 170 - "Community 170"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 170 - "Community 170"
+### Community 171 - "Community 171"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 171 - "Community 171"
+### Community 172 - "Community 172"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 172 - "Community 172"
+### Community 173 - "Community 173"
 Cohesion: 0.33
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 173 - "Community 173"
+### Community 174 - "Community 174"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 174 - "Community 174"
+### Community 175 - "Community 175"
 Cohesion: 0.33
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 175 - "Community 175"
+### Community 176 - "Community 176"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 177 - "Community 177"
+### Community 178 - "Community 178"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 178 - "Community 178"
+### Community 179 - "Community 179"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 179 - "Community 179"
-Cohesion: 0.48
-Nodes (6): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), isDuplicateRegisterOpenConflict(), skipped()
 
 ### Community 180 - "Community 180"
 Cohesion: 0.48
-Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
+Nodes (6): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), isDuplicateRegisterOpenConflict(), skipped()
 
 ### Community 181 - "Community 181"
+Cohesion: 0.48
+Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
+
+### Community 182 - "Community 182"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.33
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.33
 Nodes (2): handlePinChange(), normalizeOtpCode()
 
-### Community 191 - "Community 191"
+### Community 192 - "Community 192"
 Cohesion: 0.33
 Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.33
 Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
-
-### Community 193 - "Community 193"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 194 - "Community 194"
 Cohesion: 0.48
@@ -2640,16 +2640,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 200 - "Community 200"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
-
-### Community 201 - "Community 201"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 202 - "Community 202"
+### Community 201 - "Community 201"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 202 - "Community 202"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 203 - "Community 203"
 Cohesion: 0.43
@@ -2780,8 +2780,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 235 - "Community 235"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 236 - "Community 236"
 Cohesion: 0.33
@@ -2800,12 +2800,12 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 240 - "Community 240"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
-
-### Community 241 - "Community 241"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 241 - "Community 241"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 242 - "Community 242"
 Cohesion: 0.33
@@ -2816,52 +2816,52 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 244 - "Community 244"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 245 - "Community 245"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 246 - "Community 246"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 245 - "Community 245"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 246 - "Community 246"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
 ### Community 247 - "Community 247"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 248 - "Community 248"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 249 - "Community 249"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 250 - "Community 250"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 251 - "Community 251"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 252 - "Community 252"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 253 - "Community 253"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 253 - "Community 253"
+### Community 254 - "Community 254"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 254 - "Community 254"
+### Community 255 - "Community 255"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 255 - "Community 255"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 256 - "Community 256"
 Cohesion: 0.53

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1874
-- Graph nodes: 6546
-- Graph edges: 7302
+- Graph nodes: 6548
+- Graph edges: 7304
 - Communities: 1802
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (14 edges, Community 78) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 143) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 144) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 78) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `createRedisCluster()` (3 edges, Community 78) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `deleteKeysIndividually()` (3 edges, Community 78) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.ts
@@ -528,21 +528,21 @@ async function resolveAttentionReasonActionTargets(
     terminalId: Id<"posTerminal">;
   },
 ): Promise<TerminalHealthAttentionReason[]> {
-  const cloudRegisterSessionIdByReasonType =
+  const registerSessionIdByReasonType =
     args.attentionReasons.some((reason) => reason.source === "cloud_sync")
-      ? await resolveCloudRegisterSessionTargets(ctx, args)
+      ? await resolveRegisterSessionTargets(ctx, args)
       : new Map<TerminalHealthAttentionReason["type"], Id<"registerSession"> | null>();
 
   return args.attentionReasons.map((reason) => ({
     ...reason,
     actionTarget: getAttentionReasonActionTarget(reason, {
-      cloudRegisterSessionId:
-        cloudRegisterSessionIdByReasonType.get(reason.type) ?? null,
+      registerSessionId:
+        registerSessionIdByReasonType.get(reason.type) ?? null,
     }),
   }));
 }
 
-async function resolveCloudRegisterSessionTargets(
+async function resolveRegisterSessionTargets(
   ctx: QueryCtx,
   args: {
     attentionReasons: TerminalHealthAttentionReason[];
@@ -558,7 +558,7 @@ async function resolveCloudRegisterSessionTargets(
   );
   const entries = await Promise.all(
     [...uniqueTypes].map(async (type) => {
-      const localRegisterSessionId = getCloudReasonLocalRegisterSessionId(
+      const localRegisterSessionId = getReviewReasonLocalRegisterSessionId(
         type,
         args.syncEvidence,
       );
@@ -577,7 +577,7 @@ async function resolveCloudRegisterSessionTargets(
   return new Map(entries);
 }
 
-function getCloudReasonLocalRegisterSessionId(
+function getReviewReasonLocalRegisterSessionId(
   type: TerminalHealthAttentionReason["type"],
   syncEvidence: TerminalSyncEvidence,
 ) {
@@ -613,16 +613,16 @@ function getCloudReasonLocalRegisterSessionId(
 function getAttentionReasonActionTarget(
   reason: TerminalHealthAttentionReason,
   context: {
-    cloudRegisterSessionId: Id<"registerSession"> | null;
+    registerSessionId: Id<"registerSession"> | null;
   },
 ): TerminalHealthAttentionActionTarget {
   switch (reason.type) {
     case "cloud_conflict":
     case "cloud_held":
     case "cloud_rejected":
-      return context.cloudRegisterSessionId
+      return context.registerSessionId
         ? {
-            registerSessionId: context.cloudRegisterSessionId,
+            registerSessionId: context.registerSessionId,
             type: "cash_control_register_session",
           }
         : { type: "open_work" };

--- a/packages/athena-webapp/convex/pos/application/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminals.test.ts
@@ -699,6 +699,57 @@ describe("terminal health summaries", () => {
     );
   });
 
+  it("keeps local runtime review reasons on terminal-side guidance even when review evidence has a register session", async () => {
+    vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
+    vi.mocked(getLatestRuntimeStatusForTerminal).mockResolvedValue(
+      buildPersistedRuntimeStatus({
+        sync: {
+          ...buildRuntimeStatus().sync,
+          failedEventCount: 0,
+          reviewEventCount: 14,
+          status: "needs_review" as never,
+        },
+      }),
+    );
+    vi.mocked(getTerminalSyncEvidence).mockResolvedValue({
+      latestEvent: null,
+      latestReviewEvent: {
+        eventType: "register_opened",
+        localEventId: "local-review-1",
+        localRegisterSessionId: "local-register-1",
+        sequence: 1,
+        status: "conflicted",
+      },
+      sampledEventCount: 14,
+      acceptedCount: 0,
+      projectedCount: 0,
+      conflictedCount: 0,
+      heldCount: 0,
+      rejectedCount: 0,
+      acceptedThroughSequence: 0,
+      cursorUpdatedAt: 180,
+    });
+
+    const result = await getTerminalHealthSummary(
+      { db: null as never } as never,
+      {
+        storeId: "store-1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        now: 220,
+      },
+    );
+
+    expect(resolveTerminalRegisterSessionActionTarget).not.toHaveBeenCalled();
+    expect(result?.attentionReasons).toEqual([
+      expect.objectContaining({
+        actionTarget: { type: "pos_register" },
+        count: 14,
+        source: "local_runtime",
+        type: "local_review",
+      }),
+    ]);
+  });
+
   it("returns runtime failure, availability, and setup reasons when terminal check-in reports them", async () => {
     vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
     vi.mocked(getLatestRuntimeStatusForTerminal).mockResolvedValue(

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -17,7 +17,10 @@ const mocks = vi.hoisted(() => ({
     isLoadingStores: false,
   },
   canAccessPOS: vi.fn(() => true),
+  mutation: vi.fn(),
   useQuery: vi.fn(() => null),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
 }));
 
 vi.mock("@tanstack/react-router", () => ({
@@ -59,7 +62,15 @@ vi.mock("@tanstack/react-router", () => ({
 }));
 
 vi.mock("convex/react", () => ({
+  useMutation: () => mocks.mutation,
   useQuery: mocks.useQuery,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: mocks.toastError,
+    success: mocks.toastSuccess,
+  },
 }));
 
 vi.mock("@/hooks/useAuth", () => ({
@@ -233,6 +244,12 @@ describe("POSTerminalDetailViewContent", () => {
     mocks.activeStoreState.activeStore = { _id: "store-1" };
     mocks.activeStoreState.isLoadingStores = false;
     mocks.canAccessPOS.mockReturnValue(true);
+    mocks.mutation.mockResolvedValue({
+      data: { action: "resolved", resolvedCount: 1 },
+      kind: "ok",
+    });
+    mocks.toastError.mockClear();
+    mocks.toastSuccess.mockClear();
     mocks.useQuery.mockReturnValue(null);
     mocks.useQuery.mockClear();
   });
@@ -407,8 +424,10 @@ describe("POSTerminalDetailViewContent", () => {
     );
 
     expect(
-      screen.getByRole("link", { name: /^open register$/i }),
-    ).toHaveAttribute("href", "/wigclub/store/osu/pos/register");
+      screen.getByText(
+        "This needs a fresh check-in or terminal-side repair before support can clear it remotely.",
+      ),
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /review register session/i }),
     ).toHaveAttribute(
@@ -416,8 +435,65 @@ describe("POSTerminalDetailViewContent", () => {
       "/wigclub/store/osu/cash-controls/registers/register-session-1",
     );
     expect(
-      screen.getByRole("link", { name: /open register setup/i }),
-    ).toHaveAttribute("href", "/wigclub/store/osu/pos/settings");
+      screen.getByText(
+        "Terminal setup repair must run from this checkout station or through a terminal repair command when available.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /^open register$/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /open register setup/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("resolves mapped register reviews inline from terminal health", async () => {
+    const onResolveRegisterSessionReview = vi.fn().mockResolvedValue({
+      data: { action: "resolved", resolvedCount: 1 },
+      kind: "ok",
+    });
+
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          attentionReasons: [
+            {
+              actionTarget: {
+                registerSessionId: "register-session-1",
+                type: "cash_control_register_session",
+              },
+              count: 14,
+              latestEventSequence: 1,
+              latestEventStatus: "conflicted",
+              source: "cloud_sync",
+              summary: "14 cloud sync conflicts need review.",
+              type: "cloud_conflict",
+            },
+          ],
+        }}
+        isLoading={false}
+        onResolveRegisterSessionReview={onResolveRegisterSessionReview}
+        orgUrlSlug="wigclub"
+        storeUrlSlug="osu"
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /resolve eligible review/i }),
+    );
+
+    await waitFor(() =>
+      expect(onResolveRegisterSessionReview).toHaveBeenCalledWith({
+        registerSessionId: "register-session-1",
+      }),
+    );
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      "Eligible register review resolved",
+    );
+    expect(
+      screen.queryByRole("link", { name: /review register session/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("does not render attention reasons for a healthy terminal", () => {
@@ -535,6 +611,10 @@ describe("POSTerminalDetailView", () => {
     mocks.activeStoreState.activeStore = { _id: "store-1" };
     mocks.activeStoreState.isLoadingStores = false;
     mocks.canAccessPOS.mockReturnValue(true);
+    mocks.mutation.mockResolvedValue({
+      data: { action: "resolved", resolvedCount: 1 },
+      kind: "ok",
+    });
     mocks.useQuery.mockReturnValue(null);
     mocks.useQuery.mockClear();
   });

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
@@ -1,6 +1,7 @@
 import { Link, useParams } from "@tanstack/react-router";
-import { useQuery } from "convex/react";
+import { useMutation, useQuery } from "convex/react";
 import type { FunctionReference } from "convex/server";
+import { useState } from "react";
 import {
   AlertTriangle,
   ArrowRight,
@@ -10,6 +11,7 @@ import {
   ShieldCheck,
   Wrench,
 } from "lucide-react";
+import { toast } from "sonner";
 
 import View from "@/components/View";
 import { FadeIn } from "@/components/common/FadeIn";
@@ -22,6 +24,7 @@ import { Button } from "@/components/ui/button";
 import useGetActiveStore from "@/hooks/useGetActiveStore";
 import { useAuth } from "@/hooks/useAuth";
 import { usePermissions } from "@/hooks/usePermissions";
+import { runCommand } from "@/lib/errors/runCommand";
 import { getOrigin } from "@/lib/navigationUtils";
 import { cn } from "@/lib/utils";
 import { api } from "~/convex/_generated/api";
@@ -60,10 +63,35 @@ const posTerminalApi = api.inventory.posTerminal as unknown as {
 type POSTerminalDetailViewContentProps = {
   detail: TerminalHealthDetail | null;
   isLoading: boolean;
+  onResolveRegisterSessionReview?: (args: {
+    registerSessionId: Id<"registerSession"> | string;
+  }) => Promise<TerminalRegisterSessionReviewResult>;
   orgUrlSlug?: string;
   queryUnavailable?: boolean;
   storeUrlSlug?: string;
 };
+
+type TerminalRegisterSessionReviewResult =
+  | {
+      kind: "ok";
+      data?: {
+        action?: "already_resolved" | "resolved" | string;
+        projectedCount?: number;
+        resolvedCount?: number;
+      };
+    }
+  | {
+      kind: "user_error";
+      error: {
+        message: string;
+      };
+    }
+  | {
+      kind: "unexpected_error";
+      error: {
+        message: string;
+      };
+    };
 
 function DetailPanel({
   children,
@@ -448,10 +476,12 @@ function ConflictSection({
 
 function AttentionReasonsSection({
   detail,
+  onResolveRegisterSessionReview,
   orgUrlSlug,
   storeUrlSlug,
 }: {
   detail: TerminalHealthDetail;
+  onResolveRegisterSessionReview?: POSTerminalDetailViewContentProps["onResolveRegisterSessionReview"];
   orgUrlSlug?: string;
   storeUrlSlug?: string;
 }) {
@@ -489,6 +519,7 @@ function AttentionReasonsSection({
                 </p>
               </div>
               <AttentionReasonAction
+                onResolveRegisterSessionReview={onResolveRegisterSessionReview}
                 orgUrlSlug={orgUrlSlug}
                 reason={reason}
                 storeUrlSlug={storeUrlSlug}
@@ -502,21 +533,70 @@ function AttentionReasonsSection({
 }
 
 function AttentionReasonAction({
+  onResolveRegisterSessionReview,
   orgUrlSlug,
   reason,
   storeUrlSlug,
 }: {
+  onResolveRegisterSessionReview?: POSTerminalDetailViewContentProps["onResolveRegisterSessionReview"];
   orgUrlSlug?: string;
   reason: TerminalHealthAttentionReason;
   storeUrlSlug?: string;
 }) {
   const target = reason.actionTarget;
+  const [isResolving, setIsResolving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
 
   if (!orgUrlSlug || !storeUrlSlug || !target) {
     return null;
   }
 
   if (target.type === "cash_control_register_session") {
+    const registerSessionId = target.registerSessionId;
+    const resolveRegisterSessionReview = onResolveRegisterSessionReview;
+
+    if (resolveRegisterSessionReview) {
+      const resolveReview = async () => {
+        setIsResolving(true);
+        setErrorMessage("");
+        const result = await resolveRegisterSessionReview({
+          registerSessionId,
+        });
+        setIsResolving(false);
+
+        if (result.kind === "ok") {
+          toast.success(
+            result.data?.action === "already_resolved"
+              ? "Register review already resolved"
+              : "Eligible register review resolved",
+          );
+          return;
+        }
+
+        setErrorMessage(result.error.message);
+        toast.error(result.error.message);
+      };
+
+      return (
+        <div className="grid justify-items-start gap-layout-xs">
+          <Button
+            disabled={isResolving}
+            onClick={() => {
+              void resolveReview();
+            }}
+            size="sm"
+            variant="utility"
+          >
+            <Wrench aria-hidden="true" />
+            {isResolving ? "Resolving..." : "Resolve eligible review"}
+          </Button>
+          {errorMessage ? (
+            <p className="max-w-sm text-xs text-danger">{errorMessage}</p>
+          ) : null}
+        </div>
+      );
+    }
+
     return (
       <Button asChild size="sm" variant="utility">
         <Link
@@ -552,31 +632,19 @@ function AttentionReasonAction({
 
   if (target.type === "pos_settings") {
     return (
-      <Button asChild size="sm" variant="utility">
-        <Link
-          params={{ orgUrlSlug, storeUrlSlug }}
-          search={{ o: getOrigin() }}
-          to="/$orgUrlSlug/store/$storeUrlSlug/pos/settings"
-        >
-          Open register setup
-          <ArrowRight aria-hidden="true" />
-        </Link>
-      </Button>
+      <p className="max-w-sm text-xs text-muted-foreground">
+        Terminal setup repair must run from this checkout station or through a
+        terminal repair command when available.
+      </p>
     );
   }
 
   if (target.type === "pos_register") {
     return (
-      <Button asChild size="sm" variant="utility">
-        <Link
-          params={{ orgUrlSlug, storeUrlSlug }}
-          search={{ o: getOrigin() }}
-          to="/$orgUrlSlug/store/$storeUrlSlug/pos/register"
-        >
-          Open register
-          <ArrowRight aria-hidden="true" />
-        </Link>
-      </Button>
+      <p className="max-w-sm text-xs text-muted-foreground">
+        This needs a fresh check-in or terminal-side repair before support can
+        clear it remotely.
+      </p>
     );
   }
 
@@ -603,12 +671,14 @@ function RecoveryMetric({
 function RecoveryBlockerGroup({
   blockers,
   emptyCopy,
+  onResolveRegisterSessionReview,
   orgUrlSlug,
   storeUrlSlug,
   title,
 }: {
   blockers: TerminalRecoveryPresentationBlocker[];
   emptyCopy: string;
+  onResolveRegisterSessionReview?: POSTerminalDetailViewContentProps["onResolveRegisterSessionReview"];
   orgUrlSlug?: string;
   storeUrlSlug?: string;
   title: string;
@@ -646,6 +716,7 @@ function RecoveryBlockerGroup({
               </div>
               <RecoveryBlockerAction
                 blocker={blocker}
+                onResolveRegisterSessionReview={onResolveRegisterSessionReview}
                 orgUrlSlug={orgUrlSlug}
                 storeUrlSlug={storeUrlSlug}
               />
@@ -659,10 +730,12 @@ function RecoveryBlockerGroup({
 
 function RecoveryBlockerAction({
   blocker,
+  onResolveRegisterSessionReview,
   orgUrlSlug,
   storeUrlSlug,
 }: {
   blocker: TerminalRecoveryPresentationBlocker;
+  onResolveRegisterSessionReview?: POSTerminalDetailViewContentProps["onResolveRegisterSessionReview"];
   orgUrlSlug?: string;
   storeUrlSlug?: string;
 }) {
@@ -683,6 +756,7 @@ function RecoveryBlockerAction({
   if (blocker.actionTarget) {
     return (
       <AttentionReasonAction
+        onResolveRegisterSessionReview={onResolveRegisterSessionReview}
         orgUrlSlug={orgUrlSlug}
         reason={{
           actionTarget: blocker.actionTarget,
@@ -700,10 +774,12 @@ function RecoveryBlockerAction({
 
 function RecoveryPanel({
   detail,
+  onResolveRegisterSessionReview,
   orgUrlSlug,
   storeUrlSlug,
 }: {
   detail: TerminalHealthDetail;
+  onResolveRegisterSessionReview?: POSTerminalDetailViewContentProps["onResolveRegisterSessionReview"];
   orgUrlSlug?: string;
   storeUrlSlug?: string;
 }) {
@@ -749,6 +825,7 @@ function RecoveryPanel({
         <RecoveryBlockerGroup
           blockers={recovery.groups.cloudRepair}
           emptyCopy="No cloud-safe repair blockers are reported."
+          onResolveRegisterSessionReview={onResolveRegisterSessionReview}
           orgUrlSlug={orgUrlSlug}
           storeUrlSlug={storeUrlSlug}
           title="Cloud repair"
@@ -756,6 +833,7 @@ function RecoveryPanel({
         <RecoveryBlockerGroup
           blockers={recovery.groups.terminalRequired}
           emptyCopy="No terminal-required blockers are reported."
+          onResolveRegisterSessionReview={onResolveRegisterSessionReview}
           orgUrlSlug={orgUrlSlug}
           storeUrlSlug={storeUrlSlug}
           title="Terminal required"
@@ -763,6 +841,7 @@ function RecoveryPanel({
         <RecoveryBlockerGroup
           blockers={recovery.groups.manualReview}
           emptyCopy="No manual-review blockers are reported."
+          onResolveRegisterSessionReview={onResolveRegisterSessionReview}
           orgUrlSlug={orgUrlSlug}
           storeUrlSlug={storeUrlSlug}
           title="Manual review"
@@ -817,6 +896,7 @@ function SupportNotesSection({
 export function POSTerminalDetailViewContent({
   detail,
   isLoading,
+  onResolveRegisterSessionReview,
   orgUrlSlug,
   queryUnavailable = false,
   storeUrlSlug,
@@ -882,11 +962,13 @@ export function POSTerminalDetailViewContent({
             <main className="space-y-layout-lg">
               <RecoveryPanel
                 detail={detail}
+                onResolveRegisterSessionReview={onResolveRegisterSessionReview}
                 orgUrlSlug={orgUrlSlug}
                 storeUrlSlug={storeUrlSlug}
               />
               <AttentionReasonsSection
                 detail={detail}
+                onResolveRegisterSessionReview={onResolveRegisterSessionReview}
                 orgUrlSlug={orgUrlSlug}
                 storeUrlSlug={storeUrlSlug}
               />
@@ -932,6 +1014,31 @@ export function POSTerminalDetailView() {
         }
       : "skip",
   ) as TerminalHealthDetail | null | undefined;
+  const resolveRegisterSessionSyncReview = useMutation(
+    api.cashControls.deposits.resolveRegisterSessionSyncReview,
+  );
+
+  async function onResolveRegisterSessionReview({
+    registerSessionId,
+  }: {
+    registerSessionId: Id<"registerSession"> | string;
+  }): Promise<TerminalRegisterSessionReviewResult> {
+    if (!activeStore?._id) {
+      return {
+        kind: "user_error",
+        error: {
+          message: "Select a store before resolving this register review.",
+        },
+      };
+    }
+
+    return runCommand(() =>
+      resolveRegisterSessionSyncReview({
+        registerSessionId: registerSessionId as Id<"registerSession">,
+        storeId: activeStore._id,
+      }),
+    ) as Promise<TerminalRegisterSessionReviewResult>;
+  }
 
   if (isLoadingAccess) {
     return null;
@@ -965,6 +1072,7 @@ export function POSTerminalDetailView() {
       <POSTerminalDetailViewContent
         detail={detail ?? null}
         isLoading={detail === undefined}
+        onResolveRegisterSessionReview={onResolveRegisterSessionReview}
         orgUrlSlug={params.orgUrlSlug}
         queryUnavailable={detail === null && !params.terminalId}
         storeUrlSlug={params.storeUrlSlug}


### PR DESCRIPTION
## Summary
- keep terminal-local POS review items on the terminal page as terminal-side guidance instead of sending them through Cash Controls register review resolution
- keep inline terminal-page resolution for mapped cloud/server review items using the existing audited register-session resolver
- remove generic POS/register setup redirects from terminal attention actions when no remote resolver is available
- document the M Supplies runtime-review distinction in the POS terminal recovery solution note

## Validation
- bun run --filter @athena/webapp test -- src/components/pos/terminals/POSTerminalDetailView.test.tsx convex/pos/application/terminals.test.ts
- bun run --filter @athena/webapp lint:frontend:changed
- bun run --filter @athena/webapp lint:convex:changed
- bun run --filter @athena/webapp typecheck
- bun run pr:athena

## Production
- branch build already deployed for browser testing: gentle-tiger-flies / 20260611202433
