### PR TITLE
Expose operational category controls

### DIFF
--- a/docs/solutions/architecture/athena-pos-provisional-import-availability-2026-06-11.md
+++ b/docs/solutions/architecture/athena-pos-provisional-import-availability-2026-06-11.md
@@ -7,10 +7,11 @@ problem_type: provisional_import_pos_availability
 component: pos
 symptoms:
   - "Imported legacy inventory needs to be searchable in POS before final Athena counts are trusted"
+  - "Reserved operational categories such as legacy import or pending checkout look empty when staff views inherit storefront visibility filters"
   - "Trusted stock mismatches can block checkout even when field reality says the product is being sold"
   - "Inventory import review decisions can accidentally look like they mutate existing Athena SKUs"
-root_cause: provisional_inventory_was_modeled_like_final_trusted_stock
-resolution_type: provisional_catalog_projection_with_reviewable_stock_exceptions
+root_cause: provisional_inventory_and_reserved_categories_were_modeled_like_final_storefront_catalog
+resolution_type: provisional_catalog_projection_with_staff_visible_reserved_category_controls
 severity: high
 tags:
   - pos
@@ -53,6 +54,13 @@ inventory truth:
 - Let POS add known provisional items without enforcing `quantityAvailable`.
   Surface `Count pending` instead of `0 available` for provisional and pending
   checkout rows whose counts are not trusted yet.
+- Treat reserved operational categories as staff catalog views, not storefront
+  merchandising shelves. Catalog Ops and POS recovery surfaces should include
+  products in those categories even when the products or categories are hidden
+  from the storefront.
+- Keep storefront visibility as an explicit category control. Staff can hide or
+  reveal the category on the customer storefront without losing access to the
+  operational product list needed for cleanup.
 - Let trusted-stock mismatches complete the local sale. Cloud sync should mark
   the sale event for review with inventory mismatch evidence, not write drawer
   authority blocks or force the cashier into the drawer gate.
@@ -77,6 +85,9 @@ inventory truth:
 - Do not let provisional rows duplicate trusted catalog rows in search results.
   Deduplicate by product/SKU identity at the query boundary and cover both
   provisional-first and trusted-first ordering in tests.
+- Do not reuse customer storefront hidden filters for staff catalog operations.
+  Hidden storefront state is a merchandising decision; reserved-category cleanup
+  and pending-checkout recovery still need the full operational list.
 
 ## Validation
 
@@ -86,6 +97,8 @@ Use this focused slice when changing provisional import POS availability:
 - `convex/pos/application/queries/listRegisterCatalog.test.ts`
 - `convex/pos/application/queries/searchCatalog.test.ts`
 - `convex/pos/public/sync.test.ts`
+- `convex/http/domains/core/routes/storefrontHidden.test.ts`
+- `convex/inventory/products.sku.test.ts`
 - `src/components/operations/InventoryImportView.test.tsx`
 - `src/components/pos/SearchResultsSection.test.tsx`
 - `src/components/pos/CartItems.test.tsx`

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1897 files · ~0 words
+- 1898 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6631 nodes · 7392 edges · 1825 communities detected
+- 6642 nodes · 7406 edges · 1826 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1835,6 +1835,7 @@
 - [[_COMMUNITY_Community 1822|Community 1822]]
 - [[_COMMUNITY_Community 1823|Community 1823]]
 - [[_COMMUNITY_Community 1824|Community 1824]]
+- [[_COMMUNITY_Community 1825|Community 1825]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -2171,80 +2172,80 @@ Cohesion: 0.24
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
 ### Community 77 - "Community 77"
+Cohesion: 0.17
+Nodes (6): formatLocalStartTime(), formatLocalStartTimeFromParts(), getLocalStartTimeParts(), handleSave(), parseLocalStartMinutes(), updateLocalStartTimePart()
+
+### Community 78 - "Community 78"
 Cohesion: 0.18
 Nodes (7): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), useConvexRegisterServiceCatalog(), usePrewarmRegisterCatalogOfflineSnapshots()
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.22
 Nodes (10): extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isBarcodeShapedInput(), normalizeIdentifier(), parseCatalogSearchInput(), searchByText(), searchRegisterCatalog() (+2 more)
 
