### PR TITLE
Fix POS catalog continuity and local prod deploys

### DIFF
--- a/docs/deployment/vps-production.md
+++ b/docs/deployment/vps-production.md
@@ -13,16 +13,16 @@ This runbook captures the production VPS shape for `wigclub.store` and the steps
 
 ## Hostname Routing
 
-| Hostname | VPS target |
-| --- | --- |
-| `wigclub.store` | nginx static storefront |
-| `www.wigclub.store` | nginx static storefront |
-| `athena.wigclub.store` | nginx static Athena admin app |
-| `qa.wigclub.store` | nginx reverse proxy to storefront Vite dev server on `127.0.0.1:5176` |
-| `athena-qa.wigclub.store` | nginx reverse proxy to Athena Vite dev server on `127.0.0.1:5175` |
-| `api.wigclub.store` | nginx reverse proxy to prod Convex HTTP |
-| `dev.wigclub.store` | nginx reverse proxy to dev Convex HTTP |
-| `cache.wigclub.store` | Cloudflare Tunnel to `http://localhost:3000` |
+| Hostname                  | VPS target                                                            |
+| ------------------------- | --------------------------------------------------------------------- |
+| `wigclub.store`           | nginx static storefront                                               |
+| `www.wigclub.store`       | nginx static storefront                                               |
+| `athena.wigclub.store`    | nginx static Athena admin app                                         |
+| `qa.wigclub.store`        | nginx reverse proxy to storefront Vite dev server on `127.0.0.1:5176` |
+| `athena-qa.wigclub.store` | nginx reverse proxy to Athena Vite dev server on `127.0.0.1:5175`     |
+| `api.wigclub.store`       | nginx reverse proxy to prod Convex HTTP                               |
+| `dev.wigclub.store`       | nginx reverse proxy to dev Convex HTTP                                |
+| `cache.wigclub.store`     | Cloudflare Tunnel to `http://localhost:3000`                          |
 
 Do not expose the cache proxy through the VPS public interface. The service has cache read, write, and invalidation endpoints, so the expected runtime boundary is loopback plus Cloudflare Tunnel.
 
@@ -56,14 +56,14 @@ Do not hand-maintain separate app files under `/etc/nginx/sites-enabled`. If the
 
 The generated server blocks are:
 
-| nginx server_name | Behavior |
-| --- | --- |
-| `wigclub.store www.wigclub.store` | Serves `/root/athena/storefront/current` with SPA fallback |
-| `athena.wigclub.store` | Serves `/root/athena/athena-webapp/current` with SPA fallback |
-| `qa.wigclub.store` | Proxies to the storefront QA Vite dev server at `127.0.0.1:5176`, including websocket upgrade headers |
-| `athena-qa.wigclub.store` | Proxies to the QA Vite dev server at `127.0.0.1:5175`, including websocket upgrade headers |
-| `api.wigclub.store` | Proxies to the production Convex HTTP site with CORS handling |
-| `dev.wigclub.store` | Proxies to the dev Convex HTTP site with CORS handling |
+| nginx server_name                 | Behavior                                                                                              |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `wigclub.store www.wigclub.store` | Serves `/root/athena/storefront/current` with SPA fallback                                            |
+| `athena.wigclub.store`            | Serves `/root/athena/athena-webapp/current` with SPA fallback                                         |
+| `qa.wigclub.store`                | Proxies to the storefront QA Vite dev server at `127.0.0.1:5176`, including websocket upgrade headers |
+| `athena-qa.wigclub.store`         | Proxies to the QA Vite dev server at `127.0.0.1:5175`, including websocket upgrade headers            |
+| `api.wigclub.store`               | Proxies to the production Convex HTTP site with CORS handling                                         |
+| `dev.wigclub.store`               | Proxies to the dev Convex HTTP site with CORS handling                                                |
 
 nginx only listens on local HTTP port `80`. Public TLS is terminated at Cloudflare and traffic reaches nginx through Cloudflare Tunnel. Do not add certificate files to nginx for the tunnel-based deployment unless intentionally moving away from Cloudflare Tunnel.
 
@@ -187,9 +187,11 @@ scripts/deploy-vps.sh all
 scripts/deploy-vps.sh check-git
 ```
 
-`athena` is the default production Athena deploy path and builds locally before
-uploading the static bundle. Use `athena-remote` only when you intentionally
-want the VPS checkout to build the Athena admin app.
+`athena`, `storefront`, `full-prod`, and `all` are local-build production deploy
+paths. They build static bundles from the local checkout before uploading them
+to the VPS. `full-prod-local` remains as an explicit alias for older runbooks.
+Use `athena-remote` only when you intentionally want the VPS checkout to build
+the Athena admin app.
 
 Convex production deploys still run from the local checkout through the same entrypoint:
 
@@ -264,11 +266,11 @@ curl -sS -I -H 'Host: wigclub.store' http://127.0.0.1/
 
 The production rollback workflow needs these GitHub environment or repository secrets:
 
-| Secret | Purpose |
-| --- | --- |
-| `ATHENA_VPS_HOST` | VPS hostname or IP address reachable from GitHub Actions |
-| `ATHENA_VPS_USER` | SSH user for the VPS; use `root` unless the VPS has a dedicated deploy user |
-| `ATHENA_VPS_SSH_PRIVATE_KEY` | Private key that can SSH to the VPS user |
+| Secret                       | Purpose                                                                     |
+| ---------------------------- | --------------------------------------------------------------------------- |
+| `ATHENA_VPS_HOST`            | VPS hostname or IP address reachable from GitHub Actions                    |
+| `ATHENA_VPS_USER`            | SSH user for the VPS; use `root` unless the VPS has a dedicated deploy user |
+| `ATHENA_VPS_SSH_PRIVATE_KEY` | Private key that can SSH to the VPS user                                    |
 
 ## QA Dev Server
 
@@ -317,16 +319,16 @@ Because this exposes Vite dev servers through public hostnames, protect `athena-
 
 Athena POS receipt messaging sends customer-safe storefront receipt links through the Meta WhatsApp Cloud API. Configure these server-side Convex environment variables per environment before operators use the WhatsApp receipt action:
 
-| Variable | Purpose |
-| --- | --- |
-| `WHATSAPP_ACCESS_TOKEN` | Meta Cloud API access token for the WhatsApp Business account |
-| `WHATSAPP_PHONE_NUMBER_ID` | Meta phone number id used in `/{phone-number-id}/messages` send requests |
-| `WHATSAPP_RECEIPT_TEMPLATE_NAME` | Approved utility template name for POS receipt links |
-| `WHATSAPP_TEMPLATE_LANGUAGE` | Template language code; defaults to `en_US` when omitted |
-| `WHATSAPP_GRAPH_API_VERSION` | Meta Graph API version; defaults to `v24.0` when omitted |
-| `WHATSAPP_WEBHOOK_VERIFY_TOKEN` | Verify token configured in the Meta app webhook callback |
-| `WHATSAPP_WEBHOOK_APP_SECRET` | Meta app secret used to verify `X-Hub-Signature-256` webhook POST callbacks |
-| `STOREFRONT_RECEIPT_BASE_URL` | Public storefront origin used to build `/shop/receipt/s/{token}` links |
+| Variable                         | Purpose                                                                     |
+| -------------------------------- | --------------------------------------------------------------------------- |
+| `WHATSAPP_ACCESS_TOKEN`          | Meta Cloud API access token for the WhatsApp Business account               |
+| `WHATSAPP_PHONE_NUMBER_ID`       | Meta phone number id used in `/{phone-number-id}/messages` send requests    |
+| `WHATSAPP_RECEIPT_TEMPLATE_NAME` | Approved utility template name for POS receipt links                        |
+| `WHATSAPP_TEMPLATE_LANGUAGE`     | Template language code; defaults to `en_US` when omitted                    |
+| `WHATSAPP_GRAPH_API_VERSION`     | Meta Graph API version; defaults to `v24.0` when omitted                    |
+| `WHATSAPP_WEBHOOK_VERIFY_TOKEN`  | Verify token configured in the Meta app webhook callback                    |
+| `WHATSAPP_WEBHOOK_APP_SECRET`    | Meta app secret used to verify `X-Hub-Signature-256` webhook POST callbacks |
+| `STOREFRONT_RECEIPT_BASE_URL`    | Public storefront origin used to build `/shop/receipt/s/{token}` links      |
 
 The receipt template body variables are store name, transaction number, and receipt link, in that order. Configure the Meta webhook callback to Athena's `/webhooks/whatsapp` endpoint so `sent`, `delivered`, `read`, and `failed` statuses can update the POS delivery history.
 
@@ -343,11 +345,11 @@ DEPLOY_REF="$GITHUB_SHA" REMOTE=athena-qa-vps scripts/deploy-vps.sh qa-storefron
 
 Configure these GitHub environment or repository secrets before relying on the workflow:
 
-| Secret | Purpose |
-| --- | --- |
-| `ATHENA_QA_HOST` | VPS hostname or IP address reachable from GitHub Actions |
-| `ATHENA_QA_USER` | SSH user for the VPS; use `root` unless the VPS has a dedicated deploy user |
-| `ATHENA_QA_SSH_PRIVATE_KEY` | Private key that can SSH to the VPS user |
+| Secret                      | Purpose                                                                     |
+| --------------------------- | --------------------------------------------------------------------------- |
+| `ATHENA_QA_HOST`            | VPS hostname or IP address reachable from GitHub Actions                    |
+| `ATHENA_QA_USER`            | SSH user for the VPS; use `root` unless the VPS has a dedicated deploy user |
+| `ATHENA_QA_SSH_PRIVATE_KEY` | Private key that can SSH to the VPS user                                    |
 
 The workflow targets the `qa` GitHub Environment. Keep that environment free of required reviewers if QA should deploy without human approval after every merge.
 

--- a/docs/solutions/architecture/athena-pos-provisional-import-availability-2026-06-11.md
+++ b/docs/solutions/architecture/athena-pos-provisional-import-availability-2026-06-11.md
@@ -58,6 +58,17 @@ inventory truth:
   merchandising shelves. Catalog Ops and POS recovery surfaces should include
   products in those categories even when the products or categories are hidden
   from the storefront.
+- Treat server-projected pending checkout anchors as reusable checkout evidence,
+  not trusted stock. Those anchors are intentionally draft, hidden products with
+  hidden zero-stock SKUs; register catalog predicates must still include them
+  when the product belongs to the reserved `POS pending checkout` category and
+  there is an active pending-review or flagged `posPendingCheckoutItem` for the
+  provisional SKU.
+- Carry a distinct pending-checkout availability policy through register
+  catalog rows, availability rows, local snapshot cache, and product-card
+  presentation. The row should be sellable as `Review pending` with
+  `quantityAvailable: 0`; it should not be rendered as trusted inventory or
+  blocked as out of stock.
 - Keep storefront visibility as an explicit category control. Staff can hide or
   reveal the category on the customer storefront without losing access to the
   operational product list needed for cleanup.
@@ -88,6 +99,14 @@ inventory truth:
 - Do not reuse customer storefront hidden filters for staff catalog operations.
   Hidden storefront state is a merchandising decision; reserved-category cleanup
   and pending-checkout recovery still need the full operational list.
+- Do not let a generic `draft` product filter run before the reserved pending
+  checkout exception. Ordinary draft products must stay out of POS, but pending
+  checkout anchors must remain searchable from other terminals after they are
+  projected to the server.
+- Do not fix only the fuzzy-search path. Cross-terminal pending checkout reuse
+  depends on the register snapshot, requested availability, full availability
+  snapshot, direct barcode/SKU lookup, and exact product-id lookup staying
+  aligned.
 
 ## Validation
 

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1929 files · ~0 words
+- 1930 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6782 nodes · 7568 edges · 1857 communities detected
+- 6794 nodes · 7588 edges · 1858 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1867,6 +1867,7 @@
 - [[_COMMUNITY_Community 1854|Community 1854]]
 - [[_COMMUNITY_Community 1855|Community 1855]]
 - [[_COMMUNITY_Community 1856|Community 1856]]
+- [[_COMMUNITY_Community 1857|Community 1857]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1939,20 +1940,20 @@ Cohesion: 0.07
 Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
 
 ### Community 11 - "Community 11"
+Cohesion: 0.08
+Nodes (22): cleanInventoryMetadataValue(), formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels() (+14 more)
+
+### Community 12 - "Community 12"
 Cohesion: 0.13
 Nodes (35): buildFinalTrustedQuantitiesByRowNumber(), buildProvisionalSkuPatch(), buildSkuInsert(), buildSkuPatch(), finalizeProvisionalImportRowsForAppliedImport(), findExistingSku(), findOrCreateCategory(), findOrCreateProduct() (+27 more)
 
-### Community 12 - "Community 12"
+### Community 13 - "Community 13"
 Cohesion: 0.12
 Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
 
-### Community 13 - "Community 13"
+### Community 14 - "Community 14"
 Cohesion: 0.12
 Nodes (32): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+24 more)
-
-### Community 14 - "Community 14"
-Cohesion: 0.08
-Nodes (21): formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels(), getSkuDetailEntries() (+13 more)
 
 ### Community 15 - "Community 15"
 Cohesion: 0.07
@@ -2000,67 +2001,67 @@ Nodes (22): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphify
 
 ### Community 26 - "Community 26"
 Cohesion: 0.15
-Nodes (21): buildRecoveryReadiness(), buildTerminalRecoveryPresentation(), classifyTerminalHealth(), defaultBlockerSummary(), deriveRecoveryBlockerFromReason(), deriveRecoveryBlockers(), formatAge(), formatStatusLabel() (+13 more)
+Nodes (23): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle(), formatSignedQuantity() (+15 more)
 
 ### Community 27 - "Community 27"
+Cohesion: 0.15
+Nodes (21): buildRecoveryReadiness(), buildTerminalRecoveryPresentation(), classifyTerminalHealth(), defaultBlockerSummary(), deriveRecoveryBlockerFromReason(), deriveRecoveryBlockers(), formatAge(), formatStatusLabel() (+13 more)
+
+### Community 28 - "Community 28"
 Cohesion: 0.1
 Nodes (15): cancelItemAdjustmentWorkflow(), exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff() (+7 more)
 
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.2
 Nodes (25): asRecord(), buildPosLocalSyncUploadEvents(), customerInfoFromPayload(), getCompletedSaleItems(), getCompletedServiceLines(), hasLaterCompletedSale(), isSyncablePosLocalEvent(), isUploadDeferredByValidation() (+17 more)
 
-### Community 29 - "Community 29"
+### Community 30 - "Community 30"
 Cohesion: 0.2
 Nodes (23): completed(), executeCallbackCommand(), executeClearStaleDrawerAuthority(), executeRepairTerminalSeed(), executeRetrySync(), executeTerminalRecoveryCommand(), failed(), getCommandId() (+15 more)
 
-### Community 30 - "Community 30"
+### Community 31 - "Community 31"
 Cohesion: 0.16
 Nodes (19): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), pendingCheckoutItemMatchesLine(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding() (+11 more)
 
-### Community 31 - "Community 31"
+### Community 32 - "Community 32"
 Cohesion: 0.16
 Nodes (18): buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsTransactionSearch(), getDailyOperationsMetricLabels(), getLocalDateFromOperatingDate(), getLocalOperatingDate(), getLocalOperatingDateRange(), getLocalOperatingDateRangeFromSearch() (+10 more)
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.12
 Nodes (18): ancestorChain(), collectRawMoneyParses(), collectRawMoneyParsesFromSource(), collectRawNumericHelperNames(), collectSourceFiles(), collectStorefrontDirectMoneyFormats(), containsDisallowedRawNumericParse(), containsTerm() (+10 more)
 
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.19
 Nodes (23): assertCompoundSolutionCheck(), collectChangedFiles(), collectCompoundSolutionFindings(), collectExistingFiles(), collectMarkdownContents(), collectSourceLineChanges(), countFileLines(), extractFrontmatter() (+15 more)
 
-### Community 34 - "Community 34"
+### Community 35 - "Community 35"
 Cohesion: 0.15
 Nodes (19): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), isLocalGeneratedArtifactPath() (+11 more)
 
-### Community 35 - "Community 35"
+### Community 36 - "Community 36"
 Cohesion: 0.13
 Nodes (18): buildCartSummary(), buildSessionOperationsRow(), expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), loadPosSessionItems(), loadSessionCustomer(), loadSessionOperator() (+10 more)
 
-### Community 36 - "Community 36"
+### Community 37 - "Community 37"
 Cohesion: 0.19
 Nodes (23): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+15 more)
 
-### Community 37 - "Community 37"
+### Community 38 - "Community 38"
 Cohesion: 0.15
 Nodes (19): acquireExpenseQuantityPatchHold(), adjustExpenseQuantityPatchHold(), createDefaultExpenseSessionCommandService(), createExpenseInventoryHoldGateway(), createExpenseSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired() (+11 more)
 
-### Community 38 - "Community 38"
+### Community 39 - "Community 39"
 Cohesion: 0.09
 Nodes (2): buildCashControlsDashboardSnapshot(), sumDepositsBySession()
 
-### Community 39 - "Community 39"
+### Community 40 - "Community 40"
 Cohesion: 0.19
 Nodes (22): buildEventMessage(), buildNextEvidence(), buildNextSaleEvidence(), buildReviewPriority(), buildWorkItemPriority(), createOrReusePendingCheckoutItem(), createProvisionalCatalogAnchors(), findMatchingPendingCheckoutItem() (+14 more)
 
-### Community 40 - "Community 40"
+### Community 41 - "Community 41"
 Cohesion: 0.1
 Nodes (4): listCompletedTransactionsForDay(), listSessionItems(), listTransactionItems(), readAllQueryResults()
-
-### Community 41 - "Community 41"
-Cohesion: 0.16
-Nodes (20): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle(), formatSignedQuantity() (+12 more)
 
 ### Community 42 - "Community 42"
 Cohesion: 0.15
@@ -2199,72 +2200,72 @@ Cohesion: 0.33
 Nodes (14): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+6 more)
 
 ### Community 76 - "Community 76"
+Cohesion: 0.28
+Nodes (14): getRegisterCatalogPrice(), isActiveProvisionalImportSkuForStore(), isTrustedRegisterCatalogSku(), listRegisterCatalog(), listRegisterCatalogAvailability(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow() (+6 more)
+
+### Community 77 - "Community 77"
 Cohesion: 0.17
 Nodes (6): buildServerPricedCheckoutProducts(), calculateItemsSubtotal(), deriveDeliveryOptionFromAddress(), isDeliveryFeeWaived(), normalizeDeliveryOption(), resolveServerDeliveryFee()
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.15
 Nodes (4): formatCurrency(), formatFinancialLabel(), formatTimelineRange(), formatTimelineTime()
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.24
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
-### Community 79 - "Community 79"
+### Community 80 - "Community 80"
 Cohesion: 0.17
 Nodes (6): formatLocalStartTime(), formatLocalStartTimeFromParts(), getLocalStartTimeParts(), handleSave(), parseLocalStartMinutes(), updateLocalStartTimePart()
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.18
 Nodes (7): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), useConvexRegisterServiceCatalog(), usePrewarmRegisterCatalogOfflineSnapshots()
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.22
 Nodes (10): extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isBarcodeShapedInput(), normalizeIdentifier(), parseCatalogSearchInput(), searchByText(), searchRegisterCatalog() (+2 more)
 
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.22
 Nodes (10): createApp(), createHandlers(), createRedisClient(), createRedisCluster(), deleteKeysIndividually(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline(), scanNodeForPattern() (+2 more)
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.31
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getOperationalWorkItemStatus() (+5 more)
 
-### Community 85 - "Community 85"
+### Community 86 - "Community 86"
 Cohesion: 0.19
 Nodes (4): formatQuickAddDialogError(), handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.22
 Nodes (6): buildParticipantIdentity(), getDataPublishRouting(), getParticipantRole(), isAllowedSender(), LiveKitRemoteAssistClient, parseParticipantRole()
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.26
 Nodes (12): bestFuzzyTokenScore(), compactSearchText(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreCompactFieldContains(), scoreFuzzySearchEntry() (+4 more)
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
-
-### Community 92 - "Community 92"
-Cohesion: 0.31
-Nodes (12): getRegisterCatalogPrice(), isActiveProvisionalImportSkuForStore(), isTrustedRegisterCatalogSku(), listRegisterCatalog(), listRegisterCatalogAvailability(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow() (+4 more)
 
 ### Community 93 - "Community 93"
 Cohesion: 0.28
@@ -2707,32 +2708,32 @@ Cohesion: 0.33
 Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
 ### Community 203 - "Community 203"
+Cohesion: 0.29
+Nodes (1): ResizeObserverStub
+
+### Community 204 - "Community 204"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 204 - "Community 204"
+### Community 205 - "Community 205"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 205 - "Community 205"
+### Community 206 - "Community 206"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 206 - "Community 206"
+### Community 207 - "Community 207"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 207 - "Community 207"
+### Community 208 - "Community 208"
 Cohesion: 0.33
 Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
 
-### Community 208 - "Community 208"
+### Community 209 - "Community 209"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 209 - "Community 209"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
 
 ### Community 210 - "Community 210"
 Cohesion: 0.29
@@ -2743,28 +2744,28 @@ Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
 ### Community 212 - "Community 212"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 213 - "Community 213"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 213 - "Community 213"
+### Community 214 - "Community 214"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 214 - "Community 214"
+### Community 215 - "Community 215"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 215 - "Community 215"
+### Community 216 - "Community 216"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 216 - "Community 216"
-Cohesion: 0.33
-Nodes (1): ValkeyClient
-
 ### Community 217 - "Community 217"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ValkeyClient
 
 ### Community 218 - "Community 218"
 Cohesion: 0.33
@@ -2783,76 +2784,76 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 222 - "Community 222"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 223 - "Community 223"
 Cohesion: 0.4
 Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.4
 Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.4
 Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
-
-### Community 239 - "Community 239"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 240 - "Community 240"
 Cohesion: 0.33
@@ -2860,23 +2861,23 @@ Nodes (0):
 
 ### Community 241 - "Community 241"
 Cohesion: 0.33
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 242 - "Community 242"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 243 - "Community 243"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 244 - "Community 244"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 244 - "Community 244"
+### Community 245 - "Community 245"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
-
-### Community 245 - "Community 245"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 246 - "Community 246"
 Cohesion: 0.33
@@ -2895,12 +2896,12 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 250 - "Community 250"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
-
-### Community 251 - "Community 251"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 251 - "Community 251"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 252 - "Community 252"
 Cohesion: 0.33
@@ -2911,104 +2912,104 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 254 - "Community 254"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
-
-### Community 255 - "Community 255"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
-
-### Community 256 - "Community 256"
 Cohesion: 0.33
 Nodes (0):
 
+### Community 255 - "Community 255"
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+
+### Community 256 - "Community 256"
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+
 ### Community 257 - "Community 257"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 258 - "Community 258"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 259 - "Community 259"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 260 - "Community 260"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 261 - "Community 261"
 Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 262 - "Community 262"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 263 - "Community 263"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 263 - "Community 263"
+### Community 264 - "Community 264"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 264 - "Community 264"
+### Community 265 - "Community 265"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 265 - "Community 265"
+### Community 266 - "Community 266"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
-### Community 266 - "Community 266"
+### Community 267 - "Community 267"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 267 - "Community 267"
+### Community 268 - "Community 268"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 268 - "Community 268"
+### Community 269 - "Community 269"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 269 - "Community 269"
+### Community 270 - "Community 270"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 270 - "Community 270"
+### Community 271 - "Community 271"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 271 - "Community 271"
+### Community 272 - "Community 272"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 272 - "Community 272"
+### Community 273 - "Community 273"
 Cohesion: 0.5
 Nodes (2): createAuthorizedRegisterDepositCtx(), createQueryCtx()
 
-### Community 273 - "Community 273"
+### Community 274 - "Community 274"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 274 - "Community 274"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 275 - "Community 275"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 276 - "Community 276"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 277 - "Community 277"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
-### Community 277 - "Community 277"
+### Community 278 - "Community 278"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
-
-### Community 278 - "Community 278"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 279 - "Community 279"
 Cohesion: 0.4
@@ -3019,16 +3020,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 281 - "Community 281"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 282 - "Community 282"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 282 - "Community 282"
+### Community 283 - "Community 283"
 Cohesion: 0.6
 Nodes (3): isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult()
-
-### Community 283 - "Community 283"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 284 - "Community 284"
 Cohesion: 0.4
@@ -3043,32 +3044,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 287 - "Community 287"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 288 - "Community 288"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 288 - "Community 288"
+### Community 289 - "Community 289"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 289 - "Community 289"
+### Community 290 - "Community 290"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 290 - "Community 290"
+### Community 291 - "Community 291"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 291 - "Community 291"
+### Community 292 - "Community 292"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 292 - "Community 292"
+### Community 293 - "Community 293"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
-
-### Community 293 - "Community 293"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 294 - "Community 294"
 Cohesion: 0.4
@@ -3079,12 +3080,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 296 - "Community 296"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 297 - "Community 297"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 297 - "Community 297"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 298 - "Community 298"
 Cohesion: 0.4
@@ -3103,24 +3104,24 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 302 - "Community 302"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 303 - "Community 303"
 Cohesion: 0.5
 Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
-### Community 303 - "Community 303"
+### Community 304 - "Community 304"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 304 - "Community 304"
+### Community 305 - "Community 305"
 Cohesion: 0.5
 Nodes (2): buildTerminalOfflineReadiness(), getAppSessionReadinessInput()
 
-### Community 305 - "Community 305"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 306 - "Community 306"
 Cohesion: 0.4
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 307 - "Community 307"
 Cohesion: 0.4
@@ -3135,52 +3136,52 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 310 - "Community 310"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 311 - "Community 311"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 311 - "Community 311"
+### Community 312 - "Community 312"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 312 - "Community 312"
+### Community 313 - "Community 313"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 313 - "Community 313"
+### Community 314 - "Community 314"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 314 - "Community 314"
+### Community 315 - "Community 315"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 315 - "Community 315"
-Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 316 - "Community 316"
 Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 317 - "Community 317"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 318 - "Community 318"
 Cohesion: 0.6
-Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 319 - "Community 319"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
 ### Community 320 - "Community 320"
-Cohesion: 0.7
-Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
-
-### Community 321 - "Community 321"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 321 - "Community 321"
+Cohesion: 0.7
+Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
 ### Community 322 - "Community 322"
 Cohesion: 0.4
@@ -3195,12 +3196,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 325 - "Community 325"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 326 - "Community 326"
 Cohesion: 0.5
-Nodes (3): createVersionChecker(), shouldAutoReloadForCurrentRoute(), shouldAutoReloadForPath()
+Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 327 - "Community 327"
 Cohesion: 0.4
@@ -3231,52 +3232,52 @@ Cohesion: 0.7
 Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 334 - "Community 334"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (3): createVersionChecker(), shouldAutoReloadForCurrentRoute(), shouldAutoReloadForPath()
 
 ### Community 335 - "Community 335"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 336 - "Community 336"
-Cohesion: 0.6
-Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 337 - "Community 337"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 337 - "Community 337"
+Cohesion: 0.6
+Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+
 ### Community 338 - "Community 338"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 339 - "Community 339"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 339 - "Community 339"
+### Community 340 - "Community 340"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 340 - "Community 340"
+### Community 341 - "Community 341"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 341 - "Community 341"
+### Community 342 - "Community 342"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 342 - "Community 342"
+### Community 343 - "Community 343"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 343 - "Community 343"
+### Community 344 - "Community 344"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 344 - "Community 344"
+### Community 345 - "Community 345"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 345 - "Community 345"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 346 - "Community 346"
 Cohesion: 0.5
@@ -3287,12 +3288,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 348 - "Community 348"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
-
-### Community 349 - "Community 349"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 349 - "Community 349"
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 350 - "Community 350"
 Cohesion: 0.5
@@ -3303,72 +3304,72 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 352 - "Community 352"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 353 - "Community 353"
 Cohesion: 0.67
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 353 - "Community 353"
+### Community 354 - "Community 354"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 354 - "Community 354"
+### Community 355 - "Community 355"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 355 - "Community 355"
+### Community 356 - "Community 356"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 356 - "Community 356"
+### Community 357 - "Community 357"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 357 - "Community 357"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 358 - "Community 358"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 359 - "Community 359"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 360 - "Community 360"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 361 - "Community 361"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 361 - "Community 361"
+### Community 362 - "Community 362"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 362 - "Community 362"
+### Community 363 - "Community 363"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 363 - "Community 363"
+### Community 364 - "Community 364"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 364 - "Community 364"
+### Community 365 - "Community 365"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 365 - "Community 365"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 366 - "Community 366"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 367 - "Community 367"
 Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 368 - "Community 368"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 369 - "Community 369"
 Cohesion: 0.5
@@ -3379,20 +3380,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 371 - "Community 371"
-Cohesion: 0.67
-Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 372 - "Community 372"
 Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
+Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
 ### Community 373 - "Community 373"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 374 - "Community 374"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 375 - "Community 375"
 Cohesion: 0.5
@@ -3403,28 +3404,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 377 - "Community 377"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 378 - "Community 378"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 378 - "Community 378"
+### Community 379 - "Community 379"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 379 - "Community 379"
+### Community 380 - "Community 380"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 380 - "Community 380"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 381 - "Community 381"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 382 - "Community 382"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 383 - "Community 383"
 Cohesion: 0.5
@@ -3439,20 +3440,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 386 - "Community 386"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 387 - "Community 387"
 Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 388 - "Community 388"
 Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 389 - "Community 389"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 390 - "Community 390"
 Cohesion: 0.5
@@ -3475,16 +3476,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 395 - "Community 395"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 396 - "Community 396"
 Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 397 - "Community 397"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 398 - "Community 398"
 Cohesion: 0.5
@@ -3495,12 +3496,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 400 - "Community 400"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 401 - "Community 401"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 401 - "Community 401"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 402 - "Community 402"
 Cohesion: 0.5
@@ -9322,6 +9323,10 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1857 - "Community 1857"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -9679,2109 +9684,2111 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 804`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 805`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 806`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 807`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 808`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 809`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 810`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 811`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 812`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 813`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 814`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 815`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 816`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 817`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 818`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 819`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 820`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 821`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 822`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 823`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 824`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 825`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 826`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 827`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 828`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 829`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 830`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 831`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 832`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 833`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 834`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 835`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 836`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 837`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 838`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 839`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 840`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 841`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 842`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 843`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 844`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 845`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 846`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 847`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 848`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 849`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 850`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 851`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 852`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 853`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 854`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 855`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 856`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 857`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 858`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 859`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 860`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 861`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 862`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 863`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 864`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 865`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 866`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 867`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 868`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 869`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 870`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 871`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 872`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 873`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 874`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 875`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 876`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 877`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 878`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 879`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 880`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 881`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 882`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 883`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 884`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 885`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 886`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 887`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 888`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 889`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 890`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 891`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 892`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 893`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 894`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 895`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 896`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 897`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 898`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
+- **Thin community `Community 899`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 900`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 901`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 902`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 903`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 904`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 905`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 906`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 907`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 908`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 909`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 910`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 911`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 912`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 913`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 914`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 915`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 916`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 917`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 918`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 919`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 920`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 921`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 922`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 923`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 924`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 925`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 926`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 927`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 928`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 929`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 930`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 931`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 932`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 933`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 934`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 935`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 936`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 937`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 938`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 939`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 940`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 941`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 942`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 943`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 944`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 945`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 946`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 947`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 948`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 949`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 950`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 951`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 952`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 953`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 954`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 955`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 956`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 957`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 958`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 959`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 960`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 961`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 962`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 963`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 964`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 965`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 966`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 967`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 968`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 969`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 970`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 971`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 972`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 973`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 974`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 975`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 976`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 977`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 978`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 979`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 980`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 981`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 982`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 983`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 984`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 985`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 986`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 987`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 988`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 989`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 990`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 991`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 992`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 993`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 994`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 995`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 996`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 997`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 998`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 999`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1000`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1001`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1002`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1003`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1004`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1005`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1006`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1007`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1008`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1009`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1010`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1011`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1012`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1013`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1014`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1015`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1016`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1017`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1018`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1019`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1020`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1021`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1022`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1023`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1024`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1025`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1026`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1027`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1028`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1029`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1030`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1031`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1032`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1033`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1034`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1035`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1036`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1037`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1038`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1039`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1040`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1041`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1042`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1043`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1044`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1045`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1046`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1047`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1048`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1049`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1050`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1051`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1052`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1053`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1054`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1055`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1056`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1057`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1058`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1059`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1060`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1061`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1062`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `api.js`
+- **Thin community `Community 1063`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1064`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1065`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `server.js`
+- **Thin community `Community 1066`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `app.ts`
+- **Thin community `Community 1067`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1068`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1069`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1070`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1071`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `auth.ts`
+- **Thin community `Community 1072`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1073`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1074`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1075`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `countries.ts`
+- **Thin community `Community 1076`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `email.ts`
+- **Thin community `Community 1077`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1078`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `payment.ts`
+- **Thin community `Community 1079`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1080`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `crons.ts`
+- **Thin community `Community 1081`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1082`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `internal.ts`
+- **Thin community `Community 1083`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1084`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1085`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1086`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1087`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1088`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1089`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1090`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1091`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1092`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1093`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1094`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `env.ts`
+- **Thin community `Community 1095`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1096`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `auth.ts`
+- **Thin community `Community 1097`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1098`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `colors.ts`
+- **Thin community `Community 1099`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `index.ts`
+- **Thin community `Community 1100`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1101`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `products.ts`
+- **Thin community `Community 1102`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1103`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `stores.ts`
+- **Thin community `Community 1104`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `bag.ts`
+- **Thin community `Community 1105`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `guest.ts`
+- **Thin community `Community 1106`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `index.ts`
+- **Thin community `Community 1107`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `me.ts`
+- **Thin community `Community 1108`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `offers.ts`
+- **Thin community `Community 1109`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1110`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1111`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1112`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1113`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1114`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1115`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1116`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1117`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1118`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `user.ts`
+- **Thin community `Community 1119`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1120`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `index.ts`
+- **Thin community `Community 1121`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1122`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `http.ts`
+- **Thin community `Community 1123`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1124`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1125`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1126`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `categories.ts`
+- **Thin community `Community 1127`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `colors.ts`
+- **Thin community `Community 1128`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1129`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 1130`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1131`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1132`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1133`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1134`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `pos.ts`
+- **Thin community `Community 1135`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1136`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1137`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1138`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1139`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1140`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1141`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1142`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1143`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1144`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1145`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1146`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1147`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1148`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1149`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1150`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1151`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `types.ts`
+- **Thin community `Community 1152`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1153`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1154`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1155`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1156`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1157`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1158`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `dto.ts`
+- **Thin community `Community 1159`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1160`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1161`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1162`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `types.ts`
+- **Thin community `Community 1163`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1164`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1165`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1166`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `customers.ts`
+- **Thin community `Community 1167`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `register.ts`
+- **Thin community `Community 1168`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `sync.ts`
+- **Thin community `Community 1169`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1170`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1171`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1172`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `schema.ts`
+- **Thin community `Community 1173`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `automation.ts`
+- **Thin community `Community 1174`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1175`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `index.ts`
+- **Thin community `Community 1176`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1177`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1178`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1179`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1180`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1181`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `category.ts`
+- **Thin community `Community 1182`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `color.ts`
+- **Thin community `Community 1183`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1184`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1185`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `index.ts`
+- **Thin community `Community 1186`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1187`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1188`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1189`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1190`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `organization.ts`
+- **Thin community `Community 1191`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1192`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `product.ts`
+- **Thin community `Community 1193`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1194`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1195`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `store.ts`
+- **Thin community `Community 1196`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1197`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `index.ts`
+- **Thin community `Community 1198`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1199`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1200`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1201`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1202`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1203`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1204`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1205`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `index.ts`
+- **Thin community `Community 1206`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1207`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1208`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1209`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1210`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1211`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1212`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1213`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1214`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1215`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1216`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1217`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `customer.ts`
+- **Thin community `Community 1218`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1219`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1220`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1221`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1222`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `index.ts`
+- **Thin community `Community 1223`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1224`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1225`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1226`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1227`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1228`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1229`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1230`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1231`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1232`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1233`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1234`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1235`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1236`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1237`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1238`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1239`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1240`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1241`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1242`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `index.ts`
+- **Thin community `Community 1243`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1244`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1245`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `index.ts`
+- **Thin community `Community 1246`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1247`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1248`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1249`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1250`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1251`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1252`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `index.ts`
+- **Thin community `Community 1253`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1254`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1255`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1256`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1257`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1258`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1259`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `bag.ts`
+- **Thin community `Community 1260`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1261`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1262`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1263`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `guest.ts`
+- **Thin community `Community 1264`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `index.ts`
+- **Thin community `Community 1265`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `offer.ts`
+- **Thin community `Community 1266`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1267`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1268`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `review.ts`
+- **Thin community `Community 1269`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1270`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1271`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1272`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1273`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1274`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1275`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1276`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1277`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1278`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `bag.ts`
+- **Thin community `Community 1279`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1280`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `customer.ts`
+- **Thin community `Community 1281`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `guest.ts`
+- **Thin community `Community 1282`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1283`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1284`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1285`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1286`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `payment.ts`
+- **Thin community `Community 1287`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1288`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1289`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1290`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `users.ts`
+- **Thin community `Community 1291`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `payment.ts`
+- **Thin community `Community 1292`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1293`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1294`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1295`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1296`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1297`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `index.ts`
+- **Thin community `Community 1298`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1299`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1300`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1301`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1302`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `auth.ts`
+- **Thin community `Community 1303`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1304`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1305`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1306`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1307`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1308`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1309`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1310`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1311`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1312`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1313`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1314`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1315`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1316`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1317`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1318`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1319`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `constants.ts`
+- **Thin community `Community 1320`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1321`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1322`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1323`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `types.ts`
+- **Thin community `Community 1324`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1325`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1326`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1327`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1328`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1329`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1330`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1331`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1332`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1333`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1334`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1335`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1336`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1337`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1338`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1339`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1340`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1341`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1342`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1343`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1344`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `constants.ts`
+- **Thin community `Community 1345`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1346`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1347`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1348`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `data.ts`
+- **Thin community `Community 1349`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1350`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1351`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1352`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1353`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1354`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1355`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1356`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1357`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1358`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `constants.ts`
+- **Thin community `Community 1359`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1360`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1361`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1362`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `data.ts`
+- **Thin community `Community 1363`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1364`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1365`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1366`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1367`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1368`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1369`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1370`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1371`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1372`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1373`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1374`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1375`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `constants.ts`
+- **Thin community `Community 1376`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1377`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1378`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1379`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1380`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1381`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1382`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1383`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1384`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1385`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1386`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1387`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1388`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1389`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1390`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1391`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 1392`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1393`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1394`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1395`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1396`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1397`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1398`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1399`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1400`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1401`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1402`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1403`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1404`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1405`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1406`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1407`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1408`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `constants.ts`
+- **Thin community `Community 1409`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1410`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1411`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1412`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `data.ts`
+- **Thin community `Community 1413`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1414`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1415`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `constants.ts`
+- **Thin community `Community 1416`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1417`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1418`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1419`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1420`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `data.ts`
+- **Thin community `Community 1421`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1422`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `constants.ts`
+- **Thin community `Community 1423`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1424`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1425`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1426`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1427`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `data.ts`
+- **Thin community `Community 1428`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1429`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1430`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1431`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1432`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1433`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1434`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1435`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1436`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1437`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1438`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1439`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1440`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1441`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1442`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1443`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1444`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1445`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1446`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1447`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1448`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1449`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1450`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1451`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1452`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1453`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1454`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `POSTerminalHealthView.test.tsx`
+- **Thin community `Community 1455`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1456`** (1 nodes): `POSTerminalHealthView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1457`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1458`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `types.ts`
+- **Thin community `Community 1459`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1460`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1461`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1462`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1463`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1464`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1465`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1466`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1467`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1468`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1469`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1470`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1471`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1472`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1473`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1474`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1475`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1476`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `data.ts`
+- **Thin community `Community 1477`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1478`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1479`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1480`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1481`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1482`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1483`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1484`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1485`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1486`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1487`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1488`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1489`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `constants.ts`
+- **Thin community `Community 1490`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1491`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1492`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1493`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `data.ts`
+- **Thin community `Community 1494`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `types.ts`
+- **Thin community `Community 1495`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1496`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 1497`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 1498`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 1499`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 1500`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `index.ts`
+- **Thin community `Community 1501`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1502`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1503`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1504`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1505`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `index.tsx`
+- **Thin community `Community 1506`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1507`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1508`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1509`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1510`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1511`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1512`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1513`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1514`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `index.tsx`
+- **Thin community `Community 1515`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1516`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1517`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1518`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `button.tsx`
+- **Thin community `Community 1519`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1520`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `card.tsx`
+- **Thin community `Community 1521`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1522`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1523`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `command.tsx`
+- **Thin community `Community 1524`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1525`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1526`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1527`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `form.tsx`
+- **Thin community `Community 1528`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1529`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1530`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `input.tsx`
+- **Thin community `Community 1531`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1532`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1533`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1534`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1535`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1536`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1537`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `select.tsx`
+- **Thin community `Community 1538`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1539`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1540`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `sidebar.test.tsx`
+- **Thin community `Community 1541`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1542`** (1 nodes): `sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `table.tsx`
+- **Thin community `Community 1543`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1544`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1545`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1546`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1547`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1548`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1549`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1550`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1551`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `constants.ts`
+- **Thin community `Community 1552`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1553`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1554`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1555`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `data.ts`
+- **Thin community `Community 1556`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1557`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1558`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1559`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1560`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1561`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1562`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1563`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1564`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1565`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1566`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1567`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `index.ts`
+- **Thin community `Community 1568`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1569`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1570`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1571`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1572`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1573`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1574`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1575`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1576`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1577`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1578`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1579`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `aws.ts`
+- **Thin community `Community 1580`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `constants.ts`
+- **Thin community `Community 1581`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `countries.ts`
+- **Thin community `Community 1582`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1583`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1584`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1585`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1586`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1587`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1588`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1589`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `dto.ts`
+- **Thin community `Community 1590`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `ports.ts`
+- **Thin community `Community 1591`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `constants.ts`
+- **Thin community `Community 1592`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1593`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1594`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `index.ts`
+- **Thin community `Community 1595`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1596`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `types.ts`
+- **Thin community `Community 1597`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1598`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1599`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1600`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1601`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1602`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1603`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1604`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1605`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 1606`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1607`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1608`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1609`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 1610`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 1611`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `index.ts`
+- **Thin community `Community 1612`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 1613`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `category.ts`
+- **Thin community `Community 1614`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `product.ts`
+- **Thin community `Community 1615`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `store.ts`
+- **Thin community `Community 1616`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1617`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `user.ts`
+- **Thin community `Community 1618`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1619`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1620`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1621`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1622`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1623`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1624`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1625`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1626`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1627`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1628`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `index.tsx`
+- **Thin community `Community 1629`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1630`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1631`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1632`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1633`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1634`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1635`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1636`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `index.tsx`
+- **Thin community `Community 1637`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1638`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1639`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1640`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `home.tsx`
+- **Thin community `Community 1641`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1642`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1643`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1644`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `index.tsx`
+- **Thin community `Community 1645`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `review.tsx`
+- **Thin community `Community 1646`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1647`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1648`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `index.tsx`
+- **Thin community `Community 1649`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1650`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1651`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1652`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `index.tsx`
+- **Thin community `Community 1653`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1654`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1655`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1656`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1657`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1658`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1659`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `index.tsx`
+- **Thin community `Community 1660`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1661`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1662`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1663`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1664`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1665`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1666`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1667`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1668`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1669`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `index.tsx`
+- **Thin community `Community 1670`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1671`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `index.tsx`
+- **Thin community `Community 1672`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `new.tsx`
+- **Thin community `Community 1673`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `index.tsx`
+- **Thin community `Community 1674`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `new.tsx`
+- **Thin community `Community 1675`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1676`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1677`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `index.tsx`
+- **Thin community `Community 1678`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `new.tsx`
+- **Thin community `Community 1679`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `index.tsx`
+- **Thin community `Community 1680`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1681`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1682`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1683`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1684`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `index.tsx`
+- **Thin community `Community 1685`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1686`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1687`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1688`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `index.tsx`
+- **Thin community `Community 1689`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1690`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1691`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1692`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1693`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1694`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1695`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1696`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1697`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1698`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1699`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1700`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1701`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1702`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1703`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1704`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1705`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1706`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1707`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1708`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1709`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1710`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1711`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1712`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1713`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `setup.ts`
+- **Thin community `Community 1714`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1715`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `types.ts`
+- **Thin community `Community 1716`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1717`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1718`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1719`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1720`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1721`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `types.ts`
+- **Thin community `Community 1722`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1723`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1724`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1725`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1726`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1727`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1728`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1729`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1730`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1731`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `schema.ts`
+- **Thin community `Community 1732`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1733`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1734`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1735`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1736`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1737`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1738`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1739`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1740`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1741`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `types.ts`
+- **Thin community `Community 1742`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1743`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1744`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1745`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1746`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1747`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1748`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1749`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `constants.ts`
+- **Thin community `Community 1750`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1751`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `About.tsx`
+- **Thin community `Community 1752`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1753`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1754`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1755`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1756`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1757`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1758`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1759`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1760`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1761`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1762`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `types.ts`
+- **Thin community `Community 1763`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1764`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1765`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1766`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1767`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1768`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1769`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1770`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1771`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1772`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1773`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1774`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `button.tsx`
+- **Thin community `Community 1775`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `card.tsx`
+- **Thin community `Community 1776`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1777`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `command.tsx`
+- **Thin community `Community 1778`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1779`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1780`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1781`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `form.tsx`
+- **Thin community `Community 1782`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1783`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1784`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1785`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1786`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `input.tsx`
+- **Thin community `Community 1787`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `label.tsx`
+- **Thin community `Community 1788`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1789`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1790`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1791`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `index.ts`
+- **Thin community `Community 1792`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `types.ts`
+- **Thin community `Community 1793`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1794`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1795`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1796`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1797`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `select.tsx`
+- **Thin community `Community 1798`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1799`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1800`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `table.tsx`
+- **Thin community `Community 1801`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1802`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1803`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1804`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1805`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1806`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `config.ts`
+- **Thin community `Community 1807`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1808`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1809`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1810`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1811`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `constants.ts`
+- **Thin community `Community 1812`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `countries.ts`
+- **Thin community `Community 1813`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1814`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1815`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1816`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1817`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `index.ts`
+- **Thin community `Community 1818`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `store.ts`
+- **Thin community `Community 1819`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `bag.ts`
+- **Thin community `Community 1820`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1821`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `category.ts`
+- **Thin community `Community 1822`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `organization.ts`
+- **Thin community `Community 1823`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `product.ts`
+- **Thin community `Community 1824`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `store.ts`
+- **Thin community `Community 1825`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1826`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `user.ts`
+- **Thin community `Community 1827`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `states.ts`
+- **Thin community `Community 1828`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1829`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1830`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1831`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1832`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1833`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1834`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1835`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `index.tsx`
+- **Thin community `Community 1836`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1837`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `index.tsx`
+- **Thin community `Community 1838`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1839`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1840`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1841`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1842`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1843`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `index.tsx`
+- **Thin community `Community 1844`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1845`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1846`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1847`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1848`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1849`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `index.js`
+- **Thin community `Community 1850`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1851`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1852`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1853`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1854`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1855`** (1 nodes): `valkey-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1856`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1857`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,10 +7,10 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1929
-- Graph nodes: 6782
-- Graph edges: 7568
-- Communities: 1857
+- Code files discovered: 1930
+- Graph nodes: 6794
+- Graph edges: 7588
+- Communities: 1858
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (87 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -17,11 +17,11 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 - [validation-map.json](../../../packages/valkey-proxy-server/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `app.js` (14 edges, Community 82) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.js` (14 edges, Community 83) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `app.test.js` (6 edges, Community 151) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
-- `createRedisClient()` (4 edges, Community 82) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `createRedisCluster()` (3 edges, Community 82) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `deleteKeysIndividually()` (3 edges, Community 82) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisClient()` (4 edges, Community 83) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisCluster()` (3 edges, Community 83) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `deleteKeysIndividually()` (3 edges, Community 83) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.test.ts
@@ -13,6 +13,7 @@ type TableName =
   | "color"
   | "inventoryHold"
   | "inventoryImportProvisionalSku"
+  | "posPendingCheckoutItem"
   | "product"
   | "productSku";
 type Row = Record<string, unknown> & { _id: string };
@@ -30,6 +31,7 @@ function createRegisterCatalogCtx(
     color: new Map(),
     inventoryHold: new Map(),
     inventoryImportProvisionalSku: new Map(),
+    posPendingCheckoutItem: new Map(),
     product: new Map(),
     productSku: new Map(),
   };
@@ -47,10 +49,7 @@ function createRegisterCatalogCtx(
     );
   }
 
-  function createIndexedQuery(
-    table: TableName,
-    filters: IndexedFilter[],
-  ) {
+  function createIndexedQuery(table: TableName, filters: IndexedFilter[]) {
     const matches = Array.from(tables[table].values()).filter((row) =>
       filters.every((filter) => filter.matches(row[filter.field])),
     );
@@ -137,8 +136,7 @@ function createRegisterCatalogCtx(
                   filter.op === "eq"
                     ? (rowValue) => rowValue === filter.value
                     : (rowValue) =>
-                        typeof rowValue === "number" &&
-                        rowValue > filter.value,
+                        typeof rowValue === "number" && rowValue > filter.value,
               })),
             );
           },
