### PR TITLE
Fix store-day automation cron cadence

### DIFF
--- a/packages/athena-webapp/convex/crons.test.ts
+++ b/packages/athena-webapp/convex/crons.test.ts
@@ -9,6 +9,11 @@ describe("Convex cron registration", () => {
     expect(source).toContain(
       "internal.operations.dailyOperationsAutomation.runConfiguredDailyOperationsAutomation",
     );
+    expect(source).toContain('if (process.env.STAGE == "prod")');
+    expect(source).toContain("crons.hourly(");
+    expect(source).toContain("{ minuteUTC: 0 }");
+    expect(source).toContain("crons.cron(");
+    expect(source).toContain('"0 */2 * * *"');
     expect(source).not.toContain(
       "internal.operations.dailyOperationsAutomation.runScheduledDailyOperationsAutomation",
     );

--- a/packages/athena-webapp/convex/crons.ts
+++ b/packages/athena-webapp/convex/crons.ts
@@ -45,11 +45,20 @@ crons.interval(
   {},
 );
 
-crons.interval(
-  "daily-operations-automation",
-  { minutes: process.env.STAGE == "prod" ? 60 : 1440 },
-  internal.operations.dailyOperationsAutomation.runConfiguredDailyOperationsAutomation,
-  {},
-);
+if (process.env.STAGE == "prod") {
+  crons.hourly(
+    "daily-operations-automation",
+    { minuteUTC: 0 },
+    internal.operations.dailyOperationsAutomation.runConfiguredDailyOperationsAutomation,
+    {},
+  );
+} else {
+  crons.cron(
+    "daily-operations-automation",
+    "0 */2 * * *",
+    internal.operations.dailyOperationsAutomation.runConfiguredDailyOperationsAutomation,
+    {},
+  );
+}
 
 export default crons;

--- a/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperationsAutomation.test.ts
@@ -889,6 +889,38 @@ describe("daily operations automation adapter", () => {
     );
   });
 
+  it("catches up a late-day Opening start when a quieter non-prod tick crosses midnight", async () => {
+    const { db, inserts } = createDb({
+      automationPolicy: [
+        policy("opening.auto_start", "enabled", {
+          openingLocalStartMinutes: 22 * 60 + 30,
+          operatingTimezoneOffsetMinutes: 0,
+        }),
+      ],
+      dailyClose: [completedDailyClose()],
+      store: [store],
+    });
+
+    const result = await runConfiguredDailyOperationsAutomationWithCtx(
+      { db } as unknown as MutationCtx,
+      {
+        now: Date.UTC(2026, 5, 9, 0, 0),
+      },
+    );
+
+    expect(result.openingResults).toHaveLength(1);
+    expect(inserts).toContainEqual(
+      expect.objectContaining({
+        table: "automationRun",
+        value: expect.objectContaining({
+          action: "opening.auto_start",
+          operatingDate: "2026-06-08",
+          outcome: "applied",
+        }),
+      }),
+    );
+  });
+
   it("runs configured Opening cron at the first tick after the policy local start time", async () => {
     const { db, inserts } = createDb({
       automationPolicy: [

--- a/packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperationsAutomation.ts
@@ -25,7 +25,7 @@ const OPENING_AUTO_START_ACTION = "opening.auto_start";
 const EOD_PREPARE_ACTION = "eod.prepare";
 const AUTOMATION_POLICY_CRON_LIMIT = 500;
 const DAILY_OPERATIONS_POLICY_VERSION = "daily-operations.v1";
-const CONFIGURED_AUTOMATION_LOOKBACK_MS = 60 * 60 * 1000;
+const CONFIGURED_AUTOMATION_LOOKBACK_MS = 2 * 60 * 60 * 1000;
 
 export const dailyOperationsOpeningAutoStartAction = defineAutomationAction({
   action: OPENING_AUTO_START_ACTION,


### PR DESCRIPTION
## Summary
- Run Daily Operations automation at the top of every hour in production instead of deployment-anchored hourly intervals
- Reduce non-prod automation checks to every two hours at fixed top-of-hour ticks
- Expand the configured automation lookback to two hours so late-day configured starts are still caught

## Validation
- bun run --filter '@athena/webapp' test -- convex/crons.test.ts convex/operations/dailyOperationsAutomation.test.ts\n- bun run graphify:rebuild\n- bun run pr:athena