### PR TITLE
Complete Remote Assist live session flow

### DIFF
--- a/docs/plans/2026-06-12-001-feat-remote-assist-live-session-flow-plan.html
+++ b/docs/plans/2026-06-12-001-feat-remote-assist-live-session-flow-plan.html
@@ -1,0 +1,192 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>feat: Complete Remote Assist Live Session Flow</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #172033;
+      --muted: #647084;
+      --line: #d9dee8;
+      --panel: #ffffff;
+      --soft: #f6f8fb;
+      --accent: #2457a6;
+      --accent-soft: #e7eefb;
+      --warn: #8a5b00;
+      --warn-soft: #fff4d7;
+      --ok: #1d6b4f;
+      --ok-soft: #e5f6ef;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--ink);
+      background: #f3f5f8;
+      line-height: 1.5;
+    }
+    main {
+      width: min(1120px, calc(100vw - 40px));
+      margin: 0 auto;
+      padding: 48px 0 64px;
+    }
+    header {
+      padding-bottom: 24px;
+      border-bottom: 1px solid var(--line);
+      margin-bottom: 28px;
+    }
+    .eyebrow {
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+    }
+    h1, h2, h3 { line-height: 1.16; margin: 0; }
+    h1 { font-size: clamp(34px, 6vw, 58px); letter-spacing: 0; margin-top: 10px; }
+    h2 { font-size: 24px; margin-bottom: 12px; }
+    h3 { font-size: 17px; margin-bottom: 8px; }
+    p { margin: 0 0 12px; }
+    section {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 24px;
+      margin: 18px 0;
+    }
+    ul, ol { margin: 0; padding-left: 22px; }
+    li { margin: 7px 0; }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: .92em;
+      background: var(--soft);
+      border: 1px solid var(--line);
+      border-radius: 5px;
+      padding: 1px 5px;
+    }
+    pre {
+      overflow-x: auto;
+      background: #111827;
+      color: #f8fafc;
+      padding: 16px;
+      border-radius: 8px;
+    }
+    pre code {
+      background: transparent;
+      border: 0;
+      color: inherit;
+      padding: 0;
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 14px;
+    }
+    .tile {
+      background: var(--soft);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 16px;
+    }
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      border-radius: 999px;
+      padding: 3px 8px;
+      font-size: 12px;
+      font-weight: 700;
+      background: var(--accent-soft);
+      color: var(--accent);
+      margin-right: 6px;
+    }
+    .tag.warn { background: var(--warn-soft); color: var(--warn); }
+    .tag.ok { background: var(--ok-soft); color: var(--ok); }
+    .muted { color: var(--muted); }
+    .flow {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 10px;
+      margin-top: 14px;
+    }
+    .flow div {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 12px;
+      background: var(--soft);
+      min-height: 86px;
+    }
+    @media (max-width: 760px) {
+      main { width: min(100vw - 24px, 1120px); padding-top: 28px; }
+      section { padding: 18px; }
+      .flow { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div class="eyebrow">Active Plan · 2026-06-12</div>
+      <h1>Complete Remote Assist Live Session Flow</h1>
+      <p class="muted">Follow-on delivery for the foundation plan. POS terminals are the first adapter; Remote Assist remains a generic browser-client capability.</p>
+      <p><span class="tag">feat</span><span class="tag warn">runtime claim</span><span class="tag ok">provider neutral</span></p>
+    </header>
+
+    <section>
+      <h2>Problem</h2>
+      <p>Terminal Health can start a Remote Assist support request, but the support UI stops at <code>connecting</code>. The runtime still needs to claim the session, support needs reload-safe hydration, and both sides need visible live assist state.</p>
+    </section>
+
+    <section>
+      <h2>Delivery Goals</h2>
+      <div class="grid">
+        <div class="tile"><h3>Hydrate</h3><p>Support reloads show the current backend session instead of resetting local UI.</p></div>
+        <div class="tile"><h3>Claim</h3><p>POS runtime claims only through existing terminal sync-proof status submission.</p></div>
+        <div class="tile"><h3>Surface</h3><p>Terminal Health renders active live assist state and an end-session action.</p></div>
+        <div class="tile"><h3>Runtime</h3><p>The POS browser shows a visible banner and local disconnect control.</p></div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Flow</h2>
+      <div class="flow">
+        <div><strong>1. Support starts</strong><br /><span class="muted">Terminal Health creates a session with reason and policy context.</span></div>
+        <div><strong>2. Runtime checks in</strong><br /><span class="muted">POS status submission validates store, terminal, and sync secret.</span></div>
+        <div><strong>3. Session activates</strong><br /><span class="muted">The Remote Assist domain records runtime claim and support hydration.</span></div>
+        <div><strong>4. Both sides can end</strong><br /><span class="muted">Support end and local disconnect are idempotent and audited.</span></div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Scope Boundaries</h2>
+      <ul>
+        <li>No unattended browser screen capture.</li>
+        <li>No desktop, shell, devtools, storage mutation, raw network replay, or clipboard scraping.</li>
+        <li>No bypass of terminal integrity, drawer authority, staff authority, manager proof, Cash Controls, Operations review, payments, inventory, closeout, or reconciliation.</li>
+        <li>No non-POS adapters in this batch.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Implementation Units</h2>
+      <ol>
+        <li><strong>Remote Assist session hydration</strong>: current-session repository/query support and public support-safe API.</li>
+        <li><strong>POS runtime claim integration</strong>: claim matching unattended sessions from successful terminal runtime status submission.</li>
+        <li><strong>Runtime banner wiring</strong>: active/waiting Remote Assist state reaches the POS runtime UI and local disconnect.</li>
+        <li><strong>Terminal Health live panel</strong>: durable session card, active state, end action, and empty reason placeholder.</li>
+        <li><strong>Live assist contract</strong>: provider-neutral co-browse/control DTOs and guardrail helpers.</li>
+        <li><strong>Audit and artifacts</strong>: lifecycle assertions, solution notes, generated artifacts, graph rebuild.</li>
+      </ol>
+    </section>
+
+    <section>
+      <h2>Validation</h2>
+      <pre><code>bun run --filter '@athena/webapp' test -- convex/remoteAssist/application/sessionService.test.ts convex/remoteAssist/infrastructure/remoteAssistRepository.test.ts convex/remoteAssist/public.test.ts convex/pos/public/terminals.test.ts src/lib/remote-assist/guardrails.test.ts src/components/remote-assist/RemoteAssistRuntimeShell.test.tsx src/components/pos/terminals/POSTerminalDetailView.test.tsx
+bun run graphify:rebuild
+bun run pr:athena</code></pre>
+      <p class="muted">Browser validation is intentionally left to the user for this delivery run.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/plans/2026-06-12-001-feat-remote-assist-live-session-flow-plan.md
+++ b/docs/plans/2026-06-12-001-feat-remote-assist-live-session-flow-plan.md
@@ -1,0 +1,245 @@
+---
+title: "feat: Complete Remote Assist Live Session Flow"
+date: "2026-06-12"
+status: "active"
+type: "feat"
+origin: "docs/plans/2026-06-11-002-feat-remote-assist-foundation-plan.md"
+---
+
+# feat: Complete Remote Assist Live Session Flow
+
+## Summary
+
+Close the gap after a support user clicks **Start session** from POS Terminal Health. The existing foundation can enroll a browser client, create a Remote Assist session, and mark the support request accepted, but the visible flow still stops at `connecting`. This delivery adds the missing runtime claim path, reload-safe session hydration, visible live assist state, runtime-side presence/disconnect controls, and the first provider-neutral co-browse/control contract.
+
+POS terminals remain the first adapter. Remote Assist stays a generic browser-client foundation.
+
+## Goals
+
+- A support reload keeps the accepted/active Remote Assist session visible instead of resetting the screen.
+- A POS terminal runtime claims a pending unattended session only through the existing terminal sync-proof check-in path.
+- The support surface moves from `connecting` to an active live assist state when the runtime joins.
+- The runtime browser shows a visible Remote Assist banner and can disconnect locally.
+- The implementation creates the bounded co-browse/control contract needed for the next richer live controls without adding desktop administration, raw screen capture, or POS authority shortcuts.
+
+## Non-Goals
+
+- No arbitrary desktop, shell, browser devtools, file system, extension API, clipboard scraping, localStorage mutation, IndexedDB mutation, or raw network replay.
+- No unattended `getDisplayMedia` screen capture. Unattended mode uses sanitized in-app events and bounded app-level control intents.
+- No support-side bypass of terminal integrity, drawer authority, staff authority, manager proof, Cash Controls, Operations review, payment authority, inventory authority, closeout authority, or reconciliation ownership.
+- No new Remote Assist dashboard. POS Terminal Health remains the first launch and support surface.
+- No non-POS adapters in this batch.
+
+## Current State
+
+- `convex/remoteAssist/application/sessionService.ts` has the domain services for start, runtime claim, attended approval, and end.
+- `convex/remoteAssist/public.ts` exposes support start/end and client lookup, but no reload-safe current-session query.
+- `convex/pos/public/terminals.ts` already validates POS terminal runtime status with store, terminal, and sync-secret proof, then upserts Remote Assist client presence.
+- `POSTerminalDetailView.tsx` can start a support request, but the UI only shows a transient requested state.
+- `RemoteAssistRuntimeShell.tsx` exists, but it is not connected to hydrated backend session state.
+- `guardrails.ts` has bounded key/pointer validation and sensitive-region primitives, but no transport-facing live assist DTO.
+
+## Requirements
+
+### R1. Reload-Safe Support Hydration
+
+Terminal Health must query the current non-terminal Remote Assist session for the selected client and render it after reload. If a support user starts a session, reloads, or another authorized support user opens the same terminal, the UI must show the actual backend state: `requested`, `connecting`, `active`, `waiting_approval`, `ended`, `expired`, or `failed`.
+
+### R2. Runtime Claim Through Existing POS Proof
+
+For POS terminals, runtime claim must happen only after successful terminal status submission using the existing terminal sync-secret proof path. A support-side mutation must not be able to impersonate runtime claim. Wrong store, wrong terminal, wrong client, expired session, unsupported attended approval, or stale runtime presence must fail closed.
+
+### R3. Visible Support Live Assist Surface
+
+After runtime claim, Terminal Health must replace the dead-end `connecting` state with an active support panel showing runtime joined state, mode, client, freshness, local disconnect availability, and an explicit end-session action. The panel must be useful even before richer co-browse frames arrive.
+
+### R4. Visible Runtime State
+
+The POS browser must show a Remote Assist runtime banner while a session is active or waiting for attended approval. It must state that support is connected/requesting access and expose a local disconnect action. Disconnect must be idempotent and audited.
+
+### R5. Provider-Neutral Live Assist Contract
+
+Add the first typed contract for browser-client live assist transport:
+
+- sanitized co-browse frame metadata,
+- runtime route and viewport state,
+- sensitive-region state,
+- bounded support control intent,
+- control acceptance/rejection result,
+- participant heartbeat/disconnect state.
+
+The contract can be backed by Convex polling/events in this batch, but must not bind domain policy to a specific vendor. LiveKit-style rooms/data packets can be added behind the adapter later.
+
+### R6. Sensitive Data and Control Guardrails
+
+All live assist data must be deny-by-default for inputs and sensitive regions. PINs, staff proof, recovery codes, sync secrets, auth tokens, local payload bodies, payment fields, customer payment payloads, and raw browser storage must never be streamed, logged, or persisted.
+
+Remote control means high-level Athena app intents only: click a safe visible control, focus a safe field, navigate an allowed Athena route, or trigger an approved recovery action through the existing command rails.
+
+### R7. Audit and Lifecycle
+
+Audit events must cover support request, policy allow/deny, runtime claim, support join/hydration, sensitive-mode transitions when available, local disconnect, support end, TTL expiry, and control rejection. Audit metadata must remain non-secret.
+
+### R8. POS Recovery Boundaries
+
+Remote Assist can help support operate the visible Athena app, but terminal recovery still depends on the existing recovery and runtime check-in rails. A command acknowledgement is not enough to mark health repaired; fresh runtime evidence remains required.
+
+## User Flow
+
+```mermaid
+sequenceDiagram
+  participant Support as Support in Terminal Health
+  participant RA as Remote Assist domain
+  participant POS as POS terminal runtime
+  participant UI as Runtime browser UI
+
+  Support->>RA: Start session with reason and client id
+  RA-->>Support: Session requested/connecting
+  Support->>RA: Query current session on render/reload
+  POS->>RA: Submit runtime status with terminal sync proof
+  RA->>RA: Upsert client presence
+  RA->>RA: Claim matching unattended session
+  RA-->>Support: Current session becomes active
+  RA-->>POS: Active session in runtime status response
+  POS->>UI: Show Remote Assist banner
+  Support->>RA: End session
+  POS->>RA: Local disconnect or next status observes ended state
+```
+
+## State Model
+
+```mermaid
+stateDiagram-v2
+  [*] --> requested
+  requested --> waiting_approval: attended mode
+  requested --> connecting: unattended support accepted
+  waiting_approval --> connecting: local approval
+  connecting --> active: runtime sync-proof claim
+  active --> ended: support end or runtime disconnect
+  requested --> expired: ttl
+  connecting --> expired: ttl
+  waiting_approval --> expired: ttl
+  active --> failed: unrecoverable runtime/provider failure
+```
+
+## Implementation Units
+
+### U1. Remote Assist Session Hydration
+
+Add repository and public query support for the current session by client. Reuse existing session indexes and return only support-safe fields.
+
+- Modify: `packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistRepository.ts`
+- Modify: `packages/athena-webapp/convex/remoteAssist/public.ts`
+- Test: `packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistRepository.test.ts`
+- Test: `packages/athena-webapp/convex/remoteAssist/public.test.ts`
+
+Acceptance:
+
+- Current pending/connecting/active sessions hydrate after reload.
+- Expired and ended sessions do not appear as current support work.
+- Unauthorized org/store access still fails.
+
+### U2. POS Runtime Claim Integration
+
+Wire runtime claim into successful POS terminal runtime status submission after Remote Assist client presence upsert. Use the existing sync-secret proof path; do not expose a broad support-callable runtime-claim mutation.
+
+- Modify: `packages/athena-webapp/convex/pos/public/terminals.ts`
+- Test: `packages/athena-webapp/convex/pos/public/terminals.test.ts`
+
+Acceptance:
+
+- A successful runtime status check-in claims the matching unattended session.
+- A failed status submission does not claim or hydrate Remote Assist.
+- Wrong terminal/store/client cannot claim the session.
+- Claim is idempotent when the runtime checks in repeatedly.
+
+### U3. Runtime Session Response and Banner Wiring
+
+Return support-safe Remote Assist runtime state from the terminal status response and connect it to the existing runtime shell. The runtime browser must show active/waiting state and allow local disconnect.
+
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`
+- Modify: `packages/athena-webapp/src/components/remote-assist/RemoteAssistRuntimeShell.tsx`
+- Modify the POS shell/register component where runtime status is already composed.
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`
+- Test: `packages/athena-webapp/src/components/remote-assist/RemoteAssistRuntimeShell.test.tsx`
+
+Acceptance:
+
+- Active Remote Assist renders a visible banner in POS.
+- Local disconnect calls the runtime-safe disconnect path and updates state without requiring support refresh.
+- POS sale/payment/staff authority flows remain unchanged.
+
+### U4. Terminal Health Live Assist Panel
+
+Replace the dead-end requested toast with a durable session card and active live assist panel. The reason field must be empty by default with an operational placeholder, not an incident-specific seed.
+
+- Modify: `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx`
+- Test: `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx`
+
+Acceptance:
+
+- Starting a session shows `connecting` immediately from backend state.
+- Reload preserves the session state.
+- Runtime claim changes the panel to active.
+- Support can end the active session.
+- Operator-facing copy stays calm, clear, and restrained.
+
+### U5. Live Assist Contract and Guardrails
+
+Add typed DTOs and helpers for the first provider-neutral live assist transport boundary. Use existing guardrail helpers for bounded pointer/key validation and sensitive-region masking.
+
+- Modify or add under `packages/athena-webapp/src/lib/remote-assist/`
+- Test: `packages/athena-webapp/src/lib/remote-assist/guardrails.test.ts`
+- Test any new contract helper tests beside the implementation.
+
+Acceptance:
+
+- Control intents are allow-listed and reject unsafe targets.
+- Sensitive regions produce metadata without raw values.
+- The contract is independent of LiveKit, Twilio, Convex transport, or any other provider.
+
+### U6. Audit, Documentation, and Generated Artifacts
+
+Add missing audit assertions, refresh Remote Assist solution notes, rebuild generated artifacts, and run targeted validation.
+
+- Modify: `docs/solutions/architecture/athena-remote-assist-foundation-2026-06-11.md`
+- Run: Convex generation if schema/API changes require it.
+- Run: `bun run graphify:rebuild`
+
+Acceptance:
+
+- Audit event coverage includes runtime claim, support hydration/join, end, local disconnect, and rejected control.
+- Graph and generated artifacts are current.
+
+## Test Plan
+
+Run targeted tests during implementation:
+
+```bash
+bun run --filter '@athena/webapp' test -- convex/remoteAssist/application/sessionService.test.ts convex/remoteAssist/infrastructure/remoteAssistRepository.test.ts convex/remoteAssist/public.test.ts convex/pos/public/terminals.test.ts src/lib/remote-assist/guardrails.test.ts src/components/remote-assist/RemoteAssistRuntimeShell.test.tsx src/components/pos/terminals/POSTerminalDetailView.test.tsx
+```
+
+Run targeted type/lint checks for changed files where the package scripts support it.
+
+After reviewer approval, before delivery:
+
+```bash
+bun run graphify:rebuild
+bun run pr:athena
+```
+
+## Rollout
+
+1. Ship backend hydration and POS runtime-claim behind existing Remote Assist policy and enrollment gates.
+2. Ship support and runtime visible states with no hidden control authority.
+3. Keep rich co-browse/control use limited to the typed contract and safe placeholder states until provider-backed frames are enabled.
+4. Merge through the repository PR flow.
+5. Fast-forward root `main`.
+6. Deploy the local build to production with the Athena webapp local-build deployment path.
+
+## Risks
+
+- Runtime claim without terminal sync proof would create a support impersonation path. This plan avoids that by making POS claim ride successful terminal status submission.
+- Co-browse streams can leak secrets if redaction is not enforced before transport. This plan treats live stream data as deny-by-default.
+- Ending backend state without runtime disconnect can leave stale runtime UI. This plan makes end/disconnect idempotent and visible on both sides.
+- Support reloads can appear as duplicate sessions if current-session lookup is scoped incorrectly. This plan hydrates by client and non-terminal status instead of creating a new session on each render.

--- a/docs/solutions/architecture/athena-remote-assist-foundation-2026-06-11.md
+++ b/docs/solutions/architecture/athena-remote-assist-foundation-2026-06-11.md
@@ -72,6 +72,32 @@ Model Remote Assist around a browser-client session contract:
   and privileged adapter actions. Do not persist provider secrets, screen media,
   raw keystroke logs, PINs, proofs, sync secrets, or raw payload bodies.
 
+## Live Session Closeout
+
+The first Terminal Health implementation proved support request creation, but a
+support request alone is not a live Remote Assist session. The next boundary is
+the handoff between support-started session state and runtime-claimed session
+state.
+
+Keep that handoff split by authority:
+
+- Support can start, hydrate, and end a session through full-admin scoped
+  Remote Assist APIs.
+- POS runtimes claim unattended sessions only after the existing terminal
+  runtime status submission validates store, terminal, and sync-secret proof.
+- Terminal Health hydrates the current non-ended session by Remote Assist
+  client so a browser reload does not create a duplicate request or reset the
+  visible state.
+- The support panel should show `connecting` until the runtime check-in claims
+  the session, then show active state and an explicit end action.
+- The live assist transport contract should expose sanitized co-browse metadata
+  and bounded Athena-surface control intents before any provider-specific
+  adapter is introduced.
+
+Do not add a broad support-callable runtime claim mutation. That collapses the
+support and runtime authority boundary and makes it too easy to mark a browser
+joined without fresh runtime proof.
+
 ## POS Invariants
 
 Remote Assist can help support operate the visible Athena UI and trigger

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1898 files · ~0 words
+- 1900 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6642 nodes · 7406 edges · 1826 communities detected
+- 6651 nodes · 7413 edges · 1828 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1836,6 +1836,8 @@
 - [[_COMMUNITY_Community 1823|Community 1823]]
 - [[_COMMUNITY_Community 1824|Community 1824]]
 - [[_COMMUNITY_Community 1825|Community 1825]]
+- [[_COMMUNITY_Community 1826|Community 1826]]
+- [[_COMMUNITY_Community 1827|Community 1827]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -2248,164 +2250,164 @@ Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
 ### Community 96 - "Community 96"
+Cohesion: 0.18
+Nodes (4): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onStartRemoteAssist()
+
+### Community 97 - "Community 97"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.31
 Nodes (12): collectFilesUnder(), collectProofSnapshot(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof(), hashValidationWiring(), normalizeRepoPath(), readPrAthenaScript(), recordPrePushValidationProof() (+4 more)
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 102 - "Community 102"
+### Community 103 - "Community 103"
 Cohesion: 0.2
 Nodes (4): formatProductLineMeta(), formatServiceLabel(), formatServiceLineMeta(), formatStoredAmount()
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.21
 Nodes (5): formatDeposit(), formatMoney(), handleCancelEdit(), handleSaveEdit(), summarizeService()
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.29
 Nodes (8): isFiniteNumber(), isPointInsideViewport(), isPositiveFiniteNumber(), isRecord(), isValidViewport(), validateKeyEvent(), validatePointerEvent(), validateRemoteAssistControlEvent()
 
-### Community 105 - "Community 105"
+### Community 106 - "Community 106"
 Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
-### Community 106 - "Community 106"
+### Community 107 - "Community 107"
 Cohesion: 0.29
 Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.22
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
+Cohesion: 0.2
+Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
+
+### Community 112 - "Community 112"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 111 - "Community 111"
+### Community 113 - "Community 113"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 112 - "Community 112"
+### Community 114 - "Community 114"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 113 - "Community 113"
+### Community 115 - "Community 115"
 Cohesion: 0.25
 Nodes (5): blocked(), evaluateLocalPosReadiness(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 114 - "Community 114"
+### Community 116 - "Community 116"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
-
-### Community 115 - "Community 115"
-Cohesion: 0.18
-Nodes (0):
-
-### Community 116 - "Community 116"
-Cohesion: 0.24
-Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
 
 ### Community 117 - "Community 117"
 Cohesion: 0.18
 Nodes (0):
 
 ### Community 118 - "Community 118"
+Cohesion: 0.24
+Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
+
+### Community 119 - "Community 119"
+Cohesion: 0.18
+Nodes (0):
+
+### Community 120 - "Community 120"
 Cohesion: 0.2
 Nodes (2): diagnoseAthenaQaLiveSmoke(), stripUrlQuery()
 
-### Community 119 - "Community 119"
+### Community 121 - "Community 121"
 Cohesion: 0.31
 Nodes (6): expenseItemSuccess(), expenseSessionSuccess(), itemSuccess(), operationSuccess(), sessionSuccess(), success()
 
-### Community 120 - "Community 120"
+### Community 122 - "Community 122"
 Cohesion: 0.22
 Nodes (2): isValidEmail(), validateCustomerInfo()
 
-### Community 121 - "Community 121"
+### Community 123 - "Community 123"
 Cohesion: 0.33
 Nodes (8): buildOperationalEvent(), buildTraceMetadata(), isRecord(), matchesExistingEvent(), metadataDedupeKeysMatch(), normalizeOperationalEventTraceFields(), recordOperationalEventWithCtx(), shouldNormalizePosTrace()
 
-### Community 122 - "Community 122"
+### Community 124 - "Community 124"
 Cohesion: 0.38
 Nodes (8): buildTraceEvent(), buildTraceRecord(), displayTraceAmount(), formatTransactionLabel(), recordRegisterSessionTraceBestEffort(), resolveOccurredAt(), resolveStoreCurrency(), safeTraceWrite()
 
-### Community 123 - "Community 123"
+### Community 125 - "Community 125"
 Cohesion: 0.22
 Nodes (2): listProductSkusByProductId(), readAllQueryResults()
 
-### Community 124 - "Community 124"
+### Community 126 - "Community 126"
 Cohesion: 0.31
 Nodes (7): buildVariantSkuMoneyPayload(), createVariantSku(), modifyProduct(), onSubmit(), parseVariantDisplayMoney(), saveProduct(), updateVariantSku()
 
-### Community 125 - "Community 125"
+### Community 127 - "Community 127"
 Cohesion: 0.29
 Nodes (6): handleFileSelect(), handleRevert(), handleUpload(), resetEditState(), uploadImage(), validateFile()
 
-### Community 126 - "Community 126"
+### Community 128 - "Community 128"
 Cohesion: 0.29
 Nodes (6): handleAddService(), handleAttachBarcodeSubmit(), handleCardClick(), handleCardKeyDown(), handleClearSearch(), handleQuickAddSubmit()
 
-### Community 127 - "Community 127"
-Cohesion: 0.22
-Nodes (2): handleStartRemoteAssist(), onStartRemoteAssist()
-
-### Community 128 - "Community 128"
+### Community 129 - "Community 129"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 129 - "Community 129"
+### Community 130 - "Community 130"
 Cohesion: 0.22
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 130 - "Community 130"
+### Community 131 - "Community 131"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 131 - "Community 131"
+### Community 132 - "Community 132"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 132 - "Community 132"
+### Community 133 - "Community 133"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 133 - "Community 133"
+### Community 134 - "Community 134"
 Cohesion: 0.39
 Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.39
 Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
-
-### Community 135 - "Community 135"
-Cohesion: 0.25
-Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
 
 ### Community 136 - "Community 136"
 Cohesion: 0.22
@@ -2600,112 +2602,112 @@ Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
 ### Community 184 - "Community 184"
+Cohesion: 0.33
+Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
+
+### Community 185 - "Community 185"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 188 - "Community 188"
+### Community 189 - "Community 189"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 189 - "Community 189"
+### Community 190 - "Community 190"
 Cohesion: 0.33
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 190 - "Community 190"
+### Community 191 - "Community 191"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 191 - "Community 191"
+### Community 192 - "Community 192"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 193 - "Community 193"
-Cohesion: 0.33
-Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 194 - "Community 194"
 Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 195 - "Community 195"
 Cohesion: 0.33
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 196 - "Community 196"
+Cohesion: 0.33
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+
+### Community 197 - "Community 197"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 197 - "Community 197"
+### Community 198 - "Community 198"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 199 - "Community 199"
+### Community 200 - "Community 200"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 200 - "Community 200"
-Cohesion: 0.33
-Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
 
 ### Community 201 - "Community 201"
-Cohesion: 0.29
-Nodes (0):
+Cohesion: 0.33
+Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
 
 ### Community 202 - "Community 202"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 203 - "Community 203"
-Cohesion: 0.52
-Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 204 - "Community 204"
 Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
+### Community 204 - "Community 204"
+Cohesion: 0.29
+Nodes (0):
+
 ### Community 205 - "Community 205"
+Cohesion: 0.52
+Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+
+### Community 206 - "Community 206"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 206 - "Community 206"
+### Community 207 - "Community 207"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 207 - "Community 207"
+### Community 208 - "Community 208"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 208 - "Community 208"
+### Community 209 - "Community 209"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 209 - "Community 209"
-Cohesion: 0.33
-Nodes (1): ValkeyClient
-
 ### Community 210 - "Community 210"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ValkeyClient
 
 ### Community 211 - "Community 211"
 Cohesion: 0.33
@@ -2724,12 +2726,12 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 215 - "Community 215"
-Cohesion: 0.4
-Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 216 - "Community 216"
 Cohesion: 0.4
-Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
+Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
 ### Community 217 - "Community 217"
 Cohesion: 0.73
@@ -2816,8 +2818,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 238 - "Community 238"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 239 - "Community 239"
 Cohesion: 0.33
@@ -2836,12 +2838,12 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 243 - "Community 243"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
-
-### Community 244 - "Community 244"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 244 - "Community 244"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 245 - "Community 245"
 Cohesion: 0.33
@@ -2852,52 +2854,52 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 247 - "Community 247"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 248 - "Community 248"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 249 - "Community 249"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 248 - "Community 248"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 249 - "Community 249"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
 ### Community 250 - "Community 250"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 251 - "Community 251"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 252 - "Community 252"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 253 - "Community 253"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 254 - "Community 254"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 255 - "Community 255"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 256 - "Community 256"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 256 - "Community 256"
+### Community 257 - "Community 257"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 257 - "Community 257"
+### Community 258 - "Community 258"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 258 - "Community 258"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 259 - "Community 259"
 Cohesion: 0.53
@@ -2940,12 +2942,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 269 - "Community 269"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
-
-### Community 270 - "Community 270"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
+
+### Community 270 - "Community 270"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 271 - "Community 271"
 Cohesion: 0.4
@@ -2956,16 +2958,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 273 - "Community 273"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 274 - "Community 274"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 275 - "Community 275"
+### Community 274 - "Community 274"
 Cohesion: 0.6
 Nodes (3): isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult()
+
+### Community 275 - "Community 275"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 276 - "Community 276"
 Cohesion: 0.4
@@ -2980,12 +2982,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 279 - "Community 279"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 280 - "Community 280"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
+
+### Community 280 - "Community 280"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 281 - "Community 281"
 Cohesion: 0.7
@@ -3156,56 +3158,56 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 323 - "Community 323"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 324 - "Community 324"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 325 - "Community 325"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 326 - "Community 326"
-Cohesion: 0.6
-Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 327 - "Community 327"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 327 - "Community 327"
+Cohesion: 0.6
+Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+
 ### Community 328 - "Community 328"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 329 - "Community 329"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 329 - "Community 329"
+### Community 330 - "Community 330"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 330 - "Community 330"
+### Community 331 - "Community 331"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 331 - "Community 331"
+### Community 332 - "Community 332"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 332 - "Community 332"
+### Community 333 - "Community 333"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 333 - "Community 333"
+### Community 334 - "Community 334"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 334 - "Community 334"
+### Community 335 - "Community 335"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 335 - "Community 335"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 336 - "Community 336"
 Cohesion: 0.5
@@ -3216,12 +3218,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 338 - "Community 338"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
-
-### Community 339 - "Community 339"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 339 - "Community 339"
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 340 - "Community 340"
 Cohesion: 0.5
@@ -3232,72 +3234,72 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 342 - "Community 342"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 343 - "Community 343"
 Cohesion: 0.67
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 343 - "Community 343"
+### Community 344 - "Community 344"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 344 - "Community 344"
+### Community 345 - "Community 345"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 345 - "Community 345"
+### Community 346 - "Community 346"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 346 - "Community 346"
+### Community 347 - "Community 347"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 347 - "Community 347"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 348 - "Community 348"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 349 - "Community 349"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 350 - "Community 350"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 351 - "Community 351"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 351 - "Community 351"
+### Community 352 - "Community 352"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 352 - "Community 352"
+### Community 353 - "Community 353"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 353 - "Community 353"
+### Community 354 - "Community 354"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 354 - "Community 354"
+### Community 355 - "Community 355"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 355 - "Community 355"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 356 - "Community 356"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 357 - "Community 357"
 Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 358 - "Community 358"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 359 - "Community 359"
 Cohesion: 0.5
@@ -3308,52 +3310,52 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 361 - "Community 361"
-Cohesion: 0.67
-Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 362 - "Community 362"
 Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
+Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
 ### Community 363 - "Community 363"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 364 - "Community 364"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 365 - "Community 365"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 366 - "Community 366"
-Cohesion: 0.67
-Nodes (2): compareRemoteAssistSessionForSupportView(), getRemoteAssistSessionStatusPriority()
-
-### Community 367 - "Community 367"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 368 - "Community 368"
+### Community 367 - "Community 367"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 369 - "Community 369"
+### Community 368 - "Community 368"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 370 - "Community 370"
+### Community 369 - "Community 369"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 371 - "Community 371"
+### Community 370 - "Community 370"
 Cohesion: 0.83
 Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
-### Community 372 - "Community 372"
+### Community 371 - "Community 371"
 Cohesion: 0.83
 Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+
+### Community 372 - "Community 372"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 373 - "Community 373"
 Cohesion: 0.5
@@ -3368,20 +3370,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 376 - "Community 376"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 377 - "Community 377"
 Cohesion: 0.67
 Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
-### Community 378 - "Community 378"
+### Community 377 - "Community 377"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
-### Community 379 - "Community 379"
+### Community 378 - "Community 378"
 Cohesion: 0.67
 Nodes (2): getPosRouteScope(), Login()
+
+### Community 379 - "Community 379"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 380 - "Community 380"
 Cohesion: 0.5
@@ -3404,16 +3406,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 385 - "Community 385"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 386 - "Community 386"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), resetReplacementFields()
 
-### Community 387 - "Community 387"
+### Community 386 - "Community 386"
 Cohesion: 0.67
 Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+
+### Community 387 - "Community 387"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 388 - "Community 388"
 Cohesion: 0.5
@@ -3424,12 +3426,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 390 - "Community 390"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 391 - "Community 391"
 Cohesion: 1.0
 Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
+
+### Community 391 - "Community 391"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 392 - "Community 392"
 Cohesion: 0.5
@@ -3444,116 +3446,116 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 395 - "Community 395"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 396 - "Community 396"
 Cohesion: 0.67
 Nodes (2): applyCommandResult(), handleCreateCase()
+
+### Community 396 - "Community 396"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 397 - "Community 397"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 398 - "Community 398"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 399 - "Community 399"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
 
-### Community 400 - "Community 400"
+### Community 399 - "Community 399"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 401 - "Community 401"
+### Community 400 - "Community 400"
 Cohesion: 0.67
 Nodes (2): useGetArchivedProducts(), useGetProducts()
 
-### Community 402 - "Community 402"
+### Community 401 - "Community 401"
 Cohesion: 0.67
 Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
 
-### Community 403 - "Community 403"
+### Community 402 - "Community 402"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 404 - "Community 404"
+### Community 403 - "Community 403"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 405 - "Community 405"
+### Community 404 - "Community 404"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 406 - "Community 406"
+### Community 405 - "Community 405"
 Cohesion: 0.67
 Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
-### Community 407 - "Community 407"
+### Community 406 - "Community 406"
 Cohesion: 0.67
 Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+
+### Community 407 - "Community 407"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 408 - "Community 408"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 409 - "Community 409"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 410 - "Community 410"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 411 - "Community 411"
+### Community 410 - "Community 410"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 412 - "Community 412"
+### Community 411 - "Community 411"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 413 - "Community 413"
+### Community 412 - "Community 412"
 Cohesion: 0.83
 Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 414 - "Community 414"
+### Community 413 - "Community 413"
 Cohesion: 0.83
 Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
-### Community 415 - "Community 415"
+### Community 414 - "Community 414"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 416 - "Community 416"
+### Community 415 - "Community 415"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 417 - "Community 417"
+### Community 416 - "Community 416"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 418 - "Community 418"
+### Community 417 - "Community 417"
 Cohesion: 0.83
 Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
-### Community 419 - "Community 419"
+### Community 418 - "Community 418"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 420 - "Community 420"
+### Community 419 - "Community 419"
 Cohesion: 0.83
 Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
-### Community 421 - "Community 421"
+### Community 420 - "Community 420"
 Cohesion: 0.83
 Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
-### Community 422 - "Community 422"
+### Community 421 - "Community 421"
 Cohesion: 0.83
 Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+
+### Community 422 - "Community 422"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 423 - "Community 423"
 Cohesion: 0.5
@@ -3584,59 +3586,59 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 430 - "Community 430"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 431 - "Community 431"
 Cohesion: 0.67
 Nodes (2): useOptionalStoreContext(), useStoreContext()
 
-### Community 432 - "Community 432"
+### Community 431 - "Community 431"
 Cohesion: 0.67
 Nodes (2): clearFilters(), onMobileFiltersCloseClick()
 
-### Community 433 - "Community 433"
+### Community 432 - "Community 432"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 434 - "Community 434"
+### Community 433 - "Community 433"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 435 - "Community 435"
+### Community 434 - "Community 434"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 436 - "Community 436"
+### Community 435 - "Community 435"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 437 - "Community 437"
+### Community 436 - "Community 436"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 438 - "Community 438"
+### Community 437 - "Community 437"
 Cohesion: 0.67
 Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
-### Community 439 - "Community 439"
+### Community 438 - "Community 438"
 Cohesion: 0.67
 Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
-### Community 440 - "Community 440"
+### Community 439 - "Community 439"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 441 - "Community 441"
+### Community 440 - "Community 440"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
+
+### Community 441 - "Community 441"
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 442 - "Community 442"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 443 - "Community 443"
-Cohesion: 0.5
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 444 - "Community 444"
@@ -3644,12 +3646,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 445 - "Community 445"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 446 - "Community 446"
 Cohesion: 1.0
 Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+
+### Community 446 - "Community 446"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 447 - "Community 447"
 Cohesion: 0.67
@@ -3684,12 +3686,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 455 - "Community 455"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 456 - "Community 456"
 Cohesion: 1.0
 Nodes (2): buildCtx(), createDb()
+
+### Community 456 - "Community 456"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 457 - "Community 457"
 Cohesion: 0.67
@@ -3704,12 +3706,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 460 - "Community 460"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 461 - "Community 461"
 Cohesion: 1.0
 Nodes (2): hashPosTerminalSyncSecret(), toHex()
+
+### Community 461 - "Community 461"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 462 - "Community 462"
 Cohesion: 0.67
@@ -3717,11 +3719,11 @@ Nodes (0):
 
 ### Community 463 - "Community 463"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 464 - "Community 464"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 465 - "Community 465"
 Cohesion: 0.67
@@ -3736,12 +3738,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 468 - "Community 468"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 469 - "Community 469"
 Cohesion: 1.0
 Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+
+### Community 469 - "Community 469"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 470 - "Community 470"
 Cohesion: 0.67
@@ -3760,12 +3762,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 474 - "Community 474"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 475 - "Community 475"
 Cohesion: 1.0
 Nodes (2): expectIndex(), getTableIndexes()
+
+### Community 475 - "Community 475"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 476 - "Community 476"
 Cohesion: 0.67
@@ -3780,40 +3782,40 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 479 - "Community 479"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 480 - "Community 480"
 Cohesion: 1.0
 Nodes (2): listBagItems(), loadBagWithItems()
 
-### Community 481 - "Community 481"
+### Community 480 - "Community 480"
 Cohesion: 1.0
 Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
-### Community 482 - "Community 482"
+### Community 481 - "Community 481"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+
+### Community 482 - "Community 482"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 483 - "Community 483"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 484 - "Community 484"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 485 - "Community 485"
 Cohesion: 1.0
 Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
-### Community 486 - "Community 486"
+### Community 485 - "Community 485"
 Cohesion: 1.0
 Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
-### Community 487 - "Community 487"
+### Community 486 - "Community 486"
 Cohesion: 0.67
 Nodes (1): View()
+
+### Community 487 - "Community 487"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 488 - "Community 488"
 Cohesion: 0.67
@@ -3828,12 +3830,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 491 - "Community 491"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 492 - "Community 492"
 Cohesion: 1.0
 Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+
+### Community 492 - "Community 492"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 493 - "Community 493"
 Cohesion: 0.67
@@ -3844,16 +3846,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 495 - "Community 495"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 496 - "Community 496"
 Cohesion: 1.0
 Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
-### Community 497 - "Community 497"
+### Community 496 - "Community 496"
 Cohesion: 0.67
 Nodes (1): FadeIn()
+
+### Community 497 - "Community 497"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 498 - "Community 498"
 Cohesion: 0.67
@@ -3861,15 +3863,15 @@ Nodes (0):
 
 ### Community 499 - "Community 499"
 Cohesion: 0.67
-Nodes (0):
-
-### Community 500 - "Community 500"
-Cohesion: 0.67
 Nodes (1): VideoPlayer()
 
-### Community 501 - "Community 501"
+### Community 500 - "Community 500"
 Cohesion: 1.0
 Nodes (2): handleRefundOrder(), toast()
+
+### Community 501 - "Community 501"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 502 - "Community 502"
 Cohesion: 0.67
@@ -3945,79 +3947,79 @@ Nodes (0):
 
 ### Community 520 - "Community 520"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): SingleLineError()
 
 ### Community 521 - "Community 521"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (1): ErrorPage()
 
 ### Community 522 - "Community 522"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (1): AppSkeleton()
 
 ### Community 523 - "Community 523"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (1): DashboardSkeleton()
 
 ### Community 524 - "Community 524"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (1): TableSkeleton()
 
 ### Community 525 - "Community 525"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (1): TransactionsSkeleton()
 
 ### Community 526 - "Community 526"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
-
-### Community 527 - "Community 527"
-Cohesion: 0.67
 Nodes (1): NotFound()
 
-### Community 528 - "Community 528"
+### Community 527 - "Community 527"
 Cohesion: 1.0
 Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
-### Community 529 - "Community 529"
+### Community 528 - "Community 528"
 Cohesion: 0.67
 Nodes (1): AppContextMenu()
 
-### Community 530 - "Community 530"
+### Community 529 - "Community 529"
 Cohesion: 0.67
 Nodes (1): Badge()
 
-### Community 531 - "Community 531"
+### Community 530 - "Community 530"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 532 - "Community 532"
+### Community 531 - "Community 531"
 Cohesion: 0.67
 Nodes (1): LoadingButton()
 
-### Community 533 - "Community 533"
+### Community 532 - "Community 532"
 Cohesion: 0.67
 Nodes (1): onChange()
 
-### Community 534 - "Community 534"
+### Community 533 - "Community 533"
 Cohesion: 0.67
 Nodes (1): AlertModal()
 
-### Community 535 - "Community 535"
+### Community 534 - "Community 534"
 Cohesion: 0.67
 Nodes (1): OverlayModal()
 
-### Community 536 - "Community 536"
+### Community 535 - "Community 535"
 Cohesion: 0.67
 Nodes (1): Skeleton()
 
-### Community 537 - "Community 537"
+### Community 536 - "Community 536"
 Cohesion: 0.67
 Nodes (1): Toaster()
 
-### Community 538 - "Community 538"
+### Community 537 - "Community 537"
 Cohesion: 0.67
 Nodes (1): Spinner()
+
+### Community 538 - "Community 538"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 539 - "Community 539"
 Cohesion: 0.67
@@ -4049,11 +4051,11 @@ Nodes (0):
 
 ### Community 546 - "Community 546"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): useAuth()
 
 ### Community 547 - "Community 547"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 548 - "Community 548"
 Cohesion: 0.67
@@ -4064,32 +4066,32 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 550 - "Community 550"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 551 - "Community 551"
 Cohesion: 1.0
 Nodes (2): getApprovalGuidance(), presentCommandToast()
 
-### Community 552 - "Community 552"
+### Community 551 - "Community 551"
 Cohesion: 0.67
 Nodes (1): isInMaintenanceMode()
 
-### Community 553 - "Community 553"
+### Community 552 - "Community 552"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 554 - "Community 554"
+### Community 553 - "Community 553"
 Cohesion: 1.0
 Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
-### Community 555 - "Community 555"
+### Community 554 - "Community 554"
 Cohesion: 0.67
 Nodes (0):
 
-### Community 556 - "Community 556"
+### Community 555 - "Community 555"
 Cohesion: 1.0
 Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+
+### Community 556 - "Community 556"
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 557 - "Community 557"
 Cohesion: 0.67
@@ -9167,6 +9169,14 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1826 - "Community 1826"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1827 - "Community 1827"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -9280,2321 +9290,2325 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 667`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 668`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 669`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 670`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 671`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 672`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
+- **Thin community `Community 673`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 674`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 675`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 676`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 677`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 678`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 679`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 680`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 681`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 682`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 683`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 684`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 685`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 686`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 687`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 688`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 689`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 690`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 691`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 692`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 693`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 694`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 695`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 696`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 697`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 698`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 699`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 700`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 701`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 702`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 703`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 704`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 705`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 706`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 707`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 708`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 709`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 710`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 711`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 712`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 713`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 714`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 715`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 716`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 717`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 718`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 719`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 720`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 721`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 722`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 723`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 724`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 725`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 726`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 727`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 728`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 729`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 730`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 731`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 732`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 733`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 734`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 735`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 736`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
+- **Thin community `Community 737`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 738`** (2 nodes): `PageHeader.tsx`, `PageHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 739`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 740`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 741`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 742`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 743`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 744`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 745`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 746`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 747`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 748`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 749`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 750`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 751`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 752`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 753`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 754`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 755`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 756`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 757`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 758`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 759`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 760`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 761`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 762`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 763`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 764`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 765`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 766`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 767`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 768`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 769`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 770`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 771`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 772`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 773`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 774`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `POSSettingsView.test.tsx`, `waitForFingerprintEffect()`
+- **Thin community `Community 775`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 776`** (2 nodes): `POSSettingsView.test.tsx`, `waitForFingerprintEffect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 777`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 778`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 779`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 780`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 781`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 782`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 783`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 784`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
+- **Thin community `Community 785`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 786`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 787`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 788`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 789`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 790`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 791`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 792`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 793`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 794`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 795`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 796`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 797`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 798`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 799`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 800`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 801`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 802`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 803`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 804`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 805`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 806`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 807`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 808`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 809`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 810`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 811`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 812`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 813`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 814`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 815`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 816`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 817`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 818`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 819`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 820`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 821`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 822`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 823`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 824`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 825`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 826`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 827`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 828`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 829`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 830`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 831`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 832`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 833`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 834`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 835`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 836`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 837`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 838`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 839`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 840`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 841`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 842`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 843`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 844`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 845`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 846`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 847`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 848`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 849`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 850`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 851`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 852`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 853`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 854`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 855`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 856`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 857`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 858`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 859`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 860`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 861`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 862`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 863`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 864`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 865`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 866`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 867`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 868`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 869`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 870`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 871`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 872`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 873`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 874`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 875`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 876`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 877`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 878`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 879`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
+- **Thin community `Community 880`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 881`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 882`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 883`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 884`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 885`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 886`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 887`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 888`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 889`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 890`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 891`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 892`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 893`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 894`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 895`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 896`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 897`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 898`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 899`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 900`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 901`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 902`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 903`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 904`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 905`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 906`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 907`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 908`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 909`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 910`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 911`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 912`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 913`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 914`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 915`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 916`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 917`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 918`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 919`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 920`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 921`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 922`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 923`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 924`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 925`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 926`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 927`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 928`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 929`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 930`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 931`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 932`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 933`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 934`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 935`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 936`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 937`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 938`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 939`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 940`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 941`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 942`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 943`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 944`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 945`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 946`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 947`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 948`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 949`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 950`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 951`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 952`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 953`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 954`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 955`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 956`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 957`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 958`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 959`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 960`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 961`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 962`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 963`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 964`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 965`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 966`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 967`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 968`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 969`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 970`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 971`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 972`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 973`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 974`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 975`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 976`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 977`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 978`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 979`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 980`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 981`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 982`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 983`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 984`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 985`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 986`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 987`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 988`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 989`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 990`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 991`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 992`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 993`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 994`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 995`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 996`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 997`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 998`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 999`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1000`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1001`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1002`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1003`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1004`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1005`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1006`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1007`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1008`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1009`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1010`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1011`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1012`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1013`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1014`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1015`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1016`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1017`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1018`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1019`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1020`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1021`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1022`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1023`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1024`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1025`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1026`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1027`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1028`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1029`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1030`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1031`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1032`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1033`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1034`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1035`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1036`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1037`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1038`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1039`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (1 nodes): `api.js`
+- **Thin community `Community 1040`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1041`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1042`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (1 nodes): `server.js`
+- **Thin community `Community 1043`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (1 nodes): `app.ts`
+- **Thin community `Community 1044`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1045`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1046`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1047`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1048`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (1 nodes): `auth.ts`
+- **Thin community `Community 1049`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1050`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1051`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1052`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (1 nodes): `countries.ts`
+- **Thin community `Community 1053`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (1 nodes): `email.ts`
+- **Thin community `Community 1054`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1055`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (1 nodes): `payment.ts`
+- **Thin community `Community 1056`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1057`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (1 nodes): `crons.ts`
+- **Thin community `Community 1058`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1059`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (1 nodes): `internal.ts`
+- **Thin community `Community 1060`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1061`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1062`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1063`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1064`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1065`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1066`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1067`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1068`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1069`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1070`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1071`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `env.ts`
+- **Thin community `Community 1072`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1073`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `auth.ts`
+- **Thin community `Community 1074`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1075`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `colors.ts`
+- **Thin community `Community 1076`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `index.ts`
+- **Thin community `Community 1077`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1078`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `products.ts`
+- **Thin community `Community 1079`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1080`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `stores.ts`
+- **Thin community `Community 1081`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `bag.ts`
+- **Thin community `Community 1082`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `guest.ts`
+- **Thin community `Community 1083`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `index.ts`
+- **Thin community `Community 1084`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `me.ts`
+- **Thin community `Community 1085`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `offers.ts`
+- **Thin community `Community 1086`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1087`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1088`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1089`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1090`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1091`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1092`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1093`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1094`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1095`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `user.ts`
+- **Thin community `Community 1096`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1097`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `index.ts`
+- **Thin community `Community 1098`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1099`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `http.ts`
+- **Thin community `Community 1100`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1101`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1102`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1103`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `categories.ts`
+- **Thin community `Community 1104`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `colors.ts`
+- **Thin community `Community 1105`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1106`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 1107`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1108`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1109`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1110`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1111`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `pos.ts`
+- **Thin community `Community 1112`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1113`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1114`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1115`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1116`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1117`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1118`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1119`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1120`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1121`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1122`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1123`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1124`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1125`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1126`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1127`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1128`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `types.ts`
+- **Thin community `Community 1129`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1130`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1131`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1132`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1133`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1134`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1135`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `dto.ts`
+- **Thin community `Community 1136`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1137`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1138`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1139`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `types.ts`
+- **Thin community `Community 1140`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1141`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1142`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1143`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `customers.ts`
+- **Thin community `Community 1144`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `register.ts`
+- **Thin community `Community 1145`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `sync.ts`
+- **Thin community `Community 1146`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1147`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1148`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `schema.ts`
+- **Thin community `Community 1149`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `automation.ts`
+- **Thin community `Community 1150`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1151`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `index.ts`
+- **Thin community `Community 1152`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1153`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1154`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1155`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1156`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1157`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `category.ts`
+- **Thin community `Community 1158`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `color.ts`
+- **Thin community `Community 1159`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1160`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1161`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `index.ts`
+- **Thin community `Community 1162`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1163`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1164`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1165`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1166`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `organization.ts`
+- **Thin community `Community 1167`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1168`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `product.ts`
+- **Thin community `Community 1169`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1170`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1171`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `store.ts`
+- **Thin community `Community 1172`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1173`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `index.ts`
+- **Thin community `Community 1174`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1175`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1176`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1177`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1178`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1179`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1180`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1181`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `index.ts`
+- **Thin community `Community 1182`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1183`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1184`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1185`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1186`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1187`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1188`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1189`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1190`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1191`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1192`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1193`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `customer.ts`
+- **Thin community `Community 1194`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1195`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1196`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1197`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1198`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `index.ts`
+- **Thin community `Community 1199`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1200`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1201`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1202`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1203`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1204`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1205`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1206`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1207`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1208`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1209`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1210`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1211`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1212`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1213`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1214`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1215`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1216`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1217`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1218`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `index.ts`
+- **Thin community `Community 1219`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1220`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1221`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `index.ts`
+- **Thin community `Community 1222`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1223`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1224`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1225`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1226`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1227`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1228`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `index.ts`
+- **Thin community `Community 1229`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1230`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1231`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1232`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1233`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1234`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1235`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `bag.ts`
+- **Thin community `Community 1236`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1237`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1238`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1239`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `guest.ts`
+- **Thin community `Community 1240`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `index.ts`
+- **Thin community `Community 1241`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `offer.ts`
+- **Thin community `Community 1242`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1243`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1244`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `review.ts`
+- **Thin community `Community 1245`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1246`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1247`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1248`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1249`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1250`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1251`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1252`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1253`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1254`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `bag.ts`
+- **Thin community `Community 1255`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1256`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `customer.ts`
+- **Thin community `Community 1257`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `guest.ts`
+- **Thin community `Community 1258`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1259`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1260`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1261`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1262`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `payment.ts`
+- **Thin community `Community 1263`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1264`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1265`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1266`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `users.ts`
+- **Thin community `Community 1267`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `payment.ts`
+- **Thin community `Community 1268`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1269`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1270`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1271`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1272`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1273`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `index.ts`
+- **Thin community `Community 1274`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1275`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1276`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1277`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1278`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `auth.ts`
+- **Thin community `Community 1279`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1280`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1281`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1282`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1283`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1284`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1285`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1286`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1287`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1288`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1289`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1290`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1291`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1292`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1293`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1294`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1295`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `constants.ts`
+- **Thin community `Community 1296`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1297`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1298`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1299`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `types.ts`
+- **Thin community `Community 1300`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1301`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1302`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1303`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1304`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1305`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1306`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1307`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1308`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1309`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1310`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1311`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1312`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1313`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1314`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1315`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1316`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1317`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1318`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1319`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1320`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `constants.ts`
+- **Thin community `Community 1321`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1322`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1323`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1324`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `data.ts`
+- **Thin community `Community 1325`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1326`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1327`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1328`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1329`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1330`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1331`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1332`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1333`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1334`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `constants.ts`
+- **Thin community `Community 1335`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1336`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1337`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1338`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `data.ts`
+- **Thin community `Community 1339`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1340`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1341`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1342`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1343`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1344`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1345`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1346`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1347`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1348`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1349`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1350`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1351`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `constants.ts`
+- **Thin community `Community 1352`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1353`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1354`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1355`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1356`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1357`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1358`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1359`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1360`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1361`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1362`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1363`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1364`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1365`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1366`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1367`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1368`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1369`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1370`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1371`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1372`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1373`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1374`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1375`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1376`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1377`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1378`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1379`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1380`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1381`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1382`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1383`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `constants.ts`
+- **Thin community `Community 1384`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1385`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1386`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1387`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `data.ts`
+- **Thin community `Community 1388`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1389`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1390`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `constants.ts`
+- **Thin community `Community 1391`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1392`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1393`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1394`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1395`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `data.ts`
+- **Thin community `Community 1396`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1397`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `constants.ts`
+- **Thin community `Community 1398`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1399`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1400`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1401`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1402`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `data.ts`
+- **Thin community `Community 1403`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1404`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1405`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1406`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1407`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1408`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1409`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1410`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1411`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1412`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1413`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1414`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1415`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1416`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1417`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1418`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1419`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1420`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1421`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1422`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1423`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1424`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1425`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1426`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1427`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1428`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1429`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `POSTerminalHealthView.test.tsx`
+- **Thin community `Community 1430`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1431`** (1 nodes): `POSTerminalHealthView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1432`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1433`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `types.ts`
+- **Thin community `Community 1434`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1435`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1436`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1437`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1438`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1439`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1440`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1441`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1442`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1443`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1444`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1445`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1446`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1447`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1448`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1449`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1450`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1451`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `data.ts`
+- **Thin community `Community 1452`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1453`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1454`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1455`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1456`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1457`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1458`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1459`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1460`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1461`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1462`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1463`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1464`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `constants.ts`
+- **Thin community `Community 1465`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1466`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1467`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1468`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `data.ts`
+- **Thin community `Community 1469`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `types.ts`
+- **Thin community `Community 1470`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1471`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 1472`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `index.ts`
+- **Thin community `Community 1473`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1474`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1475`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1476`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1477`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `index.tsx`
+- **Thin community `Community 1478`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1479`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1480`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1481`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1482`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1483`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1484`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1485`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1486`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `index.tsx`
+- **Thin community `Community 1487`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1488`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1489`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1490`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `button.tsx`
+- **Thin community `Community 1491`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1492`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `card.tsx`
+- **Thin community `Community 1493`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1494`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1495`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `command.tsx`
+- **Thin community `Community 1496`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1497`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1498`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1499`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `form.tsx`
+- **Thin community `Community 1500`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1501`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1502`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `input.tsx`
+- **Thin community `Community 1503`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1504`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1505`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1506`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1507`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1508`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1509`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `select.tsx`
+- **Thin community `Community 1510`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1511`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1512`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1513`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `table.tsx`
+- **Thin community `Community 1514`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1515`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1516`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1517`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1518`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1519`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1520`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1521`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1522`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `constants.ts`
+- **Thin community `Community 1523`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1524`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1525`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1526`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `data.ts`
+- **Thin community `Community 1527`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1528`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1529`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1530`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1531`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1532`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1533`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1534`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1535`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1536`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1537`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1538`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `index.ts`
+- **Thin community `Community 1539`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1540`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1541`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1542`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1543`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1544`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1545`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1546`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1547`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1548`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1549`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1550`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `aws.ts`
+- **Thin community `Community 1551`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `constants.ts`
+- **Thin community `Community 1552`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `countries.ts`
+- **Thin community `Community 1553`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1554`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1555`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1556`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1557`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1558`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1559`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1560`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `dto.ts`
+- **Thin community `Community 1561`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `ports.ts`
+- **Thin community `Community 1562`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `constants.ts`
+- **Thin community `Community 1563`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1564`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1565`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `index.ts`
+- **Thin community `Community 1566`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1567`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `types.ts`
+- **Thin community `Community 1568`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1569`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1570`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1571`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1572`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1573`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1574`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1575`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1576`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 1577`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1578`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1579`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1580`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 1581`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `index.ts`
+- **Thin community `Community 1582`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `category.ts`
+- **Thin community `Community 1583`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `product.ts`
+- **Thin community `Community 1584`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `store.ts`
+- **Thin community `Community 1585`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1586`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `user.ts`
+- **Thin community `Community 1587`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1588`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1589`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1590`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1591`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1592`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1593`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1594`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1595`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1596`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1597`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `index.tsx`
+- **Thin community `Community 1598`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `index.tsx`
+- **Thin community `Community 1599`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1600`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1601`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1602`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1603`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1604`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1605`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `index.tsx`
+- **Thin community `Community 1606`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1607`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1608`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1609`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `home.tsx`
+- **Thin community `Community 1610`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1611`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1612`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1613`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `index.tsx`
+- **Thin community `Community 1614`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `review.tsx`
+- **Thin community `Community 1615`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1616`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1617`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `index.tsx`
+- **Thin community `Community 1618`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1619`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1620`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1621`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `index.tsx`
+- **Thin community `Community 1622`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1623`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1624`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1625`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1626`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1627`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1628`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `index.tsx`
+- **Thin community `Community 1629`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1630`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1631`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1632`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1633`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1634`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1635`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1636`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1637`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1638`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `index.tsx`
+- **Thin community `Community 1639`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1640`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1641`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `new.tsx`
+- **Thin community `Community 1642`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1643`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1644`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1645`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1646`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `index.tsx`
+- **Thin community `Community 1647`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `new.tsx`
+- **Thin community `Community 1648`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1649`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1650`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1651`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1652`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1653`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `index.tsx`
+- **Thin community `Community 1654`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1655`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1656`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1657`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `index.tsx`
+- **Thin community `Community 1658`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1659`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1660`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1661`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1662`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1663`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1664`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1665`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1666`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1667`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1668`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1669`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1670`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1671`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1672`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1673`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1674`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1675`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1676`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1677`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1678`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1679`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1680`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1681`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1682`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `setup.ts`
+- **Thin community `Community 1683`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1684`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `types.ts`
+- **Thin community `Community 1685`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1686`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1687`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1688`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1689`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1690`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `types.ts`
+- **Thin community `Community 1691`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1692`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1693`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1694`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1695`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1696`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1697`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1698`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1699`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1700`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `schema.ts`
+- **Thin community `Community 1701`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1702`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1703`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1704`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1705`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1706`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1707`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1708`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1709`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1710`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `types.ts`
+- **Thin community `Community 1711`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1712`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1713`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1714`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1715`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1716`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1717`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1718`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `constants.ts`
+- **Thin community `Community 1719`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1720`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `About.tsx`
+- **Thin community `Community 1721`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1722`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1723`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1724`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1725`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1726`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1727`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1728`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1729`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1730`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1731`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `types.ts`
+- **Thin community `Community 1732`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1733`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1734`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1735`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1736`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1737`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1738`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1739`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1740`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1741`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1742`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1743`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `button.tsx`
+- **Thin community `Community 1744`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `card.tsx`
+- **Thin community `Community 1745`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1746`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `command.tsx`
+- **Thin community `Community 1747`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1748`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1749`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1750`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `form.tsx`
+- **Thin community `Community 1751`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1752`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1753`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1754`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1755`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `input.tsx`
+- **Thin community `Community 1756`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `label.tsx`
+- **Thin community `Community 1757`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1758`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1759`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1760`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `index.ts`
+- **Thin community `Community 1761`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `types.ts`
+- **Thin community `Community 1762`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1763`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1764`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1765`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1766`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `select.tsx`
+- **Thin community `Community 1767`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1768`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1769`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `table.tsx`
+- **Thin community `Community 1770`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1771`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1772`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1773`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1774`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1775`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `config.ts`
+- **Thin community `Community 1776`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1777`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1778`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1779`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1780`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `constants.ts`
+- **Thin community `Community 1781`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `countries.ts`
+- **Thin community `Community 1782`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1783`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1784`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1785`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1786`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `index.ts`
+- **Thin community `Community 1787`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `store.ts`
+- **Thin community `Community 1788`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `bag.ts`
+- **Thin community `Community 1789`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1790`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `category.ts`
+- **Thin community `Community 1791`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `organization.ts`
+- **Thin community `Community 1792`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `product.ts`
+- **Thin community `Community 1793`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `store.ts`
+- **Thin community `Community 1794`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1795`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `user.ts`
+- **Thin community `Community 1796`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `states.ts`
+- **Thin community `Community 1797`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1798`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1799`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1800`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1801`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1802`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1803`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1804`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `index.tsx`
+- **Thin community `Community 1805`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1806`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1807`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1808`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1809`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1810`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1811`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1812`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `index.tsx`
+- **Thin community `Community 1813`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1814`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1815`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1816`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1817`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1818`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `index.js`
+- **Thin community `Community 1819`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1820`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1821`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1822`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1823`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1824`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1825`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1826`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1827`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1898
-- Graph nodes: 6642
-- Graph edges: 7406
-- Communities: 1826
+- Code files discovered: 1900
+- Graph nodes: 6651
+- Graph edges: 7413
+- Communities: 1828
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (87 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)

--- a/packages/athena-webapp/convex/pos/public/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.test.ts
@@ -17,6 +17,11 @@ const mocks = vi.hoisted(() => ({
   requireOrganizationMemberRoleWithCtx: vi.fn(),
   resolveTerminalCloudRepairCommand: vi.fn(),
   createRemoteAssistRepository: vi.fn(),
+  remoteAssistGetClientByRuntime: vi.fn(),
+  remoteAssistGetCurrentSessionForClient: vi.fn(),
+  remoteAssistGetSession: vi.fn(),
+  remoteAssistInsertEvent: vi.fn(),
+  remoteAssistPatchSession: vi.fn(),
   remoteAssistUpsertClient: vi.fn(),
   submitTerminalRuntimeStatusCommand: vi.fn(),
   updateTerminalCommand: vi.fn(),
@@ -73,12 +78,14 @@ import {
   deleteTerminal,
   getTerminalByFingerprint,
   getTerminalHealthSummary,
+  getRuntimeRemoteAssistSession,
   issueTerminalRecoveryCommand,
   listTerminalRecoveryCommands,
   listTerminalHealthSummaries,
   listTerminals,
   claimTerminalRecoveryCommand,
   acknowledgeTerminalRecoveryCommand,
+  disconnectRemoteAssistSession,
   registerTerminal,
   resolveTerminalCloudRepair,
   submitTerminalRuntimeStatus,
@@ -90,6 +97,51 @@ const SYNC_SECRET_HASH =
 
 function getHandler(definition: unknown) {
   return (definition as { _handler: Function })._handler;
+}
+
+function buildRemoteAssistClient(overrides: Record<string, unknown> = {}) {
+  return {
+    _creationTime: 1,
+    _id: "remote-client-1",
+    accessPolicy: "unattended_allowed",
+    capabilities: {
+      attendedScreenShare: true,
+      boundedControl: true,
+      sensitiveMasking: true,
+      unattendedCoBrowsing: true,
+    },
+    createdAt: 1,
+    displayName: "Front register",
+    enrollmentStatus: "active",
+    lastPresenceAt: 200,
+    organizationId: "org-1",
+    presenceStatus: "online",
+    runtimeIdentity: "terminal-1",
+    runtimeType: "pos_terminal",
+    storeId: "store-1",
+    updatedAt: 200,
+    ...overrides,
+  };
+}
+
+function buildRemoteAssistSession(overrides: Record<string, unknown> = {}) {
+  return {
+    _creationTime: 1,
+    _id: "remote-session-1",
+    clientId: "remote-client-1",
+    effectiveMode: "unattended",
+    expiresAt: 10_000,
+    organizationId: "org-1",
+    reason: "Drawer repair support",
+    requestedAt: 100,
+    requestedByUserId: "athena-user-1",
+    requestedMode: "unattended",
+    sensitiveModeActive: false,
+    status: "connecting",
+    storeId: "store-1",
+    transportProvider: "livekit",
+    ...overrides,
+  };
 }
 
 describe("POS terminal public mutations", () => {
@@ -135,8 +187,19 @@ describe("POS terminal public mutations", () => {
       repository: true,
     });
     mocks.createRemoteAssistRepository.mockReturnValue({
+      getClientByRuntime: mocks.remoteAssistGetClientByRuntime,
+      getCurrentSessionForClient: mocks.remoteAssistGetCurrentSessionForClient,
+      getSession: mocks.remoteAssistGetSession,
+      insertEvent: mocks.remoteAssistInsertEvent,
+      patchSession: mocks.remoteAssistPatchSession,
       upsertClient: mocks.remoteAssistUpsertClient,
     });
+    mocks.remoteAssistUpsertClient.mockResolvedValue(buildRemoteAssistClient());
+    mocks.remoteAssistGetClientByRuntime.mockResolvedValue(
+      buildRemoteAssistClient(),
+    );
+    mocks.remoteAssistGetCurrentSessionForClient.mockResolvedValue(null);
+    mocks.remoteAssistGetSession.mockResolvedValue(null);
     mocks.issueTerminalRecoveryCommandService.mockResolvedValue({
       kind: "ok",
       data: buildRecoveryCommand(),
@@ -543,6 +606,144 @@ describe("POS terminal public mutations", () => {
     );
   });
 
+  it("claims a connecting Remote Assist session after a successful runtime check-in", async () => {
+    const session = buildRemoteAssistSession({ status: "connecting" });
+    mocks.remoteAssistGetCurrentSessionForClient.mockResolvedValue(session);
+    mocks.remoteAssistGetSession.mockResolvedValue(session);
+    const ctx = buildCtx({
+      terminal: {
+        _id: "terminal-1",
+        storeId: "store-1",
+        status: "active",
+        registeredByUserId: "athena-user-2",
+        syncSecretHash: SYNC_SECRET_HASH,
+        displayName: "Front register",
+      },
+    });
+
+    await getHandler(submitTerminalRuntimeStatus)(ctx as never, {
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      syncSecretHash: "sync-secret-1",
+      status: buildRuntimeStatus(),
+    });
+
+    expect(mocks.remoteAssistGetCurrentSessionForClient).toHaveBeenCalledWith({
+      clientId: "remote-client-1",
+      now: 200,
+    });
+    expect(mocks.remoteAssistPatchSession).toHaveBeenCalledWith(
+      "remote-session-1",
+      {
+        startedAt: 200,
+        status: "active",
+      },
+    );
+    expect(mocks.remoteAssistInsertEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: "remote-client-1",
+        eventType: "runtime_claimed",
+        occurredAt: 200,
+        participantRole: "runtime",
+        sessionId: "remote-session-1",
+      }),
+    );
+  });
+
+  it("hydrates a runtime Remote Assist session with terminal proof", async () => {
+    mocks.remoteAssistGetCurrentSessionForClient.mockResolvedValue(
+      buildRemoteAssistSession({ status: "active" }),
+    );
+    const ctx = buildCtx({
+      terminal: {
+        _id: "terminal-1",
+        storeId: "store-1",
+        status: "active",
+        registeredByUserId: "athena-user-2",
+        syncSecretHash: SYNC_SECRET_HASH,
+      },
+    });
+
+    const result = await getHandler(getRuntimeRemoteAssistSession)(ctx as never, {
+      storeId: "store-1",
+      syncSecretHash: "sync-secret-1",
+      terminalId: "terminal-1",
+    });
+
+    expect(result).toEqual({
+      _id: "remote-session-1",
+      effectiveMode: "unattended",
+      sensitiveModeActive: false,
+      status: "active",
+    });
+    expect(mocks.remoteAssistGetCurrentSessionForClient).toHaveBeenCalledWith({
+      clientId: "remote-client-1",
+      now: expect.any(Number),
+    });
+  });
+
+  it("does not hydrate runtime Remote Assist without terminal proof", async () => {
+    const ctx = buildCtx({
+      terminal: {
+        _id: "terminal-1",
+        storeId: "store-1",
+        status: "active",
+        registeredByUserId: "athena-user-2",
+        syncSecretHash: SYNC_SECRET_HASH,
+      },
+    });
+
+    const result = await getHandler(getRuntimeRemoteAssistSession)(ctx as never, {
+      storeId: "store-1",
+      syncSecretHash: "wrong-secret",
+      terminalId: "terminal-1",
+    });
+
+    expect(result).toBeNull();
+    expect(mocks.remoteAssistGetCurrentSessionForClient).not.toHaveBeenCalled();
+  });
+
+  it("disconnects Remote Assist with runtime audit attribution", async () => {
+    const session = buildRemoteAssistSession({
+      expiresAt: Date.now() + 60_000,
+      status: "active",
+    });
+    mocks.remoteAssistGetSession.mockResolvedValue(session);
+    const ctx = buildCtx({
+      terminal: {
+        _id: "terminal-1",
+        storeId: "store-1",
+        status: "active",
+        registeredByUserId: "athena-user-2",
+        syncSecretHash: SYNC_SECRET_HASH,
+      },
+    });
+
+    const result = await getHandler(disconnectRemoteAssistSession)(ctx as never, {
+      storeId: "store-1",
+      syncSecretHash: "sync-secret-1",
+      terminalId: "terminal-1",
+      sessionId: "remote-session-1",
+    });
+
+    expect(result).toBeNull();
+    expect(mocks.remoteAssistPatchSession).toHaveBeenCalledWith(
+      "remote-session-1",
+      {
+        endedAt: expect.any(Number),
+        status: "ended",
+        terminationReason: "Terminal disconnected Remote Assist.",
+      },
+    );
+    expect(mocks.remoteAssistInsertEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "runtime_disconnected",
+        participantRole: "runtime",
+        summary: "Terminal disconnected Remote Assist.",
+      }),
+    );
+  });
+
   it("does not enroll Remote Assist presence after failed runtime status submission", async () => {
     mocks.submitTerminalRuntimeStatusCommand.mockResolvedValue({
       kind: "user_error",
@@ -569,6 +770,7 @@ describe("POS terminal public mutations", () => {
     });
 
     expect(mocks.remoteAssistUpsertClient).not.toHaveBeenCalled();
+    expect(mocks.remoteAssistGetCurrentSessionForClient).not.toHaveBeenCalled();
   });
 
   it("skips Remote Assist enrollment when the store is missing", async () => {
@@ -597,6 +799,7 @@ describe("POS terminal public mutations", () => {
     });
 
     expect(mocks.remoteAssistUpsertClient).not.toHaveBeenCalled();
+    expect(mocks.remoteAssistGetCurrentSessionForClient).not.toHaveBeenCalled();
   });
 
   it("accepts only safe app-session recovery status in runtime check-ins", async () => {

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -33,6 +33,10 @@ import {
 } from "../application/terminalRecovery/terminalCommandService";
 import { createTerminalRecoveryCommandRepository } from "../infrastructure/repositories/terminalRecoveryRepository";
 import { buildPosRemoteAssistClientPresence } from "../../remoteAssist/application/posRuntimeAdapter";
+import {
+  claimRemoteAssistSession,
+  disconnectRemoteAssistRuntimeSession,
+} from "../../remoteAssist/application/sessionService";
 import { createRemoteAssistRepository } from "../../remoteAssist/infrastructure/remoteAssistRepository";
 import {
   posTerminalRecoveryCommandPayloadValidator,
@@ -133,6 +137,20 @@ const runtimeStatusWriteResultValidator = v.object({
   terminalId: v.id("posTerminal"),
   reportedAt: v.number(),
   receivedAt: v.number(),
+});
+
+const terminalRemoteAssistSessionReturnValidator = v.object({
+  _id: v.id("remoteAssistSession"),
+  effectiveMode: v.union(v.literal("attended"), v.literal("unattended")),
+  sensitiveModeActive: v.boolean(),
+  status: v.union(
+    v.literal("pending_attended_approval"),
+    v.literal("connecting"),
+    v.literal("active"),
+    v.literal("ended"),
+    v.literal("expired"),
+    v.literal("denied"),
+  ),
 });
 
 const runtimeStatusSnapshotReturnValidator = v.object({
@@ -640,7 +658,8 @@ export const submitTerminalRuntimeStatus = mutation({
     if (result.kind === "ok") {
       const store = await ctx.db.get("store", args.storeId);
       if (store) {
-        await createRemoteAssistRepository(ctx).upsertClient(
+        const remoteAssistRepository = createRemoteAssistRepository(ctx);
+        const remoteAssistClient = await remoteAssistRepository.upsertClient(
           buildPosRemoteAssistClientPresence({
             receivedAt: result.data.receivedAt,
             runtimeStatus: safeStatus,
@@ -648,6 +667,18 @@ export const submitTerminalRuntimeStatus = mutation({
             terminal,
           }),
         );
+        const currentRemoteAssistSession =
+          await remoteAssistRepository.getCurrentSessionForClient({
+            clientId: remoteAssistClient._id,
+            now: result.data.receivedAt,
+          });
+        if (currentRemoteAssistSession?.status === "connecting") {
+          await claimRemoteAssistSession(remoteAssistRepository, {
+            clientId: remoteAssistClient._id,
+            now: result.data.receivedAt,
+            sessionId: currentRemoteAssistSession._id,
+          });
+        }
       }
       await verifyTerminalRecoveryCommandsFromRuntime(
         createTerminalRecoveryCommandRepository(ctx),
@@ -671,6 +702,91 @@ export const submitTerminalRuntimeStatus = mutation({
 });
 
 export const reportTerminalRuntimeStatus = submitTerminalRuntimeStatus;
+
+export const getRuntimeRemoteAssistSession = query({
+  args: {
+    storeId: v.id("store"),
+    syncSecretHash: v.string(),
+    terminalId: v.id("posTerminal"),
+  },
+  returns: v.union(terminalRemoteAssistSessionReturnValidator, v.null()),
+  handler: async (ctx, args) => {
+    const terminal = await requireActiveTerminalSyncSecret(ctx, {
+      storeId: args.storeId,
+      syncSecretHash: args.syncSecretHash,
+      terminalId: args.terminalId,
+    });
+    if (!terminal) {
+      return null;
+    }
+    const store = await ctx.db.get("store", args.storeId);
+    if (!store) {
+      return null;
+    }
+    const remoteAssistRepository = createRemoteAssistRepository(ctx);
+    const client = await remoteAssistRepository.getClientByRuntime({
+      organizationId: store.organizationId,
+      runtimeIdentity: args.terminalId,
+      runtimeType: "pos_terminal",
+    });
+    if (!client) {
+      return null;
+    }
+    const session = await remoteAssistRepository.getCurrentSessionForClient({
+      clientId: client._id,
+      now: Date.now(),
+    });
+    return session
+      ? {
+          _id: session._id as Id<"remoteAssistSession">,
+          effectiveMode: session.effectiveMode,
+          sensitiveModeActive: session.sensitiveModeActive,
+          status: session.status,
+        }
+      : null;
+  },
+});
+
+export const disconnectRemoteAssistSession = mutation({
+  args: {
+    sessionId: v.id("remoteAssistSession"),
+    storeId: v.id("store"),
+    syncSecretHash: v.string(),
+    terminalId: v.id("posTerminal"),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const terminal = await requireActiveTerminalSyncSecret(ctx, {
+      storeId: args.storeId,
+      syncSecretHash: args.syncSecretHash,
+      terminalId: args.terminalId,
+    });
+    if (!terminal) {
+      return null;
+    }
+    const store = await ctx.db.get("store", args.storeId);
+    if (!store) {
+      return null;
+    }
+    const remoteAssistRepository = createRemoteAssistRepository(ctx);
+    const client = await remoteAssistRepository.getClientByRuntime({
+      organizationId: store.organizationId,
+      runtimeIdentity: args.terminalId,
+      runtimeType: "pos_terminal",
+    });
+    const session = await remoteAssistRepository.getSession(args.sessionId);
+    if (!client || !session || session.clientId !== client._id) {
+      return null;
+    }
+
+    await disconnectRemoteAssistRuntimeSession(remoteAssistRepository, {
+      clientId: client._id,
+      now: Date.now(),
+      sessionId: args.sessionId,
+    });
+    return null;
+  },
+});
 
 export const registerTerminal = mutation({
   args: {

--- a/packages/athena-webapp/convex/remoteAssist/application/sessionService.test.ts
+++ b/packages/athena-webapp/convex/remoteAssist/application/sessionService.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   approveAttendedRemoteAssistSession,
   claimRemoteAssistSession,
+  disconnectRemoteAssistRuntimeSession,
   endRemoteAssistSession,
   startRemoteAssistSession,
   type RemoteAssistRepository,
@@ -53,7 +54,7 @@ describe("remote assist session service", () => {
     );
   });
 
-  it("reuses an active session for the same requester and client", async () => {
+  it("reuses an active session for the client", async () => {
     const repository = buildRepository({
       sessions: [
         buildSession({
@@ -74,6 +75,41 @@ describe("remote assist session service", () => {
       clientId: "client-1",
       now,
       reason: "M Supplies terminal recovery",
+      requestedMode: "unattended",
+    });
+
+    expect(result).toMatchObject({
+      data: {
+        _id: "session-existing",
+      },
+      kind: "ok",
+    });
+    expect(repository.insertSession).not.toHaveBeenCalled();
+    expect(repository.insertEvent).not.toHaveBeenCalled();
+  });
+
+  it("reuses an active client session requested by another support user", async () => {
+    const repository = buildRepository({
+      sessions: [
+        buildSession({
+          _id: "session-existing",
+          requestedByUserId: "user-1",
+          status: "active",
+        }),
+      ],
+    });
+
+    const result = await startRemoteAssistSession(repository, {
+      actor: {
+        organizationId: "org-1",
+        remoteAssistAllowed: true,
+        role: "support",
+        storeIds: ["store-1"],
+        userId: "user-2",
+      },
+      clientId: "client-1",
+      now,
+      reason: "Drawer repair support",
       requestedMode: "unattended",
     });
 
@@ -162,6 +198,59 @@ describe("remote assist session service", () => {
       },
       kind: "ok",
     });
+  });
+
+  it("records runtime-attributed disconnect events", async () => {
+    const repository = buildRepository({
+      session: buildSession({
+        status: "active",
+      }),
+    });
+
+    const result = await disconnectRemoteAssistRuntimeSession(repository, {
+      clientId: "client-1",
+      now,
+      sessionId: "session-1",
+    });
+
+    expect(result).toMatchObject({
+      data: {
+        status: "ended",
+        terminationReason: "Terminal disconnected Remote Assist.",
+      },
+      kind: "ok",
+    });
+    expect(repository.insertEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "runtime_disconnected",
+        participantRole: "runtime",
+        summary: "Terminal disconnected Remote Assist.",
+      }),
+    );
+  });
+
+  it("does not let another runtime disconnect a Remote Assist session", async () => {
+    const repository = buildRepository({
+      session: buildSession({
+        clientId: "client-1",
+        status: "active",
+      }),
+    });
+
+    const result = await disconnectRemoteAssistRuntimeSession(repository, {
+      clientId: "client-2",
+      now,
+      sessionId: "session-1",
+    });
+
+    expect(result).toMatchObject({
+      error: {
+        code: "authorization_failed",
+      },
+      kind: "user_error",
+    });
+    expect(repository.patchSession).not.toHaveBeenCalled();
+    expect(repository.insertEvent).not.toHaveBeenCalled();
   });
 
   it("requires local approval before an attended session can be claimed", async () => {
@@ -424,10 +513,12 @@ function buildRepository(overrides: {
     : buildSession();
   return {
     getClient: vi.fn(async () => overrides.client ?? buildClient()),
+    getCurrentSessionForClient: vi.fn(async () => overrides.sessions?.[0] ?? session),
     getSession: vi.fn(async () => session),
     insertEvent: vi.fn(async () => {}),
     insertSession: vi.fn(async (input) => {
       const insertedSession = {
+        _creationTime: 1,
         _id: "session-1",
         ...input,
       };
@@ -472,7 +563,6 @@ function buildClient(overrides: Partial<RemoteAssistClient> = {}): RemoteAssistC
 
 function buildSession(overrides: Partial<RemoteAssistSession> = {}): RemoteAssistSession {
   return {
-    _id: "session-1",
     clientId: "client-1",
     effectiveMode: "unattended",
     expiresAt: now + 1_000,
@@ -487,5 +577,7 @@ function buildSession(overrides: Partial<RemoteAssistSession> = {}): RemoteAssis
     transportProvider: "livekit",
     transportRoomId: "room-1",
     ...overrides,
+    _creationTime: overrides._creationTime ?? 1,
+    _id: overrides._id ?? "session-1",
   };
 }

--- a/packages/athena-webapp/convex/remoteAssist/application/sessionService.ts
+++ b/packages/athena-webapp/convex/remoteAssist/application/sessionService.ts
@@ -19,9 +19,13 @@ import {
 
 export type RemoteAssistRepository = {
   getClient(clientId: string): Promise<RemoteAssistClient | null>;
+  getCurrentSessionForClient(args: {
+    clientId: string;
+    now: number;
+  }): Promise<RemoteAssistSession | null>;
   getSession(sessionId: string): Promise<RemoteAssistSession | null>;
   insertSession(
-    input: Omit<RemoteAssistSession, "_id">,
+    input: Omit<RemoteAssistSession, "_id" | "_creationTime">,
   ): Promise<RemoteAssistSession>;
   insertEvent(input: RemoteAssistSessionEvent): Promise<void>;
   listReusableSessionsForClient(args: {
@@ -84,7 +88,6 @@ export async function startRemoteAssistSession(
   const reusableSession = await findReusableRemoteAssistSession(repository, {
     clientId: client._id,
     now: args.now,
-    requestedByUserId: args.actor.userId,
   });
   if (reusableSession) {
     return ok(reusableSession);
@@ -106,7 +109,7 @@ export async function startRemoteAssistSession(
     sensitiveModeActive: false,
     requestedAt: args.now,
     expiresAt: args.now + REMOTE_ASSIST_SESSION_TTL_MS,
-  } satisfies Omit<RemoteAssistSession, "_id">;
+  } satisfies Omit<RemoteAssistSession, "_id" | "_creationTime">;
   const session = await repository.insertSession(sessionInput);
 
   await repository.insertEvent({
@@ -315,12 +318,57 @@ export async function endRemoteAssistSession(
   return ok({ ...session, ...patch });
 }
 
+export async function disconnectRemoteAssistRuntimeSession(
+  repository: RemoteAssistRepository,
+  args: {
+    clientId: string;
+    now: number;
+    sessionId: string;
+  },
+): Promise<CommandResult<RemoteAssistSession>> {
+  const session = await repository.getSession(args.sessionId);
+  if (!session) {
+    return userError({
+      code: "not_found",
+      message: "Remote Assist session was not found.",
+    });
+  }
+  if (session.clientId !== args.clientId) {
+    return userError({
+      code: "authorization_failed",
+      message: "This runtime cannot disconnect the Remote Assist session.",
+    });
+  }
+  if (session.status === "ended" || session.status === "expired") {
+    return ok(session);
+  }
+  const expired = session.expiresAt <= args.now;
+  const patch = {
+    status: expired ? ("expired" as const) : ("ended" as const),
+    endedAt: args.now,
+    terminationReason: expired
+      ? "Remote Assist session expired."
+      : "Terminal disconnected Remote Assist.",
+  };
+  await repository.patchSession(session._id, patch);
+  await repository.insertEvent({
+    organizationId: session.organizationId,
+    storeId: session.storeId,
+    clientId: session.clientId,
+    sessionId: session._id,
+    participantRole: "runtime",
+    eventType: expired ? "session_expired" : "runtime_disconnected",
+    occurredAt: args.now,
+    summary: patch.terminationReason,
+  });
+  return ok({ ...session, ...patch });
+}
+
 async function findReusableRemoteAssistSession(
   repository: RemoteAssistRepository,
   args: {
     clientId: string;
     now: number;
-    requestedByUserId: string;
   },
 ) {
   const sessions = await repository.listReusableSessionsForClient({
@@ -329,7 +377,6 @@ async function findReusableRemoteAssistSession(
   });
   return (
     sessions
-      .filter((session) => session.requestedByUserId === args.requestedByUserId)
       .filter((session) => session.expiresAt > args.now)
       .find((session) =>
         ["active", "connecting", "pending_attended_approval"].includes(

--- a/packages/athena-webapp/convex/remoteAssist/application/types.ts
+++ b/packages/athena-webapp/convex/remoteAssist/application/types.ts
@@ -88,6 +88,7 @@ export type RemoteAssistClient = {
 
 export type RemoteAssistSession = {
   _id: string;
+  _creationTime: number;
   organizationId: string;
   storeId?: string;
   clientId: string;

--- a/packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistRepository.ts
+++ b/packages/athena-webapp/convex/remoteAssist/infrastructure/remoteAssistRepository.ts
@@ -20,6 +20,10 @@ export function createRemoteAssistRepository(
     clientId: string;
     now: number;
   }): Promise<RemoteAssistSession[]>;
+  getCurrentSessionForClient(args: {
+    clientId: string;
+    now: number;
+  }): Promise<RemoteAssistSession | null>;
   upsertClient(
     input: Omit<Doc<"remoteAssistClient">, "_id" | "_creationTime">,
   ): Promise<Doc<"remoteAssistClient">>;
@@ -49,6 +53,12 @@ export function createRemoteAssistRepository(
         );
       }
       return matches[0] ?? null;
+    },
+    async getCurrentSessionForClient(args) {
+      const sessions = await this.listReusableSessionsForClient(args);
+      return (
+        sessions.sort(compareRemoteAssistSessionForSupportView)[0] ?? null
+      );
     },
     async getSession(sessionId) {
       return toRemoteAssistSession(
@@ -163,6 +173,26 @@ export function createRemoteAssistRepository(
       return client;
     },
   };
+}
+
+function compareRemoteAssistSessionForSupportView(
+  left: RemoteAssistSession,
+  right: RemoteAssistSession,
+) {
+  const statusPriority: Record<RemoteAssistSession["status"], number> = {
+    active: 0,
+    connecting: 1,
+    pending_attended_approval: 2,
+    denied: 3,
+    ended: 4,
+    expired: 5,
+  };
+  const leftPriority = statusPriority[left.status] ?? 99;
+  const rightPriority = statusPriority[right.status] ?? 99;
+  if (leftPriority !== rightPriority) {
+    return leftPriority - rightPriority;
+  }
+  return right.requestedAt - left.requestedAt;
 }
 
 function toRemoteAssistClient(

--- a/packages/athena-webapp/convex/remoteAssist/public.test.ts
+++ b/packages/athena-webapp/convex/remoteAssist/public.test.ts
@@ -5,8 +5,8 @@ const mocks = vi.hoisted(() => ({
   endRemoteAssistSession: vi.fn(),
   getClient: vi.fn(),
   getClientByRuntime: vi.fn(),
+  getCurrentSessionForClient: vi.fn(),
   getSession: vi.fn(),
-  listReusableSessionsForClient: vi.fn(),
   requireAuthenticatedAthenaUserWithCtx: vi.fn(),
   requireOrganizationMemberRoleWithCtx: vi.fn(),
   startRemoteAssistSession: vi.fn(),
@@ -43,25 +43,16 @@ describe("remote assist public API", () => {
     mocks.requireOrganizationMemberRoleWithCtx.mockResolvedValue(undefined);
     mocks.getClientByRuntime.mockResolvedValue(buildClient());
     mocks.getClient.mockResolvedValue(buildClient());
+    mocks.getCurrentSessionForClient.mockResolvedValue(
+      buildSession({ status: "active" }),
+    );
     mocks.getSession.mockResolvedValue(buildSession());
     mocks.createRemoteAssistRepository.mockReturnValue({
       getClient: mocks.getClient,
       getClientByRuntime: mocks.getClientByRuntime,
+      getCurrentSessionForClient: mocks.getCurrentSessionForClient,
       getSession: mocks.getSession,
-      listReusableSessionsForClient: mocks.listReusableSessionsForClient,
     });
-    mocks.listReusableSessionsForClient.mockResolvedValue([
-      buildSession({
-        _id: "connecting-session",
-        requestedAt: 20,
-        status: "connecting",
-      }),
-      buildSession({
-        _id: "active-session",
-        requestedAt: 10,
-        status: "active",
-      }),
-    ]);
     mocks.startRemoteAssistSession.mockResolvedValue({
       kind: "ok",
       data: buildSession({ status: "connecting" }),
@@ -192,32 +183,7 @@ describe("remote assist public API", () => {
     );
   });
 
-  it("returns the current reusable session for a support client view", async () => {
-    const ctx = {};
-
-    const result = await getHandler(remoteAssistPublic.getCurrentSessionByClient)(
-      ctx,
-      {
-        clientId: "client-1",
-      },
-    );
-
-    expect(result?._id).toBe("active-session");
-    expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(
-      ctx,
-      expect.objectContaining({
-        allowedRoles: ["full_admin"],
-        organizationId: "org-1",
-        userId: "athena-user-1",
-      }),
-    );
-    expect(mocks.listReusableSessionsForClient).toHaveBeenCalledWith({
-      clientId: "client-1",
-      now: expect.any(Number),
-    });
-  });
-
-  it("returns null before authorizing a missing current-session client", async () => {
+  it("returns null before authorizing current session hydration for a missing client", async () => {
     mocks.getClient.mockResolvedValue(null);
 
     const result = await getHandler(remoteAssistPublic.getCurrentSessionByClient)(
@@ -229,7 +195,32 @@ describe("remote assist public API", () => {
 
     expect(result).toBeNull();
     expect(mocks.requireOrganizationMemberRoleWithCtx).not.toHaveBeenCalled();
-    expect(mocks.listReusableSessionsForClient).not.toHaveBeenCalled();
+    expect(mocks.getCurrentSessionForClient).not.toHaveBeenCalled();
+  });
+
+  it("requires full admin membership before hydrating the current support session", async () => {
+    const ctx = {};
+
+    const result = await getHandler(remoteAssistPublic.getCurrentSessionByClient)(
+      ctx,
+      {
+        clientId: "client-1",
+      },
+    );
+
+    expect(result).toEqual(buildSession({ status: "active" }));
+    expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({
+        allowedRoles: ["full_admin"],
+        organizationId: "org-1",
+        userId: "athena-user-1",
+      }),
+    );
+    expect(mocks.getCurrentSessionForClient).toHaveBeenCalledWith({
+      clientId: "client-1",
+      now: expect.any(Number),
+    });
   });
 
   it("returns not_found before authorizing a missing session end", async () => {

--- a/packages/athena-webapp/convex/remoteAssist/public.ts
+++ b/packages/athena-webapp/convex/remoteAssist/public.ts
@@ -109,21 +109,18 @@ export const getCurrentSessionByClient = query({
     if (!client) {
       return null;
     }
-
     await requireOrganizationMemberRoleWithCtx(ctx, {
       allowedRoles: ["full_admin"],
-      failureMessage: "You do not have access to view Remote Assist sessions.",
+      failureMessage: "You do not have access to view this Remote Assist session.",
       organizationId: client.organizationId as Id<"organization">,
       userId: athenaUser._id,
     });
 
-    const sessions = await repository.listReusableSessionsForClient({
+    const session = await repository.getCurrentSessionForClient({
       clientId: args.clientId,
       now: Date.now(),
     });
-    return toRemoteAssistSessionReturn(
-      sessions.sort(compareRemoteAssistSessionForSupportView)[0] ?? null,
-    );
+    return session ? toRemoteAssistSessionReturn(session) : null;
   },
 });
 
@@ -176,50 +173,6 @@ export const startSession = mutation({
   },
 });
 
-function compareRemoteAssistSessionForSupportView(
-  a: {
-    requestedAt: number;
-    status: string;
-  },
-  b: {
-    requestedAt: number;
-    status: string;
-  },
-) {
-  return (
-    getRemoteAssistSessionStatusPriority(b.status) -
-      getRemoteAssistSessionStatusPriority(a.status) ||
-    b.requestedAt - a.requestedAt
-  );
-}
-
-function getRemoteAssistSessionStatusPriority(status: string) {
-  switch (status) {
-    case "active":
-      return 3;
-    case "connecting":
-      return 2;
-    case "pending_attended_approval":
-      return 1;
-    default:
-      return 0;
-  }
-}
-
-function toRemoteAssistSessionReturn(session: RemoteAssistSession | null) {
-  return session
-    ? {
-        ...session,
-        _creationTime: session.requestedAt,
-        _id: session._id as Id<"remoteAssistSession">,
-        clientId: session.clientId as Id<"remoteAssistClient">,
-        organizationId: session.organizationId as Id<"organization">,
-        requestedByUserId: session.requestedByUserId as Id<"athenaUser">,
-        storeId: session.storeId as Id<"store"> | undefined,
-      }
-    : null;
-}
-
 export const endSupportSession = mutation({
   args: {
     reason: v.string(),
@@ -253,3 +206,14 @@ export const endSupportSession = mutation({
     });
   },
 });
+
+function toRemoteAssistSessionReturn(session: RemoteAssistSession) {
+  return {
+    ...session,
+    _id: session._id as Id<"remoteAssistSession">,
+    clientId: session.clientId as Id<"remoteAssistClient">,
+    organizationId: session.organizationId as Id<"organization">,
+    requestedByUserId: session.requestedByUserId as Id<"athenaUser">,
+    storeId: session.storeId as Id<"store"> | undefined,
+  };
+}

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -13,7 +13,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.
 - [`src/hooks`](../../src/hooks) — React hooks that fan out auth, shell, and feature state. Currently 43 file(s); key children: use-image-upload.ts, use-mobile.tsx, use-navigate-back.ts, use-navigation-keyboard-shortcuts.ts, use-pagination-persistence.ts.
 - [`src/contexts`](../../src/contexts) — Context providers for app-wide state and wiring. Currently 8 file(s); key children: AppShellFullscreenContext.tsx, ManagerElevationContext.test.tsx, ManagerElevationContext.tsx, OnlineOrderContext.tsx, PermissionsContext.tsx.
-- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 136 file(s); key children: access, aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts.
+- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 138 file(s); key children: access, aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts.
 - [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 16 file(s); key children: approvalPolicy.ts, auth.ts, commandResult.test.ts, commandResult.ts, currencyFormatter.test.ts.
 - [`src/utils`](../../src/utils) — Cross-cutting browser helpers and lower-level utilities. Currently 4 file(s); key children: formatNumber.ts, index.ts, versionChecker.test.ts, versionChecker.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -316,6 +316,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/lib/pos/presentation/register/useRegisterViewModel.test.ts`](../../src/lib/pos/presentation/register/useRegisterViewModel.test.ts)
 - [`src/lib/pos/presentation/syncStatusPresentation.test.ts`](../../src/lib/pos/presentation/syncStatusPresentation.test.ts)
 - [`src/lib/productUtils.test.ts`](../../src/lib/productUtils.test.ts)
+- [`src/lib/remote-assist/contract.test.ts`](../../src/lib/remote-assist/contract.test.ts)
 - [`src/lib/remote-assist/guardrails.test.ts`](../../src/lib/remote-assist/guardrails.test.ts)
 - [`src/lib/remote-assist/runtime.test.ts`](../../src/lib/remote-assist/runtime.test.ts)
 - [`src/lib/security/localPinVerifier.test.ts`](../../src/lib/security/localPinVerifier.test.ts)

--- a/packages/athena-webapp/src/components/pos/PointOfSaleView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/PointOfSaleView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import PointOfSaleView from "./PointOfSaleView";
@@ -10,6 +10,7 @@ const useLocalPosEntryContextMock = vi.fn();
 const usePermissionsMock = vi.fn();
 const usePrewarmRegisterCatalogOfflineSnapshotsMock = vi.fn();
 const usePosLocalSyncRuntimeStatusMock = vi.fn();
+const useMutationMock = vi.fn();
 const useQueryMock = vi.fn();
 
 vi.mock("@tanstack/react-router", () => ({
@@ -37,6 +38,7 @@ vi.mock("@tanstack/react-router", () => ({
 }));
 
 vi.mock("convex/react", () => ({
+  useMutation: () => useMutationMock,
   useQuery: (...args: unknown[]) => useQueryMock(...args),
 }));
 
@@ -109,6 +111,7 @@ describe("PointOfSaleView", () => {
     });
     useGetActiveOrganizationMock.mockReturnValue({
       activeOrganization: {
+        _id: "org-1",
         slug: "acme",
       },
     });
@@ -129,6 +132,7 @@ describe("PointOfSaleView", () => {
       totalSales: 12_500,
       totalTransactions: 2,
     });
+    useMutationMock.mockResolvedValue(null);
     usePosLocalSyncRuntimeStatusMock.mockReturnValue(null);
   });
 
@@ -314,6 +318,53 @@ describe("PointOfSaleView", () => {
         terminalId: "terminal-cloud-1",
       }),
     );
+  });
+
+  it("shows a Remote Assist runtime banner and disconnects with terminal proof", () => {
+    useLocalPosEntryContextMock.mockReturnValue({
+      status: "ready",
+      orgUrlSlug: "acme",
+      storeUrlSlug: "downtown",
+      storeId: "store-1",
+      terminalSeed: {
+        terminalId: "local-terminal-1",
+        cloudTerminalId: "terminal-cloud-1",
+        syncSecretHash: "secret-hash",
+        storeId: "store-1",
+        displayName: "Front register",
+        provisionedAt: 1_700,
+        schemaVersion: 2,
+      },
+      source: "live",
+    });
+    useQueryMock
+      .mockReturnValueOnce({
+        _id: "remote-session-1",
+        effectiveMode: "unattended",
+        sensitiveModeActive: false,
+        status: "active",
+      })
+      .mockReturnValue({
+        totalItemsSold: 3,
+        totalSales: 12_500,
+        totalTransactions: 2,
+      });
+
+    render(<PointOfSaleView />);
+
+    expect(screen.getByLabelText("Remote assist runtime")).toBeInTheDocument();
+    expect(screen.getByText("Control on")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /disconnect remote assist/i }),
+    );
+
+    expect(useMutationMock).toHaveBeenCalledWith({
+      sessionId: "remote-session-1",
+      storeId: "store-1",
+      syncSecretHash: "secret-hash",
+      terminalId: "terminal-cloud-1",
+    });
   });
 
   it("shows setup guidance instead of blanking when local POS authority is missing", () => {

--- a/packages/athena-webapp/src/components/pos/PointOfSaleView.tsx
+++ b/packages/athena-webapp/src/components/pos/PointOfSaleView.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "convex/react";
+import { useMutation, useQuery } from "convex/react";
 import type { ComponentType, ReactNode } from "react";
 import View from "../View";
 import useGetActiveStore from "@/hooks/useGetActiveStore";
@@ -34,6 +34,8 @@ import { usePosLocalSyncRuntimeStatus } from "@/lib/pos/infrastructure/local/use
 import { usePrewarmRegisterCatalogOfflineSnapshots } from "@/lib/pos/infrastructure/convex/catalogGateway";
 import type { Id } from "~/convex/_generated/dataModel";
 import { usePosTerminalAppSessionRecoveryRuntimeInput } from "@/lib/pos/infrastructure/terminal/posTerminalAppSessionRecoveryContext";
+import { RemoteAssistRuntimeShell } from "@/components/remote-assist/RemoteAssistRuntimeShell";
+import type { RemoteAssistRuntimeState } from "@/lib/remote-assist";
 
 type FeatureLinkProps = {
   children: ReactNode;
@@ -49,6 +51,13 @@ type FeatureLinkProps = {
 };
 
 const FeatureLink = Link as unknown as ComponentType<FeatureLinkProps>;
+
+type RemoteAssistSessionSummary = {
+  _id: Id<"remoteAssistSession"> | string;
+  effectiveMode: "attended" | "unattended" | string;
+  sensitiveModeActive: boolean;
+  status: string;
+};
 
 export default function PointOfSaleView() {
   const { activeStore } = useGetActiveStore();
@@ -80,6 +89,23 @@ export default function PointOfSaleView() {
     storeId: hubTerminalSeed?.storeId,
     terminalId: hubTerminalSeed?.cloudTerminalId ?? hubTerminalSeed?.terminalId,
   });
+  const remoteAssistRuntimeIdentity =
+    hubTerminalSeed?.cloudTerminalId ?? hubTerminalSeed?.terminalId;
+  const remoteAssistSession = useQuery(
+    api.pos.public.terminals.getRuntimeRemoteAssistSession,
+    hubTerminalSeed?.storeId &&
+      hubTerminalSeed?.syncSecretHash &&
+      remoteAssistRuntimeIdentity
+      ? {
+          storeId: hubTerminalSeed.storeId as Id<"store">,
+          syncSecretHash: hubTerminalSeed.syncSecretHash,
+          terminalId: remoteAssistRuntimeIdentity as Id<"posTerminal">,
+        }
+      : "skip",
+  ) as RemoteAssistSessionSummary | null | undefined;
+  const disconnectRemoteAssistSession = useMutation(
+    api.pos.public.terminals.disconnectRemoteAssistSession,
+  );
 
   // Get today's POS transaction summary
   const todaySummary = useQuery(
@@ -109,6 +135,9 @@ export default function PointOfSaleView() {
   const setupRequired =
     localEntryContext.status !== "loading" &&
     localEntryContext.status !== "ready";
+  const remoteAssistRuntimeState = getRemoteAssistRuntimeState(
+    remoteAssistSession,
+  );
 
   const posFeatures = [
     {
@@ -211,6 +240,22 @@ export default function PointOfSaleView() {
 
   return (
     <View hideBorder hideHeaderBottomBorder className="bg-background">
+      {remoteAssistRuntimeState &&
+      localEntryContext.status === "ready" &&
+      hubTerminalSeed &&
+      remoteAssistRuntimeIdentity ? (
+        <RemoteAssistRuntimeShell
+          onDisconnect={() => {
+            void disconnectRemoteAssistSession({
+              sessionId: remoteAssistSession!._id as Id<"remoteAssistSession">,
+              storeId: hubTerminalSeed.storeId as Id<"store">,
+              syncSecretHash: hubTerminalSeed.syncSecretHash,
+              terminalId: remoteAssistRuntimeIdentity as Id<"posTerminal">,
+            });
+          }}
+          state={remoteAssistRuntimeState}
+        />
+      ) : null}
       <FadeIn className="container mx-auto py-layout-xl">
         <PageWorkspace>
           <PageLevelHeader title="Point of Sale" />
@@ -383,4 +428,31 @@ export default function PointOfSaleView() {
       </FadeIn>
     </View>
   );
+}
+
+function getRemoteAssistRuntimeState(
+  session: RemoteAssistSessionSummary | null | undefined,
+): RemoteAssistRuntimeState | null {
+  if (!session || !["active", "connecting", "pending_attended_approval"].includes(session.status)) {
+    return null;
+  }
+  return {
+    controlEnabled:
+      session.status === "active" &&
+      session.effectiveMode === "unattended" &&
+      !session.sensitiveModeActive,
+    sessionId: session._id,
+    status:
+      session.status === "active"
+        ? "connected"
+        : session.status === "pending_attended_approval"
+          ? "blocked"
+          : "connecting",
+    supportAgentName: null,
+    viewerCount: session.status === "active" ? 1 : 0,
+    blockedReason:
+      session.status === "pending_attended_approval"
+        ? "Approval required"
+        : null,
+  };
 }

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
     isLoadingStores: false,
   },
   canAccessPOS: vi.fn(() => true),
+  hasFullAdminAccess: true,
   mutation: vi.fn(),
   useQuery: vi.fn(() => null),
   toastSuccess: vi.fn(),
@@ -84,6 +85,7 @@ vi.mock("@/hooks/useGetActiveStore", () => ({
 vi.mock("@/hooks/usePermissions", () => ({
   usePermissions: () => ({
     canAccessPOS: mocks.canAccessPOS,
+    hasFullAdminAccess: mocks.hasFullAdminAccess,
     isLoading: false,
   }),
 }));
@@ -244,6 +246,7 @@ describe("POSTerminalDetailViewContent", () => {
     mocks.activeStoreState.activeStore = { _id: "store-1" };
     mocks.activeStoreState.isLoadingStores = false;
     mocks.canAccessPOS.mockReturnValue(true);
+    mocks.hasFullAdminAccess = true;
     mocks.mutation.mockResolvedValue({
       data: { action: "resolved", resolvedCount: 1 },
       kind: "ok",
@@ -314,16 +317,11 @@ describe("POSTerminalDetailViewContent", () => {
 
     expect(screen.getByText("Remote Assist")).toBeInTheDocument();
     expect(screen.getByText("Ready for support session")).toBeInTheDocument();
-    const startSessionButton = screen.getByRole("button", {
-      name: /start session/i,
-    });
-    expect(startSessionButton).toBeDisabled();
 
     fireEvent.change(screen.getByLabelText("Reason"), {
       target: { value: "Drawer repair support" },
     });
-    expect(startSessionButton).toBeEnabled();
-    fireEvent.click(startSessionButton);
+    fireEvent.click(screen.getByRole("button", { name: /start session/i }));
 
     await waitFor(() => {
       expect(onStartRemoteAssist).toHaveBeenCalledWith({
@@ -334,21 +332,31 @@ describe("POSTerminalDetailViewContent", () => {
     expect(mocks.toastSuccess).toHaveBeenCalledWith(
       "Remote Assist session requested.",
     );
-    expect(
-      await screen.findByText("Remote Assist session connecting"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Session requested")).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /session requested/i }),
-    ).toBeDisabled();
   });
 
-  it("restores an in-progress Remote Assist session from server state", () => {
+  it("renders hydrated Remote Assist session state and ends the current session", async () => {
+    const onStartRemoteAssist = vi.fn();
+    const onEndRemoteAssist = vi.fn(async () => ({
+      data: {
+        _id: "session-1",
+        effectiveMode: "unattended",
+        endedAt: Date.now(),
+        expiresAt: Date.now() + 60_000,
+        reason: "Drawer repair support",
+        sensitiveModeActive: false,
+        status: "ended",
+        terminationReason: "Support ended the Remote Assist session.",
+      },
+      kind: "ok" as const,
+    }));
+
     render(
       <POSTerminalDetailViewContent
         canStartRemoteAssist
         detail={detail}
         isLoading={false}
+        onEndRemoteAssist={onEndRemoteAssist}
+        onStartRemoteAssist={onStartRemoteAssist}
         remoteAssistClient={{
           _id: "remote-client-1",
           accessPolicy: "unattended_allowed",
@@ -360,19 +368,40 @@ describe("POSTerminalDetailViewContent", () => {
         remoteAssistSession={{
           _id: "session-1",
           effectiveMode: "unattended",
+          expiresAt: Date.now() + 60_000,
           reason: "Drawer repair support",
-          status: "connecting",
+          sensitiveModeActive: false,
+          startedAt: Date.now(),
+          status: "active",
         }}
       />,
     );
 
     expect(
-      screen.getByText("Remote Assist session connecting"),
+      screen.getByText("Remote Assist session active"),
     ).toBeInTheDocument();
-    expect(screen.getByText("Session requested")).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /session requested/i }),
-    ).toBeDisabled();
+      screen.getByText(/Support controls stay inside Athena/),
+    ).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Reason"), {
+      target: { value: "Another support request" },
+    });
+    const startButton = screen.getByRole("button", { name: /start session/i });
+    expect(startButton).toBeDisabled();
+    fireEvent.click(startButton);
+    expect(onStartRemoteAssist).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: /end session/i }));
+
+    await waitFor(() => {
+      expect(onEndRemoteAssist).toHaveBeenCalledWith({
+        reason: "Support ended the Remote Assist session.",
+        sessionId: "session-1",
+      });
+    });
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      "Remote Assist session ended.",
+    );
   });
 
   it("shows approval-required Remote Assist responses", async () => {
@@ -422,7 +451,7 @@ describe("POSTerminalDetailViewContent", () => {
     );
 
     fireEvent.change(screen.getByLabelText("Reason"), {
-      target: { value: "Support needs cashier approval" },
+      target: { value: "Drawer repair support" },
     });
     fireEvent.click(screen.getByRole("button", { name: /start session/i }));
 
@@ -864,5 +893,27 @@ describe("POSTerminalDetailView", () => {
 
     expect(screen.getByText("No permission")).toBeInTheDocument();
     expect(mocks.useQuery).toHaveBeenCalledWith(expect.anything(), "skip");
+  });
+
+  it("does not query full-admin Remote Assist session state for POS-only users", () => {
+    mocks.hasFullAdminAccess = false;
+    (mocks.activeStoreState as { activeStore: Record<string, unknown> }).activeStore = {
+      _id: "store-1",
+      organizationId: "org-1",
+    };
+    (mocks.useQuery as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(detail)
+      .mockReturnValueOnce({
+        _id: "remote-client-1",
+        accessPolicy: "unattended_allowed",
+        displayName: "Front counter",
+        enrollmentStatus: "active",
+        lastPresenceAt: Date.now(),
+        presenceStatus: "online",
+      });
+
+    render(<POSTerminalDetailView />);
+
+    expect((mocks.useQuery.mock.calls as unknown[][])[2]?.[1]).toBe("skip");
   });
 });

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
@@ -16,10 +16,7 @@ import { toast } from "sonner";
 
 import View from "@/components/View";
 import { FadeIn } from "@/components/common/FadeIn";
-import {
-  PageLevelHeader,
-  PageWorkspace,
-} from "@/components/common/PageLevelHeader";
+import { PageLevelHeader, PageWorkspace } from "@/components/common/PageLevelHeader";
 import { EmptyState } from "@/components/states/empty/empty-state";
 import { NoPermissionView } from "@/components/states/no-permission/NoPermissionView";
 import { ProtectedAdminSignInView } from "@/components/states/signed-out/ProtectedAdminSignInView";
@@ -67,11 +64,7 @@ const posTerminalApi = api.inventory.posTerminal as unknown as {
 
 type RemoteAssistClientSummary = {
   _id: Id<"remoteAssistClient"> | string;
-  accessPolicy:
-    | "attended_required"
-    | "disabled"
-    | "unattended_allowed"
-    | string;
+  accessPolicy: "attended_required" | "disabled" | "unattended_allowed" | string;
   displayName: string;
   enrollmentStatus: "active" | "disabled" | "revoked" | string;
   lastPresenceAt?: number;
@@ -81,7 +74,11 @@ type RemoteAssistClientSummary = {
 type RemoteAssistStartResult =
   | {
       kind: "ok";
-      data: RemoteAssistSessionSummary;
+      data: {
+        _id: Id<"remoteAssistSession"> | string;
+        effectiveMode: "attended" | "unattended" | string;
+        status: string;
+      };
     }
   | {
       kind: "user_error";
@@ -98,10 +95,27 @@ type RemoteAssistStartResult =
 type RemoteAssistSessionSummary = {
   _id: Id<"remoteAssistSession"> | string;
   effectiveMode: "attended" | "unattended" | string;
-  expiresAt?: number;
-  reason?: string;
+  endedAt?: number;
+  expiresAt: number;
+  reason: string;
+  sensitiveModeActive: boolean;
+  startedAt?: number;
   status: string;
+  terminationReason?: string;
 };
+
+type RemoteAssistEndResult =
+  | {
+      kind: "ok";
+      data: RemoteAssistSessionSummary;
+    }
+  | {
+      kind: "user_error";
+      error: {
+        code?: string;
+        message: string;
+      };
+    };
 
 const remoteAssistApi = api.remoteAssist.public;
 
@@ -118,6 +132,10 @@ type POSTerminalDetailViewContentProps = {
     clientId: Id<"remoteAssistClient"> | string;
     reason: string;
   }) => Promise<RemoteAssistStartResult>;
+  onEndRemoteAssist?: (args: {
+    reason: string;
+    sessionId: Id<"remoteAssistSession"> | string;
+  }) => Promise<RemoteAssistEndResult>;
   orgUrlSlug?: string;
   queryUnavailable?: boolean;
   remoteAssistClient?: RemoteAssistClientSummary | null;
@@ -167,12 +185,16 @@ function DetailPanel({
   );
 }
 
-function Field({ label, value }: { label: string; value: React.ReactNode }) {
+function Field({
+  label,
+  value,
+}: {
+  label: string;
+  value: React.ReactNode;
+}) {
   return (
     <div>
-      <p className="text-xs font-medium uppercase text-muted-foreground">
-        {label}
-      </p>
+      <p className="text-xs font-medium uppercase text-muted-foreground">{label}</p>
       <div className="mt-1 text-sm text-foreground">{value}</div>
     </div>
   );
@@ -250,11 +272,7 @@ function TerminalContextRail({
           />
           <RailField
             label="Source"
-            value={
-              runtimeStatus
-                ? formatStatusLabel(runtimeStatus.source)
-                : "No check-in"
-            }
+            value={runtimeStatus ? formatStatusLabel(runtimeStatus.source) : "No check-in"}
           />
           <RailField
             label="Browser online"
@@ -386,7 +404,10 @@ function SyncEvidenceSection({
             label="Cursor updated"
             value={formatTerminalTimestamp(syncEvidence.cursorUpdatedAt)}
           />
-          <Field label="Recent sample" value={`${sampledEventCount} sampled`} />
+          <Field
+            label="Recent sample"
+            value={`${sampledEventCount} sampled`}
+          />
         </div>
       </div>
 
@@ -474,8 +495,7 @@ function ConflictSection({
                 {conflict.summary}
               </p>
               <p className="mt-1 text-xs text-muted-foreground">
-                Sequence {conflict.sequence} /{" "}
-                {formatStatusLabel(conflict.conflictType)}
+                Sequence {conflict.sequence} / {formatStatusLabel(conflict.conflictType)}
               </p>
             </div>
           ))
@@ -911,32 +931,25 @@ function RemoteAssistPanel({
   canStartRemoteAssist = false,
   client,
   detail,
-  currentSession,
+  onEndRemoteAssist,
   onStartRemoteAssist,
+  session,
 }: {
   canStartRemoteAssist?: boolean;
   client?: RemoteAssistClientSummary | null;
-  currentSession?: RemoteAssistSessionSummary | null;
   detail: TerminalHealthDetail;
+  onEndRemoteAssist?: POSTerminalDetailViewContentProps["onEndRemoteAssist"];
   onStartRemoteAssist?: POSTerminalDetailViewContentProps["onStartRemoteAssist"];
+  session?: RemoteAssistSessionSummary | null;
 }) {
   const [reason, setReason] = useState("");
+  const [isEnding, setIsEnding] = useState(false);
   const [isStarting, setIsStarting] = useState(false);
-  const [requestedSession, setRequestedSession] =
-    useState<RemoteAssistSessionSummary | null>(null);
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     const timerId = window.setInterval(() => setNow(Date.now()), 15_000);
     return () => window.clearInterval(timerId);
   }, []);
-  useEffect(() => {
-    setRequestedSession(null);
-  }, [client?._id]);
-  useEffect(() => {
-    if (currentSession) {
-      setRequestedSession(currentSession);
-    }
-  }, [currentSession]);
   const presenceFresh = isRemoteAssistPresenceFresh(client, now);
   const available =
     canStartRemoteAssist &&
@@ -944,13 +957,13 @@ function RemoteAssistPanel({
     client?.accessPolicy === "unattended_allowed" &&
     client?.presenceStatus === "online" &&
     presenceFresh;
-  const sessionInProgress =
-    requestedSession &&
-    !["ended", "expired"].includes(requestedSession.status);
   const availabilityCopy = getRemoteAssistAvailabilityCopy(
     client,
     presenceFresh,
     canStartRemoteAssist,
+  );
+  const hasCurrentSession = Boolean(
+    session && isRemoteAssistSessionCurrent(session),
   );
 
   async function handleStartRemoteAssist() {
@@ -961,10 +974,9 @@ function RemoteAssistPanel({
     try {
       const result = await onStartRemoteAssist({
         clientId: client._id,
-        reason,
+        reason: reason.trim(),
       });
       if (result.kind === "ok") {
-        setRequestedSession(result.data);
         toast.success("Remote Assist session requested.");
       } else if (result.kind === "approval_required") {
         toast.error(
@@ -978,6 +990,28 @@ function RemoteAssistPanel({
       toast.error("Remote Assist could not start right now.");
     } finally {
       setIsStarting(false);
+    }
+  }
+
+  async function handleEndRemoteAssist() {
+    if (!session || !onEndRemoteAssist || !isRemoteAssistSessionCurrent(session)) {
+      return;
+    }
+    setIsEnding(true);
+    try {
+      const result = await onEndRemoteAssist({
+        reason: "Support ended the Remote Assist session.",
+        sessionId: session._id,
+      });
+      if (result.kind === "ok") {
+        toast.success("Remote Assist session ended.");
+      } else {
+        toast.error(result.error.message);
+      }
+    } catch {
+      toast.error("Remote Assist could not end right now.");
+    } finally {
+      setIsEnding(false);
     }
   }
 
@@ -1000,8 +1034,7 @@ function RemoteAssistPanel({
             </p>
             {client?.lastPresenceAt ? (
               <p className="mt-2 text-xs text-muted-foreground">
-                Last Remote Assist presence{" "}
-                {formatTerminalTimestamp(client.lastPresenceAt)}.
+                Last Remote Assist presence {formatTerminalTimestamp(client.lastPresenceAt)}.
               </p>
             ) : null}
           </div>
@@ -1023,11 +1056,7 @@ function RemoteAssistPanel({
       <div className="mt-layout-md grid gap-layout-sm md:grid-cols-3">
         <RecoveryMetric
           label="Mode"
-          value={
-            client?.accessPolicy === "attended_required"
-              ? "Attended"
-              : "Unattended"
-          }
+          value={client?.accessPolicy === "attended_required" ? "Attended" : "Unattended"}
         />
         <RecoveryMetric
           label="Runtime"
@@ -1039,27 +1068,40 @@ function RemoteAssistPanel({
         />
       </div>
 
-      {requestedSession ? (
-        <div className="mt-layout-md rounded-md border border-blue-200 bg-blue-50 px-layout-md py-layout-md text-blue-950">
-          <div className="flex flex-col gap-layout-sm md:flex-row md:items-start md:justify-between">
+      {session ? (
+        <div
+          className={cn(
+            "mt-layout-md rounded-md border px-layout-md py-layout-md",
+            session.status === "active"
+              ? "border-success/25 bg-success/5"
+              : isRemoteAssistSessionCurrent(session)
+                ? "border-info/30 bg-info/10"
+                : "border-border/80 bg-surface",
+          )}
+        >
+          <div className="flex flex-col gap-layout-md lg:flex-row lg:items-start lg:justify-between">
             <div className="min-w-0">
-              <p className="text-xs font-medium uppercase text-blue-700">
+              <p className="text-xs font-medium uppercase text-muted-foreground">
                 Session
               </p>
-              <p className="mt-1 text-sm font-medium">
-                {getRemoteAssistSessionStatusLabel(requestedSession.status)}
+              <p className="mt-1 text-sm font-medium text-foreground">
+                {getRemoteAssistSessionStatusLabel(session.status)}
               </p>
-              <p className="mt-1 text-xs text-blue-800">
-                Support request accepted. The terminal runtime still needs to
-                join before live assist controls are available.
+              <p className="mt-1 text-xs text-muted-foreground">
+                {getRemoteAssistSessionStatusDescription(session)}
               </p>
             </div>
-            <Badge
-              className="w-fit rounded-md border-blue-300 bg-blue-100 text-blue-800"
-              variant="outline"
-            >
-              {formatRemoteAssistModeLabel(requestedSession.effectiveMode)}
-            </Badge>
+            {isRemoteAssistSessionCurrent(session) ? (
+              <Button
+                disabled={isEnding}
+                onClick={handleEndRemoteAssist}
+                size="sm"
+                type="button"
+                variant="outline"
+              >
+                {isEnding ? "Ending" : "End session"}
+              </Button>
+            ) : null}
           </div>
         </div>
       ) : null}
@@ -1075,57 +1117,26 @@ function RemoteAssistPanel({
           className="min-h-20 rounded-md border border-border bg-background px-layout-md py-layout-sm text-sm text-foreground outline-none ring-offset-background transition focus-visible:ring-2 focus-visible:ring-ring"
           id="remote-assist-reason"
           onChange={(event) => setReason(event.target.value)}
-          placeholder="Describe the support task for this session."
+          placeholder="Describe the support task for this terminal."
           value={reason}
         />
         <div className="flex flex-col gap-layout-xs sm:flex-row sm:items-center sm:justify-between">
           <p className="text-xs text-muted-foreground">
-            Remote Assist operates this Athena surface only; POS authority and
-            recovery gates still apply.
+            Remote Assist operates this Athena surface only; POS authority and recovery gates still apply.
           </p>
           <Button
-            disabled={
-              !available ||
-              !reason.trim() ||
-              isStarting ||
-              Boolean(sessionInProgress)
-            }
+            disabled={!available || !reason.trim() || isStarting || hasCurrentSession}
             onClick={handleStartRemoteAssist}
             type="button"
-            variant="workflow"
+            variant="default"
           >
             <MonitorUp aria-hidden="true" className="mr-2 h-4 w-4" />
-            {isStarting
-              ? "Starting"
-              : sessionInProgress
-                ? "Session requested"
-                : "Start session"}
+            {isStarting ? "Starting" : "Start session"}
           </Button>
         </div>
       </div>
     </DetailPanel>
   );
-}
-
-function getRemoteAssistSessionStatusLabel(status: string): string {
-  switch (status) {
-    case "active":
-      return "Remote Assist session active";
-    case "connecting":
-      return "Remote Assist session connecting";
-    case "pending_attended_approval":
-      return "Waiting for local approval";
-    case "ended":
-      return "Remote Assist session ended";
-    case "expired":
-      return "Remote Assist session expired";
-    default:
-      return "Remote Assist session requested";
-  }
-}
-
-function formatRemoteAssistModeLabel(mode: string): string {
-  return mode === "attended" ? "Attended" : "Unattended";
 }
 
 function SupportNotesSection({
@@ -1156,10 +1167,7 @@ function SupportNotesSection({
       ) : (
         <ul className="space-y-layout-xs text-sm text-foreground">
           {notes.map((note) => (
-            <li
-              className="rounded-md border border-border bg-background px-layout-md py-layout-sm"
-              key={note}
-            >
+            <li className="rounded-md border border-border bg-background px-layout-md py-layout-sm" key={note}>
               {note}
             </li>
           ))}
@@ -1177,8 +1185,7 @@ function getRemoteAssistAvailabilityCopy(
   if (!canStartRemoteAssist) {
     return {
       label: "Support permission required",
-      description:
-        "Only full admin support users can start Remote Assist sessions.",
+      description: "Only full admin support users can start Remote Assist sessions.",
     };
   }
   if (!client) {
@@ -1229,14 +1236,59 @@ function isRemoteAssistPresenceFresh(
 ) {
   return Boolean(
     client?.lastPresenceAt &&
-    now - client.lastPresenceAt <= REMOTE_ASSIST_PRESENCE_FRESHNESS_MS,
+      now - client.lastPresenceAt <= REMOTE_ASSIST_PRESENCE_FRESHNESS_MS,
   );
+}
+
+function isRemoteAssistSessionCurrent(session: RemoteAssistSessionSummary) {
+  return ["active", "connecting", "pending_attended_approval"].includes(
+    session.status,
+  );
+}
+
+function getRemoteAssistSessionStatusLabel(status: string) {
+  switch (status) {
+    case "active":
+      return "Remote Assist session active";
+    case "connecting":
+      return "Remote Assist session connecting";
+    case "pending_attended_approval":
+      return "Waiting for local approval";
+    case "ended":
+      return "Remote Assist session ended";
+    case "expired":
+      return "Remote Assist session expired";
+    case "denied":
+      return "Remote Assist session denied";
+    default:
+      return formatStatusLabel(status);
+  }
+}
+
+function getRemoteAssistSessionStatusDescription(
+  session: RemoteAssistSessionSummary,
+) {
+  switch (session.status) {
+    case "active":
+      return "The terminal runtime has joined. Support controls stay inside Athena and POS authority gates still apply.";
+    case "connecting":
+      return "Support request accepted. The terminal runtime still needs to join before live assist controls are available.";
+    case "pending_attended_approval":
+      return "A local operator must approve before support can connect.";
+    case "ended":
+      return session.terminationReason ?? "Support ended this Remote Assist session.";
+    case "expired":
+      return "This support request expired before it was completed.";
+    default:
+      return "Remote Assist session state is recorded for this terminal.";
+  }
 }
 
 export function POSTerminalDetailViewContent({
   canStartRemoteAssist = false,
   detail,
   isLoading,
+  onEndRemoteAssist,
   onResolveRegisterSessionReview,
   onStartRemoteAssist,
   orgUrlSlug,
@@ -1295,27 +1347,22 @@ export function POSTerminalDetailViewContent({
             <Badge className={classification.toneClassName} variant="outline">
               {classification.label}
             </Badge>
-            <Badge
-              className="border-border bg-surface-raised text-muted-foreground"
-              variant="outline"
-            >
+            <Badge className="border-border bg-surface-raised text-muted-foreground" variant="outline">
               {formatRegisterNumber(detail.terminal.registerNumber)}
             </Badge>
           </div>
 
           <div className="grid gap-layout-xl xl:grid-cols-[20rem_minmax(0,1fr)]">
-            <TerminalContextRail
-              detail={detail}
-              runtimeStatus={runtimeStatus}
-            />
+            <TerminalContextRail detail={detail} runtimeStatus={runtimeStatus} />
 
             <main className="space-y-layout-lg">
               <RemoteAssistPanel
                 canStartRemoteAssist={canStartRemoteAssist}
                 client={remoteAssistClient}
-                currentSession={remoteAssistSession}
                 detail={detail}
+                onEndRemoteAssist={onEndRemoteAssist}
                 onStartRemoteAssist={onStartRemoteAssist}
+                session={remoteAssistSession}
               />
               <RecoveryPanel
                 detail={detail}
@@ -1358,8 +1405,7 @@ export function POSTerminalDetailView() {
         terminalId?: string;
       }
     | undefined;
-  const isLoadingAccess =
-    isLoadingUser || isLoadingStores || isLoadingPermissions;
+  const isLoadingAccess = isLoadingUser || isLoadingStores || isLoadingPermissions;
   const canViewHealth = canAccessPOS();
   const canQuery = Boolean(
     activeStore?._id && user && canViewHealth && params?.terminalId,
@@ -1385,7 +1431,7 @@ export function POSTerminalDetailView() {
   ) as RemoteAssistClientSummary | null | undefined;
   const remoteAssistSession = useQuery(
     remoteAssistApi.getCurrentSessionByClient,
-    remoteAssistClient?._id
+    hasFullAdminAccess && remoteAssistClient?._id
       ? {
           clientId: remoteAssistClient._id as Id<"remoteAssistClient">,
         }
@@ -1395,6 +1441,7 @@ export function POSTerminalDetailView() {
     api.cashControls.deposits.resolveRegisterSessionSyncReview,
   );
   const startRemoteAssistSession = useMutation(remoteAssistApi.startSession);
+  const endRemoteAssistSession = useMutation(remoteAssistApi.endSupportSession);
 
   async function onResolveRegisterSessionReview({
     registerSessionId,
@@ -1436,6 +1483,19 @@ export function POSTerminalDetailView() {
     }) as Promise<RemoteAssistStartResult>;
   }
 
+  async function onEndRemoteAssist({
+    reason,
+    sessionId,
+  }: {
+    reason: string;
+    sessionId: Id<"remoteAssistSession"> | string;
+  }): Promise<RemoteAssistEndResult> {
+    return endRemoteAssistSession({
+      reason,
+      sessionId: sessionId as Id<"remoteAssistSession">,
+    }) as Promise<RemoteAssistEndResult>;
+  }
+
   if (isLoadingAccess) {
     return null;
   }
@@ -1465,18 +1525,19 @@ export function POSTerminalDetailView() {
   }
 
   return (
-    <POSTerminalDetailViewContent
-      detail={detail ?? null}
-      canStartRemoteAssist={hasFullAdminAccess}
-      isLoading={detail === undefined}
-      onResolveRegisterSessionReview={onResolveRegisterSessionReview}
-      onStartRemoteAssist={onStartRemoteAssist}
-      orgUrlSlug={params.orgUrlSlug}
-      queryUnavailable={detail === null && !params.terminalId}
-      remoteAssistClient={remoteAssistClient ?? null}
-      remoteAssistSession={remoteAssistSession ?? null}
-      storeUrlSlug={params.storeUrlSlug}
-    />
+      <POSTerminalDetailViewContent
+        detail={detail ?? null}
+        canStartRemoteAssist={hasFullAdminAccess}
+        isLoading={detail === undefined}
+        onResolveRegisterSessionReview={onResolveRegisterSessionReview}
+        onEndRemoteAssist={onEndRemoteAssist}
+        onStartRemoteAssist={onStartRemoteAssist}
+        orgUrlSlug={params.orgUrlSlug}
+        queryUnavailable={detail === null && !params.terminalId}
+        remoteAssistClient={remoteAssistClient ?? null}
+        remoteAssistSession={remoteAssistSession ?? null}
+        storeUrlSlug={params.storeUrlSlug}
+      />
   );
 }
 

--- a/packages/athena-webapp/src/lib/remote-assist/contract.test.ts
+++ b/packages/athena-webapp/src/lib/remote-assist/contract.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildRemoteAssistCoBrowseFrame,
+  validateRemoteAssistControlIntent,
+} from "./contract";
+
+describe("remote assist live contract", () => {
+  it("builds a sanitized co-browse frame without sensitive rectangles", () => {
+    expect(
+      buildRemoteAssistCoBrowseFrame({
+        capturedAt: 1_000,
+        frameId: " frame-1 ",
+        route: "/wigclub/store/wigclub/pos",
+        sensitiveRegions: [
+          {
+            id: "staff-proof",
+            label: "Staff proof",
+            rect: { x: 10, y: 20, width: 120, height: 44 },
+          },
+        ],
+        sessionId: "session-1",
+        viewport: { width: 1280, height: 720 },
+      }),
+    ).toEqual({
+      capturedAt: 1_000,
+      frameId: "frame-1",
+      redaction: {
+        inputValuesMasked: true,
+        sensitiveRegionCount: 1,
+      },
+      route: "/wigclub/store/wigclub/pos",
+      sensitiveRegions: [
+        {
+          id: "staff-proof",
+          label: "Staff proof",
+        },
+      ],
+      sessionId: "session-1",
+      viewport: { width: 1280, height: 720 },
+    });
+  });
+
+  it("accepts bounded Athena-surface control intents", () => {
+    expect(
+      validateRemoteAssistControlIntent({
+        intent: {
+          event: {
+            action: "down",
+            pointerId: "primary",
+            type: "pointer",
+            x: 42,
+            y: 56,
+          },
+          idempotencyKey: "control-1",
+          issuedAt: 1_000,
+          reason: "Open support panel",
+          sessionId: "session-1",
+          target: "athena_surface",
+        },
+        viewport: { width: 320, height: 480 },
+      }),
+    ).toEqual({
+      accepted: true,
+      event: {
+        action: "down",
+        pointerId: "primary",
+        type: "pointer",
+        x: 42,
+        y: 56,
+      },
+      idempotencyKey: "control-1",
+      sessionId: "session-1",
+    });
+  });
+
+  it("rejects controls targeting sensitive regions", () => {
+    expect(
+      validateRemoteAssistControlIntent({
+        intent: {
+          event: {
+            action: "up",
+            pointerId: "primary",
+            type: "pointer",
+            x: 42,
+            y: 56,
+          },
+          idempotencyKey: "control-2",
+          issuedAt: 1_000,
+          reason: "Inspect staff proof",
+          sessionId: "session-1",
+          target: "athena_surface",
+        },
+        sensitiveRegions: [
+          {
+            id: "staff-proof",
+            label: "Staff proof",
+            rect: { x: 10, y: 20, width: 120, height: 44 },
+          },
+        ],
+        viewport: { width: 320, height: 480 },
+      }),
+    ).toEqual({
+      accepted: false,
+      idempotencyKey: "control-2",
+      reason: "sensitive_region",
+      regionId: "staff-proof",
+      sessionId: "session-1",
+    });
+  });
+
+  it("rejects non-Athena targets before transport", () => {
+    expect(
+      validateRemoteAssistControlIntent({
+        intent: {
+          event: {
+            action: "down",
+            code: "Enter",
+            type: "key",
+          },
+          idempotencyKey: "control-3",
+          issuedAt: 1_000,
+          reason: "Run shell command",
+          sessionId: "session-1",
+          target: "devtools" as never,
+        },
+        viewport: { width: 320, height: 480 },
+      }),
+    ).toEqual({
+      accepted: false,
+      idempotencyKey: "control-3",
+      reason: "invalid_event",
+      sessionId: "session-1",
+    });
+  });
+});

--- a/packages/athena-webapp/src/lib/remote-assist/contract.ts
+++ b/packages/athena-webapp/src/lib/remote-assist/contract.ts
@@ -1,0 +1,132 @@
+import {
+  createSensitiveRegionSet,
+  validateRemoteAssistControlEvent,
+  type RemoteAssistControlEvent,
+  type RemoteAssistControlRejectionReason,
+  type RemoteAssistSensitiveRegion,
+  type RemoteAssistViewport,
+} from "./guardrails";
+
+export type RemoteAssistParticipantRole = "runtime" | "support";
+
+export type RemoteAssistRuntimeLiveState = {
+  connectedSupportCount: number;
+  localDisconnectAvailable: boolean;
+  route: string;
+  sensitiveModeActive: boolean;
+  sessionId: string;
+  status: "active" | "connecting" | "ended" | "waiting_approval";
+  viewport: RemoteAssistViewport;
+};
+
+export type RemoteAssistCoBrowseFrame = {
+  capturedAt: number;
+  frameId: string;
+  redaction: {
+    inputValuesMasked: true;
+    sensitiveRegionCount: number;
+  };
+  route: string;
+  sessionId: string;
+  sensitiveRegions: Array<Pick<RemoteAssistSensitiveRegion, "id" | "label">>;
+  viewport: RemoteAssistViewport;
+};
+
+export type RemoteAssistControlIntent = {
+  event: RemoteAssistControlEvent;
+  idempotencyKey: string;
+  issuedAt: number;
+  reason: string;
+  sessionId: string;
+  target: "athena_surface";
+};
+
+export type RemoteAssistControlResult =
+  | {
+      accepted: true;
+      event: RemoteAssistControlEvent;
+      idempotencyKey: string;
+      sessionId: string;
+    }
+  | {
+      accepted: false;
+      idempotencyKey: string;
+      reason: RemoteAssistControlRejectionReason;
+      regionId?: string;
+      sessionId: string;
+    };
+
+export function buildRemoteAssistCoBrowseFrame(args: {
+  capturedAt: number;
+  frameId: string;
+  route: string;
+  sensitiveRegions?: RemoteAssistSensitiveRegion[];
+  sessionId: string;
+  viewport: RemoteAssistViewport;
+}): RemoteAssistCoBrowseFrame {
+  const sensitiveRegions = createSensitiveRegionSet(
+    args.sensitiveRegions ?? [],
+  ).all();
+  return {
+    capturedAt: args.capturedAt,
+    frameId: args.frameId.trim(),
+    redaction: {
+      inputValuesMasked: true,
+      sensitiveRegionCount: sensitiveRegions.length,
+    },
+    route: args.route,
+    sessionId: args.sessionId,
+    sensitiveRegions: sensitiveRegions.map((region) => ({
+      id: region.id,
+      label: region.label,
+    })),
+    viewport: { ...args.viewport },
+  };
+}
+
+export function validateRemoteAssistControlIntent(args: {
+  intent: RemoteAssistControlIntent;
+  sensitiveRegions?: RemoteAssistSensitiveRegion[];
+  viewport: RemoteAssistViewport;
+}): RemoteAssistControlResult {
+  if (
+    args.intent.target !== "athena_surface" ||
+    args.intent.idempotencyKey.trim().length === 0 ||
+    args.intent.reason.trim().length === 0
+  ) {
+    return {
+      accepted: false,
+      idempotencyKey: args.intent.idempotencyKey,
+      reason: "invalid_event",
+      sessionId: args.intent.sessionId,
+    };
+  }
+
+  const sensitiveRegionSet = createSensitiveRegionSet(
+    args.sensitiveRegions ?? [],
+  );
+  const validation = validateRemoteAssistControlEvent(
+    args.intent.event,
+    args.viewport,
+    sensitiveRegionSet,
+  );
+  if (!validation.ok) {
+    return {
+      accepted: false,
+      idempotencyKey: args.intent.idempotencyKey,
+      reason: validation.reason,
+      regionId:
+        validation.reason === "sensitive_region"
+          ? validation.regionId
+          : undefined,
+      sessionId: args.intent.sessionId,
+    };
+  }
+
+  return {
+    accepted: true,
+    event: validation.event,
+    idempotencyKey: args.intent.idempotencyKey,
+    sessionId: args.intent.sessionId,
+  };
+}

--- a/packages/athena-webapp/src/lib/remote-assist/index.ts
+++ b/packages/athena-webapp/src/lib/remote-assist/index.ts
@@ -1,2 +1,3 @@
 export * from "./guardrails";
+export * from "./contract";
 export * from "./runtime";


### PR DESCRIPTION
## Summary
- completes the Remote Assist live-session handoff after Terminal Health starts support
- lets POS runtimes claim and display active support sessions using existing terminal sync proof
- hydrates current support sessions on reload, prevents duplicate starts, and adds support/runtime disconnect paths
- adds the provider-neutral live assist contract and updates the Remote Assist delivery plan/solution notes

## Validation
- `bun run --filter '@athena/webapp' test -- convex/remoteAssist/application/sessionService.test.ts convex/remoteAssist/infrastructure/remoteAssistRepository.test.ts convex/remoteAssist/public.test.ts convex/pos/public/terminals.test.ts src/lib/remote-assist/guardrails.test.ts src/lib/remote-assist/contract.test.ts src/components/remote-assist/RemoteAssistRuntimeShell.test.tsx src/components/pos/PointOfSaleView.test.tsx src/components/pos/terminals/POSTerminalDetailView.test.tsx`
- `bun run --filter '@athena/webapp' lint:convex:changed`
- `bun run --filter '@athena/webapp' lint:frontend:changed`
- `bun run --filter '@athena/webapp' typecheck`
- `bun run graphify:rebuild`
- `bun run pr:athena`