@@ -256,7 +254,7 @@ describe("listRegisterCatalog", () => {
           categoryId: "category-pos-pending-checkout",
           description: "Reviewable cashier item",
           name: "Pending Checkout Item",
-          availability: "live",
+          availability: "draft",
           isVisible: false,
         },
         {
@@ -359,8 +357,9 @@ describe("listRegisterCatalog", () => {
           sku: "PENDING-CHECKOUT",
           barcode: "111",
           images: [],
+          isVisible: false,
           price: 1000,
-          quantityAvailable: 3,
+          quantityAvailable: 0,
         },
         {
           _id: "sku-hidden",
@@ -372,6 +371,15 @@ describe("listRegisterCatalog", () => {
           isVisible: false,
           price: 1000,
           quantityAvailable: 3,
+        },
+      ],
+      posPendingCheckoutItem: [
+        {
+          _id: "pending-checkout-1",
+          storeId: "store-a",
+          status: "pending_review",
+          provisionalProductSkuId: "sku-pos-pending-checkout",
+          provisionalPrice: 1000,
         },
       ],
     });
@@ -451,7 +459,8 @@ describe("listRegisterCatalog", () => {
         length: null,
         color: "",
         areProcessingFeesAbsorbed: false,
-        availabilityPolicy: "trusted_inventory",
+        availabilityPolicy: "pending_checkout",
+        pendingCheckoutItemId: "pending-checkout-1",
       },
     ]);
 
@@ -774,6 +783,22 @@ describe("listRegisterCatalog", () => {
           sku: "SKU-OTHER",
           quantityAvailable: 9,
         },
+        {
+          _id: "sku-pending-checkout",
+          storeId: "store-a",
+          productId: "product-pending-checkout",
+          sku: "PENDING-CHECKOUT",
+          quantityAvailable: 0,
+        },
+      ],
+      posPendingCheckoutItem: [
+        {
+          _id: "pending-checkout-1",
+          storeId: "store-a",
+          status: "pending_review",
+          provisionalProductSkuId: "sku-pending-checkout",
+          provisionalPrice: 100,
+        },
       ],
     });
 
@@ -782,6 +807,7 @@ describe("listRegisterCatalog", () => {
       productSkuIds: [
         "sku-live",
         "sku-out",
+        "sku-pending-checkout",
         "sku-live",
         "sku-other-store",
         "sku-missing",
@@ -804,6 +830,13 @@ describe("listRegisterCatalog", () => {
         quantityAvailable: 0,
         availabilityPolicy: "active_provisional_import",
       },
+      {
+        productSkuId: "sku-pending-checkout",
+        skuId: "sku-pending-checkout",
+        inStock: true,
+        quantityAvailable: 0,
+        availabilityPolicy: "pending_checkout",
+      },
     ]);
   });
 
@@ -821,9 +854,7 @@ describe("listRegisterCatalog", () => {
 
     const rows = await listRegisterCatalogAvailability(ctx, {
       storeId: "store-a" as Id<"store">,
-      productSkuIds: productSkus.map(
-        (sku) => sku._id as Id<"productSku">,
-      ),
+      productSkuIds: productSkus.map((sku) => sku._id as Id<"productSku">),
     });
 
     expect(rows).toHaveLength(50);
@@ -841,6 +872,12 @@ describe("listRegisterCatalog", () => {
           _id: "category-store-a",
           storeId: "store-a",
           name: "Wigs",
+        },
+        {
+          _id: "category-pos-pending-checkout",
+          storeId: "store-a",
+          name: "POS pending checkout",
+          slug: "pos-pending-checkout",
         },
       ],
       inventoryHold: [
@@ -913,6 +950,14 @@ describe("listRegisterCatalog", () => {
           categoryId: "category-store-a",
           name: "Other Store Wig",
         },
+        {
+          _id: "product-pending-checkout",
+          storeId: "store-a",
+          categoryId: "category-pos-pending-checkout",
+          name: "Pending Checkout Item",
+          availability: "draft",
+          isVisible: false,
+        },
       ],
       productSku: [
         {
@@ -955,6 +1000,25 @@ describe("listRegisterCatalog", () => {
           price: 100,
           quantityAvailable: 9,
         },
+        {
+          _id: "sku-pending-checkout",
+          storeId: "store-a",
+          productId: "product-pending-checkout",
+          sku: "PENDING-CHECKOUT",
+          images: [],
+          isVisible: false,
+          price: 100,
+          quantityAvailable: 0,
+        },
+      ],
+      posPendingCheckoutItem: [
+        {
+          _id: "pending-checkout-1",
+          storeId: "store-a",
+          status: "pending_review",
+          provisionalProductSkuId: "sku-pending-checkout",
+          provisionalPrice: 100,
+        },
       ],
     });
 
@@ -962,29 +1026,39 @@ describe("listRegisterCatalog", () => {
       storeId: "store-a" as Id<"store">,
     });
 
-    expect(rows).toEqual([
-      {
-        productSkuId: "sku-live",
-        skuId: "sku-live",
-        inStock: true,
-        quantityAvailable: 2,
-        availabilityPolicy: "trusted_inventory",
-      },
-      {
-        productSkuId: "sku-out",
-        skuId: "sku-out",
-        inStock: false,
-        quantityAvailable: 0,
-        availabilityPolicy: "trusted_inventory",
-      },
-      {
-        productSkuId: "sku-out",
-        skuId: "sku-out",
-        inventoryImportProvisionalSkuId: "provisional-sku-out",
-        inStock: true,
-        quantityAvailable: 0,
-        availabilityPolicy: "active_provisional_import",
-      },
-    ]);
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        {
+          productSkuId: "sku-live",
+          skuId: "sku-live",
+          inStock: true,
+          quantityAvailable: 2,
+          availabilityPolicy: "trusted_inventory",
+        },
+        {
+          productSkuId: "sku-out",
+          skuId: "sku-out",
+          inStock: false,
+          quantityAvailable: 0,
+          availabilityPolicy: "trusted_inventory",
+        },
+        {
+          productSkuId: "sku-out",
+          skuId: "sku-out",
+          inventoryImportProvisionalSkuId: "provisional-sku-out",
+          inStock: true,
+          quantityAvailable: 0,
+          availabilityPolicy: "active_provisional_import",
+        },
+        {
+          productSkuId: "sku-pending-checkout",
+          skuId: "sku-pending-checkout",
+          inStock: true,
+          quantityAvailable: 0,
+          availabilityPolicy: "pending_checkout",
+        },
+      ]),
+    );
+    expect(rows).toHaveLength(4);
   });
 });