-### Community 79 - "Community 79"
+### Community 80 - "Community 80"
 Cohesion: 0.14
 Nodes (2): getBlockedPosTerminalShellCopy(), PosTerminalBlockedShell()
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.22
 Nodes (10): createApp(), createHandlers(), createRedisClient(), createRedisCluster(), deleteKeysIndividually(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline(), scanNodeForPattern() (+2 more)
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.31
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getOperationalWorkItemStatus() (+5 more)
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.19
 Nodes (4): formatQuickAddDialogError(), handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 85 - "Community 85"
+### Community 86 - "Community 86"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.26
 Nodes (12): bestFuzzyTokenScore(), compactSearchText(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreCompactFieldContains(), scoreFuzzySearchEntry() (+4 more)
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.31
 Nodes (12): getRegisterCatalogPrice(), isActiveProvisionalImportSkuForStore(), isTrustedRegisterCatalogSku(), listRegisterCatalog(), listRegisterCatalogAvailability(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow() (+4 more)
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.28
 Nodes (11): acknowledgeTerminalRecoveryCommand(), claimTerminalRecoveryCommand(), containsSecretLikeField(), issueTerminalRecoveryCommand(), loadScopedCommand(), normalizeOptionalHealthyStatus(), notFound(), pruneUndefined() (+3 more)
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 92 - "Community 92"
+### Community 93 - "Community 93"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
 
-### Community 93 - "Community 93"
+### Community 94 - "Community 94"
 Cohesion: 0.15
 Nodes (0):
 
-### Community 94 - "Community 94"
-Cohesion: 0.17
-Nodes (2): formatRegisterLabel(), getRegisterLabel()
-
 ### Community 95 - "Community 95"
 Cohesion: 0.17
-Nodes (2): handleSave(), parseLocalStartMinutes()
+Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
 ### Community 96 - "Community 96"
 Cohesion: 0.38
@@ -2287,32 +2288,32 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 106 - "Community 106"
-Cohesion: 0.36
-Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 107 - "Community 107"
 Cohesion: 0.36
-Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
+Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
 ### Community 108 - "Community 108"
+Cohesion: 0.36
+Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
+
+### Community 109 - "Community 109"
 Cohesion: 0.22
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
-
-### Community 112 - "Community 112"
-Cohesion: 0.2
-Nodes (2): handleStartRemoteAssist(), onStartRemoteAssist()
 
 ### Community 113 - "Community 113"
 Cohesion: 0.25
@@ -2331,48 +2332,48 @@ Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
 
 ### Community 117 - "Community 117"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 118 - "Community 118"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 119 - "Community 119"
+### Community 118 - "Community 118"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 120 - "Community 120"
+### Community 119 - "Community 119"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 121 - "Community 121"
+### Community 120 - "Community 120"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 122 - "Community 122"
+### Community 121 - "Community 121"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 123 - "Community 123"
+### Community 122 - "Community 122"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 124 - "Community 124"
+### Community 123 - "Community 123"
 Cohesion: 0.22
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 125 - "Community 125"
+### Community 124 - "Community 124"
 Cohesion: 0.31
 Nodes (7): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), parseVariantDisplayMoney(), saveProduct(), updateVariantSku()
 
-### Community 126 - "Community 126"
+### Community 125 - "Community 125"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 127 - "Community 127"
+### Community 126 - "Community 126"
 Cohesion: 0.29
 Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
+
+### Community 127 - "Community 127"
+Cohesion: 0.22
+Nodes (2): handleStartRemoteAssist(), onStartRemoteAssist()
 
 ### Community 128 - "Community 128"
 Cohesion: 0.2
@@ -2631,76 +2632,76 @@ Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
 
 ### Community 192 - "Community 192"
-Cohesion: 0.33
-Nodes (2): handlePinChange(), normalizeOtpCode()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 193 - "Community 193"
 Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 194 - "Community 194"
 Cohesion: 0.33
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 195 - "Community 195"
+Cohesion: 0.33
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+
+### Community 196 - "Community 196"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 197 - "Community 197"
+### Community 198 - "Community 198"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 199 - "Community 199"
-Cohesion: 0.33
-Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
 
 ### Community 200 - "Community 200"
-Cohesion: 0.29
-Nodes (0):
+Cohesion: 0.33
+Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
 
 ### Community 201 - "Community 201"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 202 - "Community 202"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 203 - "Community 203"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 203 - "Community 203"
+### Community 204 - "Community 204"
 Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
-### Community 204 - "Community 204"
+### Community 205 - "Community 205"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 205 - "Community 205"
+### Community 206 - "Community 206"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 206 - "Community 206"
+### Community 207 - "Community 207"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 207 - "Community 207"
+### Community 208 - "Community 208"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 208 - "Community 208"
-Cohesion: 0.33
-Nodes (1): ValkeyClient
-
 ### Community 209 - "Community 209"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ValkeyClient
 
 ### Community 210 - "Community 210"
 Cohesion: 0.33
@@ -2719,76 +2720,76 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 214 - "Community 214"
-Cohesion: 0.4
-Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 215 - "Community 215"
 Cohesion: 0.4
-Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
+Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
 ### Community 216 - "Community 216"
+Cohesion: 0.4
+Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
+
+### Community 217 - "Community 217"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 217 - "Community 217"
+### Community 218 - "Community 218"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 218 - "Community 218"
+### Community 219 - "Community 219"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 220 - "Community 220"
+### Community 221 - "Community 221"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 221 - "Community 221"
+### Community 222 - "Community 222"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 222 - "Community 222"
+### Community 223 - "Community 223"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.4
 Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.4
 Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
-
-### Community 231 - "Community 231"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 232 - "Community 232"
 Cohesion: 0.33
@@ -2796,23 +2797,23 @@ Nodes (0):
 
 ### Community 233 - "Community 233"
 Cohesion: 0.33
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 234 - "Community 234"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 235 - "Community 235"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 236 - "Community 236"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
-
-### Community 237 - "Community 237"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 238 - "Community 238"
 Cohesion: 0.33
@@ -2895,56 +2896,56 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 258 - "Community 258"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+
+### Community 259 - "Community 259"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 259 - "Community 259"
+### Community 260 - "Community 260"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 260 - "Community 260"
+### Community 261 - "Community 261"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 261 - "Community 261"
+### Community 262 - "Community 262"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 262 - "Community 262"
+### Community 263 - "Community 263"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 263 - "Community 263"
+### Community 264 - "Community 264"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 264 - "Community 264"
+### Community 265 - "Community 265"
 Cohesion: 0.5
 Nodes (2): createAuthorizedRegisterDepositCtx(), createQueryCtx()
 
-### Community 265 - "Community 265"
+### Community 266 - "Community 266"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 266 - "Community 266"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 267 - "Community 267"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 268 - "Community 268"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 269 - "Community 269"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
-### Community 269 - "Community 269"
+### Community 270 - "Community 270"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
-
-### Community 270 - "Community 270"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 271 - "Community 271"
 Cohesion: 0.4
@@ -2955,16 +2956,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 273 - "Community 273"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 274 - "Community 274"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 274 - "Community 274"
+### Community 275 - "Community 275"
 Cohesion: 0.6
 Nodes (3): isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult()
-
-### Community 275 - "Community 275"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 276 - "Community 276"
 Cohesion: 0.4
@@ -2979,28 +2980,28 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 279 - "Community 279"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 280 - "Community 280"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 280 - "Community 280"
+### Community 281 - "Community 281"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 281 - "Community 281"
+### Community 282 - "Community 282"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 282 - "Community 282"
+### Community 283 - "Community 283"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 283 - "Community 283"
+### Community 284 - "Community 284"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
-
-### Community 284 - "Community 284"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 285 - "Community 285"
 Cohesion: 0.4
@@ -3011,12 +3012,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 287 - "Community 287"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 288 - "Community 288"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 288 - "Community 288"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 289 - "Community 289"
 Cohesion: 0.4
@@ -3035,28 +3036,28 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 293 - "Community 293"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 294 - "Community 294"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
-### Community 294 - "Community 294"
+### Community 295 - "Community 295"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 295 - "Community 295"
+### Community 296 - "Community 296"
 Cohesion: 0.5
 Nodes (2): buildTerminalOfflineReadiness(), getAppSessionReadinessInput()
 
-### Community 296 - "Community 296"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 297 - "Community 297"
 Cohesion: 0.4
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 298 - "Community 298"
 Cohesion: 0.4
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 299 - "Community 299"
 Cohesion: 0.4
@@ -3067,44 +3068,44 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 301 - "Community 301"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 302 - "Community 302"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 302 - "Community 302"
+### Community 303 - "Community 303"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 303 - "Community 303"
+### Community 304 - "Community 304"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 304 - "Community 304"
+### Community 305 - "Community 305"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 305 - "Community 305"
+### Community 306 - "Community 306"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 306 - "Community 306"
-Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 307 - "Community 307"
 Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 308 - "Community 308"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 309 - "Community 309"
 Cohesion: 0.6
-Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 310 - "Community 310"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
 ### Community 311 - "Community 311"
 Cohesion: 0.4
@@ -3119,156 +3120,156 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 314 - "Community 314"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 315 - "Community 315"
 Cohesion: 0.5
-Nodes (3): createVersionChecker(), shouldAutoReloadForCurrentRoute(), shouldAutoReloadForPath()
+Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 316 - "Community 316"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (3): createVersionChecker(), shouldAutoReloadForCurrentRoute(), shouldAutoReloadForPath()
 
 ### Community 317 - "Community 317"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 318 - "Community 318"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 319 - "Community 319"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 320 - "Community 320"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 321 - "Community 321"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 322 - "Community 322"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
-
-### Community 323 - "Community 323"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 323 - "Community 323"
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 324 - "Community 324"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 325 - "Community 325"
-Cohesion: 0.6
-Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 326 - "Community 326"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 326 - "Community 326"
+Cohesion: 0.6
+Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+
 ### Community 327 - "Community 327"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 328 - "Community 328"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 328 - "Community 328"
+### Community 329 - "Community 329"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 329 - "Community 329"
+### Community 330 - "Community 330"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 330 - "Community 330"
+### Community 331 - "Community 331"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 331 - "Community 331"
+### Community 332 - "Community 332"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 332 - "Community 332"
+### Community 333 - "Community 333"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 333 - "Community 333"
+### Community 334 - "Community 334"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 334 - "Community 334"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 335 - "Community 335"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 336 - "Community 336"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 337 - "Community 337"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 338 - "Community 338"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 339 - "Community 339"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 340 - "Community 340"
-Cohesion: 0.67
-Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
-
-### Community 341 - "Community 341"
-Cohesion: 0.83
-Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
-
-### Community 342 - "Community 342"
-Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
-
-### Community 343 - "Community 343"
-Cohesion: 0.67
-Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
-
-### Community 344 - "Community 344"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 341 - "Community 341"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 342 - "Community 342"
+Cohesion: 0.67
+Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
+
+### Community 343 - "Community 343"
+Cohesion: 0.83
+Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+
+### Community 344 - "Community 344"
+Cohesion: 0.67
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+
 ### Community 345 - "Community 345"
 Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
 ### Community 346 - "Community 346"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 347 - "Community 347"
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 348 - "Community 348"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 348 - "Community 348"
+### Community 349 - "Community 349"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 350 - "Community 350"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 349 - "Community 349"
+### Community 351 - "Community 351"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
-
-### Community 350 - "Community 350"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 351 - "Community 351"
-Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 352 - "Community 352"
 Cohesion: 0.5
@@ -3276,83 +3277,83 @@ Nodes (0):
 
 ### Community 353 - "Community 353"
 Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 354 - "Community 354"
-Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 355 - "Community 355"
 Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 356 - "Community 356"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 357 - "Community 357"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 358 - "Community 358"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 359 - "Community 359"
-Cohesion: 0.67
-Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 360 - "Community 360"
-Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 361 - "Community 361"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
 ### Community 362 - "Community 362"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 363 - "Community 363"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 364 - "Community 364"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 365 - "Community 365"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 366 - "Community 366"
-Cohesion: 0.83
-Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
+Cohesion: 0.67
+Nodes (2): compareRemoteAssistSessionForSupportView(), getRemoteAssistSessionStatusPriority()
 
 ### Community 367 - "Community 367"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 368 - "Community 368"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 369 - "Community 369"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
 ### Community 370 - "Community 370"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 371 - "Community 371"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 372 - "Community 372"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 373 - "Community 373"
 Cohesion: 0.5
@@ -3363,24 +3364,24 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 375 - "Community 375"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 376 - "Community 376"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 377 - "Community 377"
 Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 378 - "Community 378"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 379 - "Community 379"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 380 - "Community 380"
 Cohesion: 0.5
@@ -3399,36 +3400,36 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 384 - "Community 384"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 385 - "Community 385"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 386 - "Community 386"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 385 - "Community 385"
+### Community 387 - "Community 387"
 Cohesion: 0.67
 Nodes (2): CashierAuthDialog(), getStaffDisplayName()
-
-### Community 386 - "Community 386"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 387 - "Community 387"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 388 - "Community 388"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 389 - "Community 389"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 390 - "Community 390"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 391 - "Community 391"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 392 - "Community 392"
 Cohesion: 0.5
@@ -3439,20 +3440,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 394 - "Community 394"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 395 - "Community 395"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 396 - "Community 396"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 397 - "Community 397"
-Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 398 - "Community 398"
 Cohesion: 0.5
@@ -3460,19 +3461,19 @@ Nodes (0):
 
 ### Community 399 - "Community 399"
 Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 400 - "Community 400"
-Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
-
-### Community 401 - "Community 401"
 Cohesion: 0.5
 Nodes (0):
 
+### Community 401 - "Community 401"
+Cohesion: 0.67
+Nodes (2): useGetArchivedProducts(), useGetProducts()
+
 ### Community 402 - "Community 402"
 Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
 
 ### Community 403 - "Community 403"
 Cohesion: 0.5
@@ -3480,23 +3481,23 @@ Nodes (0):
 
 ### Community 404 - "Community 404"
 Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 405 - "Community 405"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 406 - "Community 406"
+Cohesion: 0.67
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
+
+### Community 407 - "Community 407"
 Cohesion: 0.67
 Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
-### Community 406 - "Community 406"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 407 - "Community 407"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 408 - "Community 408"
-Cohesion: 0.67
-Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 409 - "Community 409"
 Cohesion: 0.5
@@ -3504,55 +3505,55 @@ Nodes (0):
 
 ### Community 410 - "Community 410"
 Cohesion: 0.67
-Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
+Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
 ### Community 411 - "Community 411"
-Cohesion: 0.83
-Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 412 - "Community 412"
-Cohesion: 0.83
-Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
+Cohesion: 0.67
+Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
 ### Community 413 - "Community 413"
 Cohesion: 0.83
-Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
+Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
 ### Community 414 - "Community 414"
+Cohesion: 0.83
+Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
+
+### Community 415 - "Community 415"
+Cohesion: 0.83
+Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
+
+### Community 416 - "Community 416"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 415 - "Community 415"
+### Community 417 - "Community 417"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 416 - "Community 416"
+### Community 418 - "Community 418"
 Cohesion: 0.83
 Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
-### Community 417 - "Community 417"
+### Community 419 - "Community 419"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 418 - "Community 418"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
-
-### Community 419 - "Community 419"
-Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 420 - "Community 420"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 421 - "Community 421"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 422 - "Community 422"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 423 - "Community 423"
 Cohesion: 0.5
@@ -3579,76 +3580,76 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 429 - "Community 429"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 430 - "Community 430"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 431 - "Community 431"
 Cohesion: 0.67
 Nodes (2): useOptionalStoreContext(), useStoreContext()
 
-### Community 430 - "Community 430"
+### Community 432 - "Community 432"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 431 - "Community 431"
+### Community 433 - "Community 433"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 432 - "Community 432"
+### Community 434 - "Community 434"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 433 - "Community 433"
+### Community 435 - "Community 435"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 434 - "Community 434"
+### Community 436 - "Community 436"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 435 - "Community 435"
+### Community 437 - "Community 437"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 436 - "Community 436"
+### Community 438 - "Community 438"
 Cohesion: 0.67
 Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
-### Community 437 - "Community 437"
+### Community 439 - "Community 439"
 Cohesion: 0.67
 Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
-### Community 438 - "Community 438"
+### Community 440 - "Community 440"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 439 - "Community 439"
+### Community 441 - "Community 441"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 440 - "Community 440"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 441 - "Community 441"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 442 - "Community 442"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 443 - "Community 443"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 444 - "Community 444"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 445 - "Community 445"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 446 - "Community 446"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 447 - "Community 447"
 Cohesion: 0.67
@@ -3683,12 +3684,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 455 - "Community 455"
-Cohesion: 1.0
-Nodes (2): buildCtx(), createDb()
-
-### Community 456 - "Community 456"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 456 - "Community 456"
+Cohesion: 1.0
+Nodes (2): buildCtx(), createDb()
 
 ### Community 457 - "Community 457"
 Cohesion: 0.67
@@ -3703,12 +3704,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 460 - "Community 460"
-Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
-
-### Community 461 - "Community 461"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 461 - "Community 461"
+Cohesion: 1.0
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 462 - "Community 462"
 Cohesion: 0.67
@@ -3716,11 +3717,11 @@ Nodes (0):
 
 ### Community 463 - "Community 463"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 464 - "Community 464"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 465 - "Community 465"
 Cohesion: 0.67
@@ -3735,12 +3736,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 468 - "Community 468"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 469 - "Community 469"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 469 - "Community 469"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 470 - "Community 470"
 Cohesion: 0.67
@@ -3759,12 +3760,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 474 - "Community 474"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 475 - "Community 475"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 475 - "Community 475"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 476 - "Community 476"
 Cohesion: 0.67
@@ -3779,40 +3780,40 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 479 - "Community 479"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 480 - "Community 480"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 481 - "Community 481"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 482 - "Community 482"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 483 - "Community 483"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 484 - "Community 484"
-Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 485 - "Community 485"
 Cohesion: 1.0
-Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 486 - "Community 486"
-Cohesion: 0.67
-Nodes (1): View()
+Cohesion: 1.0
+Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
 ### Community 487 - "Community 487"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 488 - "Community 488"
 Cohesion: 0.67
@@ -3827,12 +3828,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 491 - "Community 491"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 492 - "Community 492"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 492 - "Community 492"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 493 - "Community 493"
 Cohesion: 0.67
@@ -3843,16 +3844,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 495 - "Community 495"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 496 - "Community 496"
 Cohesion: 1.0
 Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
-### Community 496 - "Community 496"
-Cohesion: 0.67
-Nodes (1): FadeIn()
-
 ### Community 497 - "Community 497"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 498 - "Community 498"
 Cohesion: 0.67
@@ -3860,15 +3861,15 @@ Nodes (0):
 
 ### Community 499 - "Community 499"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 500 - "Community 500"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (1): VideoPlayer()
 
 ### Community 501 - "Community 501"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 502 - "Community 502"
 Cohesion: 0.67
@@ -3944,79 +3945,79 @@ Nodes (0):
 
 ### Community 520 - "Community 520"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 521 - "Community 521"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): SingleLineError()
 
 ### Community 522 - "Community 522"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): ErrorPage()
 
 ### Community 523 - "Community 523"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): AppSkeleton()
 
 ### Community 524 - "Community 524"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 525 - "Community 525"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 526 - "Community 526"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 527 - "Community 527"
+Cohesion: 0.67
+Nodes (1): NotFound()
+
+### Community 528 - "Community 528"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 528 - "Community 528"
+### Community 529 - "Community 529"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 529 - "Community 529"
+### Community 530 - "Community 530"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 530 - "Community 530"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 531 - "Community 531"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (0):
 
 ### Community 532 - "Community 532"
 Cohesion: 0.67
-Nodes (1): onChange()
+Nodes (1): LoadingButton()
 
 ### Community 533 - "Community 533"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): onChange()
 
 ### Community 534 - "Community 534"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): AlertModal()
 
 ### Community 535 - "Community 535"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (1): OverlayModal()
 
 ### Community 536 - "Community 536"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): Skeleton()
 
 ### Community 537 - "Community 537"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): Toaster()
 
 ### Community 538 - "Community 538"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 539 - "Community 539"
 Cohesion: 0.67
@@ -4048,11 +4049,11 @@ Nodes (0):
 
 ### Community 546 - "Community 546"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 547 - "Community 547"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 548 - "Community 548"
 Cohesion: 0.67
@@ -4063,32 +4064,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 550 - "Community 550"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 551 - "Community 551"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 551 - "Community 551"
+### Community 552 - "Community 552"
 Cohesion: 0.67
 Nodes (1): isInMaintenanceMode()
 
-### Community 552 - "Community 552"
+### Community 553 - "Community 553"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 553 - "Community 553"
+### Community 554 - "Community 554"
 Cohesion: 1.0
 Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
-### Community 554 - "Community 554"
+### Community 555 - "Community 555"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 555 - "Community 555"
-Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 556 - "Community 556"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 557 - "Community 557"
 Cohesion: 0.67
@@ -4104,71 +4105,71 @@ Nodes (0):
 
 ### Community 560 - "Community 560"
 Cohesion: 0.67
-Nodes (1): App()
+Nodes (0):
 
 ### Community 561 - "Community 561"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): App()
 
 ### Community 562 - "Community 562"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
-
-### Community 563 - "Community 563"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 563 - "Community 563"
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
 
 ### Community 564 - "Community 564"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 565 - "Community 565"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 566 - "Community 566"
 Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 567 - "Community 567"
-Cohesion: 0.67
-Nodes (1): hashPassword()
+Cohesion: 1.0
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 568 - "Community 568"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 569 - "Community 569"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (0):
 
 ### Community 570 - "Community 570"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): manualChunks()
 
 ### Community 571 - "Community 571"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 572 - "Community 572"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 573 - "Community 573"
 Cohesion: 1.0
 Nodes (2): getAllColors(), getBaseUrl()
 
-### Community 573 - "Community 573"
+### Community 574 - "Community 574"
 Cohesion: 0.67
 Nodes (0):
-
-### Community 574 - "Community 574"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 575 - "Community 575"
 Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 576 - "Community 576"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 577 - "Community 577"
 Cohesion: 0.67
@@ -4183,12 +4184,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 580 - "Community 580"
-Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
-
-### Community 581 - "Community 581"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 581 - "Community 581"
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 582 - "Community 582"
 Cohesion: 0.67
@@ -4199,12 +4200,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 584 - "Community 584"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
-
-### Community 585 - "Community 585"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 585 - "Community 585"
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 586 - "Community 586"
 Cohesion: 0.67
@@ -4271,16 +4272,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 602 - "Community 602"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
-
-### Community 603 - "Community 603"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 604 - "Community 604"
+### Community 603 - "Community 603"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+
+### Community 604 - "Community 604"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 605 - "Community 605"
 Cohesion: 1.0
@@ -4299,20 +4300,20 @@ Cohesion: 1.0
 Nodes (2): createFixtureRepo(), write()
 
 ### Community 609 - "Community 609"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 610 - "Community 610"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 611 - "Community 611"
-Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 612 - "Community 612"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 613 - "Community 613"
 Cohesion: 1.0
@@ -9162,2434 +9163,2438 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1825 - "Community 1825"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 612`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 613`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 613`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 614`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 614`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 615`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 615`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 616`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 616`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 617`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 617`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 618`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 618`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 619`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 619`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 620`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 620`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 621`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 621`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 622`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 622`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 623`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 623`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 624`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 624`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 625`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 625`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 626`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 626`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 627`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 627`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 628`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 628`** (2 nodes): `createMutationCtx()`, `catalogImport.test.ts`
+- **Thin community `Community 629`** (2 nodes): `createMutationCtx()`, `catalogImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 630`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 631`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 632`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 633`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 634`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 635`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 636`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 637`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 638`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 639`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 640`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 641`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 642`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 643`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 644`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 645`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 646`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 647`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 648`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 649`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 650`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 651`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 652`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 653`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 654`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 655`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 656`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 657`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `resolveTerminalCloudRepair.ts`, `resolveTerminalCloudRepair()`
+- **Thin community `Community 658`** (2 nodes): `resolveTerminalCloudRepair.ts`, `resolveTerminalCloudRepair()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 659`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 660`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 661`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 662`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 663`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 664`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 665`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `terminalRecoveryRepository.test.ts`, `buildCtx()`
+- **Thin community `Community 666`** (2 nodes): `terminalRecoveryRepository.test.ts`, `buildCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 667`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 668`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 669`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 670`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 671`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 672`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
+- **Thin community `Community 673`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 674`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 675`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 676`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 677`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 678`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 679`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 680`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 681`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 682`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 683`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 684`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 685`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 686`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 687`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 688`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 689`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 690`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 691`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 692`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 693`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 694`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 695`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 696`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 697`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 698`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 699`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 700`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 701`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 702`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 703`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 704`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 705`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 706`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 707`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 708`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 709`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 710`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 711`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 712`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 713`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 714`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 715`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 716`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 717`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 718`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 719`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 720`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 721`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 722`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 723`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 724`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 725`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 726`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 727`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 728`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 729`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 730`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 731`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 732`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 733`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 734`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 735`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 736`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
+- **Thin community `Community 737`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 738`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 739`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 740`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 741`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 742`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 743`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 744`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 745`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 746`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 747`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 748`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 749`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 750`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 751`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 752`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 753`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 754`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 755`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 756`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 757`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 758`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 759`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 760`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 761`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 762`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 763`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 764`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 765`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 766`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 767`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 768`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 769`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 770`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 771`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 772`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 773`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 774`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 775`** (2 nodes): `POSSettingsView.test.tsx`, `waitForFingerprintEffect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 776`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 777`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 778`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 779`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 780`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 781`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 782`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 783`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 784`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 785`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 786`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 787`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 788`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 789`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 790`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 791`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 792`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 793`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 794`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 795`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 796`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 797`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 798`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 799`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 800`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 801`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 802`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 803`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 804`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 805`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 806`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 807`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 808`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 809`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 810`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 811`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 812`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 813`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 814`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 815`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 816`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 817`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 818`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 819`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 820`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 821`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 822`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 823`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 824`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 825`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 826`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 827`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 828`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 829`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 830`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 831`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 832`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 833`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 834`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 835`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 836`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 837`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 838`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 839`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 840`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 841`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 842`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 843`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 844`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 845`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 846`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 847`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 848`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 849`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 850`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 851`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 852`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 853`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 854`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 855`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 856`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 857`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 858`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 859`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 860`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 861`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 862`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 863`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 864`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 865`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 866`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 867`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 868`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 869`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 870`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 871`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 872`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 873`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 874`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 875`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 876`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 877`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
+- **Thin community `Community 878`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 879`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 880`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 881`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 882`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 883`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 884`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 885`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 886`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 887`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 888`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 889`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 890`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 891`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 892`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 893`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 894`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 895`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 896`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 897`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 898`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 899`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 900`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 901`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 902`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 903`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 904`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 905`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 906`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 907`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 908`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 909`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 910`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 911`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 912`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 913`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 914`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 915`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 916`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 917`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 918`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 919`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 920`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 921`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 922`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 923`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 924`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 925`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 926`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 927`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 928`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 929`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 930`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 931`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 932`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 933`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 934`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 935`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 936`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 937`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 938`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 939`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 940`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 941`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 942`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 943`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 944`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 945`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 946`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 947`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 948`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 949`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 950`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 951`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 952`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 953`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 954`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 955`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 956`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 957`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 958`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 959`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 960`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 961`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 962`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 963`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 964`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 965`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 966`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 967`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 968`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 969`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 970`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 971`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 972`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 973`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 974`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 975`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 976`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 977`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 978`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 979`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 980`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 981`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 982`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 983`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 984`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 985`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 986`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 987`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 988`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 989`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 990`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 991`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 992`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 993`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 994`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 995`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 996`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 997`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 998`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 999`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1000`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1001`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1002`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1003`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1004`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1005`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1006`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1007`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1008`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1009`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1010`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1011`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1012`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1013`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1014`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1015`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1016`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1017`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1018`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1019`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1020`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1021`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1022`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1023`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1024`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1025`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1026`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1027`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1028`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1029`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1030`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1031`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1032`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1033`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1034`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1035`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1036`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1037`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (1 nodes): `api.js`
+- **Thin community `Community 1038`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1039`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1040`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `server.js`
+- **Thin community `Community 1041`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `app.ts`
+- **Thin community `Community 1042`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1043`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1044`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1045`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1046`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `auth.ts`
+- **Thin community `Community 1047`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1048`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1049`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1050`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `countries.ts`
+- **Thin community `Community 1051`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `email.ts`
+- **Thin community `Community 1052`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1053`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `payment.ts`
+- **Thin community `Community 1054`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1055`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `crons.ts`
+- **Thin community `Community 1056`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1057`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `internal.ts`
+- **Thin community `Community 1058`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1059`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1060`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1061`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1062`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1063`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1064`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1065`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1066`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1067`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1068`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1069`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `env.ts`
+- **Thin community `Community 1070`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1071`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `auth.ts`
+- **Thin community `Community 1072`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1073`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `colors.ts`
+- **Thin community `Community 1074`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `index.ts`
+- **Thin community `Community 1075`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1076`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `products.ts`
+- **Thin community `Community 1077`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1078`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `stores.ts`
+- **Thin community `Community 1079`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `bag.ts`
+- **Thin community `Community 1080`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `guest.ts`
+- **Thin community `Community 1081`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `index.ts`
+- **Thin community `Community 1082`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `me.ts`
+- **Thin community `Community 1083`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `offers.ts`
+- **Thin community `Community 1084`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1085`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1086`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1087`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1088`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1089`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1090`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1091`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1092`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1093`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `user.ts`
+- **Thin community `Community 1094`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1095`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `index.ts`
+- **Thin community `Community 1096`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1097`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `http.ts`
+- **Thin community `Community 1098`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1099`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1100`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1101`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `categories.ts`
+- **Thin community `Community 1102`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `colors.ts`
+- **Thin community `Community 1103`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1104`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 1105`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1106`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1107`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1108`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1109`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `pos.ts`
+- **Thin community `Community 1110`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1111`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1112`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1113`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1114`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1115`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1116`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1117`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1118`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1119`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1120`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1121`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1122`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1123`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1124`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1125`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1126`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `types.ts`
+- **Thin community `Community 1127`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1128`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1129`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1130`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1131`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1132`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1133`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `dto.ts`
+- **Thin community `Community 1134`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1135`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1136`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1137`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `types.ts`
+- **Thin community `Community 1138`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `types.ts`
+- **Thin community `Community 1139`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `types.ts`
+- **Thin community `Community 1140`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1141`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `customers.ts`
+- **Thin community `Community 1142`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `register.ts`
+- **Thin community `Community 1143`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `sync.ts`
+- **Thin community `Community 1144`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1145`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1146`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `public.ts`
+- **Thin community `Community 1147`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `schema.ts`
+- **Thin community `Community 1148`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `automation.ts`
+- **Thin community `Community 1149`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1150`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `index.ts`
+- **Thin community `Community 1151`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1152`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1153`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1154`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1155`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1156`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `category.ts`
+- **Thin community `Community 1157`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `color.ts`
+- **Thin community `Community 1158`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1159`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1160`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `index.ts`
+- **Thin community `Community 1161`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1162`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1163`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1164`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1165`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `organization.ts`
+- **Thin community `Community 1166`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1167`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `product.ts`
+- **Thin community `Community 1168`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1169`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1170`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `store.ts`
+- **Thin community `Community 1171`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1172`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `index.ts`
+- **Thin community `Community 1173`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1174`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1175`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1176`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1177`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1178`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1179`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1180`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `index.ts`
+- **Thin community `Community 1181`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1182`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1183`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1184`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1185`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1186`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1187`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1188`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1189`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1190`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1191`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1192`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `customer.ts`
+- **Thin community `Community 1193`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1194`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1195`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1196`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1197`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `index.ts`
+- **Thin community `Community 1198`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1199`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1200`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1201`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1202`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1203`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1204`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1205`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1206`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1207`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1208`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1209`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1210`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1211`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1212`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1213`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1214`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1215`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1216`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1217`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `index.ts`
+- **Thin community `Community 1218`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1219`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1220`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `index.ts`
+- **Thin community `Community 1221`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1222`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1223`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1224`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1225`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1226`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1227`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `index.ts`
+- **Thin community `Community 1228`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1229`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1230`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1231`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1232`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1233`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1234`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `bag.ts`
+- **Thin community `Community 1235`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1236`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1237`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1238`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `guest.ts`
+- **Thin community `Community 1239`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `index.ts`
+- **Thin community `Community 1240`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `offer.ts`
+- **Thin community `Community 1241`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1242`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1243`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `review.ts`
+- **Thin community `Community 1244`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1245`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1246`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1247`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1248`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1249`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1250`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1251`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1252`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1253`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `bag.ts`
+- **Thin community `Community 1254`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1255`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `customer.ts`
+- **Thin community `Community 1256`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `guest.ts`
+- **Thin community `Community 1257`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1258`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1259`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1260`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1261`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `payment.ts`
+- **Thin community `Community 1262`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1263`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1264`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1265`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `users.ts`
+- **Thin community `Community 1266`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `payment.ts`
+- **Thin community `Community 1267`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1268`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1269`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1270`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1271`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1272`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `index.ts`
+- **Thin community `Community 1273`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1274`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1275`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1276`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1277`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `auth.ts`
+- **Thin community `Community 1278`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1279`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1280`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1281`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1282`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1283`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1284`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1285`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1286`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1287`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1288`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1289`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1290`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1291`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1292`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1293`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1294`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `constants.ts`
+- **Thin community `Community 1295`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1296`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1297`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1298`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `types.ts`
+- **Thin community `Community 1299`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1300`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1301`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1302`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1303`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1304`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1305`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1306`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1307`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1308`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1309`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1310`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1311`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1312`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1313`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1314`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1315`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1316`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1317`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1318`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1319`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `constants.ts`
+- **Thin community `Community 1320`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1321`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1322`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1323`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `data.ts`
+- **Thin community `Community 1324`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1325`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1326`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1327`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1328`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1329`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1330`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1331`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1332`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1333`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `constants.ts`
+- **Thin community `Community 1334`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1335`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1336`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1337`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `data.ts`
+- **Thin community `Community 1338`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1339`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1340`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1341`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1342`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1343`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1344`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1345`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1346`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1347`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1348`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1349`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1350`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `constants.ts`
+- **Thin community `Community 1351`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1352`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1353`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1354`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1355`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1356`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1357`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1358`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1359`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1360`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1361`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1362`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1363`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1364`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1365`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1366`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1367`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1368`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1369`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1370`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1371`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1372`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1373`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1374`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1375`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1376`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1377`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1378`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1379`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1380`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1381`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1382`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `constants.ts`
+- **Thin community `Community 1383`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1384`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1385`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1386`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `data.ts`
+- **Thin community `Community 1387`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1388`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1389`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `constants.ts`
+- **Thin community `Community 1390`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1391`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1392`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1393`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1394`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `data.ts`
+- **Thin community `Community 1395`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1396`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `constants.ts`
+- **Thin community `Community 1397`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1398`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1399`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1400`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1401`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `data.ts`
+- **Thin community `Community 1402`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1403`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1404`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1405`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1406`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1407`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1408`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1409`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1410`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1411`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1412`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1413`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1414`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1415`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1416`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1417`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1418`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1419`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1420`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1421`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1422`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1423`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1424`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1425`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1426`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1427`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `POSSettingsView.test.tsx`
+- **Thin community `Community 1428`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1429`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `POSTerminalHealthView.test.tsx`
+- **Thin community `Community 1430`** (1 nodes): `POSTerminalHealthView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1431`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1432`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1433`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `types.ts`
+- **Thin community `Community 1434`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1435`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1436`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1437`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1438`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1439`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1440`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1441`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1442`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1443`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1444`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1445`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1446`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1447`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1448`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1449`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1450`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1451`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `data.ts`
+- **Thin community `Community 1452`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1453`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1454`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1455`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1456`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1457`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1458`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1459`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1460`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1461`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1462`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1463`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1464`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `constants.ts`
+- **Thin community `Community 1465`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1466`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1467`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1468`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `data.ts`
+- **Thin community `Community 1469`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `types.ts`
+- **Thin community `Community 1470`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1471`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 1472`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `index.ts`
+- **Thin community `Community 1473`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1474`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1475`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1476`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1477`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `index.tsx`
+- **Thin community `Community 1478`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1479`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1480`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1481`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1482`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1483`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1484`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1485`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1486`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `index.tsx`
+- **Thin community `Community 1487`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1488`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1489`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1490`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `button.tsx`
+- **Thin community `Community 1491`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1492`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `card.tsx`
+- **Thin community `Community 1493`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1494`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1495`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `command.tsx`
+- **Thin community `Community 1496`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1497`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1498`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1499`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `form.tsx`
+- **Thin community `Community 1500`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1501`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1502`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `input.tsx`
+- **Thin community `Community 1503`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1504`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1505`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1506`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1507`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1508`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1509`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `select.tsx`
+- **Thin community `Community 1510`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1511`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1512`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1513`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `table.tsx`
+- **Thin community `Community 1514`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1515`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1516`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1517`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1518`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1519`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1520`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1521`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1522`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `constants.ts`
+- **Thin community `Community 1523`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1524`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1525`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1526`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `data.ts`
+- **Thin community `Community 1527`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1528`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1529`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1530`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1531`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1532`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1533`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1534`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1535`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1536`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1537`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1538`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `index.ts`
+- **Thin community `Community 1539`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1540`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1541`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1542`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1543`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1544`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1545`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1546`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1547`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1548`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1549`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1550`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `aws.ts`
+- **Thin community `Community 1551`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `constants.ts`
+- **Thin community `Community 1552`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `countries.ts`
+- **Thin community `Community 1553`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1554`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1555`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1556`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1557`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1558`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1559`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1560`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `dto.ts`
+- **Thin community `Community 1561`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `ports.ts`
+- **Thin community `Community 1562`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `constants.ts`
+- **Thin community `Community 1563`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1564`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1565`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `index.ts`
+- **Thin community `Community 1566`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1567`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `types.ts`
+- **Thin community `Community 1568`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1569`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1570`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1571`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1572`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1573`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1574`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1575`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1576`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 1577`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1578`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1579`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1580`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 1581`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `index.ts`
+- **Thin community `Community 1582`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `category.ts`
+- **Thin community `Community 1583`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `product.ts`
+- **Thin community `Community 1584`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `store.ts`
+- **Thin community `Community 1585`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1586`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `user.ts`
+- **Thin community `Community 1587`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1588`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1589`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1590`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1591`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1592`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1593`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1594`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1595`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1596`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `__root.tsx`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `index.tsx`
+- **Thin community `Community 1597`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1598`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1599`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1600`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1601`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1602`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1603`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1604`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `index.tsx`
+- **Thin community `Community 1605`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1606`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1607`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1608`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `home.tsx`
+- **Thin community `Community 1609`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1610`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1611`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1612`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `index.tsx`
+- **Thin community `Community 1613`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `review.tsx`
+- **Thin community `Community 1614`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1615`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1616`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `index.tsx`
+- **Thin community `Community 1617`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1618`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1619`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1620`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `index.tsx`
+- **Thin community `Community 1621`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1622`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1623`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1624`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1625`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1626`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1627`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `index.tsx`
+- **Thin community `Community 1628`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1629`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1630`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1631`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1632`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1633`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1634`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1635`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1636`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1637`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `index.tsx`
+- **Thin community `Community 1638`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1639`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `index.tsx`
+- **Thin community `Community 1640`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `new.tsx`
+- **Thin community `Community 1641`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `index.tsx`
+- **Thin community `Community 1642`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `new.tsx`
+- **Thin community `Community 1643`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1644`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1645`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `index.tsx`
+- **Thin community `Community 1646`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `new.tsx`
+- **Thin community `Community 1647`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `index.tsx`
+- **Thin community `Community 1648`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1649`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1650`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1651`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1652`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `index.tsx`
+- **Thin community `Community 1653`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1654`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1655`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1656`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `index.tsx`
+- **Thin community `Community 1657`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1658`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1659`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1660`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1661`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1662`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1663`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1664`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1665`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1666`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1667`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1668`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1669`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1670`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1671`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1672`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1673`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1674`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1675`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1676`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1677`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1678`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1679`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1680`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1681`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `setup.ts`
+- **Thin community `Community 1682`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1683`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `types.ts`
+- **Thin community `Community 1684`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1685`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1686`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1687`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1688`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1689`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `types.ts`
+- **Thin community `Community 1690`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1691`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1692`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1693`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1694`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1695`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1696`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1697`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1698`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1699`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `schema.ts`
+- **Thin community `Community 1700`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1701`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1702`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1703`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1704`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1705`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1706`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1707`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1708`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1709`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `types.ts`
+- **Thin community `Community 1710`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1711`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1712`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1713`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1714`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1715`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1716`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1717`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `constants.ts`
+- **Thin community `Community 1718`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1719`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `About.tsx`
+- **Thin community `Community 1720`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1721`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1722`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1723`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1724`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1725`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1726`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1727`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1728`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1729`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1730`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `types.ts`
+- **Thin community `Community 1731`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1732`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1733`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1734`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1735`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1736`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1737`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1738`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1739`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1740`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1741`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1742`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `button.tsx`
+- **Thin community `Community 1743`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `card.tsx`
+- **Thin community `Community 1744`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1745`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `command.tsx`
+- **Thin community `Community 1746`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1747`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1748`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1749`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `form.tsx`
+- **Thin community `Community 1750`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1751`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1752`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1753`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1754`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `input.tsx`
+- **Thin community `Community 1755`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `label.tsx`
+- **Thin community `Community 1756`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1757`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1758`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1759`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `index.ts`
+- **Thin community `Community 1760`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `types.ts`
+- **Thin community `Community 1761`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1762`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1763`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1764`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1765`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `select.tsx`
+- **Thin community `Community 1766`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1767`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1768`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `table.tsx`
+- **Thin community `Community 1769`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1770`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1771`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1772`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1773`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1774`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `config.ts`
+- **Thin community `Community 1775`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1776`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1777`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1778`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1779`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `constants.ts`
+- **Thin community `Community 1780`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `countries.ts`
+- **Thin community `Community 1781`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1782`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1783`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1784`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1785`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `index.ts`
+- **Thin community `Community 1786`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `store.ts`
+- **Thin community `Community 1787`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `bag.ts`
+- **Thin community `Community 1788`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1789`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `category.ts`
+- **Thin community `Community 1790`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `organization.ts`
+- **Thin community `Community 1791`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `product.ts`
+- **Thin community `Community 1792`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `store.ts`
+- **Thin community `Community 1793`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1794`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `user.ts`
+- **Thin community `Community 1795`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `states.ts`
+- **Thin community `Community 1796`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1797`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1798`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1799`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1800`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1801`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1802`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1803`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `index.tsx`
+- **Thin community `Community 1804`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1805`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `index.tsx`
+- **Thin community `Community 1806`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1807`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1808`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1809`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1810`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1811`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `index.tsx`
+- **Thin community `Community 1812`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1813`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1814`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1815`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1816`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1817`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `index.js`
+- **Thin community `Community 1818`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1819`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1820`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1821`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1822`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1823`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1824`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1825`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1897
-- Graph nodes: 6631
-- Graph edges: 7392
-- Communities: 1825
+- Code files discovered: 1898
+- Graph nodes: 6642
+- Graph edges: 7406
+- Communities: 1826
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (87 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -17,11 +17,11 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 - [validation-map.json](../../../packages/valkey-proxy-server/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `app.js` (14 edges, Community 80) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.js` (14 edges, Community 81) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `app.test.js` (6 edges, Community 146) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
-- `createRedisClient()` (4 edges, Community 80) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `createRedisCluster()` (3 edges, Community 80) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `deleteKeysIndividually()` (3 edges, Community 80) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisClient()` (4 edges, Community 81) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisCluster()` (3 edges, Community 81) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `deleteKeysIndividually()` (3 edges, Community 81) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/http/domains/core/routes/categories.ts
+++ b/packages/athena-webapp/convex/http/domains/core/routes/categories.ts
@@ -9,12 +9,22 @@ const categoryRoutes: HonoWithConvex<ActionCtx> = new Hono();
 const STOREFRONT_HIDDEN_CATEGORY_SLUGS = new Set(["pos-quick-add"]);
 const STOREFRONT_HIDDEN_SUBCATEGORY_SLUGS = new Set(["uncategorized"]);
 
-export function removeStorefrontHiddenCategories<T extends { slug?: string }>(
-  categories: T[],
-) {
+export function shouldShowCategoryOnStorefront(category: {
+  showOnStorefront?: boolean;
+  slug?: string;
+}) {
+  if (category.showOnStorefront === false) {
+    return false;
+  }
+
+  return !category.slug || !STOREFRONT_HIDDEN_CATEGORY_SLUGS.has(category.slug);
+}
+
+export function removeStorefrontHiddenCategories<
+  T extends { showOnStorefront?: boolean; slug?: string },
+>(categories: T[]) {
   return categories.filter(
-    (category) =>
-      !category.slug || !STOREFRONT_HIDDEN_CATEGORY_SLUGS.has(category.slug),
+    (category) => shouldShowCategoryOnStorefront(category),
   );
 }
 

--- a/packages/athena-webapp/convex/http/domains/core/routes/storefrontHidden.test.ts
+++ b/packages/athena-webapp/convex/http/domains/core/routes/storefrontHidden.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   removeStorefrontHiddenCategories,
   removeStorefrontHiddenSubcategories as removeNestedStorefrontHiddenSubcategories,
+  shouldShowCategoryOnStorefront,
 } from "./categories";
 import { removeStorefrontHiddenSubcategoryList } from "./subcategories";
 
@@ -14,6 +15,28 @@ describe("storefront hidden inventory filters", () => {
         { slug: "pos-quick-add", name: "POS quick add" },
       ]),
     ).toEqual([{ slug: "lace-fronts", name: "Lace fronts" }]);
+  });
+
+  it("removes categories hidden by storefront visibility control", () => {
+    expect(
+      removeStorefrontHiddenCategories([
+        { slug: "lace-fronts", name: "Lace fronts" },
+        {
+          slug: "legacy-import",
+          name: "Legacy import",
+          showOnStorefront: false,
+        },
+      ]),
+    ).toEqual([{ slug: "lace-fronts", name: "Lace fronts" }]);
+  });
+
+  it("keeps reserved storefront category filters stronger than the visibility control", () => {
+    expect(
+      shouldShowCategoryOnStorefront({
+        slug: "pos-quick-add",
+        showOnStorefront: true,
+      }),
+    ).toBe(false);
   });
 
   it("removes uncategorized subcategories from nested storefront navigation", () => {

--- a/packages/athena-webapp/convex/inventory/categories.ts
+++ b/packages/athena-webapp/convex/inventory/categories.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @convex-dev/no-collect-in-query -- Admin category selectors and storefront navigation need full store-scoped category lists; category counts are bounded operational taxonomy. */
 import { mutation, query } from "../_generated/server";
 import { v } from "convex/values";
 import { categorySchema } from "../schemas/inventory";
@@ -67,7 +68,7 @@ export const getById = query({
     storeId: v.string(),
   },
   handler: async (ctx, args) => {
-    return await ctx.db.get(args.id);
+    return await ctx.db.get("category", args.id);
   },
 });
 
@@ -76,20 +77,39 @@ export const create = mutation({
   handler: async (ctx, args) => {
     const id = await ctx.db.insert(entity, args);
 
-    return await ctx.db.get(id);
+    return await ctx.db.get("category", id);
   },
 });
 
 export const update = mutation({
   args: {
     id: v.id(entity),
-    name: v.string(),
-    slug: v.string(),
+    name: v.optional(v.string()),
+    showOnStorefront: v.optional(v.boolean()),
+    slug: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await ctx.db.patch(args.id, { name: args.name, slug: args.slug });
+    const patch: Partial<{
+      name: string;
+      showOnStorefront: boolean;
+      slug: string;
+    }> = {};
 
-    return await ctx.db.get(args.id);
+    if (args.name !== undefined) {
+      patch.name = args.name;
+    }
+
+    if (args.slug !== undefined) {
+      patch.slug = args.slug;
+    }
+
+    if (args.showOnStorefront !== undefined) {
+      patch.showOnStorefront = args.showOnStorefront;
+    }
+
+    await ctx.db.patch("category", args.id, patch);
+
+    return await ctx.db.get("category", args.id);
   },
 });
 
@@ -98,7 +118,7 @@ export const remove = mutation({
     id: v.id(entity),
   },
   handler: async (ctx, args) => {
-    await ctx.db.delete(args.id);
+    await ctx.db.delete("category", args.id);
 
     return { message: "OK" };
   },

--- a/packages/athena-webapp/convex/inventory/products.sku.test.ts
+++ b/packages/athena-webapp/convex/inventory/products.sku.test.ts
@@ -439,6 +439,24 @@ describe("product catalog visibility", () => {
     expect(archivedProducts.map((product: Row) => product._id)).toEqual([
       "product-archived",
     ]);
+
+    const draftHiddenCtx = createProductsQueryCtx(seed).ctx;
+    const draftHiddenProducts = await getHandler(getAll)(draftHiddenCtx, {
+      storeId: "storezzzz" as Id<"store">,
+      availability: "draft",
+      isVisible: false,
+    });
+
+    expect(draftHiddenProducts).toEqual([
+      expect.objectContaining({
+        _id: "product-draft",
+        skus: [
+          expect.objectContaining({
+            _id: "sku-draft",
+          }),
+        ],
+      }),
+    ]);
   });
 });
 

