### PR TITLE
Fix POS local readiness stale opening state

### DIFF
--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.test.ts
@@ -286,6 +286,54 @@ describe("localPosReadiness", () => {
       canStartLocally: true,
       message:
         "Store day not started. Complete Opening Handoff before starting sales.",
+      });
+  });
+
+  it("keeps live Opening Handoff review arrears locally startable after caching not-started readiness", () => {
+    expect(
+      evaluateLocalPosReadiness({
+        closeSnapshot: { status: "ready" },
+        entryContext,
+        localReadiness: {
+          storeId: "store-1",
+          operatingDate: "2026-05-14",
+          status: "not_started",
+          source: "daily_opening",
+          updatedAt: 1_000,
+        },
+        openingSnapshot: { status: "needs_attention" },
+        operatingDate: "2026-05-14",
+        registerReadModel,
+      }),
+    ).toEqual({
+      status: "blocked",
+      reason: "not_started",
+      canStartLocally: true,
+      message:
+        "Store day not started. Complete Opening Handoff before starting sales.",
+    });
+  });
+
+  it("does not let stale local not-started readiness override a started live Opening Handoff", () => {
+    expect(
+      evaluateLocalPosReadiness({
+        closeSnapshot: { status: "ready" },
+        entryContext,
+        localReadiness: {
+          storeId: "store-1",
+          operatingDate: "2026-05-14",
+          status: "not_started",
+          source: "daily_opening",
+          updatedAt: 1_000,
+        },
+        openingSnapshot: { status: "started" },
+        operatingDate: "2026-05-14",
+        registerReadModel,
+      }),
+    ).toEqual({
+      status: "ready",
+      source: "live",
+      storeDayStatus: "started",
     });
   });
 

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts
@@ -160,11 +160,19 @@ export function evaluateLocalPosReadiness(input: {
     );
   }
 
-  if (localReadiness?.status === "not_started") {
+  if (
+    localReadiness?.status === "not_started" &&
+    input.openingSnapshot?.status !== "started"
+  ) {
     return blocked(
       "not_started",
       "Store day not started. Complete Opening Handoff before starting sales.",
-      { canStartLocally: !input.openingSnapshot },
+      {
+        canStartLocally:
+          !input.openingSnapshot ||
+          input.openingSnapshot.status === "blocked" ||
+          input.openingSnapshot.status === "needs_attention",
+      },
     );
   }
 


### PR DESCRIPTION
## Summary
- Keep live Opening Handoff started state from being overridden by stale cached local not-started readiness.
- Preserve local startability for live Opening Handoff review arrears.
- Refresh graphify artifacts through the standard Athena gate.

## Validation
- `bun run pr:athena`