--- a/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/listRegisterCatalog.ts
@@ -13,6 +13,7 @@ type RegisterCatalogRow = {
   skuId: Id<"productSku">;
   productId: Id<"product">;
   inventoryImportProvisionalSkuId?: InventoryImportProvisionalSkuId;
+  pendingCheckoutItemId?: Id<"posPendingCheckoutItem">;
   name: string;
   sku: string;
   barcode: string;
@@ -29,7 +30,8 @@ type RegisterCatalogRow = {
 
 type RegisterCatalogAvailabilityPolicy =
   | "trusted_inventory"
-  | "active_provisional_import";
+  | "active_provisional_import"
+  | "pending_checkout";
 
 type RegisterCatalogAvailabilityRow = {
   productSkuId: Id<"productSku">;
@@ -55,6 +57,11 @@ type InventoryImportProvisionalSku = {
   provisionalQuantitySold?: number;
   provisionalTransactionCount?: number;
 };
+
+type PosPendingCheckoutItem = Pick<
+  Doc<"posPendingCheckoutItem">,
+  "_id" | "provisionalProductSkuId" | "provisionalPrice" | "status" | "storeId"
+>;
 
 export const REGISTER_CATALOG_AVAILABILITY_LIMIT = 50;
 const REGISTER_CATALOG_PROVISIONAL_IMPORT_LIMIT = 5_000;
@@ -106,6 +113,7 @@ function mapSkuToRegisterCatalogRow(args: {
   sku: Doc<"productSku">;
   category: string;
   color: string;
+  pendingCheckoutItem?: PosPendingCheckoutItem;
   provisionalSku?: InventoryImportProvisionalSku;
 }): RegisterCatalogRow {
   return {
@@ -116,10 +124,16 @@ function mapSkuToRegisterCatalogRow(args: {
     ...(args.provisionalSku
       ? { inventoryImportProvisionalSkuId: args.provisionalSku._id }
       : {}),
+    ...(args.pendingCheckoutItem
+      ? { pendingCheckoutItemId: args.pendingCheckoutItem._id }
+      : {}),
     name: args.provisionalSku?.importedProductName ?? args.product.name,
     sku: args.sku.sku || args.provisionalSku?.importedSku || "",
     barcode: args.sku.barcode || args.provisionalSku?.importedBarcode || "",
-    price: args.provisionalSku?.importedPrice ?? getRegisterCatalogPrice(args.sku),
+    price:
+      args.pendingCheckoutItem?.provisionalPrice ??
+      args.provisionalSku?.importedPrice ??
+      getRegisterCatalogPrice(args.sku),
     category: args.category,
     description: args.product.description ?? "",
     image: args.sku.images[0] ?? null,
@@ -127,9 +141,11 @@ function mapSkuToRegisterCatalogRow(args: {
     length: args.sku.length ?? null,
     color: args.color,
     areProcessingFeesAbsorbed: args.product.areProcessingFeesAbsorbed ?? false,
-    availabilityPolicy: args.provisionalSku
-      ? "active_provisional_import"
-      : "trusted_inventory",
+    availabilityPolicy: args.pendingCheckoutItem
+      ? "pending_checkout"
+      : args.provisionalSku
+        ? "active_provisional_import"
+        : "trusted_inventory",
   };
 }
 
@@ -145,12 +161,14 @@ export function isTrustedRegisterCatalogSku(args: {
   const isReservedPosOperationalProduct = args.category?.slug
     ? POS_OPERATIONAL_CATEGORY_SLUGS.has(args.category.slug)
     : false;
+  const isPendingCheckoutProduct =
+    args.category?.slug === "pos-pending-checkout";
 
   return (
     args.product.availability !== "archived" &&
-    args.product.availability !== "draft" &&
+    (args.product.availability !== "draft" || isPendingCheckoutProduct) &&
     (args.product.isVisible !== false || isReservedPosOperationalProduct) &&
-    args.sku.isVisible !== false
+    (args.sku.isVisible !== false || isPendingCheckoutProduct)
   );
 }
 
@@ -177,10 +195,7 @@ async function listScopedRegisterCatalogSkus(
       productCache.set(sku.productId, product);
     }
 
-    if (
-      !product ||
-      product.storeId !== args.storeId
-    ) {
+    if (!product || product.storeId !== args.storeId) {
       continue;
     }
 
@@ -296,6 +311,51 @@ export async function readActiveProvisionalImportSkuForStoreSku(
   return isActiveProvisionalImportSkuForStore(row, args) ? row : null;
 }
 
+async function queryActivePendingCheckoutItemsForStore(
+  ctx: QueryCtx,
+  args: {
+    storeId: Id<"store">;
+  },
+) {
+  const statuses: Array<Doc<"posPendingCheckoutItem">["status"]> = [
+    "pending_review",
+    "flagged",
+  ];
+  const rows = await Promise.all(
+    statuses.map((status) =>
+      ctx.db
+        .query("posPendingCheckoutItem")
+        .withIndex("by_storeId_status_updatedAt", (q) =>
+          q.eq("storeId", args.storeId).eq("status", status),
+        )
+        .take(5_000),
+    ),
+  );
+
+  return rows.flat();
+}
+
+async function readActivePendingCheckoutItemForStoreSku(
+  ctx: QueryCtx,
+  args: {
+    storeId: Id<"store">;
+    productSkuId: Id<"productSku">;
+  },
+): Promise<PosPendingCheckoutItem | null> {
+  const row = await ctx.db
+    .query("posPendingCheckoutItem")
+    .withIndex("by_storeId_provisionalProductSkuId", (q) =>
+      q
+        .eq("storeId", args.storeId)
+        .eq("provisionalProductSkuId", args.productSkuId),
+    )
+    .first();
+
+  return row?.status === "pending_review" || row?.status === "flagged"
+    ? row
+    : null;
+}
+
 type ProvisionalIndexBuilder<TField extends string> = {
   eq(field: TField, value: unknown): ProvisionalIndexBuilder<TField>;
 };
@@ -309,6 +369,14 @@ export async function listRegisterCatalog(
   const rows: RegisterCatalogRow[] = [];
   const categoryCache = new Map<Id<"category">, string>();
   const colorCache = new Map<Id<"color">, string>();
+  const pendingCheckoutItemsBySkuId = new Map(
+    (await queryActivePendingCheckoutItemsForStore(ctx, args)).flatMap(
+      (item) =>
+        item.provisionalProductSkuId
+          ? [[item.provisionalProductSkuId, item]]
+          : [],
+    ),
+  );
   const trustedAvailableSkuIds = new Set<Id<"productSku">>();
 
   for (const { product, sku } of await listScopedRegisterCatalogSkus(
@@ -322,8 +390,13 @@ export async function listRegisterCatalog(
       mapSkuToRegisterCatalogRow({
         product,
         sku,
-        category: await readCategoryName(ctx, categoryCache, product.categoryId),
+        category: await readCategoryName(
+          ctx,
+          categoryCache,
+          product.categoryId,
+        ),
         color: await readColorName(ctx, colorCache, sku.color),
+        pendingCheckoutItem: pendingCheckoutItemsBySkuId.get(sku._id),
       }),
     );
   }
@@ -353,7 +426,11 @@ export async function listRegisterCatalog(
       mapSkuToRegisterCatalogRow({
         product,
         sku,
-        category: await readCategoryName(ctx, categoryCache, product.categoryId),
+        category: await readCategoryName(
+          ctx,
+          categoryCache,
+          product.categoryId,
+        ),
         color: await readColorName(ctx, colorCache, sku.color),
         provisionalSku,
       }),
@@ -383,9 +460,14 @@ export async function listRegisterCatalogAvailability(
       continue;
     }
 
-    const availability = await validateInventoryAvailability(ctx.db, sku._id, 1, {
-      storeId: args.storeId,
-    });
+    const availability = await validateInventoryAvailability(
+      ctx.db,
+      sku._id,
+      1,
+      {
+        storeId: args.storeId,
+      },
+    );
     const quantityAvailable = availability.available ?? 0;
 
     if (quantityAvailable > 0) {
@@ -399,11 +481,14 @@ export async function listRegisterCatalogAvailability(
       continue;
     }
 
-    const provisionalSku = await readActiveProvisionalImportSkuForStoreSku(ctx, {
-      storeId: args.storeId,
-      productId: sku.productId,
-      productSkuId: sku._id,
-    });
+    const provisionalSku = await readActiveProvisionalImportSkuForStoreSku(
+      ctx,
+      {
+        storeId: args.storeId,
+        productId: sku.productId,
+        productSkuId: sku._id,
+      },
+    );
     if (provisionalSku) {
       rows.push({
         productSkuId: sku._id,
@@ -412,6 +497,24 @@ export async function listRegisterCatalogAvailability(
         inStock: true,
         quantityAvailable: 0,
         availabilityPolicy: "active_provisional_import",
+      });
+      continue;
+    }
+
+    const pendingCheckoutItem = await readActivePendingCheckoutItemForStoreSku(
+      ctx,
+      {
+        storeId: args.storeId,
+        productSkuId: sku._id,
+      },
+    );
+    if (pendingCheckoutItem) {
+      rows.push({
+        productSkuId: sku._id,
+        skuId: sku._id,
+        inStock: true,
+        quantityAvailable: 0,
+        availabilityPolicy: "pending_checkout",
       });
       continue;
     }
@@ -439,25 +542,46 @@ export async function listRegisterCatalogAvailabilitySnapshot(
     storeId: args.storeId,
     skuIds: catalogSkus.map(({ sku }) => sku._id),
   });
+  const pendingCheckoutItemsBySkuId = new Map(
+    (await queryActivePendingCheckoutItemsForStore(ctx, args)).flatMap(
+      (item) =>
+        item.provisionalProductSkuId
+          ? [[item.provisionalProductSkuId, item]]
+          : [],
+    ),
+  );
   const activeProvisionalSkus = await queryActiveProvisionalImportSkusForStore(
     ctx,
     args,
   );
 
-  const trustedRows = catalogSkus.map(({ sku }): RegisterCatalogAvailabilityRow => {
-    const quantityAvailable = Math.max(
-      0,
-      sku.quantityAvailable - (heldQuantities.get(sku._id) ?? 0),
-    );
+  const trustedRows = catalogSkus.map(
+    ({ sku }): RegisterCatalogAvailabilityRow => {
+      const pendingCheckoutItem = pendingCheckoutItemsBySkuId.get(sku._id);
+      if (pendingCheckoutItem) {
+        return {
+          productSkuId: sku._id,
+          skuId: sku._id,
+          inStock: true,
+          quantityAvailable: 0,
+          availabilityPolicy: "pending_checkout",
+        };
+      }
 
-    return {
-      productSkuId: sku._id,
-      skuId: sku._id,
-      inStock: quantityAvailable > 0,
-      quantityAvailable,
-      availabilityPolicy: "trusted_inventory",
-    };
-  });
+      const quantityAvailable = Math.max(
+        0,
+        sku.quantityAvailable - (heldQuantities.get(sku._id) ?? 0),
+      );
+
+      return {
+        productSkuId: sku._id,
+        skuId: sku._id,
+        inStock: quantityAvailable > 0,
+        quantityAvailable,
+        availabilityPolicy: "trusted_inventory",
+      };
+    },
+  );
 
   const trustedAvailableSkuIds = new Set(
     trustedRows

--- a/packages/athena-webapp/convex/pos/application/queries/searchCatalog.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/searchCatalog.test.ts
@@ -32,15 +32,17 @@ const storeId = "store-1" as Id<"store">;
 describe("searchCatalog", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    mocks.getCategoryById.mockImplementation(async (_ctx, categoryId) =>
-      categoryById[categoryId as keyof typeof categoryById] ?? null,
+    mocks.getCategoryById.mockImplementation(
+      async (_ctx, categoryId) =>
+        categoryById[categoryId as keyof typeof categoryById] ?? null,
     );
     mocks.getColorById.mockResolvedValue({ name: "Black" });
     mocks.isConvexProductId.mockReturnValue(false);
     mocks.findStoreSkuByBarcode.mockResolvedValue(null);
     mocks.findStoreSkuBySku.mockResolvedValue(null);
-    mocks.getProductById.mockImplementation(async (_ctx, productId) =>
-      productById[productId as keyof typeof productById] ?? null,
+    mocks.getProductById.mockImplementation(
+      async (_ctx, productId) =>
+        productById[productId as keyof typeof productById] ?? null,
     );
   });
 
@@ -193,7 +195,7 @@ const productById = {
     categoryId: "category-pos-pending-checkout",
     name: "Pending Checkout Item",
     description: "",
-    availability: "live",
+    availability: "draft",
     isVisible: false,
   },
   "product-hidden-sku": {
@@ -274,9 +276,10 @@ const skuById = {
     sku: "PENDING-CHECKOUT",
     barcode: "888",
     images: [],
+    isVisible: false,
     netPrice: 1000,
     price: 1000,
-    quantityAvailable: 1,
+    quantityAvailable: 0,
   },
   "sku-hidden": {
     _id: "sku-hidden",

--- a/packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/searchCatalog.ts
@@ -44,12 +44,14 @@ function isTrustedCatalogResult(args: {
   const isReservedPosOperationalProduct = args.category?.slug
     ? POS_OPERATIONAL_CATEGORY_SLUGS.has(args.category.slug)
     : false;
+  const isPendingCheckoutProduct =
+    args.category?.slug === "pos-pending-checkout";
 
   return (
     args.product.availability !== "archived" &&
-    args.product.availability !== "draft" &&
+    (args.product.availability !== "draft" || isPendingCheckoutProduct) &&
     (args.product.isVisible !== false || isReservedPosOperationalProduct) &&
-    args.sku.isVisible !== false
+    (args.sku.isVisible !== false || isPendingCheckoutProduct)
   );
 }
 
@@ -63,7 +65,8 @@ async function mapSkuToCatalogResult(
   },
 ): Promise<CatalogResult | null> {
   const category =
-    args.category ?? (args.product ? await getCategoryById(ctx, args.product.categoryId) : null);
+    args.category ??
+    (args.product ? await getCategoryById(ctx, args.product.categoryId) : null);
 
   if (
     !args.product ||
@@ -123,7 +126,8 @@ export async function searchProducts(
     if (
       product?.storeId === args.storeId &&
       product.availability !== "archived" &&
-      product.availability !== "draft" &&
+      (product.availability !== "draft" ||
+        category?.slug === "pos-pending-checkout") &&
       (product.isVisible !== false ||
         POS_OPERATIONAL_CATEGORY_SLUGS.has(category?.slug ?? ""))
     ) {
@@ -140,7 +144,9 @@ export async function searchProducts(
         ),
       );
 
-      return results.filter((result): result is CatalogResult => result !== null);
+      return results.filter(
+        (result): result is CatalogResult => result !== null,
+      );
     }
   }
 
@@ -192,7 +198,8 @@ export async function lookupByBarcode(
     if (
       product?.storeId === args.storeId &&
       product.availability !== "archived" &&
-      product.availability !== "draft" &&
+      (product.availability !== "draft" ||
+        category?.slug === "pos-pending-checkout") &&
       (product.isVisible !== false ||
         POS_OPERATIONAL_CATEGORY_SLUGS.has(category?.slug ?? ""))
     ) {
@@ -209,7 +216,9 @@ export async function lookupByBarcode(
         ),
       );
 
-      return results.filter((result): result is CatalogResult => result !== null);
+      return results.filter(
+        (result): result is CatalogResult => result !== null,
+      );
     }
   }
 
@@ -225,7 +234,8 @@ export async function lookupByBarcode(
   if (
     !product ||
     product.availability === "archived" ||
-    product.availability === "draft" ||
+    (product.availability === "draft" &&
+      category?.slug !== "pos-pending-checkout") ||
     (product.isVisible === false &&
       !POS_OPERATIONAL_CATEGORY_SLUGS.has(category?.slug ?? ""))
   ) {

--- a/packages/athena-webapp/convex/pos/public/catalog.ts
+++ b/packages/athena-webapp/convex/pos/public/catalog.ts
@@ -42,11 +42,16 @@ const catalogResultValidator = v.object({
   skuId: v.id("productSku"),
   areProcessingFeesAbsorbed: v.boolean(),
   availabilityPolicy: v.optional(
-    v.union(v.literal("trusted_inventory"), v.literal("active_provisional_import")),
+    v.union(
+      v.literal("trusted_inventory"),
+      v.literal("active_provisional_import"),
+      v.literal("pending_checkout"),
+    ),
   ),
   inventoryImportProvisionalSkuId: v.optional(
     v.id("inventoryImportProvisionalSku"),
   ),
+  pendingCheckoutItemId: v.optional(v.id("posPendingCheckoutItem")),
 });
 
 const registerCatalogRowValidator = v.object({
@@ -57,6 +62,7 @@ const registerCatalogRowValidator = v.object({
   inventoryImportProvisionalSkuId: v.optional(
     v.id("inventoryImportProvisionalSku"),
   ),
+  pendingCheckoutItemId: v.optional(v.id("posPendingCheckoutItem")),
   name: v.string(),
   sku: v.string(),
   barcode: v.string(),
@@ -71,6 +77,7 @@ const registerCatalogRowValidator = v.object({
   availabilityPolicy: v.union(
     v.literal("trusted_inventory"),
     v.literal("active_provisional_import"),
+    v.literal("pending_checkout"),
   ),
 });
 
@@ -85,6 +92,7 @@ const registerCatalogAvailabilityValidator = v.object({
   availabilityPolicy: v.union(
     v.literal("trusted_inventory"),
     v.literal("active_provisional_import"),
+    v.literal("pending_checkout"),
   ),
 });
 
@@ -149,7 +157,8 @@ async function requireRegisterCatalogStoreAccess(
   const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
   await requireOrganizationMemberRoleWithCtx(ctx, {
     allowedRoles: ["full_admin", "pos_only"],
-    failureMessage: "You cannot view register catalog availability for this store.",
+    failureMessage:
+      "You cannot view register catalog availability for this store.",
     organizationId: store.organizationId,
     userId: athenaUser._id,
   });
@@ -202,7 +211,9 @@ async function requirePendingCheckoutSaleContext(
     throw new Error("The register session does not match this terminal.");
   }
   if (registerSession.openedByStaffProfileId !== staffProfile._id) {
-    throw new Error("The active register session does not match this staff member.");
+    throw new Error(
+      "The active register session does not match this staff member.",
+    );
   }
 
   return {
@@ -333,8 +344,7 @@ export const createOrReusePendingCheckoutItemForSale = mutation({
     const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
     await requireOrganizationMemberRoleWithCtx(ctx, {
       allowedRoles: ["full_admin", "pos_only"],
-      failureMessage:
-        "You cannot add pending checkout items for this store.",
+      failureMessage: "You cannot add pending checkout items for this store.",
       organizationId: store.organizationId,
       userId: athenaUser._id,
     });
@@ -457,7 +467,9 @@ export const resolvePendingCheckoutItemReview = mutation({
           sku: approvedSku,
         })
       ) {
-        throw new Error("Choose a valid catalog product and SKU from this store.");
+        throw new Error(
+          "Choose a valid catalog product and SKU from this store.",
+        );
       }
     }
 

--- a/packages/athena-webapp/convex/stockOps/adjustments.test.ts
+++ b/packages/athena-webapp/convex/stockOps/adjustments.test.ts
@@ -78,6 +78,8 @@ function createInventorySnapshotQueryCtx() {
         },
       ],
     ]),
+    inventoryImportProvisionalSku: new Map<string, Record<string, unknown>>(),
+    posPendingCheckoutItem: new Map<string, Record<string, unknown>>(),
     product: new Map<string, Record<string, unknown>>([
       [
         "product-1",
@@ -144,6 +146,7 @@ function createInventorySnapshotQueryCtx() {
 
         return {
           collect: async () => filteredRecords(),
+          first: async () => filteredRecords()[0] ?? null,
           take: async (limit: number) => filteredRecords().slice(0, limit),
         };
       },
@@ -192,6 +195,8 @@ function createApprovalDecisionMutationCtx() {
       ],
     ]),
     inventoryMovement: new Map<string, Record<string, unknown>>(),
+    inventoryImportProvisionalSku: new Map<string, Record<string, unknown>>(),
+    posPendingCheckoutItem: new Map<string, Record<string, unknown>>(),
     operationalEvent: new Map<string, Record<string, unknown>>(),
     operationalWorkItem: new Map<string, Record<string, unknown>>([
       [
@@ -264,13 +269,13 @@ function createApprovalDecisionMutationCtx() {
   };
 
   const queryTable = (
-    table: "inventoryMovement" | "operationalEvent" | "skuActivityEvent"
+    table: "inventoryMovement" | "operationalEvent" | "skuActivityEvent",
   ) => ({
     withIndex(
       _index: string,
       applyIndex: (query: {
         eq: (field: string, value: unknown) => unknown;
-      }) => unknown
+      }) => unknown,
     ) {
       const filters: Array<[string, unknown]> = [];
       const query = {
@@ -285,12 +290,18 @@ function createApprovalDecisionMutationCtx() {
       return {
         collect: async () =>
           Array.from(tables[table].values()).filter((record) =>
-            filters.every(([field, value]) => record[field] === value)
+            filters.every(([field, value]) => record[field] === value),
           ),
         first: async () =>
           Array.from(tables[table].values()).find((record) =>
-            filters.every(([field, value]) => record[field] === value)
+            filters.every(([field, value]) => record[field] === value),
           ) ?? null,
+        take: async (limit: number) =>
+          Array.from(tables[table].values())
+            .filter((record) =>
+              filters.every(([field, value]) => record[field] === value),
+            )
+            .slice(0, limit),
       };
     },
   });
@@ -302,7 +313,7 @@ function createApprovalDecisionMutationCtx() {
       },
       async insert(
         table: "inventoryMovement" | "operationalEvent" | "skuActivityEvent",
-        value: Record<string, unknown>
+        value: Record<string, unknown>,
       ) {
         insertCounters[table] += 1;
         const id = `${table}-${insertCounters[table]}`;
@@ -312,7 +323,7 @@ function createApprovalDecisionMutationCtx() {
       async patch(
         table: keyof typeof tables,
         id: string,
-        value: Record<string, unknown>
+        value: Record<string, unknown>,
       ) {
         const existingRecord = tables[table].get(id);
 
@@ -323,7 +334,7 @@ function createApprovalDecisionMutationCtx() {
         tables[table].set(id, { ...existingRecord, ...value });
       },
       query(
-        table: "inventoryMovement" | "operationalEvent" | "skuActivityEvent"
+        table: "inventoryMovement" | "operationalEvent" | "skuActivityEvent",
       ) {
         return queryTable(table);
       },
@@ -341,14 +352,17 @@ function createSubmissionMutationCtx(args: {
   const tables = {
     approvalRequest: new Map<string, Record<string, unknown>>(),
     athenaUser: new Map<string, Record<string, unknown>>(
-      (args.athenaUsers ?? [
-        {
-          _id: "operator-1",
-          email: "operator@example.com",
-        },
-      ]).map((athenaUser) => [athenaUser._id, athenaUser])
+      (
+        args.athenaUsers ?? [
+          {
+            _id: "operator-1",
+            email: "operator@example.com",
+          },
+        ]
+      ).map((athenaUser) => [athenaUser._id, athenaUser]),
     ),
     inventoryMovement: new Map<string, Record<string, unknown>>(),
+    inventoryImportProvisionalSku: new Map<string, Record<string, unknown>>(),
     operationalEvent: new Map<string, Record<string, unknown>>(),
     operationalWorkItem: new Map<string, Record<string, unknown>>(),
     organizationMember: new Map<string, Record<string, unknown>>(
@@ -364,7 +378,7 @@ function createSubmissionMutationCtx(args: {
               },
             ],
           ]
-        : []
+        : [],
     ),
     productSku: new Map<string, Record<string, unknown>>([
       [
@@ -380,6 +394,7 @@ function createSubmissionMutationCtx(args: {
         },
       ],
     ]),
+    posPendingCheckoutItem: new Map<string, Record<string, unknown>>(),
     skuActivityEvent: new Map<string, Record<string, unknown>>(),
     stockAdjustmentBatch: new Map<string, Record<string, unknown>>(),
     store: new Map<string, Record<string, unknown>>([
@@ -423,15 +438,17 @@ function createSubmissionMutationCtx(args: {
   const indexedQuery = (
     table:
       | "inventoryMovement"
+      | "inventoryImportProvisionalSku"
       | "operationalEvent"
+      | "posPendingCheckoutItem"
       | "skuActivityEvent"
-      | "stockAdjustmentBatch"
+      | "stockAdjustmentBatch",
   ) => ({
     withIndex(
       _index: string,
       applyIndex: (query: {
         eq: (field: string, value: unknown) => unknown;
-      }) => unknown
+      }) => unknown,
     ) {
       const filters: Array<[string, unknown]> = [];
       const query = {
@@ -446,12 +463,18 @@ function createSubmissionMutationCtx(args: {
       return {
         collect: async () =>
           Array.from(tables[table].values()).filter((record) =>
-            filters.every(([field, value]) => record[field] === value)
+            filters.every(([field, value]) => record[field] === value),
           ),
         first: async () =>
           Array.from(tables[table].values()).find((record) =>
-            filters.every(([field, value]) => record[field] === value)
+            filters.every(([field, value]) => record[field] === value),
           ) ?? null,
+        take: async (limit: number) =>
+          Array.from(tables[table].values())
+            .filter((record) =>
+              filters.every(([field, value]) => record[field] === value),
+            )
+            .slice(0, limit),
       };
     },
   });
@@ -474,7 +497,7 @@ function createSubmissionMutationCtx(args: {
           | "operationalWorkItem"
           | "skuActivityEvent"
           | "stockAdjustmentBatch",
-        value: Record<string, unknown>
+        value: Record<string, unknown>,
       ) {
         insertCounters[table] += 1;
         const id = `${table}-${insertCounters[table]}`;
@@ -484,7 +507,7 @@ function createSubmissionMutationCtx(args: {
       async patch(
         table: keyof typeof tables,
         id: string,
-        value: Record<string, unknown>
+        value: Record<string, unknown>,
       ) {
         const existingRecord = tables[table].get(id);
 
@@ -508,7 +531,7 @@ function createSubmissionMutationCtx(args: {
                 and: (...conditions: unknown[]) => unknown;
                 eq: (left: unknown, right: unknown) => unknown;
                 field: (name: string) => string;
-              }) => unknown
+              }) => unknown,
             ) {
               const filters: Array<[string, unknown]> = [];
               const queryBuilder = {
@@ -526,8 +549,11 @@ function createSubmissionMutationCtx(args: {
 
               return {
                 first: async () =>
-                  Array.from(tables.organizationMember.values()).find((record) =>
-                    filters.every(([field, value]) => record[field] === value)
+                  Array.from(tables.organizationMember.values()).find(
+                    (record) =>
+                      filters.every(
+                        ([field, value]) => record[field] === value,
+                      ),
                   ) ?? null,
               };
             },
@@ -536,7 +562,9 @@ function createSubmissionMutationCtx(args: {
 
         if (
           table === "inventoryMovement" ||
+          table === "inventoryImportProvisionalSku" ||
           table === "operationalEvent" ||
+          table === "posPendingCheckoutItem" ||
           table === "skuActivityEvent" ||
           table === "stockAdjustmentBatch"
         ) {
@@ -632,19 +660,116 @@ describe("stock ops adjustments", () => {
     ]);
   });
 
+  it("marks active provisional legacy import SKUs as blocked for stock adjustments", async () => {
+    const { ctx, tables } = createInventorySnapshotQueryCtx();
+
+    tables.inventoryImportProvisionalSku.set("provisional-1", {
+      _id: "provisional-1",
+      productSkuId: "sku-1",
+      status: "active",
+      storeId: "store-1",
+    });
+
+    const rows = await listInventorySnapshotWithCtx(ctx, {
+      now: 1_000,
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        _id: "sku-1",
+        stockAdjustmentBlockedMessage:
+          "Legacy import SKUs must be finalized before stock adjustments can update them.",
+        stockAdjustmentBlockedReason: "provisional_import",
+      }),
+    ]);
+  });
+
+  it("marks unresolved POS pending checkout SKUs as blocked for stock adjustments", async () => {
+    const { ctx, tables } = createInventorySnapshotQueryCtx();
+
+    tables.posPendingCheckoutItem.set("pending-checkout-1", {
+      _id: "pending-checkout-1",
+      provisionalProductSkuId: "sku-1",
+      status: "pending_review",
+      storeId: "store-1",
+    });
+
+    const rows = await listInventorySnapshotWithCtx(ctx, {
+      now: 1_000,
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        _id: "sku-1",
+        stockAdjustmentBlockedMessage:
+          "POS pending checkout SKUs must be finalized before stock adjustments can update them.",
+        stockAdjustmentBlockedReason: "pos_pending_checkout",
+      }),
+    ]);
+  });
+
+  it("uses store-scoped blocker scans for full-store stock adjustment snapshots", async () => {
+    const { ctx, tables } = createInventorySnapshotQueryCtx();
+
+    for (let index = 2; index <= 60; index += 1) {
+      tables.productSku.set(`sku-${index}`, {
+        _id: `sku-${index}`,
+        images: [],
+        inventoryCount: 0,
+        netPrice: 1000,
+        price: 1000,
+        productId: "product-1",
+        quantityAvailable: 0,
+        sku: `SKU-${index}`,
+        storeId: "store-1",
+      });
+    }
+    tables.inventoryImportProvisionalSku.set("provisional-60", {
+      _id: "provisional-60",
+      productSkuId: "sku-60",
+      status: "active",
+      storeId: "store-1",
+    });
+    tables.posPendingCheckoutItem.set("pending-checkout-59", {
+      _id: "pending-checkout-59",
+      provisionalProductSkuId: "sku-59",
+      status: "pending_review",
+      storeId: "store-1",
+    });
+
+    const rows = await listInventorySnapshotWithCtx(ctx, {
+      now: 1_000,
+      storeId: "store-1" as Id<"store">,
+    });
+
+    expect(rows).toHaveLength(60);
+    expect(rows.find((row) => row._id === "sku-59")).toMatchObject({
+      stockAdjustmentBlockedMessage:
+        "POS pending checkout SKUs must be finalized before stock adjustments can update them.",
+      stockAdjustmentBlockedReason: "pos_pending_checkout",
+    });
+    expect(rows.find((row) => row._id === "sku-60")).toMatchObject({
+      stockAdjustmentBlockedMessage:
+        "Legacy import SKUs must be finalized before stock adjustments can update them.",
+      stockAdjustmentBlockedReason: "provisional_import",
+    });
+  });
+
   it("calculates cycle-count deltas from the system quantity", () => {
     expect(
       calculateCycleCountQuantityDelta({
         countedQuantity: 3,
         systemQuantity: 8,
-      })
+      }),
     ).toBe(-5);
 
     expect(
       calculateCycleCountQuantityDelta({
         countedQuantity: 13,
         systemQuantity: 8,
-      })
+      }),
     ).toBe(5);
   });
 
@@ -657,21 +782,26 @@ describe("stock ops adjustments", () => {
         {
           productSkuId: "sku-1",
         },
-      ])
+      ]),
     ).toThrow("cannot include the same SKU twice");
   });
 
   it("requires valid reason codes for manual adjustments and cycle counts", () => {
-    expect(() => assertStockAdjustmentReasonCode("manual", "damage")).not.toThrow();
     expect(() =>
-      assertStockAdjustmentReasonCode("manual", "cycle_count_reconciliation")
+      assertStockAdjustmentReasonCode("manual", "damage"),
+    ).not.toThrow();
+    expect(() =>
+      assertStockAdjustmentReasonCode("manual", "cycle_count_reconciliation"),
     ).toThrow("Manual stock adjustments require a supported reason code.");
 
     expect(() =>
-      assertStockAdjustmentReasonCode("cycle_count", "cycle_count_reconciliation")
+      assertStockAdjustmentReasonCode(
+        "cycle_count",
+        "cycle_count_reconciliation",
+      ),
     ).not.toThrow();
     expect(() =>
-      assertStockAdjustmentReasonCode("cycle_count", "correction")
+      assertStockAdjustmentReasonCode("cycle_count", "correction"),
     ).toThrow("Cycle counts must reconcile with the cycle-count reason code.");
   });
 
@@ -690,19 +820,19 @@ describe("stock ops adjustments", () => {
       requiresStockAdjustmentApproval({
         adjustmentType: "manual",
         largestAbsoluteDelta: belowThreshold.largestAbsoluteDelta,
-      })
+      }),
     ).toBe(false);
     expect(
       requiresStockAdjustmentApproval({
         adjustmentType: "manual",
         largestAbsoluteDelta: atThreshold.largestAbsoluteDelta,
-      })
+      }),
     ).toBe(true);
     expect(
       requiresStockAdjustmentApproval({
         adjustmentType: "cycle_count",
         largestAbsoluteDelta: atThreshold.largestAbsoluteDelta,
-      })
+      }),
     ).toBe(false);
   });
 
@@ -712,7 +842,7 @@ describe("stock ops adjustments", () => {
         adjustmentType: "manual",
         quantityDelta: -2,
         systemQuantity: 8,
-      })
+      }),
     ).toBe(-2);
 
     expect(
@@ -720,25 +850,25 @@ describe("stock ops adjustments", () => {
         adjustmentType: "cycle_count",
         countedQuantity: 11,
         systemQuantity: 8,
-      })
+      }),
     ).toBe(3);
 
     expect(() =>
       resolveStockAdjustmentQuantityDelta({
         adjustmentType: "manual",
         systemQuantity: 8,
-      })
+      }),
     ).toThrow(
-      "Manual stock adjustments require a whole-unit delta for every selected SKU."
+      "Manual stock adjustments require a whole-unit delta for every selected SKU.",
     );
 
     expect(() =>
       resolveStockAdjustmentQuantityDelta({
         adjustmentType: "cycle_count",
         systemQuantity: 8,
-      })
+      }),
     ).toThrow(
-      "Cycle counts require an integer counted quantity for every selected SKU."
+      "Cycle counts require an integer counted quantity for every selected SKU.",
     );
   });
 
@@ -748,7 +878,7 @@ describe("stock ops adjustments", () => {
         { quantityDelta: -3 },
         { quantityDelta: 5 },
         { quantityDelta: -1 },
-      ])
+      ]),
     ).toEqual({
       largestAbsoluteDelta: 5,
       lineItemCount: 3,
@@ -760,7 +890,7 @@ describe("stock ops adjustments", () => {
     const source = getSource("./adjustments.ts");
 
     expect(source).toContain(
-      'withIndex("by_storeId_adjustmentType_submissionKey"'
+      'withIndex("by_storeId_adjustmentType_submissionKey"',
     );
     expect(source).toContain("buildApprovalRequest");
     expect(source).toContain("recordInventoryMovementWithCtx");
@@ -794,7 +924,7 @@ describe("stock ops adjustments", () => {
         reasonCode: "damage",
         storeId: "store-1" as Id<"store">,
         submissionKey: "submission-1",
-      })
+      }),
     ).rejects.toThrow("Sign in again to continue.");
   });
 
@@ -811,7 +941,7 @@ describe("stock ops adjustments", () => {
         reasonCode: "damage",
         storeId: "store-1" as Id<"store">,
         submissionKey: "submission-empty",
-      })
+      }),
     ).resolves.toMatchObject({
       kind: "user_error",
       error: {
@@ -839,7 +969,7 @@ describe("stock ops adjustments", () => {
         reasonCode: "damage",
         storeId: "store-1" as Id<"store">,
         submissionKey: "submission-auth",
-      })
+      }),
     ).resolves.toMatchObject({
       kind: "user_error",
       error: {
@@ -867,10 +997,86 @@ describe("stock ops adjustments", () => {
         reasonCode: "damage",
         storeId: "store-1" as Id<"store">,
         submissionKey: "submission-2",
-      })
+      }),
     ).rejects.toThrow(
-      "You do not have permission to adjust stock for this store."
+      "You do not have permission to adjust stock for this store.",
     );
+  });
+
+  it("rejects stock adjustments for active provisional legacy import SKUs", async () => {
+    const { ctx, tables } = createSubmissionMutationCtx({
+      authUserId: "auth-user-1",
+      membershipRole: "full_admin",
+    });
+
+    tables.inventoryImportProvisionalSku.set("provisional-1", {
+      _id: "provisional-1",
+      productSkuId: "sku-1",
+      status: "active",
+      storeId: "store-1",
+    });
+
+    await expect(
+      submitStockAdjustmentBatchWithCtx(ctx, {
+        adjustmentType: "manual",
+        lineItems: [
+          {
+            productSkuId: "sku-1" as Id<"productSku">,
+            quantityDelta: 1,
+          },
+        ],
+        reasonCode: "correction",
+        storeId: "store-1" as Id<"store">,
+        submissionKey: "legacy-import-block",
+      }),
+    ).rejects.toThrow(
+      "Legacy import SKUs must be finalized before stock adjustments can update them.",
+    );
+
+    expect(tables.productSku.get("sku-1")).toMatchObject({
+      inventoryCount: 8,
+      quantityAvailable: 6,
+    });
+    expect(tables.inventoryMovement.size).toBe(0);
+    expect(tables.stockAdjustmentBatch.size).toBe(0);
+  });
+
+  it("rejects stock adjustments for unresolved POS pending checkout SKUs", async () => {
+    const { ctx, tables } = createSubmissionMutationCtx({
+      authUserId: "auth-user-1",
+      membershipRole: "full_admin",
+    });
+
+    tables.posPendingCheckoutItem.set("pending-checkout-1", {
+      _id: "pending-checkout-1",
+      provisionalProductSkuId: "sku-1",
+      status: "flagged",
+      storeId: "store-1",
+    });
+
+    await expect(
+      submitStockAdjustmentBatchWithCtx(ctx, {
+        adjustmentType: "manual",
+        lineItems: [
+          {
+            productSkuId: "sku-1" as Id<"productSku">,
+            quantityDelta: 1,
+          },
+        ],
+        reasonCode: "correction",
+        storeId: "store-1" as Id<"store">,
+        submissionKey: "pos-pending-checkout-block",
+      }),
+    ).rejects.toThrow(
+      "POS pending checkout SKUs must be finalized before stock adjustments can update them.",
+    );
+
+    expect(tables.productSku.get("sku-1")).toMatchObject({
+      inventoryCount: 8,
+      quantityAvailable: 6,
+    });
+    expect(tables.inventoryMovement.size).toBe(0);
+    expect(tables.stockAdjustmentBatch.size).toBe(0);
   });
 
   it("returns an authorization user error when the operator lacks store membership", async () => {
@@ -891,7 +1097,7 @@ describe("stock ops adjustments", () => {
         reasonCode: "damage",
         storeId: "store-1" as Id<"store">,
         submissionKey: "submission-authz",
-      })
+      }),
     ).resolves.toMatchObject({
       kind: "user_error",
       error: {

--- a/packages/athena-webapp/convex/stockOps/adjustments.ts
+++ b/packages/athena-webapp/convex/stockOps/adjustments.ts
@@ -70,6 +70,22 @@ const TEMPORARY_DELETE_SCOPE_CONFIRMATION =
 const ACTIVE_STORE_HOLD_SUM_LIMIT = 5000;
 const ACTIVE_CHECKOUT_SESSION_SUM_LIMIT = 1000;
 const ACTIVE_CHECKOUT_ITEM_SUM_LIMIT = 5000;
+const STOCK_ADJUSTMENT_BLOCKER_POINT_LOOKUP_LIMIT = 50;
+const ACTIVE_PROVISIONAL_IMPORT_BLOCKER_SCAN_LIMIT = 1500;
+const ACTIVE_PENDING_CHECKOUT_BLOCKER_SCAN_LIMIT = 2000;
+const LEGACY_IMPORT_STOCK_ADJUSTMENT_BLOCK_MESSAGE =
+  "Legacy import SKUs must be finalized before stock adjustments can update them.";
+const POS_PENDING_CHECKOUT_STOCK_ADJUSTMENT_BLOCK_MESSAGE =
+  "POS pending checkout SKUs must be finalized before stock adjustments can update them.";
+
+type StockAdjustmentBlockedSkuReason =
+  | "provisional_import"
+  | "pos_pending_checkout";
+
+type StockAdjustmentBlockedSkuStatus = {
+  message: string;
+  reason: StockAdjustmentBlockedSkuReason;
+};
 
 function trimOptional(value?: string | null) {
   const nextValue = value?.trim();
@@ -85,7 +101,7 @@ async function listProductSkusForStockAdjustmentScopeWithCtx(
   args: {
     scopeKey: string;
     storeId: Id<"store">;
-  }
+  },
 ) {
   // eslint-disable-next-line @convex-dev/no-collect-in-query -- Temporary cleanup mutation intentionally scans the selected store scope once.
   const productSkus = await ctx.db
@@ -93,10 +109,10 @@ async function listProductSkusForStockAdjustmentScopeWithCtx(
     .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
     .collect();
   const productIds = Array.from(
-    new Set(productSkus.map((productSku) => productSku.productId))
+    new Set(productSkus.map((productSku) => productSku.productId)),
   );
   const products = await Promise.all(
-    productIds.map((productId) => ctx.db.get("product", productId))
+    productIds.map((productId) => ctx.db.get("product", productId)),
   );
   const productMap = new Map<
     Id<"product">,
@@ -108,10 +124,10 @@ async function listProductSkusForStockAdjustmentScopeWithCtx(
     }
   });
   const categoryIds = Array.from(
-    new Set(products.map((product) => product?.categoryId).filter(Boolean))
+    new Set(products.map((product) => product?.categoryId).filter(Boolean)),
   ) as Id<"category">[];
   const categories = await Promise.all(
-    categoryIds.map((categoryId) => ctx.db.get("category", categoryId))
+    categoryIds.map((categoryId) => ctx.db.get("category", categoryId)),
   );
   const categoryMap = new Map<
     Id<"category">,
@@ -138,14 +154,14 @@ async function listProductSkusForStockAdjustmentScopeWithCtx(
 }
 
 export function assertDistinctStockAdjustmentLineItems(
-  lineItems: Array<{ productSkuId: string }>
+  lineItems: Array<{ productSkuId: string }>,
 ) {
   const seenProductSkuIds = new Set<string>();
 
   lineItems.forEach((lineItem) => {
     if (seenProductSkuIds.has(lineItem.productSkuId)) {
       throw new Error(
-        "Stock adjustment batches cannot include the same SKU twice."
+        "Stock adjustment batches cannot include the same SKU twice.",
       );
     }
 
@@ -221,7 +237,7 @@ function assertNormalizedLineItem(
   } | null,
   storeId: Id<"store">,
   adjustmentType: StockAdjustmentType,
-  requestedLineItem: StockAdjustmentInputLineItem
+  requestedLineItem: StockAdjustmentInputLineItem,
 ): NormalizedStockAdjustmentLineItem {
   if (!productSku || productSku.storeId !== storeId) {
     throw new Error("Selected SKU could not be found for this store.");
@@ -236,7 +252,9 @@ function assertNormalizedLineItem(
   });
 
   if (!Number.isInteger(quantityDelta) || quantityDelta === 0) {
-    throw new Error("Stock adjustments must change inventory by at least one unit.");
+    throw new Error(
+      "Stock adjustments must change inventory by at least one unit.",
+    );
   }
 
   if (systemQuantity + quantityDelta < 0) {
@@ -268,7 +286,7 @@ async function applyStockAdjustmentBatchWithCtx(
     reasonCode: StockAdjustmentReasonCode;
     storeId: Id<"store">;
     workItemId?: Id<"operationalWorkItem">;
-  }
+  },
 ) {
   const sourceId = buildStockAdjustmentSourceId(String(args.batchId));
 
@@ -283,7 +301,7 @@ async function applyStockAdjustmentBatchWithCtx(
       inventoryCount: productSku.inventoryCount + lineItem.quantityDelta,
       quantityAvailable: Math.max(
         0,
-        productSku.quantityAvailable + lineItem.quantityDelta
+        productSku.quantityAvailable + lineItem.quantityDelta,
       ),
     });
 
@@ -305,8 +323,190 @@ async function applyStockAdjustmentBatchWithCtx(
   }
 }
 
+async function readActiveProvisionalImportSkuIdsWithCtx(
+  ctx: QueryCtx | MutationCtx,
+  args: {
+    productSkuIds: Id<"productSku">[];
+    storeId: Id<"store">;
+  },
+) {
+  const productSkuIds = Array.from(new Set(args.productSkuIds));
+
+  if (productSkuIds.length === 0) {
+    return new Set<Id<"productSku">>();
+  }
+
+  const productSkuIdSet = new Set(productSkuIds);
+
+  if (productSkuIds.length > STOCK_ADJUSTMENT_BLOCKER_POINT_LOOKUP_LIMIT) {
+    const rows = await ctx.db
+      .query("inventoryImportProvisionalSku")
+      .withIndex("by_storeId_status", (q) =>
+        q.eq("storeId", args.storeId).eq("status", "active"),
+      )
+      .take(ACTIVE_PROVISIONAL_IMPORT_BLOCKER_SCAN_LIMIT + 1);
+
+    if (rows.length > ACTIVE_PROVISIONAL_IMPORT_BLOCKER_SCAN_LIMIT) {
+      throw new Error(
+        "Stock operations has too many active legacy import SKUs to summarize. Finalize or archive stale import rows and retry.",
+      );
+    }
+
+    return new Set(
+      rows.flatMap((row) =>
+        row.productSkuId && productSkuIdSet.has(row.productSkuId)
+          ? [row.productSkuId as Id<"productSku">]
+          : [],
+      ),
+    );
+  }
+
+  const rows = await Promise.all(
+    productSkuIds.map((productSkuId) =>
+      ctx.db
+        .query("inventoryImportProvisionalSku")
+        .withIndex("by_storeId_productSkuId_status", (q) =>
+          q
+            .eq("storeId", args.storeId)
+            .eq("productSkuId", productSkuId)
+            .eq("status", "active"),
+        )
+        .first(),
+    ),
+  );
+
+  return new Set(
+    rows.flatMap((row) =>
+      row?.productSkuId ? [row.productSkuId as Id<"productSku">] : [],
+    ),
+  );
+}
+
+async function readActivePendingCheckoutSkuIdsWithCtx(
+  ctx: QueryCtx | MutationCtx,
+  args: {
+    productSkuIds: Id<"productSku">[];
+    storeId: Id<"store">;
+  },
+) {
+  const productSkuIds = Array.from(new Set(args.productSkuIds));
+
+  if (productSkuIds.length === 0) {
+    return new Set<Id<"productSku">>();
+  }
+
+  const productSkuIdSet = new Set(productSkuIds);
+
+  if (productSkuIds.length > STOCK_ADJUSTMENT_BLOCKER_POINT_LOOKUP_LIMIT) {
+    const [pendingReviewRows, flaggedRows] = await Promise.all([
+      ctx.db
+        .query("posPendingCheckoutItem")
+        .withIndex("by_storeId_status_updatedAt", (q) =>
+          q.eq("storeId", args.storeId).eq("status", "pending_review"),
+        )
+        .take(ACTIVE_PENDING_CHECKOUT_BLOCKER_SCAN_LIMIT + 1),
+      ctx.db
+        .query("posPendingCheckoutItem")
+        .withIndex("by_storeId_status_updatedAt", (q) =>
+          q.eq("storeId", args.storeId).eq("status", "flagged"),
+        )
+        .take(ACTIVE_PENDING_CHECKOUT_BLOCKER_SCAN_LIMIT + 1),
+    ]);
+
+    if (
+      pendingReviewRows.length > ACTIVE_PENDING_CHECKOUT_BLOCKER_SCAN_LIMIT ||
+      flaggedRows.length > ACTIVE_PENDING_CHECKOUT_BLOCKER_SCAN_LIMIT
+    ) {
+      throw new Error(
+        "Stock operations has too many unresolved POS pending checkout SKUs to summarize. Resolve stale pending checkout items and retry.",
+      );
+    }
+
+    return new Set(
+      [...pendingReviewRows, ...flaggedRows].flatMap((row) =>
+        row.provisionalProductSkuId &&
+        productSkuIdSet.has(row.provisionalProductSkuId)
+          ? [row.provisionalProductSkuId as Id<"productSku">]
+          : [],
+      ),
+    );
+  }
+
+  const rowsBySku = await Promise.all(
+    productSkuIds.map((productSkuId) =>
+      ctx.db
+        .query("posPendingCheckoutItem")
+        .withIndex("by_storeId_provisionalProductSkuId", (q) =>
+          q
+            .eq("storeId", args.storeId)
+            .eq("provisionalProductSkuId", productSkuId),
+        )
+        .take(20),
+    ),
+  );
+
+  return new Set(
+    rowsBySku.flatMap((rows) =>
+      rows.flatMap((row) =>
+        (row.status === "pending_review" || row.status === "flagged") &&
+        row.provisionalProductSkuId
+          ? [row.provisionalProductSkuId as Id<"productSku">]
+          : [],
+      ),
+    ),
+  );
+}
+
+async function readStockAdjustmentBlockedSkuStatusesWithCtx(
+  ctx: QueryCtx | MutationCtx,
+  args: {
+    productSkuIds: Id<"productSku">[];
+    storeId: Id<"store">;
+  },
+) {
+  const productSkuIds = Array.from(new Set(args.productSkuIds));
+  const blockedStatuses = new Map<
+    Id<"productSku">,
+    StockAdjustmentBlockedSkuStatus
+  >();
+
+  if (productSkuIds.length === 0) {
+    return blockedStatuses;
+  }
+
+  const [activeProvisionalImportSkuIds, activePendingCheckoutSkuIds] =
+    await Promise.all([
+      readActiveProvisionalImportSkuIdsWithCtx(ctx, {
+        productSkuIds,
+        storeId: args.storeId,
+      }),
+      readActivePendingCheckoutSkuIdsWithCtx(ctx, {
+        productSkuIds,
+        storeId: args.storeId,
+      }),
+    ]);
+
+  for (const productSkuId of activeProvisionalImportSkuIds) {
+    blockedStatuses.set(productSkuId, {
+      message: LEGACY_IMPORT_STOCK_ADJUSTMENT_BLOCK_MESSAGE,
+      reason: "provisional_import",
+    });
+  }
+
+  for (const productSkuId of activePendingCheckoutSkuIds) {
+    if (blockedStatuses.has(productSkuId)) continue;
+
+    blockedStatuses.set(productSkuId, {
+      message: POS_PENDING_CHECKOUT_STOCK_ADJUSTMENT_BLOCK_MESSAGE,
+      reason: "pos_pending_checkout",
+    });
+  }
+
+  return blockedStatuses;
+}
+
 function buildStockAdjustmentDecisionEventType(
-  decision: "approved" | "rejected" | "cancelled"
+  decision: "approved" | "rejected" | "cancelled",
 ) {
   return decision === "approved"
     ? "stock_adjustment_approved"
@@ -316,7 +516,7 @@ function buildStockAdjustmentDecisionEventType(
 }
 
 function buildResolvedStockAdjustmentStatus(
-  decision: "approved" | "rejected" | "cancelled"
+  decision: "approved" | "rejected" | "cancelled",
 ) {
   return decision === "approved" ? "applied" : decision;
 }
@@ -329,9 +529,12 @@ export async function resolveStockAdjustmentApprovalDecisionWithCtx(
     reviewedByStaffProfileId?: Id<"staffProfile">;
     reviewedByUserId?: Id<"athenaUser">;
     decisionNotes?: string;
-  }
+  },
 ) {
-  const approvalRequest = await ctx.db.get("approvalRequest", args.approvalRequestId);
+  const approvalRequest = await ctx.db.get(
+    "approvalRequest",
+    args.approvalRequestId,
+  );
 
   if (
     !approvalRequest ||
@@ -341,17 +544,20 @@ export async function resolveStockAdjustmentApprovalDecisionWithCtx(
     throw new Error("Inventory adjustment approval request not found.");
   }
 
-  const stockAdjustmentBatchId = approvalRequest.subjectId as Id<"stockAdjustmentBatch">;
+  const stockAdjustmentBatchId =
+    approvalRequest.subjectId as Id<"stockAdjustmentBatch">;
   const stockAdjustmentBatch = await ctx.db.get(
     "stockAdjustmentBatch",
-    stockAdjustmentBatchId
+    stockAdjustmentBatchId,
   );
 
   if (
     !stockAdjustmentBatch ||
     stockAdjustmentBatch.approvalRequestId !== args.approvalRequestId
   ) {
-    throw new Error("Stock adjustment batch not found for this approval request.");
+    throw new Error(
+      "Stock adjustment batch not found for this approval request.",
+    );
   }
 
   if (stockAdjustmentBatch.status !== "pending_approval") {
@@ -420,25 +626,28 @@ async function readActiveHeldQuantitiesForStockOpsSnapshot(
   args: {
     now: number;
     storeId: Id<"store">;
-  }
+  },
 ) {
   const holds = await ctx.db
     .query("inventoryHold")
     .withIndex("by_storeId_status_expiresAt", (q) =>
-      q.eq("storeId", args.storeId).eq("status", "active").gt("expiresAt", args.now)
+      q
+        .eq("storeId", args.storeId)
+        .eq("status", "active")
+        .gt("expiresAt", args.now),
     )
     .take(ACTIVE_STORE_HOLD_SUM_LIMIT + 1);
 
   if (holds.length > ACTIVE_STORE_HOLD_SUM_LIMIT) {
     throw new Error(
-      "Stock operations has too many active POS inventory holds to summarize. Expire stale POS sessions and retry."
+      "Stock operations has too many active POS inventory holds to summarize. Expire stale POS sessions and retry.",
     );
   }
 
   return holds.reduce((quantities, hold) => {
     quantities.set(
       hold.productSkuId,
-      (quantities.get(hold.productSkuId) ?? 0) + Math.max(0, hold.quantity)
+      (quantities.get(hold.productSkuId) ?? 0) + Math.max(0, hold.quantity),
     );
     return quantities;
   }, new Map<Id<"productSku">, number>());
@@ -449,23 +658,23 @@ async function readActiveCheckoutReservedQuantitiesForStockOpsSnapshot(
   args: {
     now: number;
     storeId: Id<"store">;
-  }
+  },
 ) {
   const activeSessionCandidates = await ctx.db
     .query("checkoutSession")
     .withIndex("by_storeId_hasCompletedCheckoutSession", (q) =>
-      q.eq("storeId", args.storeId).eq("hasCompletedCheckoutSession", false)
+      q.eq("storeId", args.storeId).eq("hasCompletedCheckoutSession", false),
     )
     .take(ACTIVE_CHECKOUT_SESSION_SUM_LIMIT + 1);
 
   if (activeSessionCandidates.length > ACTIVE_CHECKOUT_SESSION_SUM_LIMIT) {
     throw new Error(
-      "Stock operations has too many active checkout sessions to summarize. Expire stale checkout sessions and retry."
+      "Stock operations has too many active checkout sessions to summarize. Expire stale checkout sessions and retry.",
     );
   }
 
   const activeSessions = activeSessionCandidates.filter(
-    (session) => session.expiresAt > args.now
+    (session) => session.expiresAt > args.now,
   );
 
   const checkoutItemGroups = await Promise.all(
@@ -473,14 +682,14 @@ async function readActiveCheckoutReservedQuantitiesForStockOpsSnapshot(
       ctx.db
         .query("checkoutSessionItem")
         .withIndex("by_sessionId", (q) => q.eq("sesionId", session._id))
-        .take(ACTIVE_CHECKOUT_ITEM_SUM_LIMIT + 1)
-    )
+        .take(ACTIVE_CHECKOUT_ITEM_SUM_LIMIT + 1),
+    ),
   );
 
   for (const items of checkoutItemGroups) {
     if (items.length > ACTIVE_CHECKOUT_ITEM_SUM_LIMIT) {
       throw new Error(
-        "Stock operations has too many checkout items in one active session to summarize. Expire stale checkout sessions and retry."
+        "Stock operations has too many checkout items in one active session to summarize. Expire stale checkout sessions and retry.",
       );
     }
   }
@@ -490,7 +699,7 @@ async function readActiveCheckoutReservedQuantitiesForStockOpsSnapshot(
   return checkoutItems.reduce((quantities, item) => {
     quantities.set(
       item.productSkuId,
-      (quantities.get(item.productSkuId) ?? 0) + Math.max(0, item.quantity)
+      (quantities.get(item.productSkuId) ?? 0) + Math.max(0, item.quantity),
     );
     return quantities;
   }, new Map<Id<"productSku">, number>());
@@ -501,7 +710,7 @@ export async function listInventorySnapshotWithCtx(
   args: {
     now?: number;
     storeId: Id<"store">;
-  }
+  },
 ) {
   const now = args.now ?? Date.now();
   // eslint-disable-next-line @convex-dev/no-collect-in-query -- This workspace needs the full store SKU snapshot so operators can reconcile counts across the entire catalog in one pass.
@@ -509,10 +718,13 @@ export async function listInventorySnapshotWithCtx(
     .query("productSku")
     .withIndex("by_storeId", (q) => q.eq("storeId", args.storeId))
     .collect();
-  const heldQuantities = await readActiveHeldQuantitiesForStockOpsSnapshot(ctx, {
-    now,
-    storeId: args.storeId,
-  });
+  const heldQuantities = await readActiveHeldQuantitiesForStockOpsSnapshot(
+    ctx,
+    {
+      now,
+      storeId: args.storeId,
+    },
+  );
   const checkoutReservedQuantities =
     await readActiveCheckoutReservedQuantitiesForStockOpsSnapshot(ctx, {
       now,
@@ -520,14 +732,21 @@ export async function listInventorySnapshotWithCtx(
     });
 
   const productIds = Array.from(
-    new Set(productSkus.map((productSku) => productSku.productId))
+    new Set(productSkus.map((productSku) => productSku.productId)),
   );
   const colorIds = Array.from(
-    new Set(productSkus.map((productSku) => productSku.color).filter(Boolean))
+    new Set(productSkus.map((productSku) => productSku.color).filter(Boolean)),
   ) as Id<"color">[];
+  const stockAdjustmentBlockedSkuStatuses =
+    await readStockAdjustmentBlockedSkuStatusesWithCtx(ctx, {
+      productSkuIds: productSkus.map((productSku) => productSku._id),
+      storeId: args.storeId,
+    });
 
   const [products, colors] = await Promise.all([
-    Promise.all(productIds.map((productId) => ctx.db.get("product", productId))),
+    Promise.all(
+      productIds.map((productId) => ctx.db.get("product", productId)),
+    ),
     Promise.all(colorIds.map((colorId) => ctx.db.get("color", colorId))),
   ]);
 
@@ -541,11 +760,21 @@ export async function listInventorySnapshotWithCtx(
     }
   });
   const categoryIds = Array.from(
-    new Set(products.map((product) => product?.categoryId).filter(Boolean))
+    new Set(products.map((product) => product?.categoryId).filter(Boolean)),
   ) as Id<"category">[];
-  const categories = await Promise.all(
-    categoryIds.map((categoryId) => ctx.db.get("category", categoryId))
-  );
+  const subcategoryIds = Array.from(
+    new Set(products.map((product) => product?.subcategoryId).filter(Boolean)),
+  ) as Id<"subcategory">[];
+  const [categories, subcategories] = await Promise.all([
+    Promise.all(
+      categoryIds.map((categoryId) => ctx.db.get("category", categoryId)),
+    ),
+    Promise.all(
+      subcategoryIds.map((subcategoryId) =>
+        ctx.db.get("subcategory", subcategoryId),
+      ),
+    ),
+  ]);
   const categoryMap = new Map<
     Id<"category">,
     NonNullable<(typeof categories)[number]>
@@ -553,6 +782,15 @@ export async function listInventorySnapshotWithCtx(
   categories.forEach((category) => {
     if (category) {
       categoryMap.set(category._id, category);
+    }
+  });
+  const subcategoryMap = new Map<
+    Id<"subcategory">,
+    NonNullable<(typeof subcategories)[number]>
+  >();
+  subcategories.forEach((subcategory) => {
+    if (subcategory) {
+      subcategoryMap.set(subcategory._id, subcategory);
     }
   });
   const colorMap = new Map<Id<"color">, NonNullable<(typeof colors)[number]>>();
@@ -569,47 +807,59 @@ export async function listInventorySnapshotWithCtx(
 
   const rows = await Promise.all(
     activeProductSkus.map(async (productSku) => {
-        const product = productMap.get(productSku.productId);
-        const category = product?.categoryId
-          ? categoryMap.get(product.categoryId)
-          : null;
-        const color = productSku.color ? colorMap.get(productSku.color) : null;
-        const posReservedQuantity = heldQuantities.get(productSku._id) ?? 0;
-        const checkoutReservedQuantity =
-          checkoutReservedQuantities.get(productSku._id) ?? 0;
-        const reservedQuantity =
-          posReservedQuantity + checkoutReservedQuantity;
-        const durableQuantityAvailable = productSku.quantityAvailable;
-        const quantityAvailable = Math.max(
-          0,
-          durableQuantityAvailable - posReservedQuantity
-        );
+      const product = productMap.get(productSku.productId);
+      const category = product?.categoryId
+        ? categoryMap.get(product.categoryId)
+        : null;
+      const subcategory = product?.subcategoryId
+        ? subcategoryMap.get(product.subcategoryId)
+        : null;
+      const color = productSku.color ? colorMap.get(productSku.color) : null;
+      const posReservedQuantity = heldQuantities.get(productSku._id) ?? 0;
+      const checkoutReservedQuantity =
+        checkoutReservedQuantities.get(productSku._id) ?? 0;
+      const reservedQuantity = posReservedQuantity + checkoutReservedQuantity;
+      const durableQuantityAvailable = productSku.quantityAvailable;
+      const quantityAvailable = Math.max(
+        0,
+        durableQuantityAvailable - posReservedQuantity,
+      );
+      const blockedStatus = stockAdjustmentBlockedSkuStatuses.get(
+        productSku._id,
+      );
 
-        return {
-          _id: productSku._id,
-          barcode: productSku.barcode ?? null,
-          colorName: color?.name ?? null,
-          durableQuantityAvailable,
-          imageUrl: productSku.images[0] ?? null,
-          inventoryCount: productSku.inventoryCount,
-          length: productSku.length ?? null,
-          netPrice: productSku.netPrice,
-          price: productSku.price,
-          productCategory: category?.name ?? null,
-          productId: productSku.productId,
-          productName:
-            product?.name ??
-            productSku.productName ??
-            productSku.sku ??
-            String(productSku._id),
-          checkoutReservedQuantity,
-          posReservedQuantity,
-          quantityAvailable,
-          reservedQuantity,
-          size: productSku.size ?? null,
-          sku: productSku.sku ?? null,
-        };
-      })
+      return {
+        _id: productSku._id,
+        barcode: productSku.barcode ?? null,
+        colorName: color?.name ?? null,
+        durableQuantityAvailable,
+        imageUrl: productSku.images[0] ?? null,
+        inventoryCount: productSku.inventoryCount,
+        length: productSku.length ?? null,
+        netPrice: productSku.netPrice,
+        price: productSku.price,
+        productCategoryId: product?.categoryId ?? null,
+        productCategory: category?.name ?? null,
+        productCategorySlug: category?.slug ?? null,
+        productId: productSku.productId,
+        productName:
+          product?.name ??
+          productSku.productName ??
+          productSku.sku ??
+          String(productSku._id),
+        productSubcategoryId: product?.subcategoryId ?? null,
+        productSubcategory: subcategory?.name ?? null,
+        productSubcategorySlug: subcategory?.slug ?? null,
+        stockAdjustmentBlockedReason: blockedStatus?.reason ?? null,
+        stockAdjustmentBlockedMessage: blockedStatus?.message ?? null,
+        checkoutReservedQuantity,
+        posReservedQuantity,
+        quantityAvailable,
+        reservedQuantity,
+        size: productSku.size ?? null,
+        sku: productSku.sku ?? null,
+      };
+    }),
   );
 
   return rows.sort((left, right) => {
@@ -638,7 +888,7 @@ export async function temporaryDeleteStockAdjustmentScopeSkusWithCtx(
     dryRun?: boolean;
     scopeKey: string;
     storeId: Id<"store">;
-  }
+  },
 ) {
   const store = await ctx.db.get("store", args.storeId);
 
@@ -661,10 +911,13 @@ export async function temporaryDeleteStockAdjustmentScopeSkusWithCtx(
     throw new Error("A stock cleanup scope key is required.");
   }
 
-  const candidateSkus = await listProductSkusForStockAdjustmentScopeWithCtx(ctx, {
-    scopeKey,
-    storeId: args.storeId,
-  });
+  const candidateSkus = await listProductSkusForStockAdjustmentScopeWithCtx(
+    ctx,
+    {
+      scopeKey,
+      storeId: args.storeId,
+    },
+  );
   const response = {
     deletedCount: 0,
     dryRun: args.dryRun ?? true,
@@ -678,12 +931,14 @@ export async function temporaryDeleteStockAdjustmentScopeSkusWithCtx(
 
   if (args.confirmation !== TEMPORARY_DELETE_SCOPE_CONFIRMATION) {
     throw new Error(
-      `Pass confirmation "${TEMPORARY_DELETE_SCOPE_CONFIRMATION}" to delete these SKUs.`
+      `Pass confirmation "${TEMPORARY_DELETE_SCOPE_CONFIRMATION}" to delete these SKUs.`,
     );
   }
 
   await Promise.all(
-    candidateSkus.map((productSku) => ctx.db.delete("productSku", productSku._id))
+    candidateSkus.map((productSku) =>
+      ctx.db.delete("productSku", productSku._id),
+    ),
   );
 
   return {
@@ -714,7 +969,7 @@ type SubmitStockAdjustmentBatchArgs = {
 
 export async function submitStockAdjustmentBatchWithCtx(
   ctx: MutationCtx,
-  args: SubmitStockAdjustmentBatchArgs
+  args: SubmitStockAdjustmentBatchArgs,
 ) {
   const submissionKey = trimOptional(args.submissionKey);
 
@@ -731,7 +986,7 @@ export async function submitStockAdjustmentBatchWithCtx(
   assertDistinctStockAdjustmentLineItems(
     args.lineItems.map((lineItem) => ({
       productSkuId: String(lineItem.productSkuId),
-    }))
+    })),
   );
 
   const store = await ctx.db.get("store", args.storeId);
@@ -743,7 +998,8 @@ export async function submitStockAdjustmentBatchWithCtx(
 
   await requireOrganizationMemberRoleWithCtx(ctx, {
     allowedRoles: ["full_admin", "pos_only"],
-    failureMessage: "You do not have permission to adjust stock for this store.",
+    failureMessage:
+      "You do not have permission to adjust stock for this store.",
     organizationId: store.organizationId,
     userId: createdByUser._id,
   });
@@ -754,7 +1010,7 @@ export async function submitStockAdjustmentBatchWithCtx(
       q
         .eq("storeId", args.storeId)
         .eq("adjustmentType", args.adjustmentType)
-        .eq("submissionKey", submissionKey)
+        .eq("submissionKey", submissionKey),
     )
     .first();
 
@@ -763,16 +1019,28 @@ export async function submitStockAdjustmentBatchWithCtx(
   }
 
   const productSkus = await Promise.all(
-    args.lineItems.map((lineItem) => ctx.db.get("productSku", lineItem.productSkuId))
+    args.lineItems.map((lineItem) =>
+      ctx.db.get("productSku", lineItem.productSkuId),
+    ),
   );
+  const stockAdjustmentBlockedSkuStatuses =
+    await readStockAdjustmentBlockedSkuStatusesWithCtx(ctx, {
+      productSkuIds: args.lineItems.map((lineItem) => lineItem.productSkuId),
+      storeId: args.storeId,
+    });
+
+  if (stockAdjustmentBlockedSkuStatuses.size > 0) {
+    const [firstBlockedStatus] = stockAdjustmentBlockedSkuStatuses.values();
+    throw new Error(firstBlockedStatus.message);
+  }
 
   const normalizedLineItems = args.lineItems.map((requestedLineItem, index) =>
     assertNormalizedLineItem(
       productSkus[index] ?? null,
       args.storeId,
       args.adjustmentType,
-      requestedLineItem
-    )
+      requestedLineItem,
+    ),
   );
 
   const summary = summarizeStockAdjustmentLineItems(normalizedLineItems);
@@ -855,7 +1123,7 @@ export async function submitStockAdjustmentBatchWithCtx(
           subjectId: String(stockAdjustmentBatchId),
           subjectType: "stock_adjustment_batch",
           workItemId,
-        })
+        }),
       );
 
       await ctx.db.patch("operationalWorkItem", workItemId, {
@@ -918,7 +1186,7 @@ export async function submitStockAdjustmentBatchWithCtx(
 }
 
 function mapSubmitStockAdjustmentBatchError(
-  error: unknown
+  error: unknown,
 ): CommandResult<never> | null {
   const message = error instanceof Error ? error.message : "";
 
@@ -929,7 +1197,9 @@ function mapSubmitStockAdjustmentBatchError(
     });
   }
 
-  if (message === "You do not have permission to adjust stock for this store.") {
+  if (
+    message === "You do not have permission to adjust stock for this store."
+  ) {
     return userError({
       code: "authorization_failed",
       message,
@@ -952,14 +1222,17 @@ function mapSubmitStockAdjustmentBatchError(
     message === "Stock adjustment batches require at least one line item." ||
     message === "Stock adjustment batches cannot include the same SKU twice." ||
     message === "Manual stock adjustments require a supported reason code." ||
-    message === "Cycle counts must reconcile with the cycle-count reason code." ||
+    message ===
+      "Cycle counts must reconcile with the cycle-count reason code." ||
     message ===
       "Manual stock adjustments require a whole-unit delta for every selected SKU." ||
     message ===
       "Cycle counts require an integer counted quantity for every selected SKU." ||
     message ===
       "Stock adjustments must change inventory by at least one unit." ||
-    message === "Stock adjustments cannot reduce inventory below zero."
+    message === "Stock adjustments cannot reduce inventory below zero." ||
+    message === LEGACY_IMPORT_STOCK_ADJUSTMENT_BLOCK_MESSAGE ||
+    message === POS_PENDING_CHECKOUT_STOCK_ADJUSTMENT_BLOCK_MESSAGE
   ) {
     return userError({
       code: "validation_failed",
@@ -972,7 +1245,7 @@ function mapSubmitStockAdjustmentBatchError(
 
 export async function submitStockAdjustmentBatchCommandWithCtx(
   ctx: MutationCtx,
-  args: SubmitStockAdjustmentBatchArgs
+  args: SubmitStockAdjustmentBatchArgs,
 ): Promise<CommandResult<any>> {
   try {
     return ok(await submitStockAdjustmentBatchWithCtx(ctx, args));
@@ -995,7 +1268,7 @@ export const submitStockAdjustmentBatch = mutation({
         countedQuantity: v.optional(v.number()),
         productSkuId: v.id("productSku"),
         quantityDelta: v.optional(v.number()),
-      })
+      }),
     ),
     notes: v.optional(v.string()),
     reasonCode: v.string(),

--- a/packages/athena-webapp/convex/stockOps/cycleCountDrafts.test.ts
+++ b/packages/athena-webapp/convex/stockOps/cycleCountDrafts.test.ts
@@ -28,8 +28,10 @@ function createCycleCountDraftCtx() {
     cycleCountDraft: new Map<string, Record<string, any>>(),
     cycleCountDraftLine: new Map<string, Record<string, any>>(),
     inventoryMovement: new Map<string, Record<string, any>>(),
+    inventoryImportProvisionalSku: new Map<string, Record<string, any>>(),
     operationalEvent: new Map<string, Record<string, any>>(),
     operationalWorkItem: new Map<string, Record<string, any>>(),
+    posPendingCheckoutItem: new Map<string, Record<string, any>>(),
     organizationMember: new Map<string, Record<string, any>>([
       [
         "membership-1",
@@ -94,6 +96,7 @@ function createCycleCountDraftCtx() {
         return {
           collect: async () => matches(),
           first: async () => matches()[0] ?? null,
+          take: async (limit: number) => matches().slice(0, limit),
         };
       },
     };
@@ -161,8 +164,11 @@ function createCycleCountDraftCtx() {
 
               return {
                 first: async () =>
-                  Array.from(tables.organizationMember.values()).find((record) =>
-                    filters.every(([field, value]) => record[field] === value),
+                  Array.from(tables.organizationMember.values()).find(
+                    (record) =>
+                      filters.every(
+                        ([field, value]) => record[field] === value,
+                      ),
                   ) ?? null,
               };
             },
@@ -254,10 +260,13 @@ describe("cycle count drafts", () => {
       quantityAvailable: 7,
     });
 
-    const refreshed = await refreshCycleCountDraftLineBaselineCommandWithCtx(ctx, {
-      productSkuId: "sku-1" as Id<"productSku">,
-      storeId: "store-1" as Id<"store">,
-    });
+    const refreshed = await refreshCycleCountDraftLineBaselineCommandWithCtx(
+      ctx,
+      {
+        productSkuId: "sku-1" as Id<"productSku">,
+        storeId: "store-1" as Id<"store">,
+      },
+    );
 
     expect(refreshed.kind).toBe("ok");
     expect(Array.from(tables.cycleCountDraftLine.values())[0]).toMatchObject({
@@ -267,7 +276,9 @@ describe("cycle count drafts", () => {
       isDirty: false,
       staleStatus: "current",
     });
-    expect(tables.cycleCountDraft.get(String(ensured.data.draft._id))).toMatchObject({
+    expect(
+      tables.cycleCountDraft.get(String(ensured.data.draft._id)),
+    ).toMatchObject({
       changedLineCount: 0,
       staleLineCount: 0,
     });
@@ -360,10 +371,14 @@ describe("cycle count drafts", () => {
       lineItemCount: 2,
       status: "applied",
     });
-    expect(tables.cycleCountDraft.get(String(hairDraft.data.draft._id))).toMatchObject({
+    expect(
+      tables.cycleCountDraft.get(String(hairDraft.data.draft._id)),
+    ).toMatchObject({
       status: "submitted",
     });
-    expect(tables.cycleCountDraft.get(String(beveragesDraft.data.draft._id))).toMatchObject({
+    expect(
+      tables.cycleCountDraft.get(String(beveragesDraft.data.draft._id)),
+    ).toMatchObject({
       status: "submitted",
     });
   });
@@ -419,7 +434,9 @@ describe("cycle count drafts", () => {
     });
 
     expect(discarded.kind).toBe("ok");
-    expect(tables.cycleCountDraft.get(String(ensured.data.draft._id))).toMatchObject({
+    expect(
+      tables.cycleCountDraft.get(String(ensured.data.draft._id)),
+    ).toMatchObject({
       status: "discarded",
     });
     expect(tables.productSku.get("sku-1")).toMatchObject({ inventoryCount: 8 });
@@ -461,7 +478,9 @@ describe("cycle count drafts", () => {
     expect(tables.productSku.get("sku-1")).toMatchObject({
       inventoryCount: 5,
     });
-    expect(tables.cycleCountDraft.get(String(ensured.data.draft._id))).toMatchObject({
+    expect(
+      tables.cycleCountDraft.get(String(ensured.data.draft._id)),
+    ).toMatchObject({
       status: "submitted",
     });
     expect(Array.from(tables.operationalEvent.values())).toEqual(

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -7,7 +7,7 @@ This key-folder index highlights the main directories agents are likely to need 
 ## Core app surfaces
 
 - [`src/routes`](../../src/routes) — TanStack route entrypoints and authenticated shells. Currently 88 file(s); key children: __root.tsx, _authed, _authed.test.tsx, _authed.tsx, index.test.tsx.
-- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 608 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
+- [`src/components`](../../src/components) — UI components, views, and package-local feature widgets. Currently 609 file(s); key children: GenericComboBox.tsx, Navbar.tsx, OrganizationView.tsx, OrganizationsView.tsx, PermissionGate.tsx.
 - [`src/components/traces`](../../src/components/traces) — Shared workflow trace screens, ordered timelines, and trace detail primitives. Currently 3 file(s); key children: WorkflowTraceRouteLink.tsx, WorkflowTraceView.test.tsx, WorkflowTraceView.tsx.
 - [`src/components/operations`](../../src/components/operations) — Manager-queue and stock-adjustment workflows that share approval rails with other operational surfaces. Currently 26 file(s); key children: CommandApprovalDialog.test.tsx, CommandApprovalDialog.tsx, DailyCloseHistoryView.test.tsx, DailyCloseHistoryView.tsx, DailyCloseView.test.tsx.
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.test.tsx
@@ -225,6 +225,55 @@ describe("StockAdjustmentWorkspaceContent", () => {
     );
   });
 
+  it("prevents operators from adjusting provisional legacy import rows", async () => {
+    const user = userEvent.setup();
+
+    renderStockAdjustmentWorkspace({
+      inventoryItems: [
+        {
+          ...baseProps.inventoryItems[0],
+          productCategory: "Legacy import",
+          productName: "imported bonnet",
+          productSubcategory: "NULL",
+          size: "NULL",
+          stockAdjustmentBlockedMessage:
+            "Legacy import SKUs must be finalized before stock adjustments can update them.",
+          stockAdjustmentBlockedReason: "provisional_import",
+        },
+      ],
+    });
+
+    await user.click(screen.getByRole("tab", { name: /manual adjustment/i }));
+
+    const provisionalStatus = screen.getByLabelText(
+      /provisional item\. legacy import skus must be finalized/i,
+    );
+
+    expect(screen.getByText("Provisional")).toBeInTheDocument();
+    expect(screen.queryByText("NULL")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/^Legacy import SKUs must/),
+    ).not.toBeInTheDocument();
+    await user.hover(provisionalStatus);
+    expect(
+      await screen.findAllByText(
+        "Legacy import SKUs must be finalized before stock adjustments can update them.",
+      ),
+    ).not.toHaveLength(0);
+    expect(
+      screen.getByLabelText(/adjustment delta for .*imported bonnet/i),
+    ).toBeDisabled();
+
+    await user.click(
+      screen.getByRole("button", { name: /submit adjustment/i }),
+    );
+
+    expect(mockedHandlers.onSubmitBatch).not.toHaveBeenCalled();
+    expect(mockedToast.error).toHaveBeenCalledWith(
+      "Legacy import SKUs must be finalized before stock adjustments can update them.",
+    );
+  });
+
   it("submits cycle counts with counted quantities and filters unchanged lines", async () => {
     mockedHandlers.onSubmitBatch.mockResolvedValue(ok({ _id: "batch-1" }));
     vi.spyOn(Date, "now").mockReturnValue(1000);
@@ -332,7 +381,9 @@ describe("StockAdjustmentWorkspaceContent", () => {
     await user.type(dialog.getByLabelText(/search existing sku/i), "body");
     await user.click(dialog.getByRole("button", { name: /body wave bundle/i }));
     expect(
-      dialog.getByText('BW-24 - Price pending - Hair - dark brown - Medium - 24"'),
+      dialog.getByText(
+        'BW-24 - Price pending - Hair - dark brown - Medium - 24"',
+      ),
     ).toBeInTheDocument();
     await user.click(dialog.getByRole("button", { name: /attach barcode/i }));
 
@@ -493,7 +544,9 @@ describe("StockAdjustmentWorkspaceContent", () => {
       screen.getByText(/saved count: 5 SKUs across 3 categories/i),
     ).toBeInTheDocument();
     expect(screen.getByText(/current: hair, 2 SKUs/i)).toBeInTheDocument();
-    expect(screen.getByText(/categories: beverages, hair/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/categories: beverages, hair/i),
+    ).toBeInTheDocument();
     expect(screen.getByText("Count metrics")).toBeInTheDocument();
     expect(screen.getByText("All saved counts")).toBeInTheDocument();
     expect(screen.getByText("Active category")).toBeInTheDocument();
@@ -910,9 +963,7 @@ describe("StockAdjustmentWorkspaceContent", () => {
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(
-        /9 of 11 units are available to sell\. Select a SKU/i,
-      ),
+      screen.getByText(/9 of 11 units are available to sell\. Select a SKU/i),
     ).toBeInTheDocument();
     expect(screen.getAllByText("On hand").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Available").length).toBeGreaterThan(0);
@@ -1139,12 +1190,13 @@ describe("StockAdjustmentWorkspaceContent", () => {
       .getAllByRole("row")
       .map((row) => row.textContent ?? "");
 
-    expect(rowNames.findIndex((text) => text.includes("Melt Band")))
-      .toBeLessThan(
-        rowNames.findIndex((text) =>
-          text.includes("Brazilian Hair And Body Fragrance Mist"),
-        ),
-      );
+    expect(
+      rowNames.findIndex((text) => text.includes("Melt Band")),
+    ).toBeLessThan(
+      rowNames.findIndex((text) =>
+        text.includes("Brazilian Hair And Body Fragrance Mist"),
+      ),
+    );
   });
 
   it("shows matching SKUs from other categories when the active category has no results", async () => {
@@ -1184,9 +1236,7 @@ describe("StockAdjustmentWorkspaceContent", () => {
     expect(
       screen.getByText("No Hair matches. Showing 1 match in Makeup."),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText("Matches are in Makeup."),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Matches are in Makeup.")).toBeInTheDocument();
     expect(within(table).getByText("Zara Lip Gloss")).toBeInTheDocument();
     expect(within(table).queryByText("Closure Wig")).not.toBeInTheDocument();
     expect(within(table).queryByText("No results.")).not.toBeInTheDocument();
@@ -1278,7 +1328,9 @@ describe("StockAdjustmentWorkspaceContent", () => {
 
     const table = screen.getByRole("table");
 
-    expect(within(table).queryByText("Sparkling Water")).not.toBeInTheDocument();
+    expect(
+      within(table).queryByText("Sparkling Water"),
+    ).not.toBeInTheDocument();
     expect(within(table).getByText("Vibes Closure")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: /^clear$/i }));
@@ -1290,9 +1342,7 @@ describe("StockAdjustmentWorkspaceContent", () => {
       query: undefined,
       sku: "sku-beverage",
     });
-    expect(
-      screen.getByText("Showing 2 of 2 SKUs."),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Showing 2 of 2 SKUs.")).toBeInTheDocument();
     expect(within(table).getByText("Sparkling Water")).toBeInTheDocument();
     expect(within(table).getByText("Vibes Closure")).toBeInTheDocument();
   });

--- a/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
+++ b/packages/athena-webapp/src/components/operations/StockAdjustmentWorkspace.tsx
@@ -16,6 +16,7 @@ import {
 import {
   Camera,
   ExternalLink,
+  Info,
   Package,
   PackagePlus,
   RotateCcw,
@@ -74,6 +75,12 @@ import {
 } from "../ui/select";
 import { Tabs, TabsList, TabsTrigger } from "../ui/tabs";
 import { Textarea } from "../ui/textarea";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../ui/tooltip";
 
 export type InventorySnapshotItem = {
   _id: Id<"productSku">;
@@ -88,12 +95,22 @@ export type InventorySnapshotItem = {
   posReservedQuantity?: number;
   price?: number | null;
   productCategory?: string | null;
+  productCategoryId?: Id<"category"> | null;
+  productCategorySlug?: string | null;
   productId?: Id<"product"> | null;
   productName: string;
+  productSubcategory?: string | null;
+  productSubcategoryId?: Id<"subcategory"> | null;
+  productSubcategorySlug?: string | null;
   quantityAvailable: number;
   reservedQuantity?: number;
   size?: string | null;
   sku?: string | null;
+  stockAdjustmentBlockedMessage?: string | null;
+  stockAdjustmentBlockedReason?:
+    | "pos_pending_checkout"
+    | "provisional_import"
+    | null;
 };
 
 export type SubmitStockAdjustmentArgs = {
@@ -198,6 +215,7 @@ type StockAdjustmentWorkspaceContentProps = {
 type StockAdjustmentRow = {
   inputValue: string;
   inventoryItem: InventorySnapshotItem;
+  isBlocked: boolean;
   isEdited: boolean;
   quantityDelta: number;
   submittedLineItem: SubmitStockAdjustmentArgs["lineItems"][number] | null;
@@ -254,6 +272,10 @@ function getStockAdjustmentCategoryLabel(key: string) {
   return getCountScopeLabel(key);
 }
 
+function isStockAdjustmentBlocked(item: InventorySnapshotItem) {
+  return Boolean(item.stockAdjustmentBlockedReason);
+}
+
 function buildManualDrafts(inventoryItems: InventorySnapshotItem[]) {
   return Object.fromEntries(inventoryItems.map((item) => [item._id, ""]));
 }
@@ -285,6 +307,12 @@ function buildStockAdjustmentSubmissionKey(
 function trimOptional(value?: string | null) {
   const nextValue = value?.trim();
   return nextValue ? nextValue : undefined;
+}
+
+function cleanInventoryMetadataValue(value?: string | null) {
+  const nextValue = value?.trim();
+  if (!nextValue || nextValue.toLowerCase() === "null") return undefined;
+  return nextValue;
 }
 
 function pluralize(count: number, singular: string, plural = `${singular}s`) {
@@ -364,10 +392,15 @@ function formatReservationSourceSummary(args: {
 function getSkuDetailEntries(item: InventorySnapshotItem) {
   const reservationLabels = getReservationLabels(item);
   const operationalPrice = getInventoryItemOperationalPrice(item);
+  const sku = cleanInventoryMetadataValue(item.sku);
+  const barcode = cleanInventoryMetadataValue(item.barcode);
+  const productCategory = cleanInventoryMetadataValue(item.productCategory);
+  const size = cleanInventoryMetadataValue(item.size);
+  const colorName = cleanInventoryMetadataValue(item.colorName);
 
   return [
-    item.sku ? { label: "SKU", value: item.sku } : null,
-    item.barcode ? { label: "Barcode", value: item.barcode } : null,
+    sku ? { label: "SKU", value: sku } : null,
+    barcode ? { label: "Barcode", value: barcode } : null,
     typeof operationalPrice === "number"
       ? {
           label: "Price",
@@ -376,14 +409,12 @@ function getSkuDetailEntries(item: InventorySnapshotItem) {
           }),
         }
       : null,
-    item.productCategory
-      ? { label: "Category", value: item.productCategory }
-      : null,
-    item.size ? { label: "Size", value: item.size } : null,
+    productCategory ? { label: "Category", value: productCategory } : null,
+    size ? { label: "Size", value: size } : null,
     item.length !== null && item.length !== undefined
       ? { label: "Length", value: `${item.length}"` }
       : null,
-    item.colorName ? { label: "Color", value: item.colorName } : null,
+    colorName ? { label: "Color", value: colorName } : null,
     reservationLabels.length > 0
       ? {
           label: "Reserved",
@@ -420,11 +451,12 @@ function getStockAdjustmentSearchTerms(row: StockAdjustmentRow) {
   const item = row.inventoryItem;
   return [
     getInventoryItemDisplayName(item),
-    item.sku,
-    item.barcode,
-    item.colorName,
-    item.productCategory,
-    item.size,
+    cleanInventoryMetadataValue(item.sku),
+    cleanInventoryMetadataValue(item.barcode),
+    cleanInventoryMetadataValue(item.colorName),
+    cleanInventoryMetadataValue(item.productCategory),
+    cleanInventoryMetadataValue(item.productSubcategory),
+    cleanInventoryMetadataValue(item.size),
     item.length === null || item.length === undefined
       ? undefined
       : String(item.length),
@@ -1867,14 +1899,18 @@ export function StockAdjustmentWorkspaceContent({
   const rows: StockAdjustmentRow[] = useMemo(
     () =>
       inventoryItems.map((item) => {
+        const isBlocked = isStockAdjustmentBlocked(item);
+
         if (adjustmentType === "manual") {
           const rawDelta = manualDeltas[item._id] ?? "";
           const parsedDelta = rawDelta.trim() === "" ? 0 : Number(rawDelta);
-          const isEdited = Number.isInteger(parsedDelta) && parsedDelta !== 0;
+          const isEdited =
+            !isBlocked && Number.isInteger(parsedDelta) && parsedDelta !== 0;
 
           return {
             inputValue: rawDelta,
             inventoryItem: item,
+            isBlocked,
             isEdited,
             quantityDelta: isEdited ? parsedDelta : 0,
             submittedLineItem: isEdited
@@ -1898,6 +1934,7 @@ export function StockAdjustmentWorkspaceContent({
           ? parsedCount - baselineInventoryCount
           : 0;
         const isEdited =
+          !isBlocked &&
           Number.isInteger(parsedCount) &&
           parsedCount >= 0 &&
           parsedCount !== baselineInventoryCount;
@@ -1906,8 +1943,9 @@ export function StockAdjustmentWorkspaceContent({
           countedQuantity: parsedCount,
           inputValue: rawCount,
           inventoryItem: item,
+          isBlocked,
           isEdited,
-          quantityDelta,
+          quantityDelta: isEdited ? quantityDelta : 0,
           submittedLineItem: isEdited
             ? ({
                 countedQuantity: parsedCount,
@@ -1974,33 +2012,29 @@ export function StockAdjustmentWorkspaceContent({
         })),
     [inventoryItems],
   );
-  const queryAvailabilityFilteredRows = useMemo(
-    () => {
-      const scoredRows = rows
-        .map((row, position) => ({
-          position,
-          row,
-          score: scoreStockAdjustmentSearchRow(row, normalizedFilterQuery),
-        }))
-        .filter(
-          ({ row, score }) =>
-            score > 0 &&
-            rowMatchesAvailabilityFilter(row, filters.availability),
-        );
+  const queryAvailabilityFilteredRows = useMemo(() => {
+    const scoredRows = rows
+      .map((row, position) => ({
+        position,
+        row,
+        score: scoreStockAdjustmentSearchRow(row, normalizedFilterQuery),
+      }))
+      .filter(
+        ({ row, score }) =>
+          score > 0 && rowMatchesAvailabilityFilter(row, filters.availability),
+      );
 
-      if (!normalizedFilterQuery) {
-        return scoredRows.map(({ row }) => row);
-      }
+    if (!normalizedFilterQuery) {
+      return scoredRows.map(({ row }) => row);
+    }
 
-      return scoredRows
-        .sort((left, right) => {
-          if (right.score !== left.score) return right.score - left.score;
-          return left.position - right.position;
-        })
-        .map(({ row }) => row);
-    },
-    [filters.availability, normalizedFilterQuery, rows],
-  );
+    return scoredRows
+      .sort((left, right) => {
+        if (right.score !== left.score) return right.score - left.score;
+        return left.position - right.position;
+      })
+      .map(({ row }) => row);
+  }, [filters.availability, normalizedFilterQuery, rows]);
   const filteredRows = useMemo(
     () =>
       queryAvailabilityFilteredRows.filter((row) =>
@@ -2212,9 +2246,7 @@ export function StockAdjustmentWorkspaceContent({
   useEffect(() => {
     if (
       activeInventoryItemId &&
-      tableRows.some(
-        (row) => row.inventoryItem._id === activeInventoryItemId,
-      )
+      tableRows.some((row) => row.inventoryItem._id === activeInventoryItemId)
     ) {
       return;
     }
@@ -2234,10 +2266,38 @@ export function StockAdjustmentWorkspaceContent({
           const item = row.original.inventoryItem;
           const primaryLabel = getInventoryItemDisplayName(item);
           const detailEntries = getSkuDetailEntries(item);
+          const blockedMessage = item.stockAdjustmentBlockedMessage;
 
           return (
             <div className="min-w-0 space-y-1.5">
-              <p className="truncate text-sm font-medium">{primaryLabel}</p>
+              <div className="flex min-w-0 items-center gap-2">
+                <p className="truncate text-sm font-medium">{primaryLabel}</p>
+                {blockedMessage ? (
+                  <TooltipProvider delayDuration={0}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span
+                          aria-label={`Provisional item. ${blockedMessage}`}
+                          className="inline-flex shrink-0 items-center focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                          tabIndex={0}
+                        >
+                          <Badge
+                            className="gap-1 border-warning/30 bg-warning/15 px-1.5 text-[10px] font-medium text-warning"
+                            size="sm"
+                            variant="outline"
+                          >
+                            <Info className="h-3 w-3" aria-hidden="true" />
+                            Provisional
+                          </Badge>
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-64 text-xs leading-5">
+                        {blockedMessage}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                ) : null}
+              </div>
               {detailEntries.length > 0 ? (
                 <div className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
                   {detailEntries.map((entry) => (
@@ -2335,6 +2395,7 @@ export function StockAdjustmentWorkspaceContent({
         cell: ({ row }) => {
           const item = row.original.inventoryItem;
           const displayName = getInventoryItemDisplayName(item);
+          const isBlocked = row.original.isBlocked;
           const inputLabel =
             adjustmentType === "manual"
               ? "Adjustment delta"
@@ -2370,6 +2431,7 @@ export function StockAdjustmentWorkspaceContent({
               <Input
                 aria-label={`${inputLabel} for ${displayName}`}
                 className="h-10 w-36 text-right"
+                disabled={isBlocked}
                 inputMode="numeric"
                 min={adjustmentType === "manual" ? undefined : 0}
                 onFocus={() => handleSelectInventoryItem(item._id)}
@@ -2383,7 +2445,7 @@ export function StockAdjustmentWorkspaceContent({
               <Button
                 aria-label={`Restore original value for ${displayName}`}
                 className="h-10 w-10 shrink-0 text-muted-foreground"
-                disabled={!row.original.isEdited}
+                disabled={isBlocked || !row.original.isEdited}
                 onClick={(event) => {
                   event.stopPropagation();
                   handleSelectInventoryItem(item._id);
@@ -2730,11 +2792,25 @@ export function StockAdjustmentWorkspaceContent({
       await flushLocallyEditedCycleCountDraftLines();
     }
 
+    const firstBlockedRow = tableRows.find((row) => row.isBlocked);
+    const allRowsBlocked =
+      tableRows.length > 0 && tableRows.every((row) => row.isBlocked);
+
     if (
       adjustmentType === "manual"
         ? changedRows.length === 0
         : overallSummary.lineItemCount === 0 && changedRows.length === 0
     ) {
+      if (
+        allRowsBlocked &&
+        firstBlockedRow?.inventoryItem.stockAdjustmentBlockedMessage
+      ) {
+        toast.error(
+          firstBlockedRow.inventoryItem.stockAdjustmentBlockedMessage,
+        );
+        return;
+      }
+
       toast.error(
         adjustmentType === "manual"
           ? "Add at least one non-zero stock delta"
@@ -2891,8 +2967,8 @@ export function StockAdjustmentWorkspaceContent({
             filterValue={filters.availability}
             hasActiveFilters={Boolean(
               filters.query ||
-                filters.availability !== "all" ||
-                filters.category !== ALL_CATEGORY_FILTER_KEY,
+              filters.availability !== "all" ||
+              filters.category !== ALL_CATEGORY_FILTER_KEY,
             )}
             onClearFilters={handleClearFilters}
             onFilterChange={(availability) =>

--- a/packages/athena-webapp/src/components/pos/ProductCard.tsx
+++ b/packages/athena-webapp/src/components/pos/ProductCard.tsx
@@ -18,8 +18,7 @@ interface ProductCardProps {
 }
 
 function normalizeQuantity(value: string | number, maxQuantity?: number) {
-  const parsed =
-    typeof value === "number" ? value : Number.parseInt(value, 10);
+  const parsed = typeof value === "number" ? value : Number.parseInt(value, 10);
 
   if (!Number.isFinite(parsed)) {
     return 1;
@@ -51,7 +50,9 @@ export function ProductCard({
   const [quantityInput, setQuantityInput] = useState("1");
   const isProvisionalImport =
     product.availabilityPolicy === "active_provisional_import";
-  const isPendingCheckoutItem = Boolean(product.pendingCheckoutItemId);
+  const isPendingCheckoutItem =
+    product.availabilityPolicy === "pending_checkout" ||
+    Boolean(product.pendingCheckoutItemId);
   const usesPendingCount = isProvisionalImport || isPendingCheckoutItem;
   const maxQuantity = undefined;
   const selectedQuantity = normalizeQuantity(quantityInput, maxQuantity);

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
@@ -93,7 +93,9 @@ vi.mock("@/hooks/usePermissions", () => ({
 }));
 
 vi.mock("@/components/View", () => ({
-  default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+  default: ({ children }: { children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
 }));
 
 vi.mock("@/components/common/FadeIn", () => ({
@@ -101,11 +103,7 @@ vi.mock("@/components/common/FadeIn", () => ({
 }));
 
 vi.mock("@/components/common/PageLevelHeader", () => ({
-  PageLevelHeader: ({
-    title,
-  }: {
-    title: string;
-  }) => <h1>{title}</h1>,
+  PageLevelHeader: ({ title }: { title: string }) => <h1>{title}</h1>,
   PageWorkspace: ({ children }: { children?: React.ReactNode }) => (
     <div>{children}</div>
   ),
@@ -162,6 +160,7 @@ const detail: TerminalHealthDetail = {
       availabilityAgeMs: 90_000,
       catalogAgeMs: 180_000,
       registerReadModelAgeMs: 60_000,
+      serviceCatalogAgeMs: 240_000,
     },
     source: "support-diagnostics",
     staffAuthority: {
@@ -206,17 +205,16 @@ const detail: TerminalHealthDetail = {
   syncEvidence: {
     acceptedThroughSequence: 13,
     cursorUpdatedAt: Date.now() - 2 * 60_000,
-    latestEvent:
-      {
-        _id: "event-1",
-        eventType: "sale.completed",
-        localEventId: "local-1",
-        localRegisterSessionId: "local-session-1",
-        occurredAt: Date.now() - 5 * 60_000,
-        sequence: 14,
-        status: "held",
-        submittedAt: Date.now() - 4 * 60_000,
-      },
+    latestEvent: {
+      _id: "event-1",
+      eventType: "sale.completed",
+      localEventId: "local-1",
+      localRegisterSessionId: "local-session-1",
+      occurredAt: Date.now() - 5 * 60_000,
+      sequence: 14,
+      status: "held",
+      submittedAt: Date.now() - 4 * 60_000,
+    },
     unresolvedConflictCount: 1,
     unresolvedConflicts: [
       {
@@ -266,20 +264,28 @@ describe("POSTerminalDetailViewContent", () => {
   });
 
   it("renders identity, check-in, sync, conflict, and support notes", () => {
-    render(
-      <POSTerminalDetailViewContent
-        detail={detail}
-        isLoading={false}
-      />,
-    );
+    render(<POSTerminalDetailViewContent detail={detail} isLoading={false} />);
 
-    expect(screen.getByRole("heading", { name: "Front counter" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Front counter" }),
+    ).toBeInTheDocument();
     expect(screen.getAllByText("Register 1").length).toBeGreaterThan(0);
     expect(screen.getByText("Latest check-in")).toBeInTheDocument();
     expect(screen.getByText("Athena webapp")).toBeInTheDocument();
     expect(
       screen.getByText("gentle-lion-climbs (20260608193135) / b463caa2d36d"),
     ).toBeInTheDocument();
+    expect(screen.getByText("Readiness evidence")).toBeInTheDocument();
+    expect(screen.getAllByText("Availability").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Catalog").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Service catalog").length).toBeGreaterThan(0);
+    expect(screen.getByText("Register model")).toBeInTheDocument();
+    expect(
+      screen.getAllByText("Staff authority expired").length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByText("2 minutes old")).toBeInTheDocument();
+    expect(screen.getByText("3 minutes old")).toBeInTheDocument();
+    expect(screen.getByText("4 minutes old")).toBeInTheDocument();
     expect(
       screen.getByText("Why this terminal needs attention"),
     ).toBeInTheDocument();
@@ -289,9 +295,15 @@ describe("POSTerminalDetailViewContent", () => {
     expect(
       screen.getByText("1 synced item is held before projection."),
     ).toBeInTheDocument();
-    expect(screen.getByText("Local runtime review / next upload #14")).toBeInTheDocument();
-    expect(screen.getAllByText("Cloud sync evidence").length).toBeGreaterThan(0);
-    expect(screen.getByText("Staff authority changed before sync.")).toBeInTheDocument();
+    expect(
+      screen.getByText("Local runtime review / next upload #14"),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Cloud sync evidence").length).toBeGreaterThan(
+      0,
+    );
+    expect(
+      screen.getByText("Staff authority changed before sync."),
+    ).toBeInTheDocument();
     expect(screen.getByText("register.opened")).toBeInTheDocument();
     expect(screen.getByText("cart.item_added")).toBeInTheDocument();
     expect(screen.getByText("Uploaded")).toBeInTheDocument();
@@ -484,8 +496,12 @@ describe("POSTerminalDetailViewContent", () => {
       />,
     );
 
-    expect(screen.getByText("Waiting for runtime enrollment")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /start session/i })).toBeDisabled();
+    expect(
+      screen.getByText("Waiting for runtime enrollment"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /start session/i }),
+    ).toBeDisabled();
   });
 
   it("keeps Remote Assist unavailable when presence is stale", () => {
@@ -506,7 +522,9 @@ describe("POSTerminalDetailViewContent", () => {
     );
 
     expect(screen.getByText("Runtime not online")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /start session/i })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /start session/i }),
+    ).toBeDisabled();
   });
 
   it("keeps Remote Assist unavailable for users who cannot start support sessions", () => {
@@ -527,7 +545,9 @@ describe("POSTerminalDetailViewContent", () => {
     );
 
     expect(screen.getByText("Support permission required")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /start session/i })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /start session/i }),
+    ).toBeDisabled();
   });
 
   it("keeps attended-required Remote Assist unavailable until runtime approval exists", () => {
@@ -548,7 +568,9 @@ describe("POSTerminalDetailViewContent", () => {
     );
 
     expect(screen.getByText("Local approval required")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /start session/i })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /start session/i }),
+    ).toBeDisabled();
   });
 
   it("renders the support recovery panel with safe cloud and terminal actions", () => {
@@ -565,7 +587,8 @@ describe("POSTerminalDetailViewContent", () => {
             },
             {
               source: "terminal_runtime",
-              summary: "authorization_failed: stale terminal sync secret rejected",
+              summary:
+                "authorization_failed: stale terminal sync secret rejected",
               type: "terminal_authorization_failed",
             },
           ],
@@ -609,15 +632,21 @@ describe("POSTerminalDetailViewContent", () => {
       ).length,
     ).toBeGreaterThan(0);
     expect(
-      screen.getByRole("button", { name: /resolve duplicate drawer attempts/i }),
+      screen.getByRole("button", {
+        name: /resolve duplicate drawer attempts/i,
+      }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /send terminal repair command/i }),
     ).toBeInTheDocument();
     expect(screen.getByText(/pending/i)).toBeInTheDocument();
-    expect(screen.getAllByText("Waiting For Check In").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Waiting For Check In").length).toBeGreaterThan(
+      0,
+    );
     expect(
-      screen.queryByText(/register_opened|already open|authorization_failed|sync secret/i),
+      screen.queryByText(
+        /register_opened|already open|authorization_failed|sync secret/i,
+      ),
     ).not.toBeInTheDocument();
   });
 
@@ -678,7 +707,8 @@ describe("POSTerminalDetailViewContent", () => {
             {
               actionTarget: { type: "pos_settings" },
               source: "terminal_runtime",
-              summary: "Terminal setup data is not ready on this checkout station.",
+              summary:
+                "Terminal setup data is not ready on this checkout station.",
               type: "terminal_seed_missing",
             },
           ],
@@ -810,10 +840,7 @@ describe("POSTerminalDetailViewContent", () => {
 
   it("renders no-data and query unavailable states", () => {
     const { rerender } = render(
-      <POSTerminalDetailViewContent
-        detail={null}
-        isLoading={false}
-      />,
+      <POSTerminalDetailViewContent detail={null} isLoading={false} />,
     );
 
     expect(screen.getByText("Terminal not found")).toBeInTheDocument();
@@ -913,7 +940,9 @@ describe("POSTerminalDetailView", () => {
 
   it("does not query full-admin Remote Assist session state for POS-only users", () => {
     mocks.hasFullAdminAccess = false;
-    (mocks.activeStoreState as { activeStore: Record<string, unknown> }).activeStore = {
+    (
+      mocks.activeStoreState as { activeStore: Record<string, unknown> }
+    ).activeStore = {
       _id: "store-1",
       organizationId: "org-1",
     };

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
@@ -38,12 +38,12 @@ import type { Id } from "~/convex/_generated/dataModel";
 import {
   buildTerminalRecoveryPresentation,
   classifyTerminalHealth,
+  formatAge,
   formatRegisterNumber,
   formatStatusLabel,
   formatTerminalTimestamp,
   getRecentSyncEvents,
   getReviewEvidenceCount,
-  getSnapshotAgeSummary,
   getStaffAuthorityLabel,
   getSupportSafeAttentionReasonSummary,
   getTerminalAttentionReasons,
@@ -221,6 +221,97 @@ function RailField({
   );
 }
 
+function getStaffAuthorityTone(
+  status?: TerminalRuntimeStatus["staffAuthority"] | null,
+) {
+  switch (status?.status) {
+    case "ready":
+      return "success";
+    case "expired":
+    case "missing":
+      return "warning";
+    default:
+      return "neutral";
+  }
+}
+
+function RailSignalRow({
+  label,
+  tone = "neutral",
+  value,
+}: {
+  label: string;
+  tone?: "neutral" | "success" | "warning";
+  value: React.ReactNode;
+}) {
+  return (
+    <div className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-layout-sm py-layout-xs">
+      <span className="min-w-0 truncate text-xs font-medium text-muted-foreground">
+        {label}
+      </span>
+      <span
+        className={cn(
+          "min-w-0 text-right text-xs font-medium leading-5",
+          tone === "success"
+            ? "text-success"
+            : tone === "warning"
+              ? "text-warning-foreground"
+              : "text-foreground",
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function SnapshotReadinessGroup({
+  runtimeStatus,
+}: {
+  runtimeStatus: TerminalRuntimeStatus | null;
+}) {
+  const snapshots = runtimeStatus?.snapshots;
+  const staffAuthorityTone = getStaffAuthorityTone(
+    runtimeStatus?.staffAuthority,
+  );
+
+  return (
+    <div className="space-y-layout-xs rounded-md border border-border/80 bg-surface px-layout-md py-layout-sm">
+      <div className="flex items-center justify-between gap-layout-sm">
+        <p className="text-xs font-medium uppercase text-muted-foreground">
+          Readiness evidence
+        </p>
+        <span className="text-xs text-muted-foreground">
+          {runtimeStatus ? "From latest check-in" : "Not reported"}
+        </span>
+      </div>
+      <div className="divide-y divide-border/70">
+        <RailSignalRow
+          label="Availability"
+          value={formatAge(snapshots?.availabilityAgeMs)}
+        />
+        <RailSignalRow
+          label="Catalog"
+          value={formatAge(snapshots?.catalogAgeMs)}
+        />
+        <RailSignalRow
+          label="Service catalog"
+          value={formatAge(snapshots?.serviceCatalogAgeMs)}
+        />
+        <RailSignalRow
+          label="Register model"
+          value={formatAge(snapshots?.registerReadModelAgeMs)}
+        />
+        <RailSignalRow
+          label="Staff authority"
+          tone={staffAuthorityTone}
+          value={getStaffAuthorityLabel(runtimeStatus?.staffAuthority)}
+        />
+      </div>
+    </div>
+  );
+}
+
 function RailSection({
   children,
   icon,
@@ -296,22 +387,19 @@ function TerminalContextRail({
                   : "Not reported"
             }
           />
-          <RailField
-            label="Snapshots"
-            value={getSnapshotAgeSummary(runtimeStatus?.snapshots)}
-          />
-          <RailField
-            label="Staff authority"
-            value={getStaffAuthorityLabel(runtimeStatus?.staffAuthority)}
-          />
+          <SnapshotReadinessGroup runtimeStatus={runtimeStatus} />
         </RailSection>
       </div>
     </aside>
   );
 }
 
-function formatRuntimeBuildVersion(runtimeStatus: TerminalRuntimeStatus | null) {
-  const appVersion = normalizeOptionalRuntimeMetadata(runtimeStatus?.appVersion);
+function formatRuntimeBuildVersion(
+  runtimeStatus: TerminalRuntimeStatus | null,
+) {
+  const appVersion = normalizeOptionalRuntimeMetadata(
+    runtimeStatus?.appVersion,
+  );
   const buildSha = normalizeOptionalRuntimeMetadata(runtimeStatus?.buildSha);
   const shortBuildSha = buildSha?.slice(0, 12);
 

--- a/packages/athena-webapp/src/components/pos/types.ts
+++ b/packages/athena-webapp/src/components/pos/types.ts
@@ -49,7 +49,10 @@ export interface Product {
   skuId?: Id<"productSku">;
   pendingCheckoutItemId?: Id<"posPendingCheckoutItem">;
   inventoryImportProvisionalSkuId?: Id<"inventoryImportProvisionalSku">;
-  availabilityPolicy?: "trusted_inventory" | "active_provisional_import";
+  availabilityPolicy?:
+    | "trusted_inventory"
+    | "active_provisional_import"
+    | "pending_checkout";
   pendingCheckoutItemLocalDefinition?: PosLocalSyncPendingCheckoutItemDefinedPayload;
   areProcessingFeesAbsorbed?: boolean;
 }

--- a/packages/athena-webapp/src/components/products/Products.test.tsx
+++ b/packages/athena-webapp/src/components/products/Products.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -10,6 +10,10 @@ import Products from "./Products";
 const quickAddProductSkuMock = vi.fn();
 const mockedProducts = vi.hoisted(() => ({
   allProducts: [] as Product[],
+  categories: [] as Array<{ _id: string; name: string; slug: string }>,
+  draftProducts: [] as Product[],
+  hiddenDraftProducts: [] as Product[],
+  hiddenLiveProducts: [] as Product[],
 }));
 
 class ResizeObserverStub {
@@ -28,16 +32,53 @@ vi.mock("@tanstack/react-router", () => ({
 }));
 
 vi.mock("~/src/hooks/useGetCategories", () => ({
-  useGetCategories: () => [],
+  useGetCategories: () => mockedProducts.categories,
 }));
 
 vi.mock("~/src/hooks/useGetProducts", () => ({
-  useGetProducts: () => mockedProducts.allProducts,
+  useGetProducts: (args?: { availability?: string; isVisible?: boolean }) => {
+    if (args?.availability === "draft" && args.isVisible === false) {
+      return mockedProducts.hiddenDraftProducts;
+    }
+    if (args?.availability === "live" && args.isVisible === false) {
+      return mockedProducts.hiddenLiveProducts;
+    }
+    if (args?.availability === "draft") {
+      return mockedProducts.draftProducts;
+    }
+
+    return mockedProducts.allProducts;
+  },
   useGetUnresolvedProducts: () => [],
 }));
 
 vi.mock("convex/react", () => ({
-  useQuery: () => ({ name: "Home Care" }),
+  useQuery: (_query: unknown, args: unknown) => {
+    if (
+      args &&
+      typeof args === "object" &&
+      "storeId" in args &&
+      !("id" in args)
+    ) {
+      return productsToInventoryItems([
+        ...mockedProducts.allProducts,
+        ...mockedProducts.draftProducts,
+        ...mockedProducts.hiddenLiveProducts,
+        ...mockedProducts.hiddenDraftProducts,
+      ]);
+    }
+
+    if (
+      args &&
+      typeof args === "object" &&
+      "id" in args &&
+      args.id === "subcategory-legacy"
+    ) {
+      return { name: "Imported accessories" };
+    }
+
+    return { name: "Home Care" };
+  },
 }));
 
 vi.mock("~/src/hooks/usePermissions", () => ({
@@ -70,6 +111,10 @@ describe("Products", () => {
   beforeEach(() => {
     quickAddProductSkuMock.mockReset();
     mockedProducts.allProducts = [];
+    mockedProducts.categories = [];
+    mockedProducts.draftProducts = [];
+    mockedProducts.hiddenDraftProducts = [];
+    mockedProducts.hiddenLiveProducts = [];
   });
 
   it("quick adds a product with variants from the products workspace", async () => {
@@ -87,19 +132,31 @@ describe("Products", () => {
     render(<Products />);
 
     await user.click(screen.getByRole("button", { name: /quick add/i }));
-    await user.type(screen.getByLabelText(/product name/i), "Restock item");
-    await user.type(screen.getByLabelText(/barcode/i), "123456789");
-    await user.type(screen.getByLabelText(/selling price/i), "45");
-    await user.click(screen.getByLabelText(/add multiple variants/i));
+    const dialog = screen.getByRole("dialog");
+    await user.type(
+      within(dialog).getByLabelText(/product name/i),
+      "Restock item",
+    );
+    await user.type(within(dialog).getByLabelText(/barcode/i), "123456789");
+    await user.type(within(dialog).getByLabelText(/selling price/i), "45");
+    await user.click(within(dialog).getByLabelText(/add multiple variants/i));
     await user.click(screen.getByRole("button", { name: /add variant/i }));
-    await user.type(screen.getAllByLabelText(/barcode/i)[1], "987654321");
-    await user.type(screen.getAllByLabelText(/selling price/i)[1], "50");
+    await user.type(
+      within(dialog).getAllByLabelText(/barcode/i)[1],
+      "987654321",
+    );
+    await user.type(
+      within(dialog).getAllByLabelText(/selling price/i)[1],
+      "50",
+    );
 
     await user.click(
       screen.getByRole("button", { name: /add product variants/i }),
     );
 
-    await waitFor(() => expect(quickAddProductSkuMock).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(quickAddProductSkuMock).toHaveBeenCalledTimes(2),
+    );
     expect(quickAddProductSkuMock).toHaveBeenNthCalledWith(1, {
       storeId: "store-1",
       createdByUserId: "user-1",
@@ -130,8 +187,11 @@ describe("Products", () => {
     );
     await user.click(screen.getByRole("button", { name: /quick add/i }));
 
-    expect(screen.getByLabelText(/product name/i)).toHaveValue("");
-    expect(screen.getByLabelText(/barcode/i)).toHaveValue("075724640412");
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByLabelText(/product name/i)).toHaveValue("");
+    expect(within(dialog).getByLabelText(/barcode/i)).toHaveValue(
+      "075724640412",
+    );
   });
 
   it("prefills quick add product name from a text product search", async () => {
@@ -145,10 +205,11 @@ describe("Products", () => {
     );
     await user.click(screen.getByRole("button", { name: /quick add/i }));
 
-    expect(screen.getByLabelText(/product name/i)).toHaveValue(
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByLabelText(/product name/i)).toHaveValue(
       "Mahogany Teakwood",
     );
-    expect(screen.getByLabelText(/barcode/i)).toHaveValue("");
+    expect(within(dialog).getByLabelText(/barcode/i)).toHaveValue("");
   });
 
   it("fuzzy matches product search across product and SKU fields", async () => {
@@ -239,4 +300,303 @@ describe("Products", () => {
     expect(screen.getByText("Closure Wig")).toBeInTheDocument();
     expect(screen.queryByText("Mahogany Teakwood")).not.toBeInTheDocument();
   });
+
+  it("uses the shared SKU filter bar for product search filters", async () => {
+    const user = userEvent.setup();
+    mockedProducts.categories = [
+      { _id: "category-1", name: "Hair", slug: "hair" },
+      { _id: "category-2", name: "Home Care", slug: "home-care" },
+    ];
+    mockedProducts.allProducts = [
+      makeProduct({
+        id: "product-1",
+        categoryId: "category-1",
+        categoryName: "Hair",
+        categorySlug: "hair",
+        inventoryCount: 8,
+        name: "Closure Wig",
+        sku: "CW-18",
+      }),
+      makeProduct({
+        id: "product-2",
+        categoryId: "category-2",
+        categoryName: "Home Care",
+        categorySlug: "home-care",
+        inventoryCount: 0,
+        name: "Mahogany Teakwood",
+        sku: "CANDLE-1",
+      }),
+    ];
+
+    render(<Products />);
+
+    expect(
+      screen.getByRole("textbox", {
+        name: /search products, skus, or barcodes/i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: /filter by availability/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Showing 2 of 2 products.")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /hair, 1 product/i }));
+
+    expect(screen.getByText("Closure Wig")).toBeInTheDocument();
+    expect(screen.queryByText("Mahogany Teakwood")).not.toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 2 products.")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /^clear$/i }));
+
+    expect(screen.queryByText("Search results")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Categories").length).toBeGreaterThan(1);
+  });
+
+  it("filters product search by availability", async () => {
+    const user = userEvent.setup();
+    mockedProducts.allProducts = [
+      makeProduct({
+        id: "product-1",
+        inventoryCount: 8,
+        name: "Closure Wig",
+        sku: "CW-18",
+      }),
+      makeProduct({
+        id: "product-2",
+        inventoryCount: 0,
+        name: "Mahogany Teakwood",
+        sku: "CANDLE-1",
+      }),
+    ];
+
+    render(<Products />);
+
+    await user.click(
+      screen.getByRole("combobox", { name: /filter by availability/i }),
+    );
+    await user.click(
+      await screen.findByRole("option", { name: "Out of stock" }),
+    );
+
+    expect(screen.getByText("Mahogany Teakwood")).toBeInTheDocument();
+    expect(screen.queryByText("Closure Wig")).not.toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 2 products.")).toBeInTheDocument();
+  });
+
+  it("searches draft products from the products workspace", async () => {
+    const user = userEvent.setup();
+    mockedProducts.categories = [
+      { _id: "category-legacy", name: "Legacy import", slug: "legacy-import" },
+      { _id: "category-books", name: "Books", slug: "books" },
+    ];
+    mockedProducts.draftProducts = [
+      makeProduct({
+        availability: "draft",
+        categoryId: "category-legacy",
+        categoryName: "Legacy import",
+        categorySlug: "legacy-import",
+        id: "product-legacy",
+        inventoryCount: 3,
+        isVisible: false,
+        name: "Imported Bonnet",
+        sku: "OLD-BONNET",
+      }),
+      makeProduct({
+        availability: "draft",
+        categoryId: "category-books",
+        categoryName: "Books",
+        categorySlug: "books",
+        id: "product-draft-book",
+        inventoryCount: 2,
+        name: "Draft Book",
+        sku: "BOOK-DRAFT",
+      }),
+    ];
+
+    render(<Products />);
+
+    await user.type(
+      screen.getByRole("textbox", {
+        name: /search products, skus, or barcodes/i,
+      }),
+      "bonnet",
+    );
+
+    expect(screen.getByText("Imported Bonnet")).toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 2 products.")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /legacy import, 1 product/i }),
+    ).toBeInTheDocument();
+
+    await user.clear(
+      screen.getByRole("textbox", {
+        name: /search products, skus, or barcodes/i,
+      }),
+    );
+    await user.type(
+      screen.getByRole("textbox", {
+        name: /search products, skus, or barcodes/i,
+      }),
+      "draft",
+    );
+
+    expect(screen.getByText("Draft Book")).toBeInTheDocument();
+  });
+
+  it("searches hidden SKUs for hidden draft products", async () => {
+    const user = userEvent.setup();
+    mockedProducts.categories = [
+      { _id: "category-legacy", name: "Legacy import", slug: "legacy-import" },
+    ];
+    mockedProducts.draftProducts = [
+      makeProduct({
+        availability: "draft",
+        categoryId: "category-legacy",
+        categoryName: "Legacy import",
+        categorySlug: "legacy-import",
+        id: "product-hidden-draft",
+        inventoryCount: 0,
+        isVisible: false,
+        name: "Imported Cubic Wig",
+        sku: "",
+        skus: [],
+        subcategoryId: "subcategory-legacy",
+        subcategoryName: "Imported accessories",
+        subcategorySlug: "imported-accessories",
+      }),
+    ];
+    mockedProducts.hiddenDraftProducts = [
+      makeProduct({
+        availability: "draft",
+        categoryId: "category-legacy",
+        categoryName: "Legacy import",
+        categorySlug: "legacy-import",
+        id: "product-hidden-draft",
+        inventoryCount: 4,
+        isVisible: false,
+        name: "Imported Cubic Wig",
+        sku: "CUBIC-LEGACY",
+        skuIsVisible: false,
+        subcategoryId: "subcategory-legacy",
+        subcategoryName: "Imported accessories",
+        subcategorySlug: "imported-accessories",
+      }),
+    ];
+
+    render(<Products />);
+
+    await user.type(
+      screen.getByRole("textbox", {
+        name: /search products, skus, or barcodes/i,
+      }),
+      "cubic",
+    );
+
+    expect(screen.getByText("Imported Cubic Wig")).toBeInTheDocument();
+    expect(screen.getByText("Imported accessories")).toBeInTheDocument();
+    expect(screen.getByText("Showing 1 of 1 product.")).toBeInTheDocument();
+  });
 });
+
+function makeProduct({
+  availability = "live",
+  categoryId = "category-1",
+  categoryName = "Hair",
+  categorySlug = "hair",
+  id,
+  inventoryCount,
+  isVisible = true,
+  name,
+  sku,
+  skuIsVisible = true,
+  skus,
+  subcategoryId = "subcategory-1",
+  subcategoryName = "Wigs",
+  subcategorySlug = "wigs",
+}: {
+  availability?: Product["availability"];
+  categoryId?: string;
+  categoryName?: string;
+  categorySlug?: string;
+  id: string;
+  inventoryCount: number;
+  isVisible?: boolean;
+  name: string;
+  sku: string;
+  skuIsVisible?: boolean;
+  skus?: Product["skus"];
+  subcategoryId?: string;
+  subcategoryName?: string;
+  subcategorySlug?: string;
+}): Product {
+  return {
+    _id: id as Id<"product">,
+    _creationTime: 1,
+    availability,
+    categoryId: categoryId as Id<"category">,
+    categoryName,
+    categorySlug,
+    createdByUserId: "user-1" as Id<"athenaUser">,
+    currency: "GHS",
+    inventoryCount,
+    isVisible,
+    name,
+    organizationId: "org-1" as Id<"organization">,
+    quantityAvailable: inventoryCount,
+    slug: name.toLowerCase().replace(/\s+/g, "-"),
+    skus: skus ?? [
+      {
+        _id: `${id}-sku` as Id<"productSku">,
+        _creationTime: 1,
+        barcode: "",
+        colorName: "",
+        images: [],
+        inventoryCount,
+        length: undefined,
+        price: 2500,
+        productCategory: categoryName,
+        productId: id as Id<"product">,
+        productName: name,
+        quantityAvailable: inventoryCount,
+        size: "",
+        sku,
+        isVisible: skuIsVisible,
+        storeId: "store-1" as Id<"store">,
+      },
+    ],
+    storeId: "store-1" as Id<"store">,
+    subcategoryId: subcategoryId as Id<"subcategory">,
+    subcategoryName,
+    subcategorySlug,
+  };
+}
+
+function productsToInventoryItems(products: Product[]) {
+  return products.flatMap((product) =>
+    product.skus.map((sku) => ({
+      _id: sku._id,
+      barcode: sku.barcode ?? null,
+      colorName: sku.colorName ?? null,
+      durableQuantityAvailable: sku.quantityAvailable,
+      imageUrl: sku.images[0] ?? null,
+      inventoryCount: sku.inventoryCount,
+      length: sku.length ?? null,
+      netPrice: sku.netPrice,
+      price: sku.price,
+      productCategory: product.categoryName ?? sku.productCategory ?? null,
+      productCategoryId: product.categoryId,
+      productCategorySlug: product.categorySlug ?? null,
+      productId: product._id,
+      productName: product.name,
+      productSubcategory: product.subcategoryName ?? null,
+      productSubcategoryId: product.subcategoryId,
+      productSubcategorySlug: product.subcategorySlug ?? null,
+      checkoutReservedQuantity: 0,
+      posReservedQuantity: 0,
+      quantityAvailable: sku.quantityAvailable,
+      reservedQuantity: 0,
+      size: sku.size ?? null,
+      sku: sku.sku ?? null,
+    })),
+  );
+}

--- a/packages/athena-webapp/src/components/products/Products.tsx
+++ b/packages/athena-webapp/src/components/products/Products.tsx
@@ -2,19 +2,10 @@ import { Link, useSearch } from "@tanstack/react-router";
 import { useGetCategories } from "~/src/hooks/useGetCategories";
 import { getOrigin } from "~/src/lib/navigationUtils";
 import { Button } from "../ui/button";
-import {
-  ArchiveIcon,
-  FolderTree,
-  PackageXIcon,
-  PlusIcon,
-  Search,
-} from "lucide-react";
-import {
-  useGetUnresolvedProducts,
-  useGetProducts,
-} from "~/src/hooks/useGetProducts";
+import { ArchiveIcon, FolderTree, PackageXIcon, PlusIcon } from "lucide-react";
+import { useGetUnresolvedProducts } from "~/src/hooks/useGetProducts";
 import { useState, useMemo } from "react";
-import { Input } from "../ui/input";
+import { useQuery } from "convex/react";
 import { GenericDataTable } from "../base/table/data-table";
 import { productColumns } from "./products-table/components/productColumns";
 import { EmptyState } from "../states/empty/empty-state";
@@ -40,40 +31,147 @@ import {
   normalizeSkuSearchQuery,
 } from "~/src/lib/stockOps/skuSearch";
 import type { Product } from "~/types";
+import type { Id } from "~/convex/_generated/dataModel";
+import { api } from "~/convex/_generated/api";
+import { SkuSearchFilterBar } from "../stock-ops/SkuSearchFilterBar";
+import type { InventorySnapshotItem } from "../operations/StockAdjustmentWorkspace";
+
+const ALL_CATEGORY_FILTER_KEY = "all";
+
+type ProductAvailabilityFilter = "all" | "available" | "out_of_stock";
+
+const PRODUCT_AVAILABILITY_FILTER_OPTIONS: Array<{
+  label: string;
+  value: ProductAvailabilityFilter;
+}> = [
+  { label: "All stock", value: "all" },
+  { label: "Available", value: "available" },
+  { label: "Out of stock", value: "out_of_stock" },
+];
 
 export default function Products() {
   const categories = useGetCategories();
   const unresolvedProducts = useGetUnresolvedProducts();
-  const allProducts = useGetProducts();
   const [searchValue, setSearchValue] = useState("");
   const [isQuickAddOpen, setIsQuickAddOpen] = useState(false);
   const [quickAddInitialName, setQuickAddInitialName] = useState("");
   const [quickAddInitialLookupCode, setQuickAddInitialLookupCode] =
     useState("");
+  const [availabilityFilter, setAvailabilityFilter] =
+    useState<ProductAvailabilityFilter>("all");
+  const [categoryFilter, setCategoryFilter] = useState(ALL_CATEGORY_FILTER_KEY);
   const { hasFullAdminAccess } = usePermissions();
   const { activeStore } = useGetActiveStore();
   const { user } = useAuth();
   const { o } = useSearch({ strict: false });
   const quickAddProductSku = usePOSQuickAddProductSku();
+  const inventoryItems = useQuery(
+    api.stockOps.adjustments.listInventorySnapshot,
+    activeStore?._id ? { storeId: activeStore._id } : "skip",
+  ) as InventorySnapshotItem[] | undefined;
 
+  const categorySlugById = useMemo(() => {
+    return new Map(
+      (categories ?? []).map((category) => [category._id, category.slug]),
+    );
+  }, [categories]);
+  const products = useMemo(
+    () =>
+      buildProductsFromInventorySnapshot(
+        inventoryItems ?? [],
+        categories ?? [],
+        activeStore?._id,
+      ),
+    [activeStore?._id, categories, inventoryItems],
+  );
   const filteredProducts = useMemo(() => {
-    if (!allProducts) return null;
-    if (!searchValue.trim()) return null;
+    if (!inventoryItems) return null;
 
     const normalizedQuery = normalizeSkuSearchQuery(searchValue);
 
-    return allProducts.filter((product) =>
-      productMatchesCatalogSearch(product, normalizedQuery),
-    );
-  }, [allProducts, searchValue]);
+    return products.filter((product) => {
+      if (!productMatchesAvailabilityFilter(product, availabilityFilter)) {
+        return false;
+      }
+
+      if (
+        !productMatchesCategoryFilter(product, categoryFilter, categorySlugById)
+      ) {
+        return false;
+      }
+
+      return productMatchesCatalogSearch(product, normalizedQuery);
+    });
+  }, [
+    availabilityFilter,
+    categoryFilter,
+    categorySlugById,
+    inventoryItems,
+    products,
+    searchValue,
+  ]);
 
   const hasSearchInput = searchValue.trim().length > 0;
-  const showSearchResults = hasSearchInput && filteredProducts !== null;
+  const hasActiveFilters =
+    hasSearchInput ||
+    availabilityFilter !== "all" ||
+    categoryFilter !== ALL_CATEGORY_FILTER_KEY;
+  const showSearchResults = hasActiveFilters && filteredProducts !== null;
   const unresolvedProductCount = unresolvedProducts?.length ?? 0;
   const categoryCount = categories?.length ?? 0;
-  const productCount = allProducts?.length ?? 0;
+  const productCount = products.length;
   const outOfStockProductCount =
-    allProducts?.filter((product) => product.inventoryCount === 0).length ?? 0;
+    products.filter((product) => product.inventoryCount === 0).length ?? 0;
+  const categoryFilterOptions = useMemo(() => {
+    const productCountsByCategory = new Map<string, number>();
+
+    for (const product of products) {
+      const categoryKey = getProductCategoryFilterKey(
+        product,
+        categorySlugById,
+      );
+
+      if (!categoryKey) continue;
+
+      productCountsByCategory.set(
+        categoryKey,
+        (productCountsByCategory.get(categoryKey) ?? 0) + 1,
+      );
+    }
+
+    const optionsByKey = new Map<
+      string,
+      { itemCount: number; key: string; label: string }
+    >();
+
+    for (const category of categories ?? []) {
+      const itemCount = productCountsByCategory.get(category.slug) ?? 0;
+
+      if (itemCount > 0) {
+        optionsByKey.set(category.slug, {
+          itemCount,
+          key: category.slug,
+          label: category.name,
+        });
+      }
+    }
+
+    for (const product of products) {
+      const key = getProductCategoryFilterKey(product, categorySlugById);
+
+      if (!key || optionsByKey.has(key)) continue;
+
+      optionsByKey.set(key, {
+        itemCount: productCountsByCategory.get(key) ?? 0,
+        key,
+        label: product.categoryName ?? key,
+      });
+    }
+
+    return [...optionsByKey.values()].sort((left, right) =>
+      left.label.localeCompare(right.label),
+    );
+  }, [categories, categorySlugById, products]);
 
   const handleQuickAddSubmit = async ({
     name,
@@ -125,6 +223,12 @@ export default function Products() {
     setIsQuickAddOpen(true);
   };
 
+  const handleClearFilters = () => {
+    setSearchValue("");
+    setAvailabilityFilter("all");
+    setCategoryFilter(ALL_CATEGORY_FILTER_KEY);
+  };
+
   return (
     <PageWorkspace>
       <PageLevelHeader
@@ -138,42 +242,104 @@ export default function Products() {
         <PageWorkspaceMain>
           <section className="min-w-0 overflow-hidden rounded-lg border border-border bg-surface-raised shadow-surface">
             <div className="min-w-0 space-y-layout-lg px-layout-md py-layout-md">
-              <div className="flex flex-col gap-layout-sm lg:flex-row lg:items-center lg:justify-between">
-                <div className="relative max-w-2xl flex-1">
-                  <Search
-                    aria-hidden
-                    className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
-                  />
-                  <Input
-                    placeholder="Search products..."
-                    value={searchValue}
-                    onChange={(event) => setSearchValue(event.target.value)}
-                    className="pl-9"
-                  />
-                </div>
-                {hasFullAdminAccess ? (
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Button variant="ghost" onClick={handleOpenQuickAdd}>
-                      <PlusIcon className="h-4 w-4" />
-                      Quick add
-                    </Button>
-                    <Link
-                      to={"/$orgUrlSlug/store/$storeUrlSlug/products/new"}
-                      params={(prev) => ({
-                        ...prev,
-                        orgUrlSlug: prev.orgUrlSlug!,
-                        storeUrlSlug: prev.storeUrlSlug!,
-                      })}
-                      search={{ o: getOrigin() }}
-                    >
-                      <Button variant="ghost">
+              <SkuSearchFilterBar
+                action={
+                  hasFullAdminAccess ? (
+                    <>
+                      <Button
+                        variant="ghost"
+                        onClick={handleOpenQuickAdd}
+                        type="button"
+                      >
                         <PlusIcon className="h-4 w-4" />
-                        New Product
+                        Quick add
                       </Button>
-                    </Link>
+                      <Link
+                        to={"/$orgUrlSlug/store/$storeUrlSlug/products/new"}
+                        params={(prev) => ({
+                          ...prev,
+                          orgUrlSlug: prev.orgUrlSlug!,
+                          storeUrlSlug: prev.storeUrlSlug!,
+                        })}
+                        search={{ o: getOrigin() }}
+                      >
+                        <Button variant="ghost">
+                          <PlusIcon className="h-4 w-4" />
+                          New Product
+                        </Button>
+                      </Link>
+                    </>
+                  ) : null
+                }
+                ariaLabel="Product search and filters"
+                className="bg-background"
+                filterId="product-availability-filter"
+                filterLabel="Filter by availability"
+                filterOptions={PRODUCT_AVAILABILITY_FILTER_OPTIONS}
+                filterValue={availabilityFilter}
+                hasActiveFilters={hasActiveFilters}
+                onClearFilters={handleClearFilters}
+                onFilterChange={setAvailabilityFilter}
+                onQueryChange={setSearchValue}
+                query={searchValue}
+                searchId="product-sku-search"
+                searchLabel="Search products, SKUs, or barcodes"
+                searchPlaceholder="Search products, SKUs, or barcode"
+                secondaryFilters={
+                  <div
+                    aria-label="Filter by category"
+                    className="flex flex-col gap-2 sm:flex-row sm:items-center"
+                    role="group"
+                  >
+                    <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                      Categories
+                    </span>
+                    <div className="flex min-w-0 flex-wrap gap-1.5">
+                      {[
+                        {
+                          itemCount: products.length,
+                          key: ALL_CATEGORY_FILTER_KEY,
+                          label: "All categories",
+                        },
+                        ...categoryFilterOptions,
+                      ].map((category) => {
+                        const isSelected = categoryFilter === category.key;
+
+                        return (
+                          <button
+                            aria-label={`${category.label}, ${category.itemCount} ${category.itemCount === 1 ? "product" : "products"}`}
+                            aria-pressed={isSelected}
+                            className={cn(
+                              "rounded-md border px-2.5 py-1 text-xs font-medium transition-colors",
+                              isSelected
+                                ? "border-action-workflow-border bg-action-workflow-soft text-foreground"
+                                : "border-border bg-background text-muted-foreground hover:bg-muted hover:text-foreground",
+                            )}
+                            key={category.key}
+                            onClick={() =>
+                              setCategoryFilter(
+                                isSelected
+                                  ? ALL_CATEGORY_FILTER_KEY
+                                  : category.key,
+                              )
+                            }
+                            type="button"
+                          >
+                            {category.label}
+                          </button>
+                        );
+                      })}
+                    </div>
                   </div>
-                ) : null}
-              </div>
+                }
+                summary={
+                  <>
+                    Showing {filteredProducts?.length ?? products.length} of{" "}
+                    {products.length}{" "}
+                    {products.length === 1 ? "product" : "products"}.
+                  </>
+                }
+              />
 
               {showSearchResults ? (
                 <div className="min-w-0 overflow-hidden rounded-lg border border-border bg-background">
@@ -358,5 +524,111 @@ function productMatchesCatalogSearch(product: Product, query: string) {
       ]),
     ],
     query,
+  );
+}
+
+function productMatchesAvailabilityFilter(
+  product: Product,
+  filter: ProductAvailabilityFilter,
+) {
+  if (filter === "available") return product.inventoryCount > 0;
+  if (filter === "out_of_stock") return product.inventoryCount === 0;
+
+  return true;
+}
+
+function productMatchesCategoryFilter(
+  product: Product,
+  filter: string,
+  categorySlugById: Map<string, string>,
+) {
+  if (filter === ALL_CATEGORY_FILTER_KEY) return true;
+
+  return getProductCategoryFilterKey(product, categorySlugById) === filter;
+}
+
+function getProductCategoryFilterKey(
+  product: Product,
+  categorySlugById: Map<string, string>,
+) {
+  return (
+    product.categorySlug ??
+    categorySlugById.get(product.categoryId) ??
+    product.categoryName ??
+    product.categoryId
+  );
+}
+
+function buildProductsFromInventorySnapshot(
+  inventoryItems: InventorySnapshotItem[],
+  categories: Array<{ _id: Id<"category">; name: string; slug: string }>,
+  storeId: Id<"store"> | undefined,
+) {
+  const categoryByName = new Map(
+    categories.map((category) => [category.name, category]),
+  );
+  const productsById = new Map<Id<"product">, Product>();
+
+  for (const item of inventoryItems) {
+    const productId =
+      item.productId ?? (`inventory-product-${item._id}` as Id<"product">);
+    const category = item.productCategory
+      ? categoryByName.get(item.productCategory)
+      : undefined;
+    const existingProduct = productsById.get(productId);
+    const sku = {
+      _id: item._id,
+      _creationTime: 0,
+      barcode: item.barcode ?? undefined,
+      colorName: item.colorName ?? null,
+      images: item.imageUrl ? [item.imageUrl] : [],
+      inventoryCount: item.inventoryCount,
+      length: item.length ?? undefined,
+      netPrice: item.netPrice ?? undefined,
+      price: item.price ?? 0,
+      productCategory: item.productCategory ?? undefined,
+      productId,
+      productName: item.productName,
+      quantityAvailable: item.quantityAvailable,
+      size: item.size ?? undefined,
+      sku: item.sku ?? undefined,
+      storeId: storeId ?? ("" as Id<"store">),
+    };
+
+    if (existingProduct) {
+      existingProduct.inventoryCount =
+        (existingProduct.inventoryCount ?? 0) + item.inventoryCount;
+      existingProduct.quantityAvailable =
+        (existingProduct.quantityAvailable ?? 0) + item.quantityAvailable;
+      existingProduct.skus.push(sku);
+      continue;
+    }
+
+    productsById.set(productId, {
+      _id: productId,
+      _creationTime: 0,
+      availability: "live",
+      categoryId:
+        item.productCategoryId ?? category?._id ?? ("" as Id<"category">),
+      categoryName: item.productCategory ?? undefined,
+      categorySlug: item.productCategorySlug ?? category?.slug,
+      createdByUserId: "" as Id<"athenaUser">,
+      currency: "GHS",
+      inventoryCount: item.inventoryCount,
+      isVisible: true,
+      name: item.productName,
+      organizationId: "" as Id<"organization">,
+      quantityAvailable: item.quantityAvailable,
+      skus: [sku],
+      slug: String(productId),
+      storeId: storeId ?? ("" as Id<"store">),
+      subcategoryId: item.productSubcategoryId ?? ("" as Id<"subcategory">),
+      subcategoryName: item.productSubcategory ?? undefined,
+      subcategorySlug: item.productSubcategorySlug ?? undefined,
+    });
+  }
+
+  return [...productsById.values()].sort((left, right) =>
+    left.name.localeCompare(right.name),
   );
 }

--- a/packages/athena-webapp/src/components/products/products-table/components/ProductTaxonomyCells.tsx
+++ b/packages/athena-webapp/src/components/products/products-table/components/ProductTaxonomyCells.tsx
@@ -1,0 +1,71 @@
+import { Link } from "@tanstack/react-router";
+import { useQuery } from "convex/react";
+
+import { api } from "~/convex/_generated/api";
+import { Badge } from "~/src/components/ui/badge";
+import { getOrigin } from "~/src/lib/navigationUtils";
+import type { Product } from "~/types";
+
+export function ProductCategoryCell({ product }: { product: Product }) {
+  const canQueryCategory = Boolean(product.categoryId && product.storeId);
+  const category = useQuery(
+    api.inventory.categories.getById,
+    canQueryCategory
+      ? {
+          id: product.categoryId,
+          storeId: product.storeId,
+        }
+      : "skip",
+  );
+  const categoryName = category?.name ?? product.categoryName;
+
+  return <ProductTaxonomyBadge product={product} value={categoryName} />;
+}
+
+export function ProductSubcategoryCell({ product }: { product: Product }) {
+  const canQuerySubcategory = Boolean(product.subcategoryId && product.storeId);
+  const subcategory = useQuery(
+    api.inventory.subcategories.getById,
+    canQuerySubcategory
+      ? {
+          id: product.subcategoryId,
+          storeId: product.storeId,
+        }
+      : "skip",
+  );
+  const subcategoryName = subcategory?.name ?? product.subcategoryName;
+
+  return <ProductTaxonomyBadge product={product} value={subcategoryName} />;
+}
+
+function ProductTaxonomyBadge({
+  product,
+  value,
+}: {
+  product: Product;
+  value?: string;
+}) {
+  if (!value) return null;
+
+  return (
+    <div className="flex space-x-2">
+      <Link
+        to="/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug"
+        params={(prev) => ({
+          ...prev,
+          orgUrlSlug: prev.orgUrlSlug!,
+          storeUrlSlug: prev.storeUrlSlug!,
+          productSlug: product._id,
+        })}
+        search={{ o: getOrigin() }}
+        className="flex items-center gap-8"
+      >
+        <div className="flex items-center gap-4">
+          <Badge variant="outline" className="bg-gray-100 text-gray-700">
+            <p className="text-xs">{value}</p>
+          </Badge>
+        </div>
+      </Link>
+    </div>
+  );
+}

--- a/packages/athena-webapp/src/components/products/products-table/components/productColumns.tsx
+++ b/packages/athena-webapp/src/components/products/products-table/components/productColumns.tsx
@@ -3,12 +3,14 @@ import { DataTableColumnHeader } from "~/src/components/base/table/data-table-co
 import { Link } from "@tanstack/react-router";
 import { Product } from "~/types";
 import { ProductStatus } from "../../../product/ProductStatus";
-import { useQuery } from "convex/react";
-import { api } from "~/convex/_generated/api";
 import { Badge } from "~/src/components/ui/badge";
 import { capitalizeWords } from "~/src/lib/utils";
 import { getOrigin } from "~/src/lib/navigationUtils";
 import { AlertOctagon } from "lucide-react";
+import {
+  ProductCategoryCell,
+  ProductSubcategoryCell,
+} from "./ProductTaxonomyCells";
 
 export const productColumns: ColumnDef<Product>[] = [
   {
@@ -20,11 +22,11 @@ export const productColumns: ColumnDef<Product>[] = [
       const sku = row.original.skus[0];
 
       const hasNoImages = row.original.skus.some(
-        (sku) => sku.images.length === 0
+        (sku) => sku.images.length === 0,
       );
 
       const someSkusHavePriceZero = row.original.skus.some(
-        (sku) => sku.price === 0
+        (sku) => sku.price === 0,
       );
 
       return (
@@ -90,75 +92,21 @@ export const productColumns: ColumnDef<Product>[] = [
 
       // Check if any SKU matches
       return row.original.skus.some((sku) =>
-        sku.sku?.toLowerCase().includes(searchValue)
+        sku.sku?.toLowerCase().includes(searchValue),
       );
     },
   },
   {
     accessorKey: "categoryId",
     header: ({ column }) => <DataTableColumnHeader column={column} title="" />,
-    cell: ({ row }) => {
-      const category = useQuery(api.inventory.categories.getById, {
-        id: row.original.categoryId,
-        storeId: row.original.storeId,
-      });
-
-      return (
-        <div className="flex space-x-2">
-          <Link
-            to="/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug"
-            params={(prev) => ({
-              ...prev,
-              orgUrlSlug: prev.orgUrlSlug!,
-              storeUrlSlug: prev.storeUrlSlug!,
-              productSlug: row.original._id,
-            })}
-            search={{ o: getOrigin() }}
-            className="flex items-center gap-8"
-          >
-            <div className="flex items-center gap-4">
-              <Badge variant="outline" className="bg-gray-100 text-gray-700">
-                <p className="text-xs">{category?.name}</p>
-              </Badge>
-            </div>
-          </Link>
-        </div>
-      );
-    },
+    cell: ({ row }) => <ProductCategoryCell product={row.original} />,
     enableSorting: false,
     enableHiding: true,
   },
   {
     accessorKey: "subcategoryId",
     header: ({ column }) => <DataTableColumnHeader column={column} title="" />,
-    cell: ({ row }) => {
-      const subcategory = useQuery(api.inventory.subcategories.getById, {
-        id: row.original.subcategoryId,
-        storeId: row.original.storeId,
-      });
-
-      return (
-        <div className="flex space-x-2">
-          <Link
-            to="/$orgUrlSlug/store/$storeUrlSlug/products/$productSlug"
-            params={(prev) => ({
-              ...prev,
-              orgUrlSlug: prev.orgUrlSlug!,
-              storeUrlSlug: prev.storeUrlSlug!,
-              productSlug: row.original._id,
-            })}
-            search={{ o: getOrigin() }}
-            className="flex items-center gap-8"
-          >
-            <div className="flex items-center gap-4">
-              <Badge variant="outline" className="bg-gray-100 text-gray-700">
-                <p className="text-xs">{subcategory?.name}</p>
-              </Badge>
-            </div>
-          </Link>
-        </div>
-      );
-    },
+    cell: ({ row }) => <ProductSubcategoryCell product={row.original} />,
     enableSorting: false,
     enableHiding: true,
   },

--- a/packages/athena-webapp/src/lib/pos/application/dto.ts
+++ b/packages/athena-webapp/src/lib/pos/application/dto.ts
@@ -152,11 +152,13 @@ export interface PosCatalogItemDto {
   areProcessingFeesAbsorbed: boolean;
   availabilityPolicy?: PosRegisterCatalogAvailabilityPolicy;
   inventoryImportProvisionalSkuId?: Id<"inventoryImportProvisionalSku">;
+  pendingCheckoutItemId?: Id<"posPendingCheckoutItem">;
 }
 
 export type PosRegisterCatalogAvailabilityPolicy =
   | "trusted_inventory"
-  | "active_provisional_import";
+  | "active_provisional_import"
+  | "pending_checkout";
 
 export interface PosRegisterCatalogRowDto {
   id: Id<"productSku"> | Id<"inventoryImportProvisionalSku">;
@@ -176,6 +178,7 @@ export interface PosRegisterCatalogRowDto {
   color: string;
   areProcessingFeesAbsorbed: boolean;
   availabilityPolicy?: PosRegisterCatalogAvailabilityPolicy;
+  pendingCheckoutItemId?: Id<"posPendingCheckoutItem">;
 }
 
 export interface PosRegisterCatalogInput {

--- a/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearch.ts
@@ -25,8 +25,12 @@ export interface RegisterCatalogSearchRow {
   color?: string | null;
   image?: string | null;
   areProcessingFeesAbsorbed?: boolean | null;
-  availabilityPolicy?: "trusted_inventory" | "active_provisional_import";
+  availabilityPolicy?:
+    | "trusted_inventory"
+    | "active_provisional_import"
+    | "pending_checkout";
   inventoryImportProvisionalSkuId?: string | null;
+  pendingCheckoutItemId?: string | null;
 }
 
 export type RegisterCatalogSearchResult =
@@ -201,7 +205,10 @@ export function searchRegisterCatalog(
 export function buildRegisterServiceCatalogIndex(
   rows: readonly RegisterServiceCatalogSearchRow[],
 ): RegisterServiceCatalogIndex {
-  const byServiceCatalogId = new Map<string, RegisterServiceCatalogSearchRow[]>();
+  const byServiceCatalogId = new Map<
+    string,
+    RegisterServiceCatalogSearchRow[]
+  >();
   const indexedRows = rows.map((row) => {
     addKey(byServiceCatalogId, normalizeIdentifier(row.serviceCatalogId), row);
 
@@ -323,9 +330,13 @@ function extractIdentifierFromUrl(input: string): string | null {
     if (sku) return sku;
     if (productId) return productId;
 
-    const productPathMatch = url.pathname.match(/\/(?:shop\/)?product\/([^/?#]+)/);
+    const productPathMatch = url.pathname.match(
+      /\/(?:shop\/)?product\/([^/?#]+)/,
+    );
 
-    return productPathMatch?.[1] ? decodeURIComponent(productPathMatch[1]) : null;
+    return productPathMatch?.[1]
+      ? decodeURIComponent(productPathMatch[1])
+      : null;
   } catch {
     return null;
   }
@@ -365,7 +376,9 @@ function searchRegisterServiceCatalogByText(
 }
 
 function normalizeIdentifier(value: unknown): string {
-  return String(value ?? "").trim().toLowerCase();
+  return String(value ?? "")
+    .trim()
+    .toLowerCase();
 }
 
 function normalizeSearchText(value: unknown): string {
@@ -378,11 +391,7 @@ function normalizeSearchText(value: unknown): string {
     .replace(/\s+/g, " ");
 }
 
-function addKey<T>(
-  map: Map<string, T[]>,
-  key: string,
-  row: T,
-): void {
+function addKey<T>(map: Map<string, T[]>, key: string, row: T): void {
   if (!key) {
     return;
   }

--- a/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearchPresentation.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearchPresentation.test.ts
@@ -32,4 +32,34 @@ describe("mapCatalogRowToProduct", () => {
       availabilityStatus: "available",
     });
   });
+
+  it("marks pending checkout catalog rows available without trusted inventory", () => {
+    const product = mapCatalogRowToProduct(
+      {
+        id: "sku-pending-checkout",
+        productId: "product-pending-checkout",
+        productSkuId: "sku-pending-checkout",
+        pendingCheckoutItemId: "pending-checkout-1",
+        availabilityPolicy: "pending_checkout",
+        name: "Pending checkout item",
+        sku: "PENDING-CHECKOUT",
+        barcode: "123",
+        price: 20,
+      },
+      {
+        availabilityPolicy: "pending_checkout",
+        inStock: true,
+        quantityAvailable: 0,
+      },
+    );
+
+    expect(product).toMatchObject({
+      pendingCheckoutItemId: "pending-checkout-1",
+      availabilityPolicy: "pending_checkout",
+      availabilityStatus: "available",
+      availabilityMessage: "Review pending",
+      inStock: true,
+      quantityAvailable: 0,
+    });
+  });
 });

--- a/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearchPresentation.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/catalogSearchPresentation.ts
@@ -4,7 +4,10 @@ import type { Id } from "~/convex/_generated/dataModel";
 
 export type RegisterCatalogAvailability = {
   availabilitySource?: "live" | "local";
-  availabilityPolicy?: "trusted_inventory" | "active_provisional_import";
+  availabilityPolicy?:
+    | "trusted_inventory"
+    | "active_provisional_import"
+    | "pending_checkout";
   inventoryImportProvisionalSkuId?: Id<"inventoryImportProvisionalSku">;
   inStock: boolean;
   quantityAvailable: number;
@@ -25,13 +28,16 @@ export function mapCatalogRowToProduct(
     row.availabilityPolicy ?? availability?.availabilityPolicy;
   const isProvisionalImport =
     availabilityPolicy === "active_provisional_import";
+  const isPendingCheckout = availabilityPolicy === "pending_checkout";
   const availabilityStatus = isProvisionalImport
     ? "available"
-    : quantityAvailable === undefined
-      ? "unknown"
-      : availability?.inStock && quantityAvailable > 0
-        ? "available"
-        : "out_of_stock";
+    : isPendingCheckout
+      ? "available"
+      : quantityAvailable === undefined
+        ? "unknown"
+        : availability?.inStock && quantityAvailable > 0
+          ? "available"
+          : "out_of_stock";
 
   return {
     id: row.id ?? row.productSkuId,
@@ -44,12 +50,13 @@ export function mapCatalogRowToProduct(
     image: row.image ?? null,
     inStock: availabilityStatus === "available",
     availabilityStatus,
-    availabilityMessage:
-      isProvisionalImport
-        ? "Count pending"
+    availabilityMessage: isProvisionalImport
+      ? "Count pending"
+      : isPendingCheckout
+        ? "Review pending"
         : availabilityStatus === "unknown"
-        ? POS_AVAILABILITY_NOT_READY_MESSAGE
-        : undefined,
+          ? POS_AVAILABILITY_NOT_READY_MESSAGE
+          : undefined,
     quantityAvailable,
     size: row.size ?? "",
     length:
@@ -61,16 +68,20 @@ export function mapCatalogRowToProduct(
     color: row.color ?? "",
     productId: row.productId as Id<"product">,
     skuId: row.productSkuId as Id<"productSku">,
-    inventoryImportProvisionalSkuId:
-      (row.inventoryImportProvisionalSkuId ??
-        availability?.inventoryImportProvisionalSkuId) as
-        | Id<"inventoryImportProvisionalSku">
-        | undefined,
+    inventoryImportProvisionalSkuId: (row.inventoryImportProvisionalSkuId ??
+      availability?.inventoryImportProvisionalSkuId) as
+      | Id<"inventoryImportProvisionalSku">
+      | undefined,
+    pendingCheckoutItemId: row.pendingCheckoutItemId as
+      | Id<"posPendingCheckoutItem">
+      | undefined,
     availabilityPolicy,
     areProcessingFeesAbsorbed: Boolean(row.areProcessingFeesAbsorbed),
   };
 }
 
 export function normalizeExactInput(value: string | undefined): string {
-  return String(value ?? "").trim().toLowerCase();
+  return String(value ?? "")
+    .trim()
+    .toLowerCase();
 }

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts
@@ -53,13 +53,11 @@ const mockReadTerminalIntegrityState = vi.fn();
 const mockWriteDrawerAuthorityState = vi.fn();
 const mockUsePosTerminalAppSessionRecoveryRuntimeInput = vi.fn();
 
-let mockActiveStore:
-  | {
-      _id: Id<"store">;
-      currency: string;
-      organizationId: Id<"organization">;
-    }
-  | null;
+let mockActiveStore: {
+  _id: Id<"store">;
+  currency: string;
+  organizationId: Id<"organization">;
+} | null;
 let mockTerminal:
   | {
       _id: Id<"posTerminal">;
@@ -207,7 +205,10 @@ let mockRegisterCatalogRows: Array<{
   color: string;
   areProcessingFeesAbsorbed: boolean;
   inventoryImportProvisionalSkuId?: Id<"inventoryImportProvisionalSku">;
-  availabilityPolicy?: "trusted_inventory" | "active_provisional_import";
+  availabilityPolicy?:
+    | "trusted_inventory"
+    | "active_provisional_import"
+    | "pending_checkout";
 }>;
 let mockRegisterServiceCatalogRows: Array<{
   serviceCatalogId: Id<"serviceCatalog">;
@@ -225,7 +226,10 @@ let mockRegisterCatalogAvailabilityRows: Array<{
   inStock: boolean;
   quantityAvailable: number;
   inventoryImportProvisionalSkuId?: Id<"inventoryImportProvisionalSku">;
-  availabilityPolicy?: "trusted_inventory" | "active_provisional_import";
+  availabilityPolicy?:
+    | "trusted_inventory"
+    | "active_provisional_import"
+    | "pending_checkout";
 }>;
 
 vi.mock("convex/react", () => ({
@@ -411,7 +415,10 @@ function buildRegisterCatalogAvailabilityRow(
 }
 
 function buildLocalEvent(
-  overrides: Partial<Record<string, unknown>> & { sequence: number; type: string },
+  overrides: Partial<Record<string, unknown>> & {
+    sequence: number;
+    type: string;
+  },
 ) {
   const { sequence, type, ...rest } = overrides;
 
@@ -487,7 +494,9 @@ function getTestOperatingDate(date = new Date()) {
   ].join("-");
 }
 
-function buildCashierPresence(overrides: Partial<Record<string, unknown>> = {}) {
+function buildCashierPresence(
+  overrides: Partial<Record<string, unknown>> = {},
+) {
   const expiresAt = Date.now() + 60_000;
   return {
     activeRoles: ["cashier"],
@@ -660,10 +669,12 @@ describe("useRegisterViewModel", () => {
       value: null,
     });
     mockWriteProvisionedTerminalSeedAndClearTerminalIntegrity.mockReset();
-    mockWriteProvisionedTerminalSeedAndClearTerminalIntegrity.mockResolvedValue({
-      ok: true,
-      value: null,
-    });
+    mockWriteProvisionedTerminalSeedAndClearTerminalIntegrity.mockResolvedValue(
+      {
+        ok: true,
+        value: null,
+      },
+    );
     mockGetStaffAuthorityReadiness.mockReset();
     mockGetStaffAuthorityReadiness.mockResolvedValue({
       ok: true,
@@ -1327,9 +1338,9 @@ describe("useRegisterViewModel", () => {
       ],
     });
 
-    const runtimeInput = mockUsePosLocalSyncRuntimeStatus.mock.calls.at(-1)?.[0] as
-      | { onLocalEventsChanged?: () => void }
-      | undefined;
+    const runtimeInput = mockUsePosLocalSyncRuntimeStatus.mock.calls.at(
+      -1,
+    )?.[0] as { onLocalEventsChanged?: () => void } | undefined;
     await act(async () => {
       runtimeInput?.onLocalEventsChanged?.();
     });
@@ -1415,8 +1426,12 @@ describe("useRegisterViewModel", () => {
     const { result } = renderHook(() => useRegisterViewModel());
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated(buildStaffAuthenticationResult());
-      result.current.authDialog?.onAuthenticated(buildStaffAuthenticationResult());
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
     });
 
     expect(
@@ -2300,7 +2315,9 @@ describe("useRegisterViewModel", () => {
     );
 
     await act(async () => {
-      result.current.authDialog?.onAuthenticated(buildStaffAuthenticationResult());
+      result.current.authDialog?.onAuthenticated(
+        buildStaffAuthenticationResult(),
+      );
     });
 
     expect(result.current.cart.items).toHaveLength(1);
@@ -2448,7 +2465,9 @@ describe("useRegisterViewModel", () => {
       "drawer-1",
     );
     expect(result.current.drawerGate?.onReopenRegister).toBeUndefined();
-    expect(result.current.drawerGate?.onCloseoutSecondaryAction).toBeUndefined();
+    expect(
+      result.current.drawerGate?.onCloseoutSecondaryAction,
+    ).toBeUndefined();
     expect(result.current.productEntry.disabled).toBe(true);
     expect(mockStartSession).not.toHaveBeenCalled();
   });
@@ -3244,9 +3263,7 @@ describe("useRegisterViewModel", () => {
       ),
     );
     expect(mockMarkLocalEventsSynced).not.toHaveBeenCalled();
-    expect(toast.success).toHaveBeenCalledWith(
-      "Register closed.",
-    );
+    expect(toast.success).toHaveBeenCalledWith("Register closed.");
   });
 
   it("keeps the POS drawer gate open when local closeout persistence fails", async () => {
@@ -3276,7 +3293,9 @@ describe("useRegisterViewModel", () => {
       input.type === "register.closeout_started"
         ? {
             ok: false,
-            error: { message: "POS local store could not write the local event." },
+            error: {
+              message: "POS local store could not write the local event.",
+            },
           }
         : { ok: true, value: { localEventId: "local-event-1" } },
     );
@@ -3914,7 +3933,9 @@ describe("useRegisterViewModel", () => {
       input.type === "register.reopened"
         ? {
             ok: false,
-            error: { message: "POS local store could not write the local event." },
+            error: {
+              message: "POS local store could not write the local event.",
+            },
           }
         : { ok: true, value: { localEventId: "local-event-1" } },
     );
@@ -4362,9 +4383,8 @@ describe("useRegisterViewModel", () => {
         },
       ],
     });
-    const { projectLocalRegisterReadModel } = await import(
-      "../../infrastructure/local/registerReadModel"
-    );
+    const { projectLocalRegisterReadModel } =
+      await import("../../infrastructure/local/registerReadModel");
     const replayed = projectLocalRegisterReadModel({
       events: (await mockListLocalEvents()).value,
       isOnline: true,
@@ -4411,9 +4431,9 @@ describe("useRegisterViewModel", () => {
       await result.current.sessionPanel?.onStartNewSession();
     });
 
-    expect(mockAppendLocalEvent.mock.calls.map(([event]) => event.type)).toEqual(
-      ["register.opened", "session.started"],
-    );
+    expect(
+      mockAppendLocalEvent.mock.calls.map(([event]) => event.type),
+    ).toEqual(["register.opened", "session.started"]);
     expect(mockAppendLocalEvent).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
@@ -5267,7 +5287,9 @@ describe("useRegisterViewModel", () => {
       await completePromise;
     });
 
-    expect(mockAppendLocalEvent.mock.calls.map(([event]) => event.type)).toEqual([
+    expect(
+      mockAppendLocalEvent.mock.calls.map(([event]) => event.type),
+    ).toEqual([
       "register.opened",
       "session.started",
       "cart.service_added",
@@ -6525,7 +6547,10 @@ describe("useRegisterViewModel", () => {
           sequence: localEvents.length + 1,
         }),
       );
-      return { ok: true, value: { localEventId: `event-${localEvents.length}` } };
+      return {
+        ok: true,
+        value: { localEventId: `event-${localEvents.length}` },
+      };
     });
 
     const { useRegisterViewModel } = await import("./useRegisterViewModel");
@@ -6908,9 +6933,10 @@ describe("useRegisterViewModel", () => {
       result.current.productEntry.setProductSearchQuery("searchable");
     });
     await waitFor(() => {
-      const latestInput = mockUseConvexRegisterCatalogAvailability.mock.calls.at(
-        -1,
-      )?.[0] as { productSkuIds?: Array<Id<"productSku">> } | undefined;
+      const latestInput =
+        mockUseConvexRegisterCatalogAvailability.mock.calls.at(-1)?.[0] as
+          | { productSkuIds?: Array<Id<"productSku">> }
+          | undefined;
       const cartSkuIndex =
         latestInput?.productSkuIds?.indexOf("sku-2" as Id<"productSku">) ?? -1;
       const searchSkuIndex =
@@ -7489,7 +7515,9 @@ describe("useRegisterViewModel", () => {
       input.type === "register.opened"
         ? {
             ok: false,
-            error: { message: "POS local store could not write the local event." },
+            error: {
+              message: "POS local store could not write the local event.",
+            },
           }
         : { ok: true, value: { localEventId: "local-event-1" } },
     );
@@ -8034,7 +8062,9 @@ describe("useRegisterViewModel", () => {
     };
     mockActiveSession = null;
     mockRegisterCatalogRows = [buildRegisterCatalogRow()];
-    mockRegisterCatalogAvailabilityRows = [buildRegisterCatalogAvailabilityRow()];
+    mockRegisterCatalogAvailabilityRows = [
+      buildRegisterCatalogAvailabilityRow(),
+    ];
 
     const { useRegisterViewModel } = await import("./useRegisterViewModel");
     const { result } = renderHook(() => useRegisterViewModel());
@@ -8118,7 +8148,9 @@ describe("useRegisterViewModel", () => {
       registerSessionId: "drawer-1" as Id<"registerSession">,
     };
     mockRegisterCatalogRows = [buildRegisterCatalogRow()];
-    mockRegisterCatalogAvailabilityRows = [buildRegisterCatalogAvailabilityRow()];
+    mockRegisterCatalogAvailabilityRows = [
+      buildRegisterCatalogAvailabilityRow(),
+    ];
 
     const { useRegisterViewModel } = await import("./useRegisterViewModel");
     const { result } = renderHook(() => useRegisterViewModel());
@@ -8162,9 +8194,7 @@ describe("useRegisterViewModel", () => {
       await result.current.checkout.onCompleteTransaction();
     });
 
-    const localEvents = mockAppendLocalEvent.mock.calls.map(
-      ([event]) => event,
-    );
+    const localEvents = mockAppendLocalEvent.mock.calls.map(([event]) => event);
     const eventTypes = localEvents.map((event) => event.type);
     expect(eventTypes).toEqual(
       expect.arrayContaining([
@@ -8276,9 +8306,7 @@ describe("useRegisterViewModel", () => {
       );
     });
 
-    const localEvents = mockAppendLocalEvent.mock.calls.map(
-      ([event]) => event,
-    );
+    const localEvents = mockAppendLocalEvent.mock.calls.map(([event]) => event);
     const pendingDefinitionIndex = localEvents.findIndex(
       (event) => event?.type === "pending_checkout_item.defined",
     );
@@ -8597,7 +8625,9 @@ describe("useRegisterViewModel", () => {
       registerSessionId: "drawer-1" as Id<"registerSession">,
     };
     mockRegisterCatalogRows = [buildRegisterCatalogRow()];
-    mockRegisterCatalogAvailabilityRows = [buildRegisterCatalogAvailabilityRow()];
+    mockRegisterCatalogAvailabilityRows = [
+      buildRegisterCatalogAvailabilityRow(),
+    ];
 
     const { useRegisterViewModel } = await import("./useRegisterViewModel");
     const { result } = renderHook(() => useRegisterViewModel());
@@ -8851,9 +8881,7 @@ describe("useRegisterViewModel", () => {
       ),
     );
     expect(mockMarkLocalEventsSynced).not.toHaveBeenCalled();
-    expect(toast.success).toHaveBeenCalledWith(
-      "Drawer open",
-    );
+    expect(toast.success).toHaveBeenCalledWith("Drawer open");
     await waitFor(() => expect(result.current.drawerGate).toBeNull());
     expect(result.current.productEntry.disabled).toBe(false);
     expect(result.current.syncStatus).toEqual(
@@ -8882,9 +8910,9 @@ describe("useRegisterViewModel", () => {
       ],
     });
 
-    const runtimeInput = mockUsePosLocalSyncRuntimeStatus.mock.calls.at(-1)?.[0] as
-      | { onLocalEventsChanged?: () => void }
-      | undefined;
+    const runtimeInput = mockUsePosLocalSyncRuntimeStatus.mock.calls.at(
+      -1,
+    )?.[0] as { onLocalEventsChanged?: () => void } | undefined;
     await act(async () => {
       runtimeInput?.onLocalEventsChanged?.();
     });
@@ -8992,7 +9020,9 @@ describe("useRegisterViewModel", () => {
     await act(async () => {
       await result.current.cart.onClearCart();
     });
-    expect(mockReleaseSessionInventoryHoldsAndDeleteItems).not.toHaveBeenCalled();
+    expect(
+      mockReleaseSessionInventoryHoldsAndDeleteItems,
+    ).not.toHaveBeenCalled();
     expect(result.current.cart.items).toEqual([]);
 
     await act(async () => {
@@ -9028,7 +9058,9 @@ describe("useRegisterViewModel", () => {
           type: "session.payments_updated",
           localPosSessionId: expect.stringMatching(/^local-pos-session-/),
           payload: expect.objectContaining({
-            payments: [expect.objectContaining({ method: "cash", amount: 200 })],
+            payments: [
+              expect.objectContaining({ method: "cash", amount: 200 }),
+            ],
             stage: "paymentAdded",
           }),
         }),
@@ -9043,9 +9075,7 @@ describe("useRegisterViewModel", () => {
     expect(completed).toBe(true);
     expect(mockUpdateSession).not.toHaveBeenCalled();
     expect(mockCompleteTransaction).not.toHaveBeenCalled();
-    expect(result.current.checkout.completedOrderNumber).toMatch(
-      /^\d{6}$/,
-    );
+    expect(result.current.checkout.completedOrderNumber).toMatch(/^\d{6}$/);
     expect(mockAppendLocalEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "transaction.completed",
@@ -9800,7 +9830,9 @@ describe("useRegisterViewModel", () => {
         "staff-1" as Id<"staffProfile">,
       );
     });
-    await waitFor(() => expect(result.current.checkout.cartItems).toHaveLength(1));
+    await waitFor(() =>
+      expect(result.current.checkout.cartItems).toHaveLength(1),
+    );
 
     let addPaymentPromise: Promise<boolean> | undefined;
     await act(async () => {
@@ -9821,9 +9853,9 @@ describe("useRegisterViewModel", () => {
       await clearPromise;
     });
 
-    expect(mockAppendLocalEvent.mock.calls.map(([event]) => event.type)).toEqual(
-      ["session.payments_updated", "cart.cleared"],
-    );
+    expect(
+      mockAppendLocalEvent.mock.calls.map(([event]) => event.type),
+    ).toEqual(["session.payments_updated", "cart.cleared"]);
     expect(result.current.checkout.payments).toEqual([]);
     expect(result.current.checkout.cartItems).toEqual([]);
   });
@@ -10072,7 +10104,10 @@ describe("useRegisterViewModel", () => {
       ]),
     );
 
-    pendingAppend.resolve({ ok: true, value: { localEventId: "local-event-1" } });
+    pendingAppend.resolve({
+      ok: true,
+      value: { localEventId: "local-event-1" },
+    });
     await act(async () => {
       await addPromise;
     });
@@ -10136,7 +10171,10 @@ describe("useRegisterViewModel", () => {
     expect(result.current.cart.items[0].quantity).toBe(2);
     expect(result.current.checkout.cartItems[0].quantity).toBe(2);
 
-    pendingAppend.resolve({ ok: true, value: { localEventId: "local-event-1" } });
+    pendingAppend.resolve({
+      ok: true,
+      value: { localEventId: "local-event-1" },
+    });
     await act(async () => {
       await addPromise;
     });
@@ -10414,7 +10452,9 @@ describe("useRegisterViewModel", () => {
               quantity: 2,
             }),
           ]),
-          payments: [expect.objectContaining({ method: "cash", amount: 10_000 })],
+          payments: [
+            expect.objectContaining({ method: "cash", amount: 10_000 }),
+          ],
         }),
       }),
     );
@@ -10442,7 +10482,9 @@ describe("useRegisterViewModel", () => {
       input.type === "session.started"
         ? {
             ok: false,
-            error: { message: "POS local store could not write the local event." },
+            error: {
+              message: "POS local store could not write the local event.",
+            },
           }
         : { ok: true, value: { localEventId: "local-event-1" } },
     );
@@ -10620,7 +10662,10 @@ describe("useRegisterViewModel", () => {
     expect(result.current.cart.items).toHaveLength(0);
     expect(result.current.checkout.cartItems).toHaveLength(0);
 
-    pendingAppend.resolve({ ok: true, value: { localEventId: "local-event-1" } });
+    pendingAppend.resolve({
+      ok: true,
+      value: { localEventId: "local-event-1" },
+    });
     await act(async () => {
       await removePromise;
     });
@@ -10778,25 +10823,25 @@ describe("useRegisterViewModel", () => {
         sync: { status: "pending" },
       },
     ];
-    mockAppendLocalEvent.mockImplementation((input: Record<string, unknown>) => {
-      localEvents.push({
-        localEventId: `local-event-${localEvents.length + 1}`,
-        schemaVersion: 1,
-        sequence: localEvents.length + 1,
-        createdAt: 1_000 + localEvents.length + 1,
-        sync: { status: "pending" },
-        ...input,
-      });
-      if (
-        input.type === "cart.item_added"
-      ) {
-        return pendingRemove.promise;
-      }
-      return Promise.resolve({
-        ok: true,
-        value: { localEventId: `local-event-${localEvents.length}` },
-      });
-    });
+    mockAppendLocalEvent.mockImplementation(
+      (input: Record<string, unknown>) => {
+        localEvents.push({
+          localEventId: `local-event-${localEvents.length + 1}`,
+          schemaVersion: 1,
+          sequence: localEvents.length + 1,
+          createdAt: 1_000 + localEvents.length + 1,
+          sync: { status: "pending" },
+          ...input,
+        });
+        if (input.type === "cart.item_added") {
+          return pendingRemove.promise;
+        }
+        return Promise.resolve({
+          ok: true,
+          value: { localEventId: `local-event-${localEvents.length}` },
+        });
+      },
+    );
     mockListLocalEvents.mockImplementation(() =>
       Promise.resolve({ ok: true, value: localEvents }),
     );
@@ -10924,7 +10969,10 @@ describe("useRegisterViewModel", () => {
     expect(result.current.cart.items).toHaveLength(1);
     expect(result.current.checkout.cartItems).toHaveLength(1);
 
-    pendingAppend.resolve({ ok: true, value: { localEventId: "local-event-1" } });
+    pendingAppend.resolve({
+      ok: true,
+      value: { localEventId: "local-event-1" },
+    });
     await act(async () => {
       await clearPromise;
     });
@@ -11016,7 +11064,9 @@ describe("useRegisterViewModel", () => {
       input.type === "session.payments_updated"
         ? {
             ok: false,
-            error: { message: "POS local store could not write the local event." },
+            error: {
+              message: "POS local store could not write the local event.",
+            },
           }
         : { ok: true, value: { localEventId: "local-event-1" } },
     );
@@ -11140,7 +11190,9 @@ describe("useRegisterViewModel", () => {
       input.type === "session.payments_updated"
         ? {
             ok: false,
-            error: { message: "POS local store could not write the local event." },
+            error: {
+              message: "POS local store could not write the local event.",
+            },
           }
         : { ok: true, value: { localEventId: "local-event-1" } },
     );
@@ -11175,7 +11227,9 @@ describe("useRegisterViewModel", () => {
       input.type === "session.payments_updated"
         ? {
             ok: false,
-            error: { message: "POS local store could not write the local event." },
+            error: {
+              message: "POS local store could not write the local event.",
+            },
           }
         : { ok: true, value: { localEventId: "local-event-1" } },
     );
@@ -11317,10 +11371,9 @@ describe("useRegisterViewModel", () => {
     });
 
     expect(updated).toBe(false);
-    expect(mockAppendLocalEvent.mock.calls.map(([event]) => event.type)).toEqual([
-      "session.payments_updated",
-      "transaction.completed",
-    ]);
+    expect(
+      mockAppendLocalEvent.mock.calls.map(([event]) => event.type),
+    ).toEqual(["session.payments_updated", "transaction.completed"]);
     expect(mockAppendLocalEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "transaction.completed",
@@ -11385,9 +11438,9 @@ describe("useRegisterViewModel", () => {
     });
 
     expect(addedDuringClear).toBe(false);
-    expect(mockAppendLocalEvent.mock.calls.map(([event]) => event.type)).toEqual(
-      ["session.payments_updated", "cart.cleared"],
-    );
+    expect(
+      mockAppendLocalEvent.mock.calls.map(([event]) => event.type),
+    ).toEqual(["session.payments_updated", "cart.cleared"]);
     expect(result.current.checkout.payments).toEqual([]);
     expect(result.current.checkout.cartItems).toEqual([]);
   });
@@ -11577,7 +11630,9 @@ describe("useRegisterViewModel", () => {
       await result.current.cart.onClearCart();
     });
 
-    expect(mockReleaseSessionInventoryHoldsAndDeleteItems).not.toHaveBeenCalled();
+    expect(
+      mockReleaseSessionInventoryHoldsAndDeleteItems,
+    ).not.toHaveBeenCalled();
     expect(mockAppendLocalEvent).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: "cart.item_added" }),
     );
@@ -11680,7 +11735,9 @@ describe("useRegisterViewModel", () => {
             localReceiptNumber: expect.stringMatching(/^local-txn-/),
             receiptNumber: expect.stringMatching(/^\d{6}$/),
             items: [expect.objectContaining({ localItemId: "item-1" })],
-            payments: [expect.objectContaining({ method: "cash", amount: 120 })],
+            payments: [
+              expect.objectContaining({ method: "cash", amount: 120 }),
+            ],
           }),
         }),
       ),
@@ -11735,10 +11792,7 @@ describe("useRegisterViewModel", () => {
         expect.objectContaining({
           type: "transaction.completed",
           validationMetadata: expect.objectContaining({
-            flags: [
-              "app-session-unverified",
-              "cloud-validation-uncertain",
-            ],
+            flags: ["app-session-unverified", "cloud-validation-uncertain"],
             uploadDeferredUntil: "app-session-validated",
           }),
         }),
@@ -12024,7 +12078,9 @@ describe("useRegisterViewModel", () => {
       input.type === "transaction.completed"
         ? {
             ok: false,
-            error: { message: "POS local store could not write the local event." },
+            error: {
+              message: "POS local store could not write the local event.",
+            },
           }
         : { ok: true, value: { localEventId: "local-event-1" } },
     );

--- a/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts
@@ -403,7 +403,8 @@ function validateRestoredCashierPresence(input: {
     !hasRegisterOperatorRole(presence.activeRoles)
   ) {
     return {
-      message: "Cashier sign-in no longer matches this register. Sign in to continue.",
+      message:
+        "Cashier sign-in no longer matches this register. Sign in to continue.",
       status: "invalidated",
     };
   }
@@ -531,10 +532,12 @@ function getCloseoutLocalRegisterSessionId(
   localRegisterReadModel?: PosLocalRegisterReadModel | null,
 ): string | undefined {
   const cloudRegisterSessionId = session?._id?.toString();
-  const localActiveRegisterSession = localRegisterReadModel?.activeRegisterSession;
+  const localActiveRegisterSession =
+    localRegisterReadModel?.activeRegisterSession;
   if (
     cloudRegisterSessionId &&
-    localActiveRegisterSession?.cloudRegisterSessionId === cloudRegisterSessionId
+    localActiveRegisterSession?.cloudRegisterSessionId ===
+      cloudRegisterSessionId
   ) {
     return localActiveRegisterSession.localRegisterSessionId;
   }
@@ -944,7 +947,9 @@ function mapLocalCartItemToCartItem(item: PosLocalCartItemReadModel): CartItem {
 }
 
 function normalizePendingCheckoutSearchText(value: string | null | undefined) {
-  return String(value ?? "").trim().toLowerCase();
+  return String(value ?? "")
+    .trim()
+    .toLowerCase();
 }
 
 function pendingCheckoutFieldsMatchSearch(
@@ -1105,20 +1110,14 @@ function recordOrNull(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
-function stringFromRecord(
-  record: Record<string, unknown> | null,
-  key: string,
-) {
+function stringFromRecord(record: Record<string, unknown> | null, key: string) {
   const value = record?.[key];
   return typeof value === "string" && value.trim().length > 0
     ? value
     : undefined;
 }
 
-function numberFromRecord(
-  record: Record<string, unknown> | null,
-  key: string,
-) {
+function numberFromRecord(record: Record<string, unknown> | null, key: string) {
   const value = record?.[key];
   return typeof value === "number" && Number.isFinite(value)
     ? value
@@ -1151,25 +1150,23 @@ function matchingServiceLineDraft(
   const serviceCatalogId = service.serviceCatalogId?.toString();
   const normalizedName = service.name.trim().toLowerCase();
 
-  return drafts.find(
-    (line) => {
-      const lineCatalogId = line.serviceCatalogId?.toString();
+  return drafts.find((line) => {
+    const lineCatalogId = line.serviceCatalogId?.toString();
 
-      if (serviceCatalogId && lineCatalogId) {
-        return serviceCatalogId === lineCatalogId;
-      }
+    if (serviceCatalogId && lineCatalogId) {
+      return serviceCatalogId === lineCatalogId;
+    }
 
-      if (serviceCatalogId || lineCatalogId) {
-        return false;
-      }
+    if (serviceCatalogId || lineCatalogId) {
+      return false;
+    }
 
-      return (
-        line.name.trim().toLowerCase() === normalizedName &&
-        line.serviceMode === service.serviceMode &&
-        line.pricingModel === service.pricingModel
-      );
-    },
-  );
+    return (
+      line.name.trim().toLowerCase() === normalizedName &&
+      line.serviceMode === service.serviceMode &&
+      line.pricingModel === service.pricingModel
+    );
+  });
 }
 
 function serviceLineStateToLocalPayload(line: RegisterServiceLineState) {
@@ -1302,7 +1299,8 @@ function addLocalAvailabilityDeltaConsumption(input: {
 
     const unsyncedQuantity = Math.max(
       0,
-      item.quantity - (input.syncedCartQuantityBySku.get(item.productSkuId) ?? 0),
+      item.quantity -
+        (input.syncedCartQuantityBySku.get(item.productSkuId) ?? 0),
     );
     if (unsyncedQuantity <= 0) continue;
 
@@ -1382,7 +1380,8 @@ function cartItemsFromLocalRegisterModel(
     if (event.type !== "cart.item_added") continue;
     const payload = recordFromPayload(event.payload);
     const eventLocalPosSessionId =
-      event.localPosSessionId || stringFromPayload(payload, "localPosSessionId");
+      event.localPosSessionId ||
+      stringFromPayload(payload, "localPosSessionId");
     if (eventLocalPosSessionId !== localPosSessionId) continue;
 
     const productSkuId = stringFromPayload(payload, "productSkuId");
@@ -1429,9 +1428,7 @@ function mergeCartItemsBySku(
   baseItems: CartItem[],
   overlayItems: CartItem[],
 ): CartItem[] {
-  const mergedItemsBySku = new Map(
-    baseItems.flatMap(cartItemSkuEntry),
-  );
+  const mergedItemsBySku = new Map(baseItems.flatMap(cartItemSkuEntry));
 
   for (const item of overlayItems) {
     const skuId = item.skuId;
@@ -1561,11 +1558,11 @@ function isEmptyLocalSaleShell(
 ): sale is PosLocalActiveSaleReadModel {
   return Boolean(
     sale &&
-      sale.items.length === 0 &&
-      sale.payments.length === 0 &&
-      sale.subtotal === 0 &&
-      sale.tax === 0 &&
-      sale.total === 0,
+    sale.items.length === 0 &&
+    sale.payments.length === 0 &&
+    sale.subtotal === 0 &&
+    sale.tax === 0 &&
+    sale.total === 0,
   );
 }
 
@@ -1587,10 +1584,9 @@ export function useRegisterViewModel(): RegisterViewModel {
     (localEntryContext.status === "ready"
       ? localEntryContext.storeId
       : undefined)) as Id<"store"> | undefined;
-  const activeStoreOrganizationId = (activeStore as
-    | { organizationId?: string }
-    | null
-    | undefined)?.organizationId;
+  const activeStoreOrganizationId = (
+    activeStore as { organizationId?: string } | null | undefined
+  )?.organizationId;
   const activeStoreCurrency = activeStore?.currency ?? "GHS";
   const navigateBack = useNavigateBack();
   const [staffProfileId, setStaffProfileId] =
@@ -1608,9 +1604,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     ? trimOptional(terminal.registerNumber)
     : undefined;
   const terminalTransactionCapability =
-    normalizePosTerminalTransactionCapability(
-      terminal?.transactionCapability,
-    );
+    normalizePosTerminalTransactionCapability(terminal?.transactionCapability);
   const terminalCanTransactProducts = posTerminalCanTransactProducts(
     terminalTransactionCapability,
   );
@@ -1870,8 +1864,8 @@ export function useRegisterViewModel(): RegisterViewModel {
     projectedLocalActiveSale?.staffProfileId ?? null;
   const isProjectedLocalActiveSaleOwnedByCurrentStaff = Boolean(
     projectedLocalActiveSale &&
-      staffProfileId &&
-      projectedLocalActiveSaleStaffProfileId === staffProfileId,
+    staffProfileId &&
+    projectedLocalActiveSaleStaffProfileId === staffProfileId,
   );
   const cloudRegisterSessionBlocksLocalProjection =
     isKnownCloudRegisterSessionBlockingLocalProjection(
@@ -1887,7 +1881,8 @@ export function useRegisterViewModel(): RegisterViewModel {
       localRegisterReadModel.activeRegisterSession.status,
     )
       ? {
-          expectedCash: localRegisterReadModel.activeRegisterSession.expectedCash,
+          expectedCash:
+            localRegisterReadModel.activeRegisterSession.expectedCash,
           localRegisterSessionId:
             localRegisterReadModel.activeRegisterSession.localRegisterSessionId,
           openedAt: localRegisterReadModel.activeRegisterSession.openedAt,
@@ -1897,8 +1892,8 @@ export function useRegisterViewModel(): RegisterViewModel {
             localRegisterReadModel.activeRegisterSession.registerNumber ?? "",
           storeId: activeStoreId!,
           terminalId: terminal._id,
-      }
-    : null;
+        }
+      : null;
   const projectedLocalCloseoutBlockedRegisterSession =
     localRegisterReadModel?.activeRegisterSession?.status === "closing" &&
     !latestLocalCloseoutIsSynced &&
@@ -1919,7 +1914,8 @@ export function useRegisterViewModel(): RegisterViewModel {
           managerApprovalRequestId: undefined,
           openedAt: localRegisterReadModel.activeRegisterSession.openedAt,
           variance:
-            localRegisterReadModel.activeRegisterSession.countedCash === undefined
+            localRegisterReadModel.activeRegisterSession.countedCash ===
+            undefined
               ? undefined
               : localRegisterReadModel.activeRegisterSession.countedCash -
                 localRegisterReadModel.activeRegisterSession.expectedCash,
@@ -1929,8 +1925,8 @@ export function useRegisterViewModel(): RegisterViewModel {
                 ? "synced"
                 : localRegisterReadModel.syncStatus.state === "needs_review" ||
                     localRegisterReadModel.syncStatus.state === "failed"
-                ? "needs_review"
-                : "locally_closed_pending_sync",
+                  ? "needs_review"
+                  : "locally_closed_pending_sync",
             pendingEventCount: localStaffPendingUploadCount,
           },
         }
@@ -1965,7 +1961,7 @@ export function useRegisterViewModel(): RegisterViewModel {
       ? registerState.activeRegisterSession
       : syncedCloseoutReviewRegisterSession
         ? syncedCloseoutReviewRegisterSession
-      : projectedLocalCloseoutBlockedRegisterSession;
+        : projectedLocalCloseoutBlockedRegisterSession;
   const activeRegisterNumber =
     activeSession?.registerNumber ??
     usableActiveRegisterSession?.registerNumber ??
@@ -1983,13 +1979,15 @@ export function useRegisterViewModel(): RegisterViewModel {
     cloudRegisterSessionId;
   const isProjectedLocalActiveSaleLockedToAnotherStaff = Boolean(
     projectedLocalActiveSale &&
-      (!staffProfileId || projectedLocalActiveSaleStaffProfileId !== staffProfileId),
+    (!staffProfileId ||
+      projectedLocalActiveSaleStaffProfileId !== staffProfileId),
   );
-  const isProjectedLocalActiveSaleEmptyShell =
-    isEmptyLocalSaleShell(projectedLocalActiveSale);
+  const isProjectedLocalActiveSaleEmptyShell = isEmptyLocalSaleShell(
+    projectedLocalActiveSale,
+  );
   const shouldReplaceProjectedLocalActiveSaleForCurrentStaff = Boolean(
     isProjectedLocalActiveSaleLockedToAnotherStaff &&
-      isProjectedLocalActiveSaleEmptyShell,
+    isProjectedLocalActiveSaleEmptyShell,
   );
   const registerNumber = activeRegisterNumber ?? terminalRegisterNumber ?? "";
   const heldSessions = useConvexHeldSessions({
@@ -2001,11 +1999,11 @@ export function useRegisterViewModel(): RegisterViewModel {
   const cashier = registerState?.cashier ?? null;
   const canSignedInStaffOpenDrawer = Boolean(
     hasRegisterOperatorRole(cashier?.activeRoles) ||
-      hasRegisterOperatorRole(localAuthenticatedStaff?.activeRoles),
+    hasRegisterOperatorRole(localAuthenticatedStaff?.activeRoles),
   );
   const isCashierManager = Boolean(
     hasRegisterManagerRole(cashier?.activeRoles) ||
-      hasRegisterManagerRole(localAuthenticatedStaff?.activeRoles),
+    hasRegisterManagerRole(localAuthenticatedStaff?.activeRoles),
   );
   const activeSessionConflict = registerState?.activeSessionConflict ?? null;
 
@@ -2170,7 +2168,8 @@ export function useRegisterViewModel(): RegisterViewModel {
 
       if (typeof indexedDB === "undefined") {
         setCashierPresenceRestore({
-          message: "Cashier sign-in could not be restored. Sign in to continue.",
+          message:
+            "Cashier sign-in could not be restored. Sign in to continue.",
           status: "failed",
         });
         return;
@@ -2186,7 +2185,8 @@ export function useRegisterViewModel(): RegisterViewModel {
 
       if (!storeDayReadiness.ok) {
         setCashierPresenceRestore({
-          message: "Cashier sign-in could not be restored. Sign in to continue.",
+          message:
+            "Cashier sign-in could not be restored. Sign in to continue.",
           status: "failed",
         });
         return;
@@ -2197,7 +2197,8 @@ export function useRegisterViewModel(): RegisterViewModel {
         storeDayReadiness.value?.status !== "reopened"
       ) {
         setCashierPresenceRestore({
-          message: "Store day not ready. Complete opening before cashier sign-in.",
+          message:
+            "Store day not ready. Complete opening before cashier sign-in.",
           status: "failed",
         });
         return;
@@ -2237,7 +2238,8 @@ export function useRegisterViewModel(): RegisterViewModel {
 
       if (!presenceResult.ok) {
         setCashierPresenceRestore({
-          message: "Cashier sign-in could not be restored. Sign in to continue.",
+          message:
+            "Cashier sign-in could not be restored. Sign in to continue.",
           status: "failed",
         });
         return;
@@ -2260,7 +2262,8 @@ export function useRegisterViewModel(): RegisterViewModel {
       });
 
       if (nextRestoreState.status === "restored") {
-        staffProfileIdRef.current = presence.staffProfileId as Id<"staffProfile">;
+        staffProfileIdRef.current =
+          presence.staffProfileId as Id<"staffProfile">;
         staffProofTokenRef.current = presence.staffProofToken ?? null;
         setStaffProfileId(presence.staffProfileId as Id<"staffProfile">);
         setStaffProofToken(presence.staffProofToken ?? null);
@@ -2269,7 +2272,8 @@ export function useRegisterViewModel(): RegisterViewModel {
           displayName: presence.displayName ?? "Signed-in cashier",
         });
       } else if (nextRestoreState.status === "validation_pending") {
-        staffProfileIdRef.current = presence.staffProfileId as Id<"staffProfile">;
+        staffProfileIdRef.current =
+          presence.staffProfileId as Id<"staffProfile">;
         staffProofTokenRef.current = null;
         setStaffProfileId(presence.staffProfileId as Id<"staffProfile">);
         setStaffProofToken(null);
@@ -2342,7 +2346,11 @@ export function useRegisterViewModel(): RegisterViewModel {
     let cancelled = false;
 
     async function refreshLocalStaffAuthorityStatus() {
-      if (!activeStoreId || !terminal?._id || typeof indexedDB === "undefined") {
+      if (
+        !activeStoreId ||
+        !terminal?._id ||
+        typeof indexedDB === "undefined"
+      ) {
         setLocalStaffAuthorityStatus("unavailable");
         return;
       }
@@ -2381,10 +2389,10 @@ export function useRegisterViewModel(): RegisterViewModel {
 
     return Boolean(
       result.ok &&
-        result.value &&
-        result.value.storeId === activeStoreId! &&
-        result.value.cloudTerminalId === terminal._id &&
-        result.value.syncSecretHash,
+      result.value &&
+      result.value.storeId === activeStoreId! &&
+      result.value.cloudTerminalId === terminal._id &&
+      result.value.syncSecretHash,
     );
   }, [activeStoreId, terminal?._id]);
   const readCurrentLocalRegisterModel = useCallback(async () => {
@@ -2427,7 +2435,9 @@ export function useRegisterViewModel(): RegisterViewModel {
   const enqueueCartMutation = useCallback(
     (mutation: () => Promise<boolean | void>) => {
       if (checkoutMutationLockedRef.current) {
-        toast.error("Finish the current checkout update before changing the sale.");
+        toast.error(
+          "Finish the current checkout update before changing the sale.",
+        );
         return Promise.resolve(false);
       }
 
@@ -2523,7 +2533,8 @@ export function useRegisterViewModel(): RegisterViewModel {
         _creationTime: sale.startedAt,
         storeId: activeStoreId as Id<"store">,
         terminalId: sale.terminalId,
-        staffProfileId: (sale.staffProfileId as Id<"staffProfile">) ?? undefined,
+        staffProfileId:
+          (sale.staffProfileId as Id<"staffProfile">) ?? undefined,
         status: "active",
         createdAt: sale.startedAt,
         expiresAt: Number.MAX_SAFE_INTEGER,
@@ -2587,15 +2598,17 @@ export function useRegisterViewModel(): RegisterViewModel {
   ]);
   const visibleActiveSession = asCloudOperableSession(
     activeSession &&
-    !locallyCompletedSessionIdsRef.current.has(activeSession._id.toString()) &&
-    localRegisterReadModel?.activeSale?.localPosSessionId !==
-      activeSession._id.toString() &&
-    !localRegisterReadModel?.clearedSaleIds.includes(
-      activeSession._id.toString(),
-    ) &&
-    !localRegisterReadModel?.completedSales.some(
-      (sale) => sale.localPosSessionId === activeSession._id.toString(),
-    )
+      !locallyCompletedSessionIdsRef.current.has(
+        activeSession._id.toString(),
+      ) &&
+      localRegisterReadModel?.activeSale?.localPosSessionId !==
+        activeSession._id.toString() &&
+      !localRegisterReadModel?.clearedSaleIds.includes(
+        activeSession._id.toString(),
+      ) &&
+      !localRegisterReadModel?.completedSales.some(
+        (sale) => sale.localPosSessionId === activeSession._id.toString(),
+      )
       ? activeSession
       : null,
   );
@@ -2654,8 +2667,9 @@ export function useRegisterViewModel(): RegisterViewModel {
   activeCartItemsRef.current = activeCartItems;
   localRegisterReadModelRef.current = localRegisterReadModel;
   const localAvailabilityConsumptionBySkuId = useMemo(() => {
-    const quantities =
-      localAvailabilityConsumptionFromReadModel(localRegisterReadModel);
+    const quantities = localAvailabilityConsumptionFromReadModel(
+      localRegisterReadModel,
+    );
 
     for (const product of Object.values(optimisticCartProducts)) {
       if (!product.skuId) continue;
@@ -2674,10 +2688,14 @@ export function useRegisterViewModel(): RegisterViewModel {
   const localRegisterCatalogAvailabilityBySkuId = useMemo(() => {
     const adjusted = new Map<string, RegisterCatalogAvailability>();
 
-    for (const [productSkuId, availability] of registerCatalogAvailabilityBySkuId) {
+    for (const [
+      productSkuId,
+      availability,
+    ] of registerCatalogAvailabilityBySkuId) {
       const quantityAvailable = Math.max(
         0,
-        availability.availabilityPolicy === "active_provisional_import"
+        availability.availabilityPolicy === "active_provisional_import" ||
+          availability.availabilityPolicy === "pending_checkout"
           ? 0
           : Math.trunc(availability.quantityAvailable) -
               (localAvailabilityConsumptionBySkuId.get(productSkuId) ?? 0),
@@ -2686,7 +2704,8 @@ export function useRegisterViewModel(): RegisterViewModel {
       adjusted.set(productSkuId, {
         ...availability,
         inStock:
-          availability.availabilityPolicy === "active_provisional_import"
+          availability.availabilityPolicy === "active_provisional_import" ||
+          availability.availabilityPolicy === "pending_checkout"
             ? availability.inStock
             : availability.inStock && quantityAvailable > 0,
         quantityAvailable,
@@ -2729,9 +2748,10 @@ export function useRegisterViewModel(): RegisterViewModel {
       ...registerMetadataSearchState,
       canAutoAdd: Boolean(
         registerMetadataSearchState.exactMatch &&
-          exactAvailability &&
-          (exactAvailability.availabilityPolicy === "active_provisional_import" ||
-            exactAvailability.quantityAvailable >= 0),
+        exactAvailability &&
+        (exactAvailability.availabilityPolicy === "active_provisional_import" ||
+          exactAvailability.availabilityPolicy === "pending_checkout" ||
+          exactAvailability.quantityAvailable >= 0),
       ),
     };
   }, [
@@ -2774,28 +2794,29 @@ export function useRegisterViewModel(): RegisterViewModel {
           : [],
       ),
     );
-    const savedPendingCheckoutProducts = mapLocalPendingCheckoutEventsToProducts(
-      localRegisterReadModel?.sourceEvents ?? [],
-    ).filter(
-      (product) =>
-        product.skuId &&
-        product.pendingCheckoutItemId &&
-        !catalogProductSkuIds.has(product.skuId.toString()) &&
-        !activePendingCheckoutSkuIds.has(product.skuId.toString()) &&
-        !activePendingCheckoutItemIds.has(
-          product.pendingCheckoutItemId.toString(),
-        ) &&
-        pendingCheckoutFieldsMatchSearch(
-          {
-            barcode: product.barcode,
-            name: product.name,
-            productId: product.productId?.toString(),
-            sku: product.sku,
-            skuId: product.skuId?.toString(),
-          },
-          productSearchQuery,
-        ),
-    );
+    const savedPendingCheckoutProducts =
+      mapLocalPendingCheckoutEventsToProducts(
+        localRegisterReadModel?.sourceEvents ?? [],
+      ).filter(
+        (product) =>
+          product.skuId &&
+          product.pendingCheckoutItemId &&
+          !catalogProductSkuIds.has(product.skuId.toString()) &&
+          !activePendingCheckoutSkuIds.has(product.skuId.toString()) &&
+          !activePendingCheckoutItemIds.has(
+            product.pendingCheckoutItemId.toString(),
+          ) &&
+          pendingCheckoutFieldsMatchSearch(
+            {
+              barcode: product.barcode,
+              name: product.name,
+              productId: product.productId?.toString(),
+              sku: product.sku,
+              skuId: product.skuId?.toString(),
+            },
+            productSearchQuery,
+          ),
+      );
 
     return [
       ...activePendingCheckoutProducts,
@@ -2817,9 +2838,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         ),
       )
     : null;
-  if (
-    isCloudOperableSession(operableActiveSession)
-  ) {
+  if (isCloudOperableSession(operableActiveSession)) {
     unmountSessionRef.current = operableActiveSession._id;
     unmountSessionCartItemCountRef.current = activeCartItems.length;
   } else {
@@ -2865,40 +2884,37 @@ export function useRegisterViewModel(): RegisterViewModel {
     () => calculatePosCartTotals(activeCartItems),
     [activeCartItems],
   );
-  const serviceSearchResults = useMemo(
-    () => {
-      if (!terminalCanTransactServices) {
-        return [];
-      }
+  const serviceSearchResults = useMemo(() => {
+    if (!terminalCanTransactServices) {
+      return [];
+    }
 
-      const index = buildRegisterServiceCatalogIndex(
-        serviceCatalogRows
-          .filter((row) => row.status === undefined || row.status === "active")
-          .map(mapServiceCatalogRowToSearchRow),
-      );
-      return searchRegisterServiceCatalog(index, productSearchQuery, {
-        limit: 25,
-      }).results.map((result) =>
-        mapServiceCatalogRowToRegisterSearchResult({
-          serviceCatalogId: result.serviceCatalogId as Id<"serviceCatalog">,
-          name: result.name,
-          description: result.description ?? undefined,
-          serviceMode: result.serviceMode,
-          pricingModel: result.pricingModel,
-          basePrice: result.basePrice ?? undefined,
-          depositType: result.depositType,
-          depositValue: result.depositValue ?? undefined,
-          requiresManagerApproval: result.requiresManagerApproval,
-          status: "active",
-          updatedAt: serviceCatalogRows.find(
-            (row) => row.serviceCatalogId.toString() === result.serviceCatalogId,
-          )?.updatedAt,
-          checkoutReadiness: result.checkoutReadiness,
-        }),
-      );
-    },
-    [productSearchQuery, serviceCatalogRows, terminalCanTransactServices],
-  );
+    const index = buildRegisterServiceCatalogIndex(
+      serviceCatalogRows
+        .filter((row) => row.status === undefined || row.status === "active")
+        .map(mapServiceCatalogRowToSearchRow),
+    );
+    return searchRegisterServiceCatalog(index, productSearchQuery, {
+      limit: 25,
+    }).results.map((result) =>
+      mapServiceCatalogRowToRegisterSearchResult({
+        serviceCatalogId: result.serviceCatalogId as Id<"serviceCatalog">,
+        name: result.name,
+        description: result.description ?? undefined,
+        serviceMode: result.serviceMode,
+        pricingModel: result.pricingModel,
+        basePrice: result.basePrice ?? undefined,
+        depositType: result.depositType,
+        depositValue: result.depositValue ?? undefined,
+        requiresManagerApproval: result.requiresManagerApproval,
+        status: "active",
+        updatedAt: serviceCatalogRows.find(
+          (row) => row.serviceCatalogId.toString() === result.serviceCatalogId,
+        )?.updatedAt,
+        checkoutReadiness: result.checkoutReadiness,
+      }),
+    );
+  }, [productSearchQuery, serviceCatalogRows, terminalCanTransactServices]);
   const serviceSubtotal = useMemo(
     () =>
       calculatePosCartTotals(serviceLineDrafts.map(serviceLineStateToCartLine))
@@ -2927,18 +2943,17 @@ export function useRegisterViewModel(): RegisterViewModel {
   const hasInProgressSaleDraft =
     hasActiveCartDraft || hasActiveCustomerDetails || payments.length > 0;
   const hasClearableSaleState = Boolean(
-    operableActiveSession &&
-    hasInProgressSaleDraft,
+    operableActiveSession && hasInProgressSaleDraft,
   );
   const hasActivePosSession = Boolean(operableActiveSession?._id);
   const hasCloudBlockedRecoverableLocalSale = Boolean(
     cloudRegisterSessionBlocksLocalProjection &&
-      projectedLocalActiveSale &&
-      isProjectedLocalActiveSaleOwnedByCurrentStaff,
+    projectedLocalActiveSale &&
+    isProjectedLocalActiveSaleOwnedByCurrentStaff,
   );
   const activeSessionNeedsRegisterBinding = Boolean(
     isCloudOperableSession(operableActiveSession) &&
-      !operableActiveSession.registerSessionId,
+    !operableActiveSession.registerSessionId,
   );
   const activeSessionHasMismatchedRegisterBinding = Boolean(
     isCloudOperableSession(operableActiveSession) &&
@@ -2971,10 +2986,10 @@ export function useRegisterViewModel(): RegisterViewModel {
   );
   const hasDraftDrawerRecoveryState = Boolean(
     hasInProgressSaleDraft &&
-      !usableActiveRegisterSession &&
-      !locallyOperableRegisterSession &&
-      !localEventRegisterSessionId &&
-      !isTransactionCompleted,
+    !usableActiveRegisterSession &&
+    !locallyOperableRegisterSession &&
+    !localEventRegisterSessionId &&
+    !isTransactionCompleted,
   );
   const localSaleAuthorityBlockReason =
     localRegisterReadModel?.saleBlockReason ?? null;
@@ -3063,17 +3078,17 @@ export function useRegisterViewModel(): RegisterViewModel {
       ? "terminalRepair"
       : hasLifecycleReviewDrawerBlock
         ? "recovery"
-      : localSaleAuthorityBlockReason === "drawer_authority" &&
-          hasRecoverableDrawerAuthorityBlock
-        ? "drawerAuthorityRepair"
-        : hasCloseoutBlockedDrawerState || activeCloseoutRegisterSession
-          ? "closeoutBlocked"
-          : hasMissingDrawerRecoveryState ||
-              hasCloudBlockedRecoverableLocalSale ||
-              hasDraftDrawerRecoveryState ||
-              activeSessionHasBlockedRegisterBinding
-            ? "recovery"
-            : "initialSetup";
+        : localSaleAuthorityBlockReason === "drawer_authority" &&
+            hasRecoverableDrawerAuthorityBlock
+          ? "drawerAuthorityRepair"
+          : hasCloseoutBlockedDrawerState || activeCloseoutRegisterSession
+            ? "closeoutBlocked"
+            : hasMissingDrawerRecoveryState ||
+                hasCloudBlockedRecoverableLocalSale ||
+                hasDraftDrawerRecoveryState ||
+                activeSessionHasBlockedRegisterBinding
+              ? "recovery"
+              : "initialSetup";
   const handleRepairTerminalSetup = useCallback(async () => {
     if (!activeStoreId || !terminal?._id || typeof indexedDB === "undefined") {
       setDrawerErrorMessage(
@@ -3347,8 +3362,8 @@ export function useRegisterViewModel(): RegisterViewModel {
         locallyOperableRegisterSession?.localRegisterSessionId ===
           localRegisterSessionId ||
         (localRegisterReadModel?.canSell &&
-          localRegisterReadModel.activeRegisterSession?.localRegisterSessionId ===
-            localRegisterSessionId)
+          localRegisterReadModel.activeRegisterSession
+            ?.localRegisterSessionId === localRegisterSessionId)
       ) {
         return true;
       }
@@ -3396,7 +3411,9 @@ export function useRegisterViewModel(): RegisterViewModel {
     ],
   );
 
-  const ensureLocalPosSessionId = useCallback(async (): Promise<string | null> => {
+  const ensureLocalPosSessionId = useCallback(async (): Promise<
+    string | null
+  > => {
     const localRegisterSessionId =
       locallyOperableRegisterSession?.localRegisterSessionId ??
       localEventRegisterSessionId;
@@ -3420,7 +3437,9 @@ export function useRegisterViewModel(): RegisterViewModel {
           requireEmpty: true,
         }))
       ) {
-        toast.error("This local sale belongs to another signed-in staff member.");
+        toast.error(
+          "This local sale belongs to another signed-in staff member.",
+        );
         return null;
       }
       const localSession = await localCommandGateway.startSession({
@@ -3465,7 +3484,9 @@ export function useRegisterViewModel(): RegisterViewModel {
     }
 
     if (!(await hasProvisionedLocalSyncSeed())) {
-      toast.error("Terminal setup required. Register this terminal before selling.");
+      toast.error(
+        "Terminal setup required. Register this terminal before selling.",
+      );
       return null;
     }
 
@@ -3522,7 +3543,10 @@ export function useRegisterViewModel(): RegisterViewModel {
   const projectedLocalSaleId = projectedLocalActiveSale?.localPosSessionId;
   const projectedLocalSaleUpdatedAt = projectedLocalActiveSale?.updatedAt;
   useEffect(() => {
-    if (!projectedLocalServiceLines || !isProjectedLocalActiveSaleOwnedByCurrentStaff) {
+    if (
+      !projectedLocalServiceLines ||
+      !isProjectedLocalActiveSaleOwnedByCurrentStaff
+    ) {
       return;
     }
 
@@ -3676,10 +3700,13 @@ export function useRegisterViewModel(): RegisterViewModel {
       }
 
       if (!(await hasProvisionedLocalSyncSeed())) {
-        logger.warn("[POS] Skipped checkout persistence before terminal setup", {
-          sessionId: operableActiveSession._id,
-          stage: args.stage,
-        });
+        logger.warn(
+          "[POS] Skipped checkout persistence before terminal setup",
+          {
+            sessionId: operableActiveSession._id,
+            stage: args.stage,
+          },
+        );
         return false;
       }
 
@@ -3830,7 +3857,9 @@ export function useRegisterViewModel(): RegisterViewModel {
       hasServiceOnlyLocalDraft
     ) {
       if (checkoutMutationLockedRef.current) {
-        toast.error("Finish the current checkout update before clearing the sale.");
+        toast.error(
+          "Finish the current checkout update before clearing the sale.",
+        );
         return false;
       }
 
@@ -3973,134 +4002,143 @@ export function useRegisterViewModel(): RegisterViewModel {
     ],
   );
 
-  const handleStartNewSession = useCallback(async (options?: {
-    force?: boolean;
-    staffProfileId?: Id<"staffProfile">;
-  }) => {
-    if (guardActiveSessionConflict()) {
-      return;
-    }
+  const handleStartNewSession = useCallback(
+    async (options?: {
+      force?: boolean;
+      staffProfileId?: Id<"staffProfile">;
+    }) => {
+      if (guardActiveSessionConflict()) {
+        return;
+      }
 
-    const actingStaffProfileId = options?.staffProfileId ?? staffProfileId;
+      const actingStaffProfileId = options?.staffProfileId ?? staffProfileId;
 
-    if (!activeStoreId || !terminal?._id || !actingStaffProfileId) {
-      toast.error("Register sign-in required. Sign in before starting a sale.");
-      return;
-    }
-
-    if (
-      projectedLocalActiveSale &&
-      projectedLocalActiveSale.staffProfileId !== actingStaffProfileId &&
-      isEmptyLocalSaleShell(projectedLocalActiveSale) &&
-      !(await clearProjectedLocalSaleForStaff(actingStaffProfileId))
-    ) {
-      toast.error("This local sale belongs to another signed-in staff member.");
-      return;
-    }
-
-    const localRegisterSessionId =
-      locallyOperableRegisterSession?.localRegisterSessionId ??
-      localEventRegisterSessionId;
-
-    if (!localRegisterSessionId) {
-      toast.error("Drawer closed. Open the drawer before starting a sale.");
-      return;
-    }
-
-    const sessionStartKey = `${localRegisterSessionId}:${actingStaffProfileId}`;
-    if (pendingSessionStartKeyRef.current === sessionStartKey) {
-      return;
-    }
-    pendingSessionStartKeyRef.current = sessionStartKey;
-    let keepSessionStartGuard = false;
-
-    try {
-      if (!(await hasProvisionedLocalSyncSeed())) {
-        toast.error("Terminal setup required. Register this terminal before selling.");
+      if (!activeStoreId || !terminal?._id || !actingStaffProfileId) {
+        toast.error(
+          "Register sign-in required. Sign in before starting a sale.",
+        );
         return;
       }
 
       if (
-        !(await ensureLocalRegisterSessionReady(localRegisterSessionId, {
-          staffProfileId: actingStaffProfileId,
-        }))
+        projectedLocalActiveSale &&
+        projectedLocalActiveSale.staffProfileId !== actingStaffProfileId &&
+        isEmptyLocalSaleShell(projectedLocalActiveSale) &&
+        !(await clearProjectedLocalSaleForStaff(actingStaffProfileId))
       ) {
+        toast.error(
+          "This local sale belongs to another signed-in staff member.",
+        );
+        return;
+      }
+
+      const localRegisterSessionId =
+        locallyOperableRegisterSession?.localRegisterSessionId ??
+        localEventRegisterSessionId;
+
+      if (!localRegisterSessionId) {
         toast.error("Drawer closed. Open the drawer before starting a sale.");
         return;
       }
 
-      if (operableActiveSession) {
-        const hasDraftState =
-          operableActiveSession.cartItems.length > 0 ||
-          serviceLineDrafts.length > 0;
-        const handled = hasDraftState
-          ? await holdCurrentSession("Auto-held for new session")
-          : true;
-
-        if (!handled) {
-          return;
-        }
-      }
-
-      const result = await localCommandGateway.startSession({
-        storeId: activeStoreId!,
-        terminalId: terminal._id as Id<"posTerminal">,
-        staffProfileId: actingStaffProfileId,
-        registerNumber,
-        localRegisterSessionId,
-        validationMetadata: localSaleValidationMetadata,
-      });
-
-      if (result.kind !== "ok") {
-        await refreshLocalRegisterReadModel();
-        presentOperatorError(result.error.message);
+      const sessionStartKey = `${localRegisterSessionId}:${actingStaffProfileId}`;
+      if (pendingSessionStartKeyRef.current === sessionStartKey) {
         return;
       }
+      pendingSessionStartKeyRef.current = sessionStartKey;
+      let keepSessionStartGuard = false;
 
-      const localPosSessionId = result.data.localPosSessionId;
-      keepSessionStartGuard = true;
-      noteLocalRegisterEventChanged();
-      resetDraftState({
-        keepCashier: true,
-      });
-      setLocalOperablePosSession({
-        localPosSessionId,
-        localRegisterSessionId,
-        registerNumber,
-        startedAt: Date.now(),
-        storeId: activeStoreId!,
-        terminalId: terminal._id,
-      });
-      bootstrapInitialized.current = true;
-    } finally {
-      if (
-        !keepSessionStartGuard &&
-        pendingSessionStartKeyRef.current === sessionStartKey
-      ) {
-        pendingSessionStartKeyRef.current = null;
+      try {
+        if (!(await hasProvisionedLocalSyncSeed())) {
+          toast.error(
+            "Terminal setup required. Register this terminal before selling.",
+          );
+          return;
+        }
+
+        if (
+          !(await ensureLocalRegisterSessionReady(localRegisterSessionId, {
+            staffProfileId: actingStaffProfileId,
+          }))
+        ) {
+          toast.error("Drawer closed. Open the drawer before starting a sale.");
+          return;
+        }
+
+        if (operableActiveSession) {
+          const hasDraftState =
+            operableActiveSession.cartItems.length > 0 ||
+            serviceLineDrafts.length > 0;
+          const handled = hasDraftState
+            ? await holdCurrentSession("Auto-held for new session")
+            : true;
+
+          if (!handled) {
+            return;
+          }
+        }
+
+        const result = await localCommandGateway.startSession({
+          storeId: activeStoreId!,
+          terminalId: terminal._id as Id<"posTerminal">,
+          staffProfileId: actingStaffProfileId,
+          registerNumber,
+          localRegisterSessionId,
+          validationMetadata: localSaleValidationMetadata,
+        });
+
+        if (result.kind !== "ok") {
+          await refreshLocalRegisterReadModel();
+          presentOperatorError(result.error.message);
+          return;
+        }
+
+        const localPosSessionId = result.data.localPosSessionId;
+        keepSessionStartGuard = true;
+        noteLocalRegisterEventChanged();
+        resetDraftState({
+          keepCashier: true,
+        });
+        setLocalOperablePosSession({
+          localPosSessionId,
+          localRegisterSessionId,
+          registerNumber,
+          startedAt: Date.now(),
+          storeId: activeStoreId!,
+          terminalId: terminal._id,
+        });
+        bootstrapInitialized.current = true;
+      } finally {
+        if (
+          !keepSessionStartGuard &&
+          pendingSessionStartKeyRef.current === sessionStartKey
+        ) {
+          pendingSessionStartKeyRef.current = null;
+        }
       }
-    }
-  }, [
-    operableActiveSession,
-    localEventRegisterSessionId,
-    activeStoreId,
-    staffProfileId,
-    clearProjectedLocalSaleForStaff,
-    guardActiveSessionConflict,
-    ensureLocalRegisterSessionReady,
-    hasProvisionedLocalSyncSeed,
-    holdCurrentSession,
-    localCommandGateway,
-    localSaleValidationMetadata,
-    locallyOperableRegisterSession?.localRegisterSessionId,
-    noteLocalRegisterEventChanged,
-    projectedLocalActiveSale,
-    refreshLocalRegisterReadModel,
-    registerNumber,
-    resetDraftState,
-    serviceLineDrafts.length,
-    terminal?._id,
-  ]);
+    },
+    [
+      operableActiveSession,
+      localEventRegisterSessionId,
+      activeStoreId,
+      staffProfileId,
+      clearProjectedLocalSaleForStaff,
+      guardActiveSessionConflict,
+      ensureLocalRegisterSessionReady,
+      hasProvisionedLocalSyncSeed,
+      holdCurrentSession,
+      localCommandGateway,
+      localSaleValidationMetadata,
+      locallyOperableRegisterSession?.localRegisterSessionId,
+      noteLocalRegisterEventChanged,
+      projectedLocalActiveSale,
+      refreshLocalRegisterReadModel,
+      registerNumber,
+      resetDraftState,
+      serviceLineDrafts.length,
+      terminal?._id,
+    ],
+  );
 
   const handleOpenDrawer = useCallback(async () => {
     if (!activeStoreId || !terminal?._id || !staffProfileId) {
@@ -4120,9 +4158,7 @@ export function useRegisterViewModel(): RegisterViewModel {
     const isOnline = globalThis.navigator?.onLine ?? true;
 
     if (isOnline && !staffProofToken) {
-      setDrawerErrorMessage(
-        "Sign in again before opening the drawer.",
-      );
+      setDrawerErrorMessage("Sign in again before opening the drawer.");
       toast.error("Sign out, then sign in again before opening the drawer.");
       return;
     }
@@ -4611,10 +4647,7 @@ export function useRegisterViewModel(): RegisterViewModel {
   );
 
   const defineLocalPendingCheckoutItem = useCallback(
-    async (input: {
-      localPosSessionId: string;
-      product: Product;
-    }) => {
+    async (input: { localPosSessionId: string; product: Product }) => {
       if (!input.product.pendingCheckoutItemLocalDefinition) {
         return true;
       }
@@ -4647,7 +4680,9 @@ export function useRegisterViewModel(): RegisterViewModel {
   const handleAddService = useCallback(
     async (service: RegisterServiceSearchResult, amount?: number) => {
       if (checkoutMutationLockedRef.current) {
-        toast.error("Finish the current checkout update before changing the sale.");
+        toast.error(
+          "Finish the current checkout update before changing the sale.",
+        );
         return false;
       }
 
@@ -4655,7 +4690,9 @@ export function useRegisterViewModel(): RegisterViewModel {
         .catch(() => undefined)
         .then(async () => {
           if (!staffProfileId) {
-            toast.error("Register sign-in required. Sign in before adding services.");
+            toast.error(
+              "Register sign-in required. Sign in before adding services.",
+            );
             return false;
           }
 
@@ -4665,7 +4702,9 @@ export function useRegisterViewModel(): RegisterViewModel {
           }
 
           if (activeSessionHasBlockedRegisterBinding) {
-            toast.error("Drawer closed. Open the drawer before adding services.");
+            toast.error(
+              "Drawer closed. Open the drawer before adding services.",
+            );
             return false;
           }
 
@@ -4673,8 +4712,8 @@ export function useRegisterViewModel(): RegisterViewModel {
             service.pricingModel === "starting_at" ||
             service.pricingModel === "quote_after_consultation";
           const lineAmount = requiresAmount
-            ? amount ?? 0
-            : service.basePrice ?? 0;
+            ? (amount ?? 0)
+            : (service.basePrice ?? 0);
 
           if (requiresAmount && lineAmount <= 0) {
             toast.error(
@@ -4725,7 +4764,8 @@ export function useRegisterViewModel(): RegisterViewModel {
             terminalId: terminal._id,
             storeId: activeStoreId,
             registerNumber,
-            localRegisterSessionId: localEventRegisterSessionId ?? registerNumber,
+            localRegisterSessionId:
+              localEventRegisterSessionId ?? registerNumber,
             localPosSessionId,
             staffProfileId,
             validationMetadata: localSaleValidationMetadata,
@@ -4737,7 +4777,10 @@ export function useRegisterViewModel(): RegisterViewModel {
             return false;
           }
 
-          const nextServiceLineDrafts = [...currentServiceLineDrafts, serviceLine];
+          const nextServiceLineDrafts = [
+            ...currentServiceLineDrafts,
+            serviceLine,
+          ];
           serviceLineDraftsRef.current = nextServiceLineDrafts;
           setServiceLineDrafts(nextServiceLineDrafts);
           setShowProductEntry(true);
@@ -4767,12 +4810,16 @@ export function useRegisterViewModel(): RegisterViewModel {
   const handleUpdateServiceAmount = useCallback(
     async (lineId: string, amount: number) => {
       if (checkoutMutationLockedRef.current) {
-        toast.error("Finish the current checkout update before changing the sale.");
+        toast.error(
+          "Finish the current checkout update before changing the sale.",
+        );
         return;
       }
 
       if (activeSessionHasBlockedRegisterBinding) {
-        toast.error("Drawer closed. Open the drawer before changing this sale.");
+        toast.error(
+          "Drawer closed. Open the drawer before changing this sale.",
+        );
         return;
       }
 
@@ -4784,12 +4831,7 @@ export function useRegisterViewModel(): RegisterViewModel {
           if (!localPosSessionId) {
             return;
           }
-          if (
-            existing &&
-            activeStoreId &&
-            terminal?._id &&
-            staffProfileId
-          ) {
+          if (existing && activeStoreId && terminal?._id && staffProfileId) {
             const nextLine = {
               ...existing,
               price: amount,
@@ -4802,7 +4844,8 @@ export function useRegisterViewModel(): RegisterViewModel {
               terminalId: terminal._id,
               storeId: activeStoreId,
               registerNumber,
-              localRegisterSessionId: localEventRegisterSessionId ?? registerNumber,
+              localRegisterSessionId:
+                localEventRegisterSessionId ?? registerNumber,
               localPosSessionId,
               staffProfileId,
               validationMetadata: localSaleValidationMetadata,
@@ -4849,73 +4892,76 @@ export function useRegisterViewModel(): RegisterViewModel {
     ],
   );
 
-  const handleRemoveService = useCallback(async (lineId: string) => {
-    if (checkoutMutationLockedRef.current) {
-      toast.error("Finish the current checkout update before changing the sale.");
-      return;
-    }
+  const handleRemoveService = useCallback(
+    async (lineId: string) => {
+      if (checkoutMutationLockedRef.current) {
+        toast.error(
+          "Finish the current checkout update before changing the sale.",
+        );
+        return;
+      }
 
-    if (activeSessionHasBlockedRegisterBinding) {
-      toast.error("Drawer closed. Open the drawer before changing this sale.");
-      return;
-    }
+      if (activeSessionHasBlockedRegisterBinding) {
+        toast.error(
+          "Drawer closed. Open the drawer before changing this sale.",
+        );
+        return;
+      }
 
-    const queued = serviceMutationQueueRef.current
-      .catch(() => undefined)
-      .then(async () => {
-        const existing = serviceLineDrafts.find((item) => item.id === lineId);
-        const localPosSessionId = await ensureLocalPosSessionId();
-        if (!localPosSessionId) {
-          return;
-        }
-        if (
-          existing &&
-          activeStoreId &&
-          terminal?._id &&
-          staffProfileId
-        ) {
-          const savedLocally = await localCommandGateway.appendServiceLine({
-            terminalId: terminal._id,
-            storeId: activeStoreId,
-            registerNumber,
-            localRegisterSessionId: localEventRegisterSessionId ?? registerNumber,
-            localPosSessionId,
-            staffProfileId,
-            validationMetadata: localSaleValidationMetadata,
-            payload: {
-              ...serviceLineStateToLocalPayload(existing),
-              quantity: 0,
-              unitPrice: 0,
-              totalPrice: 0,
-            },
-          });
-          if (!savedLocally) {
-            presentOperatorError("Unable to update this sale. Try again.");
+      const queued = serviceMutationQueueRef.current
+        .catch(() => undefined)
+        .then(async () => {
+          const existing = serviceLineDrafts.find((item) => item.id === lineId);
+          const localPosSessionId = await ensureLocalPosSessionId();
+          if (!localPosSessionId) {
             return;
           }
-        }
+          if (existing && activeStoreId && terminal?._id && staffProfileId) {
+            const savedLocally = await localCommandGateway.appendServiceLine({
+              terminalId: terminal._id,
+              storeId: activeStoreId,
+              registerNumber,
+              localRegisterSessionId:
+                localEventRegisterSessionId ?? registerNumber,
+              localPosSessionId,
+              staffProfileId,
+              validationMetadata: localSaleValidationMetadata,
+              payload: {
+                ...serviceLineStateToLocalPayload(existing),
+                quantity: 0,
+                unitPrice: 0,
+                totalPrice: 0,
+              },
+            });
+            if (!savedLocally) {
+              presentOperatorError("Unable to update this sale. Try again.");
+              return;
+            }
+          }
 
-        setServiceLineDrafts((current) =>
-          current.filter((item) => item.id !== lineId),
-        );
-      });
-    serviceMutationQueueRef.current = queued.then(
-      () => undefined,
-      () => undefined,
-    );
-    return queued;
-  }, [
-    activeSessionHasBlockedRegisterBinding,
-    activeStoreId,
-    ensureLocalPosSessionId,
-    localCommandGateway,
-    localSaleValidationMetadata,
-    localEventRegisterSessionId,
-    registerNumber,
-    serviceLineDrafts,
-    staffProfileId,
-    terminal?._id,
-  ]);
+          setServiceLineDrafts((current) =>
+            current.filter((item) => item.id !== lineId),
+          );
+        });
+      serviceMutationQueueRef.current = queued.then(
+        () => undefined,
+        () => undefined,
+      );
+      return queued;
+    },
+    [
+      activeSessionHasBlockedRegisterBinding,
+      activeStoreId,
+      ensureLocalPosSessionId,
+      localCommandGateway,
+      localSaleValidationMetadata,
+      localEventRegisterSessionId,
+      registerNumber,
+      serviceLineDrafts,
+      staffProfileId,
+      terminal?._id,
+    ],
+  );
 
   const handleAddProduct = useCallback(
     async (product: Product, quantity = 1) => {
@@ -4975,7 +5021,9 @@ export function useRegisterViewModel(): RegisterViewModel {
 
           if (
             product.availabilityPolicy !== "active_provisional_import" &&
-            availability?.availabilityPolicy !== "active_provisional_import"
+            product.availabilityPolicy !== "pending_checkout" &&
+            availability?.availabilityPolicy !== "active_provisional_import" &&
+            availability?.availabilityPolicy !== "pending_checkout"
           ) {
             if (quantityAvailable === undefined) {
               toast.error(POS_AVAILABILITY_NOT_READY_MESSAGE);
@@ -5207,8 +5255,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         const isProvisionalImportLine = Boolean(
           ("inventoryImportProvisionalSkuId" in item
             ? item.inventoryImportProvisionalSkuId
-            : undefined) ??
-            queuedLocalItem?.inventoryImportProvisionalSkuId,
+            : undefined) ?? queuedLocalItem?.inventoryImportProvisionalSkuId,
         );
 
         if (
@@ -5223,9 +5270,54 @@ export function useRegisterViewModel(): RegisterViewModel {
           }
         }
 
-      const itemIsLocalOnly = item.id.toString().startsWith("optimistic:");
-      if (itemIsLocalOnly) {
-        if (!item.skuId) return;
+        const itemIsLocalOnly = item.id.toString().startsWith("optimistic:");
+        if (itemIsLocalOnly) {
+          if (!item.skuId) return;
+          if (quantity <= 0) {
+            const savedLocally = await appendLocalCartItem({
+              localPosSessionId: operableActiveSession._id.toString(),
+              payload: buildLocalCartItemPayloadFromCartItem({
+                item,
+                localItemId: itemId.toString(),
+                quantity: 0,
+              }),
+            });
+            if (!savedLocally) {
+              presentOperatorError("Unable to update this sale. Try again.");
+              return;
+            }
+            noteLocalRegisterEventChanged();
+            setOptimisticCartProducts((current) => {
+              const next = { ...current };
+              delete next[optimisticCartProductKeyFromCartItem(item)];
+              return next;
+            });
+            return;
+          }
+
+          const savedLocally = await appendLocalCartItem({
+            localPosSessionId: operableActiveSession._id.toString(),
+            payload: buildLocalCartItemPayloadFromCartItem({
+              item,
+              localItemId: itemId.toString(),
+              quantity,
+            }),
+          });
+          if (!savedLocally) {
+            presentOperatorError("Unable to update this sale. Try again.");
+            return;
+          }
+          noteLocalRegisterEventChanged();
+          setOptimisticCartProducts((current) => ({
+            ...current,
+            [optimisticCartProductKeyFromCartItem(item)]: {
+              ...item,
+              quantity,
+            },
+          }));
+          return;
+        }
+
         if (quantity <= 0) {
           const savedLocally = await appendLocalCartItem({
             localPosSessionId: operableActiveSession._id.toString(),
@@ -5235,94 +5327,49 @@ export function useRegisterViewModel(): RegisterViewModel {
               quantity: 0,
             }),
           });
+
           if (!savedLocally) {
             presentOperatorError("Unable to update this sale. Try again.");
             return;
           }
+
+          setOptimisticCartQuantities((current) => ({
+            ...current,
+            [itemId]: 0,
+          }));
           noteLocalRegisterEventChanged();
-          setOptimisticCartProducts((current) => {
-            const next = { ...current };
-            delete next[optimisticCartProductKeyFromCartItem(item)];
-            return next;
-          });
           return;
         }
 
-        const savedLocally = await appendLocalCartItem({
-          localPosSessionId: operableActiveSession._id.toString(),
-          payload: buildLocalCartItemPayloadFromCartItem({
-            item,
-            localItemId: itemId.toString(),
-            quantity,
-          }),
-        });
-        if (!savedLocally) {
-          presentOperatorError("Unable to update this sale. Try again.");
-          return;
-        }
-        noteLocalRegisterEventChanged();
-        setOptimisticCartProducts((current) => ({
-          ...current,
-          [optimisticCartProductKeyFromCartItem(item)]: {
-            ...item,
-            quantity,
-          },
-        }));
-        return;
-      }
-
-      if (quantity <= 0) {
-        const savedLocally = await appendLocalCartItem({
-          localPosSessionId: operableActiveSession._id.toString(),
-          payload: buildLocalCartItemPayloadFromCartItem({
-            item,
-            localItemId: itemId.toString(),
-            quantity: 0,
-          }),
-        });
-
-        if (!savedLocally) {
-          presentOperatorError("Unable to update this sale. Try again.");
+        if (!item.productId || !item.skuId) {
+          toast.error("Item details unavailable. Remove it and add it again.");
           return;
         }
 
         setOptimisticCartQuantities((current) => ({
           ...current,
-          [itemId]: 0,
+          [itemId]: quantity,
         }));
-        noteLocalRegisterEventChanged();
-        return;
-      }
 
-      if (!item.productId || !item.skuId) {
-        toast.error("Item details unavailable. Remove it and add it again.");
-        return;
-      }
-
-      setOptimisticCartQuantities((current) => ({
-        ...current,
-        [itemId]: quantity,
-      }));
-
-      const savedLocally = await appendLocalCartItem({
-        localPosSessionId: operableActiveSession._id.toString(),
-        payload: buildLocalCartItemPayloadFromCartItem({
-          item,
-          localItemId: itemId.toString(),
-          quantity,
-        }),
-      });
-
-      if (!savedLocally) {
-        setOptimisticCartQuantities((current) => {
-          const next = { ...current };
-          delete next[itemId];
-          return next;
+        const savedLocally = await appendLocalCartItem({
+          localPosSessionId: operableActiveSession._id.toString(),
+          payload: buildLocalCartItemPayloadFromCartItem({
+            item,
+            localItemId: itemId.toString(),
+            quantity,
+          }),
         });
-        presentOperatorError("Unable to update this sale. Try again.");
-        return;
-      }
-      noteLocalRegisterEventChanged();
+
+        if (!savedLocally) {
+          setOptimisticCartQuantities((current) => {
+            const next = { ...current };
+            delete next[itemId];
+            return next;
+          });
+          presentOperatorError("Unable to update this sale. Try again.");
+          return;
+        }
+        noteLocalRegisterEventChanged();
       });
     },
     [
@@ -5431,7 +5478,9 @@ export function useRegisterViewModel(): RegisterViewModel {
 
   const handleClearCart = useCallback(async () => {
     if (checkoutMutationLockedRef.current) {
-      toast.error("Finish the current checkout update before clearing the sale.");
+      toast.error(
+        "Finish the current checkout update before clearing the sale.",
+      );
       return;
     }
 
@@ -5529,7 +5578,9 @@ export function useRegisterViewModel(): RegisterViewModel {
 
       const blockedExactProduct =
         exactSearchProduct ??
-        (registerSearchProducts.length === 1 ? registerSearchProducts[0] : null);
+        (registerSearchProducts.length === 1
+          ? registerSearchProducts[0]
+          : null);
 
       if (blockedExactProduct && !registerSearchState.canAutoAdd) {
         await handleAddProduct(blockedExactProduct);
@@ -5575,7 +5626,8 @@ export function useRegisterViewModel(): RegisterViewModel {
         setLocalAuthenticatedStaff(null);
       } else {
         authenticatedStaffProfileId = result.staffProfileId;
-        const authenticatedStaffProofToken = readStaffProofFromAuthResult(result);
+        const authenticatedStaffProofToken =
+          readStaffProofFromAuthResult(result);
         staffProfileIdRef.current = authenticatedStaffProfileId;
         staffProofTokenRef.current = authenticatedStaffProofToken;
         setStaffProfileId(authenticatedStaffProfileId);
@@ -5731,10 +5783,10 @@ export function useRegisterViewModel(): RegisterViewModel {
 
     const isRecoveringLocalSale = Boolean(
       drawerGateMode === "recovery" &&
-        operableActiveSession &&
-        (isLocalOperableSession(operableActiveSession) ||
-          localRegisterReadModel?.activeSale?.localPosSessionId ===
-            operableActiveSession._id.toString()),
+      operableActiveSession &&
+      (isLocalOperableSession(operableActiveSession) ||
+        localRegisterReadModel?.activeSale?.localPosSessionId ===
+          operableActiveSession._id.toString()),
     );
 
     if (isRecoveringLocalSale) {
@@ -5796,7 +5848,9 @@ export function useRegisterViewModel(): RegisterViewModel {
 
   const handleCompleteTransaction = useCallback(async () => {
     if (checkoutMutationLockedRef.current) {
-      toast.error("Finish the current checkout update before completing the sale.");
+      toast.error(
+        "Finish the current checkout update before completing the sale.",
+      );
       return false;
     }
 
@@ -5811,7 +5865,9 @@ export function useRegisterViewModel(): RegisterViewModel {
     }
 
     if (activeSessionHasBlockedRegisterBinding) {
-      toast.error("Drawer closed. Open the drawer before completing this sale.");
+      toast.error(
+        "Drawer closed. Open the drawer before completing this sale.",
+      );
       return false;
     }
 
@@ -5845,9 +5901,7 @@ export function useRegisterViewModel(): RegisterViewModel {
         return false;
       }
       if (serviceCheckoutBlockMessage) {
-        toast.error(
-          serviceCheckoutBlockMessage,
-        );
+        toast.error(serviceCheckoutBlockMessage);
         return false;
       }
       const paidTotal = currentPayments.reduce(
@@ -5855,7 +5909,9 @@ export function useRegisterViewModel(): RegisterViewModel {
         0,
       );
       if (saleTotals.total > 0 && paidTotal < saleTotals.total) {
-        toast.error("Payment required. Add payment before completing the sale.");
+        toast.error(
+          "Payment required. Add payment before completing the sale.",
+        );
         return false;
       }
       const finishCompletedSale = (input: {
@@ -5903,7 +5959,9 @@ export function useRegisterViewModel(): RegisterViewModel {
         });
 
       if (!(await hasProvisionedLocalSyncSeed())) {
-        toast.error("Terminal setup required. Register this terminal before completing the sale.");
+        toast.error(
+          "Terminal setup required. Register this terminal before completing the sale.",
+        );
         return false;
       }
 
@@ -5991,7 +6049,9 @@ export function useRegisterViewModel(): RegisterViewModel {
       } | null,
     ) => {
       if (checkoutMutationLockedRef.current) {
-        toast.error("Finish the current checkout update before changing payments.");
+        toast.error(
+          "Finish the current checkout update before changing payments.",
+        );
         return Promise.resolve(false);
       }
 
@@ -6027,7 +6087,11 @@ export function useRegisterViewModel(): RegisterViewModel {
       );
       return queued;
     },
-    [allocateCheckoutStateVersion, persistCheckoutStateLocally, setPaymentState],
+    [
+      allocateCheckoutStateVersion,
+      persistCheckoutStateLocally,
+      setPaymentState,
+    ],
   );
 
   const handleAddPayment = useCallback(
@@ -6175,7 +6239,8 @@ export function useRegisterViewModel(): RegisterViewModel {
           canHoldSession: Boolean(operableActiveSession) && hasActiveCartDraft,
           canClearSale: hasClearableSaleState,
           disableNewSession: Boolean(
-            cashierPresenceBlocksSale || operableActiveSession?.status === "active",
+            cashierPresenceBlocksSale ||
+            operableActiveSession?.status === "active",
           ),
           heldSessions:
             heldSessions?.map((session) => ({
@@ -6220,8 +6285,9 @@ export function useRegisterViewModel(): RegisterViewModel {
   const cashierCard =
     activeStoreId && terminal?._id && staffProfileId
       ? {
-          cashierName:
-            cashier ? getCashierDisplayName(cashier) : localAuthenticatedStaff?.displayName ?? "",
+          cashierName: cashier
+            ? getCashierDisplayName(cashier)
+            : (localAuthenticatedStaff?.displayName ?? ""),
           onSignOut: handleCashierSignOut,
         }
       : null;
@@ -6319,7 +6385,7 @@ export function useRegisterViewModel(): RegisterViewModel {
               ),
               hasPendingCloseoutApproval: Boolean(
                 activeCloseoutRegisterSession?.managerApprovalRequestId ||
-                  activeCloseoutRegisterSessionHasSyncReview,
+                activeCloseoutRegisterSessionHasSyncReview,
               ),
               errorMessage: drawerErrorMessage,
               isCloseoutSubmitting: isSubmittingCloseout,
@@ -6518,11 +6584,11 @@ export function useRegisterViewModel(): RegisterViewModel {
               : null,
           storeId: activeStoreId!,
           terminalId: terminal._id,
-	          onAuthenticated: (
-	            result: StaffAuthenticationResult | Id<"staffProfile">,
-	          ) => {
-	            handleCashierAuthenticated(result);
-	          },
+          onAuthenticated: (
+            result: StaffAuthenticationResult | Id<"staffProfile">,
+          ) => {
+            handleCashierAuthenticated(result);
+          },
           onDismiss: handleNavigateBack,
         }
       : null;
@@ -6565,7 +6631,8 @@ export function useRegisterViewModel(): RegisterViewModel {
         lastFailure: localRuntimeSyncSource?.debug?.lastFailure,
         lastHeldEventCount: localRuntimeSyncSource?.debug?.lastHeldEventCount,
         lastLocalSequence: localRegisterReadModel?.syncStatus.lastLocalSequence,
-        lastReviewEventCount: localRuntimeSyncSource?.debug?.lastReviewEventCount,
+        lastReviewEventCount:
+          localRuntimeSyncSource?.debug?.lastReviewEventCount,
         lastRuntimeTrigger:
           localRuntimeSyncSource?.debug?.lastTrigger ?? "none",
         lastRuntimeTriggerAt: localRuntimeSyncSource?.debug?.lastTriggerAt,
@@ -6599,9 +6666,9 @@ export function useRegisterViewModel(): RegisterViewModel {
           ? "runtime"
           : localReadModelSyncSource
             ? "local-read-model"
-          : localSyncSource
-            ? "register-state"
-            : "none",
+            : localSyncSource
+              ? "register-state"
+              : "none",
         staffProof: staffProofToken ? "present" : "missing",
         status: syncStatus?.status ?? "synced",
       },

--- a/scripts/deploy-qa-vps.test.ts
+++ b/scripts/deploy-qa-vps.test.ts
@@ -12,26 +12,44 @@ describe("VPS QA deploy contract", () => {
   it("configures distinct nginx proxies for Athena QA and storefront QA", async () => {
     const setupScript = await readRepoFile("scripts/setup-production-vps.sh");
 
-    expect(setupScript).toContain('STOREFRONT_QA_HOST="${STOREFRONT_QA_HOST:-qa.wigclub.store}"');
-    expect(setupScript).toContain('ATHENA_QA_HOST="${ATHENA_QA_HOST:-athena-qa.wigclub.store}"');
-    expect(setupScript).toContain('STOREFRONT_QA_PORT="${STOREFRONT_QA_PORT:-5176}"');
-    expect(setupScript).toContain('"https://$STOREFRONT_QA_HOST" "https://$STOREFRONT_QA_HOST";');
+    expect(setupScript).toContain(
+      'STOREFRONT_QA_HOST="${STOREFRONT_QA_HOST:-qa.wigclub.store}"',
+    );
+    expect(setupScript).toContain(
+      'ATHENA_QA_HOST="${ATHENA_QA_HOST:-athena-qa.wigclub.store}"',
+    );
+    expect(setupScript).toContain(
+      'STOREFRONT_QA_PORT="${STOREFRONT_QA_PORT:-5176}"',
+    );
+    expect(setupScript).toContain(
+      '"https://$STOREFRONT_QA_HOST" "https://$STOREFRONT_QA_HOST";',
+    );
     expect(setupScript).toContain("server_name $STOREFRONT_QA_HOST;");
-    expect(setupScript).toContain("proxy_pass http://127.0.0.1:$STOREFRONT_QA_PORT;");
+    expect(setupScript).toContain(
+      "proxy_pass http://127.0.0.1:$STOREFRONT_QA_PORT;",
+    );
     expect(setupScript).toContain("server_name $ATHENA_QA_HOST;");
-    expect(setupScript).toContain("proxy_pass http://127.0.0.1:$ATHENA_QA_PORT;");
+    expect(setupScript).toContain(
+      "proxy_pass http://127.0.0.1:$ATHENA_QA_PORT;",
+    );
   });
 
   it("starts separate PM2 dev servers for Athena QA and storefront QA", async () => {
     const deployScript = await readRepoFile("scripts/deploy-vps.sh");
 
-    expect(deployScript).toContain('ATHENA_QA_PORT="${ATHENA_QA_PORT:-${QA_PORT:-5175}}"');
-    expect(deployScript).toContain('STOREFRONT_QA_PORT="${STOREFRONT_QA_PORT:-5176}"');
+    expect(deployScript).toContain(
+      'ATHENA_QA_PORT="${ATHENA_QA_PORT:-${QA_PORT:-5175}}"',
+    );
+    expect(deployScript).toContain(
+      'STOREFRONT_QA_PORT="${STOREFRONT_QA_PORT:-5176}"',
+    );
     expect(deployScript).toContain("deploy_athena_qa()");
     expect(deployScript).toContain("deploy_storefront_qa()");
     expect(deployScript).toContain("configure_storefront_qa_nginx()");
     expect(deployScript).toContain("configure_api_gateway_cors()");
-    expect(deployScript).toContain('python3 - "$config_file" "https://$STOREFRONT_QA_HOST"');
+    expect(deployScript).toContain(
+      'python3 - "$config_file" "https://$STOREFRONT_QA_HOST"',
+    );
     expect(deployScript).toContain("Could not find the nginx CORS origin map.");
     expect(deployScript).toContain("/etc/nginx/conf.d/wigclub.conf");
     expect(deployScript).toContain("nginx -t");
@@ -40,10 +58,14 @@ describe("VPS QA deploy contract", () => {
     expect(deployScript).toContain("pm2 delete storefront-qa");
     expect(deployScript).toContain("pm2 start bun --name athena-qa");
     expect(deployScript).toContain("pm2 start bun --name storefront-qa");
-    expect(deployScript).toContain('PROD_API_URL="${PROD_API_URL:-https://api.wigclub.store}"');
-    expect(deployScript).toContain('VITE_API_URL=$PROD_API_URL');
-    expect(deployScript).not.toContain('VITE_API_URL=$PROD_CONVEX_SITE');
-    expect(deployScript).toContain('DEV_API_URL="${DEV_API_URL:-https://dev.wigclub.store}"');
+    expect(deployScript).toContain(
+      'PROD_API_URL="${PROD_API_URL:-https://api.wigclub.store}"',
+    );
+    expect(deployScript).toContain("VITE_API_URL=$PROD_API_URL");
+    expect(deployScript).not.toContain("VITE_API_URL=$PROD_CONVEX_SITE");
+    expect(deployScript).toContain(
+      'DEV_API_URL="${DEV_API_URL:-https://dev.wigclub.store}"',
+    );
     expect(deployScript).toContain(
       'remote_script "$REMOTE_SOURCE_DIR" "$STOREFRONT_QA_PORT" "$DEV_API_URL" "$STOREFRONT_QA_HOST"',
     );
@@ -65,11 +87,16 @@ describe("VPS QA deploy contract", () => {
     expect(deployScript).toContain("build_static_app_locally()");
     expect(deployScript).toContain("deploy_static_app_local()");
     expect(deployScript).toContain('eval "$env_script bun run build"');
-    expect(deployScript).toContain('rsync -a --delete "$package_dir/dist/" "$REMOTE:$version_path/"');
+    expect(deployScript).toContain(
+      'rsync -a --delete "$package_dir/dist/" "$REMOTE:$version_path/"',
+    );
     expect(deployScript).toContain('"built_on": "local"');
     expect(deployScript).toContain("deploy_athena_local");
     expect(deployScript).toContain("deploy_storefront_local");
     expect(deployScript).toMatch(/athena\)\s+deploy_athena_local/);
+    expect(deployScript).toMatch(
+      /full-prod\)\s+require_remote_source[\s\S]*deploy_athena_local[\s\S]*deploy_storefront_local/,
+    );
     expect(deployScript).toContain("athena-remote");
     expect(interactiveScript).toContain("athena-webapp local build");
     expect(interactiveScript).toContain("storefront local build");
@@ -83,7 +110,9 @@ describe("VPS QA deploy contract", () => {
   });
 
   it("deploys storefront QA only for storefront changes and both QA surfaces for shared deploy changes", async () => {
-    const workflow = await readRepoFile(".github/workflows/athena-qa-deploy.yml");
+    const workflow = await readRepoFile(
+      ".github/workflows/athena-qa-deploy.yml",
+    );
 
     expect(workflow).toContain("fetch-depth: 0");
     expect(workflow).toContain("github.event.before");
@@ -94,11 +123,11 @@ describe("VPS QA deploy contract", () => {
     expect(workflow).toContain('echo "shared=true" >> "$GITHUB_OUTPUT"');
     expect(workflow).toContain("scripts/deploy-vps.sh qa-storefront");
     expect(workflow).toContain("scripts/deploy-vps.sh qa-athena");
-    expect(workflow).toContain('Host: qa.wigclub.store');
-    expect(workflow).toContain('Host: athena-qa.wigclub.store');
-    expect(workflow).toContain('%{http_code}');
-    expect(workflow).toContain('<title>Wigclub</title>');
-    expect(workflow).toContain('/src/main.tsx');
+    expect(workflow).toContain("Host: qa.wigclub.store");
+    expect(workflow).toContain("Host: athena-qa.wigclub.store");
+    expect(workflow).toContain("%{http_code}");
+    expect(workflow).toContain("<title>Wigclub</title>");
+    expect(workflow).toContain("/src/main.tsx");
   });
 
   it("resets generated remote checkout drift before switching deploy refs", async () => {
@@ -113,7 +142,9 @@ describe("VPS QA deploy contract", () => {
   });
 
   it("schedules browser-level Athena QA smoke checks", async () => {
-    const workflow = await readRepoFile(".github/workflows/athena-qa-smoke.yml");
+    const workflow = await readRepoFile(
+      ".github/workflows/athena-qa-smoke.yml",
+    );
 
     expect(workflow).toContain("schedule:");
     expect(workflow).toContain("- cron:");
@@ -121,9 +152,11 @@ describe("VPS QA deploy contract", () => {
     expect(workflow).toContain("fetch-depth: 0");
     expect(workflow).toContain("run: bun install --frozen-lockfile");
     expect(workflow).toContain("run: bunx playwright install chromium");
-    expect(workflow).toContain("ATHENA_QA_URL: https://athena-qa.wigclub.store/");
     expect(workflow).toContain(
-      "run: bun run harness:behavior --scenario athena-qa-live-smoke --record-video"
+      "ATHENA_QA_URL: https://athena-qa.wigclub.store/",
+    );
+    expect(workflow).toContain(
+      "run: bun run harness:behavior --scenario athena-qa-live-smoke --record-video",
     );
     expect(workflow).toContain("actions/upload-artifact@v4");
     expect(workflow).toContain("artifacts/harness-behavior");

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -40,9 +40,9 @@ Commands:
   qa-athena         Refresh the Athena admin QA dev server.
   qa-storefront     Refresh the storefront QA dev server.
   convex-prod       Deploy Convex from the local checkout.
-  full-prod         Deploy Convex, Athena admin, storefront, and Valkey proxy.
-  full-prod-local   Deploy Convex, locally built static apps, and Valkey proxy.
-  all               Deploy full-prod and refresh QA.
+  full-prod         Deploy Convex, locally built static apps, and Valkey proxy.
+  full-prod-local   Alias for full-prod.
+  all               Deploy full-prod with local builds and refresh QA.
   rollback <app> <version|previous>
                      Roll back athena or storefront to a deployed static version.
   rollback-athena <version|previous>
@@ -841,7 +841,7 @@ case "$command" in
     require_remote_source "$REMOTE_REPO" "$REMOTE_SOURCE_DIR" "$DEPLOY_REF"
     deploy_convex_prod
     deploy_athena_local
-    deploy_storefront "$REMOTE_SOURCE_DIR" "$ATHENA_ROOT"
+    deploy_storefront_local
     deploy_valkey_proxy "$REMOTE_SOURCE_DIR" "$ATHENA_ROOT"
     ;;
   full-prod-local)
@@ -855,7 +855,7 @@ case "$command" in
     require_remote_source "$REMOTE_REPO" "$REMOTE_SOURCE_DIR" "$DEPLOY_REF"
     deploy_convex_prod
     deploy_athena_local
-    deploy_storefront "$REMOTE_SOURCE_DIR" "$ATHENA_ROOT"
+    deploy_storefront_local
     deploy_valkey_proxy "$REMOTE_SOURCE_DIR" "$ATHENA_ROOT"
     deploy_qa
     ;;


### PR DESCRIPTION
## Summary
- include legacy import and POS pending checkout catalog anchors across Products, stock adjustments, and POS register search
- block stock updates for provisional legacy/POS pending checkout SKUs and tighten the compact badge/detail presentation
- make production full deploy defaults use local static builds for Athena and storefront

## Validation
- bun run pr:athena
- bun run --filter '@athena/webapp' test:e2e:prod:pos (rerun after one live production timeout during pre-push)