--- a/packages/athena-webapp/convex/inventory/products.ts
+++ b/packages/athena-webapp/convex/inventory/products.ts
@@ -182,16 +182,18 @@ export const getAll = query({
     const storefrontHiddenSubcategoryIds = new Set<Id<"subcategory">>();
 
     if (args.excludeStorefrontHidden) {
-      const quickAddCategory = await ctx.db
+      const categories = await ctx.db
         .query("category")
-        .withIndex("by_storeId_slug", (q) =>
-          q.eq("storeId", args.storeId).eq("slug", "pos-quick-add")
-        )
-        .first();
+        .filter((q) => q.eq(q.field("storeId"), args.storeId))
+        .collect();
 
-      if (quickAddCategory) {
-        storefrontHiddenCategoryIds.add(quickAddCategory._id);
-      }
+      categories
+        .filter(
+          (category) =>
+            category.slug === "pos-quick-add" ||
+            category.showOnStorefront === false,
+        )
+        .forEach((category) => storefrontHiddenCategoryIds.add(category._id));
 
       const uncategorizedSubcategories = await ctx.db
         .query("subcategory")
@@ -577,6 +579,7 @@ export const getByIdOrSlug = query({
     let category: string | undefined;
     let subcategory: string | undefined;
     let categorySlug: string | undefined;
+    let categoryShowOnStorefront: boolean | undefined;
     let subcategorySlug: string | undefined;
 
     if (product) {
@@ -589,12 +592,15 @@ export const getByIdOrSlug = query({
       subcategory = productSubcategory?.name;
 
       categorySlug = productCategory?.slug;
+      categoryShowOnStorefront = productCategory?.showOnStorefront;
       subcategorySlug = productSubcategory?.slug;
     }
 
     if (
       args.filters?.excludeStorefrontHidden &&
-      (categorySlug === "pos-quick-add" || subcategorySlug === "uncategorized")
+      (categorySlug === "pos-quick-add" ||
+        categoryShowOnStorefront === false ||
+        subcategorySlug === "uncategorized")
     ) {
       return null;
     }

--- a/packages/athena-webapp/convex/remoteAssist/public.test.ts
+++ b/packages/athena-webapp/convex/remoteAssist/public.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   getClient: vi.fn(),
   getClientByRuntime: vi.fn(),
   getSession: vi.fn(),
+  listReusableSessionsForClient: vi.fn(),
   requireAuthenticatedAthenaUserWithCtx: vi.fn(),
   requireOrganizationMemberRoleWithCtx: vi.fn(),
   startRemoteAssistSession: vi.fn(),
@@ -47,7 +48,20 @@ describe("remote assist public API", () => {
       getClient: mocks.getClient,
       getClientByRuntime: mocks.getClientByRuntime,
       getSession: mocks.getSession,
+      listReusableSessionsForClient: mocks.listReusableSessionsForClient,
     });
+    mocks.listReusableSessionsForClient.mockResolvedValue([
+      buildSession({
+        _id: "connecting-session",
+        requestedAt: 20,
+        status: "connecting",
+      }),
+      buildSession({
+        _id: "active-session",
+        requestedAt: 10,
+        status: "active",
+      }),
+    ]);
     mocks.startRemoteAssistSession.mockResolvedValue({
       kind: "ok",
       data: buildSession({ status: "connecting" }),
@@ -66,6 +80,7 @@ describe("remote assist public API", () => {
 
   it("exposes only support-scoped session lifecycle mutations in v1", () => {
     expect(remoteAssistPublic).toHaveProperty("getClientByRuntime");
+    expect(remoteAssistPublic).toHaveProperty("getCurrentSessionByClient");
     expect(remoteAssistPublic).toHaveProperty("startSession");
     expect(remoteAssistPublic).toHaveProperty("endSupportSession");
   });
@@ -175,6 +190,46 @@ describe("remote assist public API", () => {
         transportRoomId: "room-1",
       }),
     );
+  });
+
+  it("returns the current reusable session for a support client view", async () => {
+    const ctx = {};
+
+    const result = await getHandler(remoteAssistPublic.getCurrentSessionByClient)(
+      ctx,
+      {
+        clientId: "client-1",
+      },
+    );
+
+    expect(result?._id).toBe("active-session");
+    expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        allowedRoles: ["full_admin"],
+        organizationId: "org-1",
+        userId: "athena-user-1",
+      }),
+    );
+    expect(mocks.listReusableSessionsForClient).toHaveBeenCalledWith({
+      clientId: "client-1",
+      now: expect.any(Number),
+    });
+  });
+
+  it("returns null before authorizing a missing current-session client", async () => {
+    mocks.getClient.mockResolvedValue(null);
+
+    const result = await getHandler(remoteAssistPublic.getCurrentSessionByClient)(
+      {},
+      {
+        clientId: "client-1",
+      },
+    );
+
+    expect(result).toBeNull();
+    expect(mocks.requireOrganizationMemberRoleWithCtx).not.toHaveBeenCalled();
+    expect(mocks.listReusableSessionsForClient).not.toHaveBeenCalled();
   });
 
   it("returns not_found before authorizing a missing session end", async () => {

--- a/packages/athena-webapp/convex/remoteAssist/public.ts
+++ b/packages/athena-webapp/convex/remoteAssist/public.ts
@@ -22,6 +22,7 @@ import {
   endRemoteAssistSession,
   startRemoteAssistSession,
 } from "./application/sessionService";
+import type { RemoteAssistSession } from "./application/types";
 import { createRemoteAssistRepository } from "./infrastructure/remoteAssistRepository";
 
 const remoteAssistClientReturnValidator = v.object({
@@ -96,6 +97,36 @@ export const getClientByRuntime = query({
   },
 });
 
+export const getCurrentSessionByClient = query({
+  args: {
+    clientId: v.id("remoteAssistClient"),
+  },
+  returns: v.union(remoteAssistSessionReturnValidator, v.null()),
+  handler: async (ctx, args) => {
+    const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
+    const repository = createRemoteAssistRepository(ctx);
+    const client = await repository.getClient(args.clientId);
+    if (!client) {
+      return null;
+    }
+
+    await requireOrganizationMemberRoleWithCtx(ctx, {
+      allowedRoles: ["full_admin"],
+      failureMessage: "You do not have access to view Remote Assist sessions.",
+      organizationId: client.organizationId as Id<"organization">,
+      userId: athenaUser._id,
+    });
+
+    const sessions = await repository.listReusableSessionsForClient({
+      clientId: args.clientId,
+      now: Date.now(),
+    });
+    return toRemoteAssistSessionReturn(
+      sessions.sort(compareRemoteAssistSessionForSupportView)[0] ?? null,
+    );
+  },
+});
+
 export const startSession = mutation({
   args: {
     clientId: v.id("remoteAssistClient"),
@@ -144,6 +175,50 @@ export const startSession = mutation({
     });
   },
 });
+
+function compareRemoteAssistSessionForSupportView(
+  a: {
+    requestedAt: number;
+    status: string;
+  },
+  b: {
+    requestedAt: number;
+    status: string;
+  },
+) {
+  return (
+    getRemoteAssistSessionStatusPriority(b.status) -
+      getRemoteAssistSessionStatusPriority(a.status) ||
+    b.requestedAt - a.requestedAt
+  );
+}
+
+function getRemoteAssistSessionStatusPriority(status: string) {
+  switch (status) {
+    case "active":
+      return 3;
+    case "connecting":
+      return 2;
+    case "pending_attended_approval":
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+function toRemoteAssistSessionReturn(session: RemoteAssistSession | null) {
+  return session
+    ? {
+        ...session,
+        _creationTime: session.requestedAt,
+        _id: session._id as Id<"remoteAssistSession">,
+        clientId: session.clientId as Id<"remoteAssistClient">,
+        organizationId: session.organizationId as Id<"organization">,
+        requestedByUserId: session.requestedByUserId as Id<"athenaUser">,
+        storeId: session.storeId as Id<"store"> | undefined,
+      }
+    : null;
+}
 
 export const endSupportSession = mutation({
   args: {

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -7,7 +7,7 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Core app surfaces
 
 - [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 88 file(s); key children: __root.tsx, _authed, _authed.test.tsx, _authed.tsx, index.test.tsx.
-- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 600 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
+- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 601 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
 - [`src/components/traces`](../../src/components/traces) — Shared workflow trace screens, ordered timelines, and trace detail primitives. Currently 3 file(s); key children: WorkflowTraceRouteLink.tsx, WorkflowTraceView.test.tsx, WorkflowTraceView.tsx.
 - [`src/components/operations`](../../src/components/operations) — Manager-queue and stock-adjustment workflows that share approval rails with other operational surfaces. Currently 26 file(s); key children: CommandApprovalDialog.test.tsx, CommandApprovalDialog.tsx, DailyCloseHistoryView.test.tsx, DailyCloseHistoryView.tsx, DailyCloseView.test.tsx.
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.

--- a/packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx
+++ b/packages/athena-webapp/src/components/add-product/CategorySubcategoryManager.tsx
@@ -8,7 +8,7 @@ import {
   SelectValue,
 } from "../ui/select";
 import { Separator } from "../ui/separator";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { LoadingButton } from "../ui/loading-button";
 import { CheckCircledIcon, TrashIcon } from "@radix-ui/react-icons";
 import { toast } from "sonner";
@@ -16,13 +16,26 @@ import { Ban } from "lucide-react";
 import useGetActiveStore from "@/hooks/useGetActiveStore";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "~/convex/_generated/api";
-import { Category } from "~/types";
+import { Category, Subcategory } from "~/types";
 import { Id } from "~/convex/_generated/dataModel";
 import { toSlug } from "~/src/lib/utils";
 import { Checkbox } from "../ui/checkbox";
 import { presentUnexpectedErrorToast } from "~/src/lib/errors/presentUnexpectedErrorToast";
 
 export type CategoryManageOption = "category" | "subcategory";
+
+type CategoryOption = {
+  id: Id<"category">;
+  name: string;
+  slug: string;
+  showOnStorefront: boolean;
+};
+
+type SubcategoryOption = {
+  categoryId: Id<"category">;
+  id: Id<"subcategory">;
+  name: string;
+};
 
 function Sidebar({
   selected,
@@ -60,30 +73,29 @@ function CategoryManager() {
   const [name, setName] = useState<string | null>(null);
   const [categoryId, setCategoryId] = useState<Id<"category"> | null>(null);
 
-  const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
-
   const [categoryIdToRename, setCategoryIdToRename] =
     useState<Id<"category"> | null>(null);
 
   const [updatedName, setUpdatedName] = useState<string | null>(null);
+  const [storefrontCategoryId, setStorefrontCategoryId] =
+    useState<Id<"category"> | null>(null);
+  const [isStorefrontVisible, setIsStorefrontVisible] = useState(true);
 
   const [isCreateMutationPending, setIsCreateMutationPending] = useState(false);
   const [isUpdateMutationPending, setIsUpdateMutationPending] = useState(false);
   const [isDeleteMutationPending, setIsDeleteMutationPending] = useState(false);
+  const [
+    isStorefrontVisibilityMutationPending,
+    setIsStorefrontVisibilityMutationPending,
+  ] = useState(false);
 
-  const categories =
+  const categories: CategoryOption[] =
     categoriesData?.map((category: Category) => ({
       name: category.name,
+      slug: category.slug,
       id: category._id,
+      showOnStorefront: category.showOnStorefront !== false,
     })) || [];
-
-  useEffect(() => {
-    const idToUse = categoryId || categoryIdToRename;
-
-    const name = categories.find(({ id }) => id == idToUse?.toString())?.name;
-
-    if (name) setSelectedCategory(name);
-  }, [categoryId, categoryIdToRename]);
 
   const createCategory = useMutation(api.inventory.categories.create);
 
@@ -107,7 +119,7 @@ function CategoryManager() {
       toast(`Category '${name}' created`, {
         icon: <CheckCircledIcon className="w-4 h-4" />,
       });
-    } catch (e) {
+    } catch {
       presentUnexpectedErrorToast("Something went wrong", {
         icon: <Ban className="w-4 h-4" />,
       });
@@ -132,12 +144,45 @@ function CategoryManager() {
       toast(`Category updated to '${updatedName}'`, {
         icon: <CheckCircledIcon className="w-4 h-4" />,
       });
-    } catch (e) {
+    } catch {
       presentUnexpectedErrorToast("Something went wrong", {
         icon: <Ban className="w-4 h-4" />,
       });
     } finally {
       setIsUpdateMutationPending(false);
+    }
+  };
+
+  const updateStorefrontVisibility = async () => {
+    if (!storefrontCategoryId || !activeStore) {
+      throw new Error("Missing data to update category storefront visibility");
+    }
+
+    const category = categories.find(({ id }) => id === storefrontCategoryId);
+
+    try {
+      setIsStorefrontVisibilityMutationPending(true);
+      await updateCategory({
+        id: storefrontCategoryId,
+        name: category?.name,
+        slug: category?.slug,
+        showOnStorefront: isStorefrontVisible,
+      });
+
+      toast(
+        `${category?.name ?? "Category"} ${
+          isStorefrontVisible ? "shown on" : "hidden from"
+        } storefront`,
+        {
+          icon: <CheckCircledIcon className="w-4 h-4" />,
+        },
+      );
+    } catch {
+      presentUnexpectedErrorToast("Something went wrong", {
+        icon: <Ban className="w-4 h-4" />,
+      });
+    } finally {
+      setIsStorefrontVisibilityMutationPending(false);
     }
   };
 
@@ -153,7 +198,7 @@ function CategoryManager() {
       toast(`Category '${name}' created`, {
         icon: <CheckCircledIcon className="w-4 h-4" />,
       });
-    } catch (e) {
+    } catch {
       presentUnexpectedErrorToast("Something went wrong", {
         icon: <Ban className="w-4 h-4" />,
       });
@@ -209,7 +254,7 @@ function CategoryManager() {
                   <SelectValue placeholder="Select category" />
                 </SelectTrigger>
                 <SelectContent>
-                  {categories.map((category: any) => {
+                  {categories.map((category) => {
                     return (
                       <SelectItem key={category.id} value={category.id}>
                         {category.name}
@@ -245,6 +290,88 @@ function CategoryManager() {
       </div>
 
       <div className="space-y-2">
+        <p className="text-muted-foreground text-sm">
+          Storefront visibility
+        </p>
+        <Separator className="mt-2" />
+
+        <div className="grid gap-4 py-4">
+          <div className="flex gap-4 items-center">
+            <Label
+              className="text-muted-foreground w-[30%]"
+              htmlFor="storefront-category"
+            >
+              Category
+            </Label>
+
+            <div className="flex gap-4 w-full">
+              <Select
+                onValueChange={(value) => {
+                  const category = categories.find(({ id }) => id === value);
+                  setStorefrontCategoryId(value as Id<"category">);
+                  setIsStorefrontVisible(
+                    category?.showOnStorefront !== false,
+                  );
+                }}
+              >
+                <SelectTrigger
+                  id="storefront-category"
+                  aria-label="Select storefront category"
+                >
+                  <SelectValue placeholder="Select category" />
+                </SelectTrigger>
+                <SelectContent>
+                  {categories.map((category) => {
+                    return (
+                      <SelectItem key={category.id} value={category.id}>
+                        {category.name}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="flex w-full items-center gap-4">
+            <Label
+              className="text-muted-foreground w-[30%]"
+              htmlFor="show-on-storefront"
+            >
+              Visibility
+            </Label>
+
+            <div className="flex w-full flex-wrap items-center gap-4">
+              <div className="flex items-center gap-2">
+                <Checkbox
+                  id="show-on-storefront"
+                  checked={isStorefrontVisible}
+                  onCheckedChange={(checked) =>
+                    setIsStorefrontVisible(checked === true)
+                  }
+                  className="h-4 w-4 text-primary border-gray-300 focus:ring-primary"
+                />
+                <label htmlFor="show-on-storefront" className="text-sm">
+                  Show on storefront
+                </label>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Hidden categories stay available in catalog ops.
+              </p>
+              <LoadingButton
+                disabled={!storefrontCategoryId}
+                isLoading={isStorefrontVisibilityMutationPending}
+                onClick={() => updateStorefrontVisibility()}
+                variant={"outline"}
+              >
+                Save visibility
+              </LoadingButton>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
         <p className="text-muted-foreground text-sm">Delete category</p>
         <Separator className="mt-2" />
 
@@ -261,7 +388,7 @@ function CategoryManager() {
                 <SelectValue placeholder="Select category" />
               </SelectTrigger>
               <SelectContent>
-                {categories.map((category: any) => {
+                {categories.map((category) => {
                   return (
                     <SelectItem key={category.id} value={category.id}>
                       {category.name}
@@ -298,9 +425,6 @@ function SubcategoryManager() {
     activeStore ? { storeId: activeStore._id } : "skip"
   );
 
-  const [selectedSubcategory, setSelectedSubcategory] = useState<string | null>(
-    null
-  );
   const [name, setName] = useState<string | null>(null);
 
   const [subcategoryIdToRename, setSubcategoryIdToRename] =
@@ -322,9 +446,9 @@ function SubcategoryManager() {
 
   const [lockCategory, setLockCategory] = useState(false);
 
-  const subcategories =
+  const subcategories: SubcategoryOption[] =
     subcategoriesData
-      ?.map((subcategory: any) => ({
+      ?.map((subcategory: Subcategory) => ({
         name: subcategory.name,
         id: subcategory._id,
         categoryId: subcategory.categoryId,
@@ -332,30 +456,24 @@ function SubcategoryManager() {
       .filter((s) => s.categoryId == newCategoryId || !lockCategory)
       .sort((a, b) => a.name.localeCompare(b.name)) || [];
 
-  const subcategoriesFull =
+  const subcategoriesFull: SubcategoryOption[] =
     subcategoriesData
-      ?.map((subcategory: any) => ({
+      ?.map((subcategory: Subcategory) => ({
         name: subcategory.name,
         id: subcategory._id,
         categoryId: subcategory.categoryId,
       }))
       .sort((a, b) => a.name.localeCompare(b.name)) || [];
 
-  const categories =
+  const categories: CategoryOption[] =
     categoriesData
-      ?.map((category: any) => ({
+      ?.map((category: Category) => ({
         name: category.name,
+        slug: category.slug,
         id: category._id,
+        showOnStorefront: category.showOnStorefront !== false,
       }))
       .sort((a, b) => a.name.localeCompare(b.name)) || [];
-
-  useEffect(() => {
-    const idToUse = subcategoryId || subcategoryIdToRename;
-
-    const name = subcategories.find(({ id }) => id == idToUse)?.name;
-
-    if (name) setSelectedSubcategory(name);
-  }, [subcategoryId, subcategoryIdToRename]);
 
   const createSubcategory = useMutation(api.inventory.subcategories.create);
 
@@ -363,11 +481,11 @@ function SubcategoryManager() {
 
   const deleteSubcategory = useMutation(api.inventory.subcategories.remove);
 
-  const selectedSubcategoryToDelete: string = subcategoriesFull.find(
+  const selectedSubcategoryToDelete: string | undefined = subcategoriesFull.find(
     (s) => s.id === subcategoryId
   )?.name;
 
-  const selectedSubcategoryToRename: string = subcategories.find(
+  const selectedSubcategoryToRename: string | undefined = subcategories.find(
     (s) => s.id === subcategoryIdToRename
   )?.name;
 
@@ -388,7 +506,7 @@ function SubcategoryManager() {
       toast(`Category '${name}' created`, {
         icon: <CheckCircledIcon className="w-4 h-4" />,
       });
-    } catch (e) {
+    } catch {
       presentUnexpectedErrorToast("Something went wrong", {
         icon: <Ban className="w-4 h-4" />,
       });
@@ -416,7 +534,7 @@ function SubcategoryManager() {
       toast(`Subcategory updated`, {
         icon: <CheckCircledIcon className="w-4 h-4" />,
       });
-    } catch (e) {
+    } catch {
       presentUnexpectedErrorToast("Something went wrong", {
         icon: <Ban className="w-4 h-4" />,
       });
@@ -437,7 +555,7 @@ function SubcategoryManager() {
       toast(`Subcategory '${name}' created`, {
         icon: <CheckCircledIcon className="w-4 h-4" />,
       });
-    } catch (e) {
+    } catch {
       presentUnexpectedErrorToast("Something went wrong", {
         icon: <Ban className="w-4 h-4" />,
       });
@@ -475,7 +593,7 @@ function SubcategoryManager() {
                   <SelectValue placeholder="Select category" />
                 </SelectTrigger>
                 <SelectContent>
-                  {categories.map((category: any) => {
+                  {categories.map((category) => {
                     return (
                       <SelectItem key={category.id} value={category.id}>
                         {category.name}
@@ -507,7 +625,7 @@ function SubcategoryManager() {
               checked={lockCategory}
               onCheckedChange={(e) => {
                 setSubcategoryIdToRename(null);
-                setLockCategory(e as boolean);
+                setLockCategory(e === true);
               }}
               className="h-4 w-4 text-primary border-gray-300 focus:ring-primary"
             />
@@ -526,7 +644,7 @@ function SubcategoryManager() {
               <SelectValue placeholder="Select category" />
             </SelectTrigger>
             <SelectContent>
-              {categories.map((category: any) => {
+              {categories.map((category) => {
                 return (
                   <SelectItem key={category.id} value={category.id}>
                     {category.name}
@@ -545,7 +663,7 @@ function SubcategoryManager() {
               <SelectValue placeholder="Select subcategory" />
             </SelectTrigger>
             <SelectContent>
-              {subcategories.map((subcategory: any) => {
+              {subcategories.map((subcategory) => {
                 return (
                   <SelectItem
                     key={subcategory.id}
@@ -596,7 +714,7 @@ function SubcategoryManager() {
                 <SelectValue placeholder="Select subcategory" />
               </SelectTrigger>
               <SelectContent>
-                {subcategoriesFull.map((subcategory: any) => {
+                {subcategoriesFull.map((subcategory) => {
                   return (
                     <SelectItem
                       key={subcategory.id}

--- a/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/settings/POSSettingsView.test.tsx
@@ -1,11 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   ButtonHTMLAttributes,
   InputHTMLAttributes,
   LabelHTMLAttributes,
   ReactNode,
 } from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const mocks = vi.hoisted(() => ({
@@ -42,24 +42,30 @@ vi.mock("@tanstack/react-router", () => ({
   Link: ({
     children,
     params,
+    search,
     to,
     ...props
   }: {
     children?: ReactNode;
-    params?: { orgUrlSlug: string; storeUrlSlug: string };
+    params?: { orgUrlSlug: string; storeUrlSlug: string; terminalId?: string };
+    search?: Record<string, string>;
     to?: string;
-  }) => (
-    <a
-      href={
-        to
-          ?.replace("$orgUrlSlug", params?.orgUrlSlug ?? "")
-          .replace("$storeUrlSlug", params?.storeUrlSlug ?? "") ?? "#"
-      }
-      {...props}
-    >
-      {children}
-    </a>
-  ),
+  }) => {
+    const path =
+      to
+        ?.replace("$orgUrlSlug", params?.orgUrlSlug ?? "")
+        .replace("$storeUrlSlug", params?.storeUrlSlug ?? "")
+        .replace("$terminalId", params?.terminalId ?? "") ?? "#";
+    const query = search
+      ? `?${new URLSearchParams(search).toString()}`
+      : "";
+
+    return (
+      <a href={`${path}${query}`} {...props}>
+        {children}
+      </a>
+    );
+  },
   useParams: () => ({ orgUrlSlug: "acme", storeUrlSlug: "downtown" }),
 }));
 
@@ -155,8 +161,17 @@ async function waitForFingerprintEffect() {
 }
 
 describe("registerAndProvisionPosTerminal", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   beforeEach(() => {
     vi.restoreAllMocks();
+    window.history.replaceState(
+      null,
+      "",
+      "/acme/store/downtown/pos/settings?o=%2Facme%2Fstore%2Fdowntown%2Fpos",
+    );
     window.localStorage.clear();
     mocks.rotateRecoveryCode.mockResolvedValue({
       code: "abc123-def456",
@@ -449,8 +464,13 @@ describe("registerAndProvisionPosTerminal", () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Enable store-day auto-start")).toBeChecked();
-    expect(screen.getByLabelText("Local start time")).toHaveValue("08:30");
-    expect(screen.getByLabelText("Store UTC offset")).toHaveValue(-120);
+    expect(screen.getByRole("combobox", { name: "Store day start hour" }))
+      .toHaveTextContent("08");
+    expect(screen.getByRole("combobox", { name: "Store day start minute" }))
+      .toHaveTextContent("30");
+    expect(screen.getByRole("combobox", { name: "Store day start period" }))
+      .toHaveTextContent("AM");
+    expect(screen.queryByLabelText("Store UTC offset")).not.toBeInTheDocument();
     expect(
       screen.getByText("Blockers stay available for manager review."),
     ).toBeInTheDocument();
@@ -465,8 +485,14 @@ describe("registerAndProvisionPosTerminal", () => {
     render(<POSSettingsView />);
 
     await user.click(await screen.findByLabelText("Enable store-day auto-start"));
-    await user.clear(screen.getByLabelText("Local start time"));
-    await user.type(screen.getByLabelText("Local start time"), "07:45");
+    await user.click(
+      screen.getByRole("combobox", { name: "Store day start hour" }),
+    );
+    await user.click(await screen.findByRole("option", { name: "07" }));
+    await user.click(
+      screen.getByRole("combobox", { name: "Store day start minute" }),
+    );
+    await user.click(await screen.findByRole("option", { name: "45" }));
     await user.click(
       screen.getByRole("button", { name: "Save store-day automation" }),
     );
@@ -476,7 +502,7 @@ describe("registerAndProvisionPosTerminal", () => {
         localStartMinutes: 465,
         mode: "disabled",
         openingBlockerHandling: "start_with_manager_review",
-        operatingTimezoneOffsetMinutes: -120,
+        operatingTimezoneOffsetMinutes: 0,
         storeId: "store-1",
       }),
     );
@@ -507,10 +533,10 @@ describe("registerAndProvisionPosTerminal", () => {
     render(<POSSettingsView />);
 
     await user.click(await screen.findByLabelText("Enable store-day auto-start"));
-    await user.clear(screen.getByLabelText("Local start time"));
-    await user.type(screen.getByLabelText("Local start time"), "08:15");
-    await user.clear(screen.getByLabelText("Store UTC offset"));
-    await user.type(screen.getByLabelText("Store UTC offset"), "0");
+    await user.click(
+      screen.getByRole("combobox", { name: "Store day start minute" }),
+    );
+    await user.click(await screen.findByRole("option", { name: "15" }));
     await user.click(
       screen.getByRole("button", { name: "Save store-day automation" }),
     );
@@ -541,7 +567,9 @@ describe("registerAndProvisionPosTerminal", () => {
 
     render(<POSSettingsView />);
 
-    expect(await screen.findByRole("button", { name: /revoke/i })).toBeDisabled();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /revoke/i })).toBeDisabled(),
+    );
   });
 
   it("hides recovery-code management from non-full-admin accounts", async () => {
@@ -567,6 +595,9 @@ describe("registerAndProvisionPosTerminal", () => {
 
   it("shows a normalized error when store-day automation cannot save", async () => {
     const user = userEvent.setup();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
     mocks.updateOpeningAutoStartPolicy.mockRejectedValue(
       new Error("internal duplicate_policy stack"),
     );
@@ -574,7 +605,7 @@ describe("registerAndProvisionPosTerminal", () => {
     render(<POSSettingsView />);
 
     await user.click(
-      await screen.findByRole("button", {
+      screen.getByRole("button", {
         name: "Save store-day automation",
       }),
     );
@@ -585,14 +616,23 @@ describe("registerAndProvisionPosTerminal", () => {
     expect(
       await screen.findByText("Store-day automation settings were not saved."),
     ).toBeInTheDocument();
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "internal duplicate_policy stack",
+      }),
+    );
     expect(screen.queryByText(/duplicate_policy/)).not.toBeInTheDocument();
   });
 
   it("hands off roster and support work to terminal health", async () => {
     render(<POSSettingsView />);
 
-    expect(await screen.findByText("Terminal health")).toBeInTheDocument();
-    expect(screen.getByText("Offline diagnostics need attention")).toBeInTheDocument();
+    expect(screen.getByText("Terminal health")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(
+        screen.getByText("Offline diagnostics need attention"),
+      ).toBeInTheDocument(),
+    );
     expect(
       screen.getByText((_content, element) =>
         Boolean(element?.textContent?.trim() === "1 of 7 reporting"),
@@ -613,7 +653,55 @@ describe("registerAndProvisionPosTerminal", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: "Open terminal health" }),
-    ).toHaveAttribute("href", "/acme/store/downtown/pos/terminals");
+    ).toHaveAttribute(
+      "href",
+      "/acme/store/downtown/pos/terminals?o=%252Facme%252Fstore%252Fdowntown%252Fpos%252Fsettings%253Fo%253D%25252Facme%25252Fstore%25252Fdowntown%25252Fpos",
+    );
+  });
+
+  it("links terminal health to the current terminal and keeps settings as the origin", async () => {
+    mocks.useQuery.mockImplementation((ref) =>
+      ref === "getRecoveryCodeStatus"
+        ? {
+            failedAttemptCount: 0,
+            lastUsedAt: undefined,
+            lockedUntil: undefined,
+            plaintextCode: "mintlamp42",
+            rotatedAt: 1,
+            status: "active",
+          }
+        : ref === "getOpeningAutoStartPolicy"
+          ? {
+              localStartMinutes: 510,
+              mode: "enabled",
+              openingBlockerHandling: "start_with_manager_review",
+              operatingTimezoneOffsetMinutes: 0,
+            }
+          : ref === "getTerminalByFingerprint"
+            ? {
+                _id: "terminal-existing",
+                _creationTime: 1,
+                browserInfo: { userAgent: "test" },
+                displayName: "Front counter",
+                fingerprintHash: "fingerprint-1",
+                registeredAt: 1,
+                registeredByUserId: "user-1",
+                registerNumber: "3",
+                status: "active",
+                storeId: "store-1",
+              }
+            : null,
+    );
+
+    render(<POSSettingsView />);
+
+    expect(screen.getByText("Terminal health")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Open terminal health" }),
+    ).toHaveAttribute(
+      "href",
+      "/acme/store/downtown/pos/terminals/terminal-existing?o=%252Facme%252Fstore%252Fdowntown%252Fpos%252Fsettings%253Fo%253D%25252Facme%25252Fstore%25252Fdowntown%25252Fpos",
+    );
   });
 
   it("shows when the current register is ready for offline checkout", async () => {

--- a/packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx
+++ b/packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx
@@ -2,10 +2,18 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, useParams } from "@tanstack/react-router";
 import { useMutation, useQuery } from "convex/react";
 import type { ComponentType, ReactNode } from "react";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { LoadingButton } from "@/components/ui/loading-button";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { FadeIn } from "../../common/FadeIn";
 import { PageLevelHeader, PageWorkspace } from "../../common/PageLevelHeader";
 import View from "../../View";
@@ -45,6 +53,7 @@ import {
 } from "~/shared/posTerminalLoginMode";
 import { usePosTerminalAppSessionRecoveryRuntimeInput } from "@/lib/pos/infrastructure/terminal/posTerminalAppSessionRecoveryContext";
 import type { PosTerminalRuntimeAppSessionRecoveryInput } from "@/lib/pos/infrastructure/local/terminalRuntimeStatus";
+import { getOrigin } from "@/lib/navigationUtils";
 
 type HealthLinkProps = {
   children: ReactNode;
@@ -52,7 +61,9 @@ type HealthLinkProps = {
   params: {
     orgUrlSlug: string;
     storeUrlSlug: string;
+    terminalId?: string;
   };
+  search?: { o: string };
   to: string;
 };
 
@@ -60,6 +71,13 @@ const HealthLink = Link as unknown as ComponentType<HealthLinkProps>;
 const POS_APP_SHELL_CACHE_PREFIX = "athena-pos-app-shell-";
 const DEFAULT_STORE_DAY_AUTO_START_MINUTES = 8 * 60;
 const DEFAULT_STORE_DAY_TIMEZONE_OFFSET_MINUTES = 0;
+const STORE_DAY_AUTOMATION_HOURS = Array.from({ length: 12 }, (_, index) =>
+  String(index + 1).padStart(2, "0"),
+);
+const STORE_DAY_AUTOMATION_MINUTES = Array.from({ length: 60 }, (_, index) =>
+  String(index).padStart(2, "0"),
+);
+type StoreDayAutomationPeriod = "AM" | "PM";
 const terminalCapabilityOptions: Array<{
   value: PosTerminalTransactionCapability;
   label: string;
@@ -379,6 +397,52 @@ function formatLocalStartTime(minutes?: number | null) {
   return `${String(hours).padStart(2, "0")}:${String(remainder).padStart(2, "0")}`;
 }
 
+function getLocalStartTimeParts(value: string) {
+  const parsedMinutes = parseLocalStartMinutes(value);
+  const safeMinutes = parsedMinutes ?? DEFAULT_STORE_DAY_AUTO_START_MINUTES;
+  const hour24 = Math.floor(safeMinutes / 60);
+  const minute = safeMinutes % 60;
+  const period: StoreDayAutomationPeriod = hour24 >= 12 ? "PM" : "AM";
+  const hour12 = hour24 % 12 || 12;
+
+  return {
+    hour: String(hour12).padStart(2, "0"),
+    minute: String(minute).padStart(2, "0"),
+    period,
+  };
+}
+
+function formatLocalStartTimeFromParts(args: {
+  hour: string;
+  minute: string;
+  period: StoreDayAutomationPeriod;
+}) {
+  const hour12 = Number(args.hour);
+  const minute = Number(args.minute);
+
+  if (
+    !Number.isInteger(hour12) ||
+    hour12 < 1 ||
+    hour12 > 12 ||
+    !Number.isInteger(minute) ||
+    minute < 0 ||
+    minute > 59
+  ) {
+    return formatLocalStartTime(DEFAULT_STORE_DAY_AUTO_START_MINUTES);
+  }
+
+  const hour24 =
+    args.period === "PM"
+      ? hour12 === 12
+        ? 12
+        : hour12 + 12
+      : hour12 === 12
+        ? 0
+        : hour12;
+
+  return `${String(hour24).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+}
+
 function parseLocalStartMinutes(value: string) {
   const match = /^(\d{2}):(\d{2})$/.exec(value);
 
@@ -390,15 +454,6 @@ function parseLocalStartMinutes(value: string) {
   if (hours > 23 || minutes > 59) return null;
 
   return hours * 60 + minutes;
-}
-
-function normalizeTimezoneOffsetMinutes(value?: number | null) {
-  return typeof value === "number" &&
-    Number.isInteger(value) &&
-    value >= -14 * 60 &&
-    value <= 14 * 60
-    ? value
-    : DEFAULT_STORE_DAY_TIMEZONE_OFFSET_MINUTES;
 }
 
 function StoreDayAutomationAdminPanel({
@@ -418,9 +473,6 @@ function StoreDayAutomationAdminPanel({
   const [localStartTime, setLocalStartTime] = useState(
     formatLocalStartTime(DEFAULT_STORE_DAY_AUTO_START_MINUTES),
   );
-  const [timezoneOffsetMinutes, setTimezoneOffsetMinutes] = useState(
-    DEFAULT_STORE_DAY_TIMEZONE_OFFSET_MINUTES,
-  );
   const [isSaving, setIsSaving] = useState(false);
   const [message, setMessage] = useState<{
     kind: "error" | "success";
@@ -428,38 +480,36 @@ function StoreDayAutomationAdminPanel({
   } | null>(null);
   const policyLocalStartMinutes = policy?.localStartMinutes;
   const policyMode = policy?.mode;
-  const policyTimezoneOffsetMinutes = policy?.operatingTimezoneOffsetMinutes;
 
   useEffect(() => {
-    if (
-      policyLocalStartMinutes == null &&
-      policyMode == null &&
-      policyTimezoneOffsetMinutes == null
-    ) {
+    if (policyLocalStartMinutes == null && policyMode == null) {
       return;
     }
 
     setIsEnabled(policyMode === "enabled");
     setLocalStartTime(formatLocalStartTime(policyLocalStartMinutes));
-    setTimezoneOffsetMinutes(
-      normalizeTimezoneOffsetMinutes(policyTimezoneOffsetMinutes),
-    );
-  }, [policyLocalStartMinutes, policyMode, policyTimezoneOffsetMinutes]);
+  }, [policyLocalStartMinutes, policyMode]);
 
   if (isLoading || !hasFullAdminAccess) {
     return null;
   }
 
   const localStartMinutes = parseLocalStartMinutes(localStartTime);
-  const timezoneOffsetIsValid =
-    Number.isInteger(timezoneOffsetMinutes) &&
-    timezoneOffsetMinutes >= -14 * 60 &&
-    timezoneOffsetMinutes <= 14 * 60;
   const canSave =
-    Boolean(storeId) &&
-    localStartMinutes !== null &&
-    timezoneOffsetIsValid &&
-    !isSaving;
+    Boolean(storeId) && localStartMinutes !== null && !isSaving;
+  const localStartTimeParts = getLocalStartTimeParts(localStartTime);
+
+  const updateLocalStartTimePart = (
+    key: keyof typeof localStartTimeParts,
+    value: string,
+  ) => {
+    setLocalStartTime(
+      formatLocalStartTimeFromParts({
+        ...localStartTimeParts,
+        [key]: value,
+      }),
+    );
+  };
 
   const handleSave = async () => {
     const parsedStartMinutes = parseLocalStartMinutes(localStartTime);
@@ -480,14 +530,6 @@ function StoreDayAutomationAdminPanel({
       return;
     }
 
-    if (!timezoneOffsetIsValid) {
-      setMessage({
-        kind: "error",
-        text: "Enter a valid store UTC offset.",
-      });
-      return;
-    }
-
     setIsSaving(true);
     setMessage(null);
     try {
@@ -495,7 +537,7 @@ function StoreDayAutomationAdminPanel({
         localStartMinutes: parsedStartMinutes,
         mode: isEnabled ? "enabled" : "disabled",
         openingBlockerHandling: "start_with_manager_review",
-        operatingTimezoneOffsetMinutes: timezoneOffsetMinutes,
+        operatingTimezoneOffsetMinutes: DEFAULT_STORE_DAY_TIMEZONE_OFFSET_MINUTES,
         storeId,
       });
       setMessage({
@@ -537,14 +579,13 @@ function StoreDayAutomationAdminPanel({
           </span>
         </div>
 
-        <div className="grid gap-layout-md sm:grid-cols-[minmax(0,1fr)_12rem_12rem]">
+        <div className="grid gap-layout-md sm:grid-cols-[minmax(0,1fr)_12rem]">
           <label className="flex min-h-[5rem] items-start gap-layout-sm rounded-md border border-border bg-background p-layout-sm text-sm">
-            <input
+            <Checkbox
               aria-label="Enable store-day auto-start"
               checked={isEnabled}
-              className="mt-1 h-4 w-4 rounded border-border text-signal focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-              onChange={(event) => setIsEnabled(event.target.checked)}
-              type="checkbox"
+              className="mt-1"
+              onCheckedChange={(checked) => setIsEnabled(checked === true)}
             />
             <span>
               <span className="block font-medium text-foreground">
@@ -558,37 +599,73 @@ function StoreDayAutomationAdminPanel({
           </label>
 
           <div className="space-y-layout-xs">
-            <Label htmlFor="store-day-auto-start-time">Local start time</Label>
-            <Input
-              id="store-day-auto-start-time"
-              className="h-control-standard bg-background"
-              onChange={(event) => setLocalStartTime(event.target.value)}
-              type="time"
-              value={localStartTime}
-            />
+            <Label>Local start time</Label>
+            <div className="grid grid-cols-[1fr_1fr_1fr] gap-layout-2xs">
+              <Select
+                onValueChange={(value) =>
+                  updateLocalStartTimePart("hour", value)
+                }
+                value={localStartTimeParts.hour}
+              >
+                <SelectTrigger
+                  aria-label="Store day start hour"
+                  className="bg-background"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {STORE_DAY_AUTOMATION_HOURS.map((hour) => (
+                    <SelectItem key={hour} value={hour}>
+                      {hour}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <Select
+                onValueChange={(value) =>
+                  updateLocalStartTimePart("minute", value)
+                }
+                value={localStartTimeParts.minute}
+              >
+                <SelectTrigger
+                  aria-label="Store day start minute"
+                  className="bg-background"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {STORE_DAY_AUTOMATION_MINUTES.map((minute) => (
+                    <SelectItem key={minute} value={minute}>
+                      {minute}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              <Select
+                onValueChange={(value) =>
+                  updateLocalStartTimePart(
+                    "period",
+                    value as StoreDayAutomationPeriod,
+                  )
+                }
+                value={localStartTimeParts.period}
+              >
+                <SelectTrigger
+                  aria-label="Store day start period"
+                  className="bg-background"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="AM">AM</SelectItem>
+                  <SelectItem value="PM">PM</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
             <p className="text-xs text-muted-foreground">
               Saved as store-local minutes for the scheduled automation check.
-            </p>
-          </div>
-
-          <div className="space-y-layout-xs">
-            <Label htmlFor="store-day-timezone-offset">
-              Store UTC offset
-            </Label>
-            <Input
-              id="store-day-timezone-offset"
-              className="h-control-standard bg-background"
-              max={14 * 60}
-              min={-14 * 60}
-              onChange={(event) =>
-                setTimezoneOffsetMinutes(Number(event.target.value))
-              }
-              step={15}
-              type="number"
-              value={timezoneOffsetMinutes}
-            />
-            <p className="text-xs text-muted-foreground">
-              Minutes from store local time to UTC. Accra is 0.
             </p>
           </div>
         </div>
@@ -1430,8 +1507,16 @@ export function POSSettingsView({
                   params={{
                     orgUrlSlug: routeParams.orgUrlSlug,
                     storeUrlSlug: routeParams.storeUrlSlug,
+                    ...(existingTerminal
+                      ? { terminalId: String(existingTerminal._id) }
+                      : {}),
                   }}
-                  to="/$orgUrlSlug/store/$storeUrlSlug/pos/terminals"
+                  search={{ o: getOrigin() }}
+                  to={
+                    existingTerminal
+                      ? "/$orgUrlSlug/store/$storeUrlSlug/pos/terminals/$terminalId"
+                      : "/$orgUrlSlug/store/$storeUrlSlug/pos/terminals"
+                  }
                 >
                   Open terminal health
                 </HealthLink>

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
@@ -314,18 +314,65 @@ describe("POSTerminalDetailViewContent", () => {
 
     expect(screen.getByText("Remote Assist")).toBeInTheDocument();
     expect(screen.getByText("Ready for support session")).toBeInTheDocument();
+    const startSessionButton = screen.getByRole("button", {
+      name: /start session/i,
+    });
+    expect(startSessionButton).toBeDisabled();
 
-    fireEvent.click(screen.getByRole("button", { name: /start session/i }));
+    fireEvent.change(screen.getByLabelText("Reason"), {
+      target: { value: "Drawer repair support" },
+    });
+    expect(startSessionButton).toBeEnabled();
+    fireEvent.click(startSessionButton);
 
     await waitFor(() => {
       expect(onStartRemoteAssist).toHaveBeenCalledWith({
         clientId: "remote-client-1",
-        reason: "M Supplies terminal recovery",
+        reason: "Drawer repair support",
       });
     });
     expect(mocks.toastSuccess).toHaveBeenCalledWith(
       "Remote Assist session requested.",
     );
+    expect(
+      await screen.findByText("Remote Assist session connecting"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Session requested")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /session requested/i }),
+    ).toBeDisabled();
+  });
+
+  it("restores an in-progress Remote Assist session from server state", () => {
+    render(
+      <POSTerminalDetailViewContent
+        canStartRemoteAssist
+        detail={detail}
+        isLoading={false}
+        remoteAssistClient={{
+          _id: "remote-client-1",
+          accessPolicy: "unattended_allowed",
+          displayName: "Front counter",
+          enrollmentStatus: "active",
+          lastPresenceAt: Date.now(),
+          presenceStatus: "online",
+        }}
+        remoteAssistSession={{
+          _id: "session-1",
+          effectiveMode: "unattended",
+          reason: "Drawer repair support",
+          status: "connecting",
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText("Remote Assist session connecting"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Session requested")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /session requested/i }),
+    ).toBeDisabled();
   });
 
   it("shows approval-required Remote Assist responses", async () => {
@@ -374,6 +421,9 @@ describe("POSTerminalDetailViewContent", () => {
       />,
     );
 
+    fireEvent.change(screen.getByLabelText("Reason"), {
+      target: { value: "Support needs cashier approval" },
+    });
     fireEvent.click(screen.getByRole("button", { name: /start session/i }));
 
     await waitFor(() => {

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
@@ -16,7 +16,10 @@ import { toast } from "sonner";
 
 import View from "@/components/View";
 import { FadeIn } from "@/components/common/FadeIn";
-import { PageLevelHeader, PageWorkspace } from "@/components/common/PageLevelHeader";
+import {
+  PageLevelHeader,
+  PageWorkspace,
+} from "@/components/common/PageLevelHeader";
 import { EmptyState } from "@/components/states/empty/empty-state";
 import { NoPermissionView } from "@/components/states/no-permission/NoPermissionView";
 import { ProtectedAdminSignInView } from "@/components/states/signed-out/ProtectedAdminSignInView";
@@ -64,7 +67,11 @@ const posTerminalApi = api.inventory.posTerminal as unknown as {
 
 type RemoteAssistClientSummary = {
   _id: Id<"remoteAssistClient"> | string;
-  accessPolicy: "attended_required" | "disabled" | "unattended_allowed" | string;
+  accessPolicy:
+    | "attended_required"
+    | "disabled"
+    | "unattended_allowed"
+    | string;
   displayName: string;
   enrollmentStatus: "active" | "disabled" | "revoked" | string;
   lastPresenceAt?: number;
@@ -74,11 +81,7 @@ type RemoteAssistClientSummary = {
 type RemoteAssistStartResult =
   | {
       kind: "ok";
-      data: {
-        _id: Id<"remoteAssistSession"> | string;
-        effectiveMode: "attended" | "unattended" | string;
-        status: string;
-      };
+      data: RemoteAssistSessionSummary;
     }
   | {
       kind: "user_error";
@@ -91,6 +94,14 @@ type RemoteAssistStartResult =
       kind: "approval_required";
       approval: ApprovalRequirement;
     };
+
+type RemoteAssistSessionSummary = {
+  _id: Id<"remoteAssistSession"> | string;
+  effectiveMode: "attended" | "unattended" | string;
+  expiresAt?: number;
+  reason?: string;
+  status: string;
+};
 
 const remoteAssistApi = api.remoteAssist.public;
 
@@ -110,6 +121,7 @@ type POSTerminalDetailViewContentProps = {
   orgUrlSlug?: string;
   queryUnavailable?: boolean;
   remoteAssistClient?: RemoteAssistClientSummary | null;
+  remoteAssistSession?: RemoteAssistSessionSummary | null;
   storeUrlSlug?: string;
 };
 
@@ -155,16 +167,12 @@ function DetailPanel({
   );
 }
 
-function Field({
-  label,
-  value,
-}: {
-  label: string;
-  value: React.ReactNode;
-}) {
+function Field({ label, value }: { label: string; value: React.ReactNode }) {
   return (
     <div>
-      <p className="text-xs font-medium uppercase text-muted-foreground">{label}</p>
+      <p className="text-xs font-medium uppercase text-muted-foreground">
+        {label}
+      </p>
       <div className="mt-1 text-sm text-foreground">{value}</div>
     </div>
   );
@@ -242,7 +250,11 @@ function TerminalContextRail({
           />
           <RailField
             label="Source"
-            value={runtimeStatus ? formatStatusLabel(runtimeStatus.source) : "No check-in"}
+            value={
+              runtimeStatus
+                ? formatStatusLabel(runtimeStatus.source)
+                : "No check-in"
+            }
           />
           <RailField
             label="Browser online"
@@ -374,10 +386,7 @@ function SyncEvidenceSection({
             label="Cursor updated"
             value={formatTerminalTimestamp(syncEvidence.cursorUpdatedAt)}
           />
-          <Field
-            label="Recent sample"
-            value={`${sampledEventCount} sampled`}
-          />
+          <Field label="Recent sample" value={`${sampledEventCount} sampled`} />
         </div>
       </div>
 
@@ -465,7 +474,8 @@ function ConflictSection({
                 {conflict.summary}
               </p>
               <p className="mt-1 text-xs text-muted-foreground">
-                Sequence {conflict.sequence} / {formatStatusLabel(conflict.conflictType)}
+                Sequence {conflict.sequence} /{" "}
+                {formatStatusLabel(conflict.conflictType)}
               </p>
             </div>
           ))
@@ -901,20 +911,32 @@ function RemoteAssistPanel({
   canStartRemoteAssist = false,
   client,
   detail,
+  currentSession,
   onStartRemoteAssist,
 }: {
   canStartRemoteAssist?: boolean;
   client?: RemoteAssistClientSummary | null;
+  currentSession?: RemoteAssistSessionSummary | null;
   detail: TerminalHealthDetail;
   onStartRemoteAssist?: POSTerminalDetailViewContentProps["onStartRemoteAssist"];
 }) {
-  const [reason, setReason] = useState("M Supplies terminal recovery");
+  const [reason, setReason] = useState("");
   const [isStarting, setIsStarting] = useState(false);
+  const [requestedSession, setRequestedSession] =
+    useState<RemoteAssistSessionSummary | null>(null);
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     const timerId = window.setInterval(() => setNow(Date.now()), 15_000);
     return () => window.clearInterval(timerId);
   }, []);
+  useEffect(() => {
+    setRequestedSession(null);
+  }, [client?._id]);
+  useEffect(() => {
+    if (currentSession) {
+      setRequestedSession(currentSession);
+    }
+  }, [currentSession]);
   const presenceFresh = isRemoteAssistPresenceFresh(client, now);
   const available =
     canStartRemoteAssist &&
@@ -922,6 +944,9 @@ function RemoteAssistPanel({
     client?.accessPolicy === "unattended_allowed" &&
     client?.presenceStatus === "online" &&
     presenceFresh;
+  const sessionInProgress =
+    requestedSession &&
+    !["ended", "expired"].includes(requestedSession.status);
   const availabilityCopy = getRemoteAssistAvailabilityCopy(
     client,
     presenceFresh,
@@ -939,6 +964,7 @@ function RemoteAssistPanel({
         reason,
       });
       if (result.kind === "ok") {
+        setRequestedSession(result.data);
         toast.success("Remote Assist session requested.");
       } else if (result.kind === "approval_required") {
         toast.error(
@@ -974,7 +1000,8 @@ function RemoteAssistPanel({
             </p>
             {client?.lastPresenceAt ? (
               <p className="mt-2 text-xs text-muted-foreground">
-                Last Remote Assist presence {formatTerminalTimestamp(client.lastPresenceAt)}.
+                Last Remote Assist presence{" "}
+                {formatTerminalTimestamp(client.lastPresenceAt)}.
               </p>
             ) : null}
           </div>
@@ -996,7 +1023,11 @@ function RemoteAssistPanel({
       <div className="mt-layout-md grid gap-layout-sm md:grid-cols-3">
         <RecoveryMetric
           label="Mode"
-          value={client?.accessPolicy === "attended_required" ? "Attended" : "Unattended"}
+          value={
+            client?.accessPolicy === "attended_required"
+              ? "Attended"
+              : "Unattended"
+          }
         />
         <RecoveryMetric
           label="Runtime"
@@ -1007,6 +1038,31 @@ function RemoteAssistPanel({
           value={formatTerminalTimestamp(detail.runtimeStatus?.receivedAt)}
         />
       </div>
+
+      {requestedSession ? (
+        <div className="mt-layout-md rounded-md border border-blue-200 bg-blue-50 px-layout-md py-layout-md text-blue-950">
+          <div className="flex flex-col gap-layout-sm md:flex-row md:items-start md:justify-between">
+            <div className="min-w-0">
+              <p className="text-xs font-medium uppercase text-blue-700">
+                Session
+              </p>
+              <p className="mt-1 text-sm font-medium">
+                {getRemoteAssistSessionStatusLabel(requestedSession.status)}
+              </p>
+              <p className="mt-1 text-xs text-blue-800">
+                Support request accepted. The terminal runtime still needs to
+                join before live assist controls are available.
+              </p>
+            </div>
+            <Badge
+              className="w-fit rounded-md border-blue-300 bg-blue-100 text-blue-800"
+              variant="outline"
+            >
+              {formatRemoteAssistModeLabel(requestedSession.effectiveMode)}
+            </Badge>
+          </div>
+        </div>
+      ) : null}
 
       <div className="mt-layout-md grid gap-layout-sm">
         <label
@@ -1019,25 +1075,57 @@ function RemoteAssistPanel({
           className="min-h-20 rounded-md border border-border bg-background px-layout-md py-layout-sm text-sm text-foreground outline-none ring-offset-background transition focus-visible:ring-2 focus-visible:ring-ring"
           id="remote-assist-reason"
           onChange={(event) => setReason(event.target.value)}
+          placeholder="Describe the support task for this session."
           value={reason}
         />
         <div className="flex flex-col gap-layout-xs sm:flex-row sm:items-center sm:justify-between">
           <p className="text-xs text-muted-foreground">
-            Remote Assist operates this Athena surface only; POS authority and recovery gates still apply.
+            Remote Assist operates this Athena surface only; POS authority and
+            recovery gates still apply.
           </p>
           <Button
-            disabled={!available || !reason.trim() || isStarting}
+            disabled={
+              !available ||
+              !reason.trim() ||
+              isStarting ||
+              Boolean(sessionInProgress)
+            }
             onClick={handleStartRemoteAssist}
             type="button"
-            variant="default"
+            variant="workflow"
           >
             <MonitorUp aria-hidden="true" className="mr-2 h-4 w-4" />
-            {isStarting ? "Starting" : "Start session"}
+            {isStarting
+              ? "Starting"
+              : sessionInProgress
+                ? "Session requested"
+                : "Start session"}
           </Button>
         </div>
       </div>
     </DetailPanel>
   );
+}
+
+function getRemoteAssistSessionStatusLabel(status: string): string {
+  switch (status) {
+    case "active":
+      return "Remote Assist session active";
+    case "connecting":
+      return "Remote Assist session connecting";
+    case "pending_attended_approval":
+      return "Waiting for local approval";
+    case "ended":
+      return "Remote Assist session ended";
+    case "expired":
+      return "Remote Assist session expired";
+    default:
+      return "Remote Assist session requested";
+  }
+}
+
+function formatRemoteAssistModeLabel(mode: string): string {
+  return mode === "attended" ? "Attended" : "Unattended";
 }
 
 function SupportNotesSection({
@@ -1068,7 +1156,10 @@ function SupportNotesSection({
       ) : (
         <ul className="space-y-layout-xs text-sm text-foreground">
           {notes.map((note) => (
-            <li className="rounded-md border border-border bg-background px-layout-md py-layout-sm" key={note}>
+            <li
+              className="rounded-md border border-border bg-background px-layout-md py-layout-sm"
+              key={note}
+            >
               {note}
             </li>
           ))}
@@ -1086,7 +1177,8 @@ function getRemoteAssistAvailabilityCopy(
   if (!canStartRemoteAssist) {
     return {
       label: "Support permission required",
-      description: "Only full admin support users can start Remote Assist sessions.",
+      description:
+        "Only full admin support users can start Remote Assist sessions.",
     };
   }
   if (!client) {
@@ -1137,7 +1229,7 @@ function isRemoteAssistPresenceFresh(
 ) {
   return Boolean(
     client?.lastPresenceAt &&
-      now - client.lastPresenceAt <= REMOTE_ASSIST_PRESENCE_FRESHNESS_MS,
+    now - client.lastPresenceAt <= REMOTE_ASSIST_PRESENCE_FRESHNESS_MS,
   );
 }
 
@@ -1150,6 +1242,7 @@ export function POSTerminalDetailViewContent({
   orgUrlSlug,
   queryUnavailable = false,
   remoteAssistClient,
+  remoteAssistSession,
   storeUrlSlug,
 }: POSTerminalDetailViewContentProps) {
   if (queryUnavailable) {
@@ -1202,18 +1295,25 @@ export function POSTerminalDetailViewContent({
             <Badge className={classification.toneClassName} variant="outline">
               {classification.label}
             </Badge>
-            <Badge className="border-border bg-surface-raised text-muted-foreground" variant="outline">
+            <Badge
+              className="border-border bg-surface-raised text-muted-foreground"
+              variant="outline"
+            >
               {formatRegisterNumber(detail.terminal.registerNumber)}
             </Badge>
           </div>
 
           <div className="grid gap-layout-xl xl:grid-cols-[20rem_minmax(0,1fr)]">
-            <TerminalContextRail detail={detail} runtimeStatus={runtimeStatus} />
+            <TerminalContextRail
+              detail={detail}
+              runtimeStatus={runtimeStatus}
+            />
 
             <main className="space-y-layout-lg">
               <RemoteAssistPanel
                 canStartRemoteAssist={canStartRemoteAssist}
                 client={remoteAssistClient}
+                currentSession={remoteAssistSession}
                 detail={detail}
                 onStartRemoteAssist={onStartRemoteAssist}
               />
@@ -1258,7 +1358,8 @@ export function POSTerminalDetailView() {
         terminalId?: string;
       }
     | undefined;
-  const isLoadingAccess = isLoadingUser || isLoadingStores || isLoadingPermissions;
+  const isLoadingAccess =
+    isLoadingUser || isLoadingStores || isLoadingPermissions;
   const canViewHealth = canAccessPOS();
   const canQuery = Boolean(
     activeStore?._id && user && canViewHealth && params?.terminalId,
@@ -1282,6 +1383,14 @@ export function POSTerminalDetailView() {
         }
       : "skip",
   ) as RemoteAssistClientSummary | null | undefined;
+  const remoteAssistSession = useQuery(
+    remoteAssistApi.getCurrentSessionByClient,
+    remoteAssistClient?._id
+      ? {
+          clientId: remoteAssistClient._id as Id<"remoteAssistClient">,
+        }
+      : "skip",
+  ) as RemoteAssistSessionSummary | null | undefined;
   const resolveRegisterSessionSyncReview = useMutation(
     api.cashControls.deposits.resolveRegisterSessionSyncReview,
   );
@@ -1356,17 +1465,18 @@ export function POSTerminalDetailView() {
   }
 
   return (
-      <POSTerminalDetailViewContent
-        detail={detail ?? null}
-        canStartRemoteAssist={hasFullAdminAccess}
-        isLoading={detail === undefined}
-        onResolveRegisterSessionReview={onResolveRegisterSessionReview}
-        onStartRemoteAssist={onStartRemoteAssist}
-        orgUrlSlug={params.orgUrlSlug}
-        queryUnavailable={detail === null && !params.terminalId}
-        remoteAssistClient={remoteAssistClient ?? null}
-        storeUrlSlug={params.storeUrlSlug}
-      />
+    <POSTerminalDetailViewContent
+      detail={detail ?? null}
+      canStartRemoteAssist={hasFullAdminAccess}
+      isLoading={detail === undefined}
+      onResolveRegisterSessionReview={onResolveRegisterSessionReview}
+      onStartRemoteAssist={onStartRemoteAssist}
+      orgUrlSlug={params.orgUrlSlug}
+      queryUnavailable={detail === null && !params.terminalId}
+      remoteAssistClient={remoteAssistClient ?? null}
+      remoteAssistSession={remoteAssistSession ?? null}
+      storeUrlSlug={params.storeUrlSlug}
+    />
   );
 }
 

--- a/packages/athena-webapp/src/components/products/ProductsListView.logic.ts
+++ b/packages/athena-webapp/src/components/products/ProductsListView.logic.ts
@@ -1,0 +1,28 @@
+import type { ProductAvailability } from "~/src/hooks/useGetProducts";
+
+const POS_OPERATIONAL_CATEGORY_SLUGS = new Set([
+  "pos-pending-checkout",
+  "pos-quick-add",
+]);
+
+type CategoryProductQueryOptions = {
+  availability?: ProductAvailability;
+  isVisible?: boolean;
+};
+
+export function getCategoryProductQueryOptions(
+  categorySlug: string | undefined,
+): CategoryProductQueryOptions {
+  if (categorySlug === "legacy-import") {
+    return {
+      availability: "draft",
+      isVisible: false,
+    };
+  }
+
+  if (categorySlug && POS_OPERATIONAL_CATEGORY_SLUGS.has(categorySlug)) {
+    return { availability: "live" };
+  }
+
+  return {};
+}

--- a/packages/athena-webapp/src/components/products/ProductsListView.test.ts
+++ b/packages/athena-webapp/src/components/products/ProductsListView.test.ts
@@ -1,18 +1,29 @@
 import { describe, expect, it } from "vitest";
 
-import { getCategoryProductAvailability } from "./ProductsListView";
+import { getCategoryProductQueryOptions } from "./ProductsListView.logic";
 
 describe("ProductsListView category query", () => {
   it("requests live products for the reserved POS quick-add category", () => {
-    expect(getCategoryProductAvailability("pos-quick-add")).toBe("live");
+    expect(getCategoryProductQueryOptions("pos-quick-add")).toEqual({
+      availability: "live",
+    });
   });
 
   it("requests live products for the reserved POS pending-checkout category", () => {
-    expect(getCategoryProductAvailability("pos-pending-checkout")).toBe("live");
+    expect(getCategoryProductQueryOptions("pos-pending-checkout")).toEqual({
+      availability: "live",
+    });
+  });
+
+  it("requests hidden draft products for the legacy import category", () => {
+    expect(getCategoryProductQueryOptions("legacy-import")).toEqual({
+      availability: "draft",
+      isVisible: false,
+    });
   });
 
   it("leaves normal category queries on the default visible live-product path", () => {
-    expect(getCategoryProductAvailability("hair")).toBeUndefined();
-    expect(getCategoryProductAvailability(undefined)).toBeUndefined();
+    expect(getCategoryProductQueryOptions("hair")).toEqual({});
+    expect(getCategoryProductQueryOptions(undefined)).toEqual({});
   });
 });

--- a/packages/athena-webapp/src/components/products/ProductsListView.tsx
+++ b/packages/athena-webapp/src/components/products/ProductsListView.tsx
@@ -4,16 +4,17 @@ import {
   useProductsTableState,
 } from "./ProductsTableContext";
 import { useGetProducts } from "~/src/hooks/useGetProducts";
-import type { ProductAvailability } from "~/src/hooks/useGetProducts";
 import { useState, useMemo } from "react";
+import { useGetCategories } from "~/src/hooks/useGetCategories";
 import View from "../View";
 import { FadeIn } from "../common/FadeIn";
 import StoreProducts from "./StoreProducts";
 import { capitalizeWords, slugToWords } from "~/src/lib/utils";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, Eye, EyeOff } from "lucide-react";
 import { ToggleGroup, ToggleGroupItem } from "../ui/toggle-group";
 import { Button } from "../ui/button";
-import { useAction } from "convex/react";
+import { Switch } from "../ui/switch";
+import { useAction, useMutation } from "convex/react";
 import { api } from "~/convex/_generated/api";
 import { toast } from "sonner";
 import {
@@ -21,19 +22,7 @@ import {
   PageWorkspace,
   PageWorkspaceMain,
 } from "../common/PageLevelHeader";
-
-const POS_OPERATIONAL_CATEGORY_SLUGS = new Set([
-  "pos-pending-checkout",
-  "pos-quick-add",
-]);
-
-export function getCategoryProductAvailability(
-  categorySlug: string | undefined,
-): ProductAvailability | undefined {
-  return categorySlug && POS_OPERATIONAL_CATEGORY_SLUGS.has(categorySlug)
-    ? "live"
-    : undefined;
-}
+import { getCategoryProductQueryOptions } from "./ProductsListView.logic";
 
 const ProductActionsToggleGroup = ({
   outOfStockProductsCount,
@@ -62,19 +51,51 @@ const ProductActionsToggleGroup = ({
 };
 
 const CategoryWorkspaceActions = ({
+  categorySlug,
   outOfStockProductsCount,
   selectedProductActions,
   setSelectedProductActions,
   hasProducts,
 }: {
+  categorySlug: string;
   outOfStockProductsCount: number;
   selectedProductActions: string[];
   setSelectedProductActions: (actions: string[]) => void;
   hasProducts: boolean;
 }) => {
+  const categories = useGetCategories();
+  const updateCategory = useMutation(api.inventory.categories.update);
   const clearAllCache = useAction(api.inventory.productUtil.clearAllCache);
+  const category = categories?.find(({ slug }) => slug === categorySlug);
   const [isClearCacheMutationPending, setIsClearCacheMutationPending] =
     useState(false);
+  const [
+    isStorefrontVisibilityMutationPending,
+    setIsStorefrontVisibilityMutationPending,
+  ] = useState(false);
+
+  const isStorefrontVisible = category?.showOnStorefront !== false;
+
+  const handleStorefrontVisibilityChange = async (checked: boolean) => {
+    if (!category) return;
+
+    setIsStorefrontVisibilityMutationPending(true);
+    try {
+      await updateCategory({
+        id: category._id,
+        name: category.name,
+        slug: category.slug,
+        showOnStorefront: checked,
+      });
+      toast.success(
+        `${category.name} ${checked ? "shown on" : "hidden from"} storefront`,
+      );
+    } catch {
+      toast.error("Failed to update category visibility");
+    } finally {
+      setIsStorefrontVisibilityMutationPending(false);
+    }
+  };
 
   const handleClearCache = async () => {
     setIsClearCacheMutationPending(true);
@@ -89,8 +110,28 @@ const CategoryWorkspaceActions = ({
   };
 
   return (
-    <div className="flex flex-col gap-layout-sm sm:flex-row sm:items-center sm:justify-between">
-      <div className="flex flex-wrap items-center gap-2">
+    <section
+      aria-label="Category controls"
+      className="rounded-md border bg-background px-3 py-2"
+    >
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        {category ? (
+          <div className="flex min-h-9 items-center gap-2 rounded-md border px-3">
+            {isStorefrontVisible ? (
+              <Eye className="h-4 w-4 text-muted-foreground" />
+            ) : (
+              <EyeOff className="h-4 w-4 text-muted-foreground" />
+            )}
+            <span className="text-sm text-muted-foreground">Storefront</span>
+            <Switch
+              aria-label="Show category on storefront"
+              checked={isStorefrontVisible}
+              disabled={isStorefrontVisibilityMutationPending}
+              onCheckedChange={handleStorefrontVisibilityChange}
+            />
+          </div>
+        ) : null}
+
         {outOfStockProductsCount > 0 && (
           <ProductActionsToggleGroup
             outOfStockProductsCount={outOfStockProductsCount}
@@ -98,20 +139,18 @@ const CategoryWorkspaceActions = ({
             setSelectedProductActions={setSelectedProductActions}
           />
         )}
-      </div>
 
-      <div className="flex flex-wrap items-center gap-2">
         {hasProducts && (
           <Button
             variant="ghost"
             onClick={handleClearCache}
             disabled={isClearCacheMutationPending}
           >
-            Clear Cache
+            Clear cache
           </Button>
         )}
       </div>
-    </div>
+    </section>
   );
 };
 
@@ -119,11 +158,14 @@ function Body() {
   const { categorySlug, o } = useSearch({ strict: false });
   const { productsTableState } = useProductsTableState();
   const { subcategorySlug } = productsTableState;
+  const categoryProductQueryOptions = getCategoryProductQueryOptions(
+    categorySlug ?? undefined,
+  );
 
   const products = useGetProducts({
     subcategorySlug: subcategorySlug ?? undefined,
     categorySlug: categorySlug ?? undefined,
-    availability: getCategoryProductAvailability(categorySlug ?? undefined),
+    ...categoryProductQueryOptions,
   });
 
   const [selectedProductActions, setSelectedProductActions] = useState<
@@ -156,10 +198,11 @@ function Body() {
           <PageWorkspaceMain>
             {categorySlug ? (
               <CategoryWorkspaceActions
+                categorySlug={categorySlug}
                 outOfStockProductsCount={outOfStockProducts?.length || 0}
                 selectedProductActions={selectedProductActions}
                 setSelectedProductActions={setSelectedProductActions}
-                hasProducts={filteredProducts.length != 0}
+                hasProducts={products?.length != 0}
               />
             ) : null}
             <StoreProducts products={filteredProducts} />

--- a/packages/athena-webapp/src/components/ui/checkbox.tsx
+++ b/packages/athena-webapp/src/components/ui/checkbox.tsx
@@ -11,7 +11,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-signal ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-signal data-[state=checked]:text-signal-foreground",
+      "peer h-4 w-4 shrink-0 rounded-[5px] border border-signal ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-signal data-[state=checked]:text-signal-foreground",
       className
     )}
     {...props}

--- a/packages/athena-webapp/src/hooks/useGetProducts.ts
+++ b/packages/athena-webapp/src/hooks/useGetProducts.ts
@@ -9,10 +9,12 @@ export const useGetProducts = ({
   subcategorySlug,
   categorySlug,
   availability,
+  isVisible,
 }: {
   subcategorySlug?: string;
   categorySlug?: string;
   availability?: ProductAvailability;
+  isVisible?: boolean;
 } = {}) => {
   const { activeStore } = useGetActiveStore();
 
@@ -24,6 +26,7 @@ export const useGetProducts = ({
           subcategory: subcategorySlug ? [subcategorySlug] : undefined,
           category: categorySlug ? [categorySlug] : undefined,
           availability,
+          isVisible,
           filters: {
             isPriceZero: true,
           },


### PR DESCRIPTION
## Summary
- show reserved operational category products in staff catalog surfaces while keeping storefront visibility explicit
- add storefront/category controls to the product list and include pending checkout/legacy import recovery rows
- align POS settings controls with app primitives and link terminal health back with origin context
- include remote assist public foundation coverage from the moved dirty set

## Validation
- bun run --filter '@athena/webapp' test -- src/components/pos/settings/POSSettingsView.test.tsx src/components/pos/terminals/POSTerminalDetailView.test.tsx src/components/products/ProductsListView.test.ts convex/inventory/products.sku.test.ts convex/http/domains/core/routes/storefrontHidden.test.ts convex/remoteAssist/public.test.ts
- bun run --filter '@athena/webapp' lint:frontend:changed
- bun run --filter '@athena/webapp' lint:convex:changed
- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json
- bun run graphify:rebuild
- git diff --check
- bun run pr:athena

Note: POSSettingsView tests still emit React act warnings from async/Radix updates, but the focused tests and full gate pass.