### PR TITLE
Enable remote terminal recovery commands

### DIFF
--- a/docs/solutions/architecture/athena-pos-remote-terminal-health-recovery-2026-06-11.md
+++ b/docs/solutions/architecture/athena-pos-remote-terminal-health-recovery-2026-06-11.md
@@ -73,6 +73,37 @@ Add a terminal recovery layer on top of existing terminal health evidence:
   should explain safe cloud repair, terminal-required action, manual-review
   blockers, and verification state without exposing backend exception text.
 
+## Remote Command Operation
+
+Terminal Health recovery controls issue only the action metadata returned by the
+current recovery preview. Support does not type a command or edit payloads in the
+browser. Cloud repair uses the preview precondition hash. Terminal-local repair
+uses the preview command type, non-secret command context, and expected evidence.
+
+Generic command examples:
+
+- `repair_terminal_seed` may be queued when terminal setup data or terminal
+  integrity is blocked. Expected evidence should ask the next terminal check-in
+  to show terminal integrity healthy, and when relevant, terminal seed ready and
+  local store available.
+- `clear_stale_drawer_authority` may be queued when drawer authority is blocked
+  by a stale local/cloud register-session pair. The command context should name
+  the target local register-session id and cloud register-session id, and
+  expected evidence should require drawer authority healthy for that local
+  session.
+
+Command acknowledgement and verification are separate. A completed
+acknowledgement means the matching terminal ran the local helper and recorded the
+result. Recovery is not verified until a fresh runtime check-in matches the
+expected evidence. While a command is pending, claimed, completed, or waiting for
+verification, Terminal Health should disable duplicate unsafe clicks.
+
+Manual-review evidence remains outside remote terminal repair. Sale, payment,
+inventory, closeout, variance, manager-rejected, and unresolved business-fact
+items stay in Operations or Cash Controls. Remote terminal commands can clear
+safe terminal-local setup and authority blockers only when their preconditions
+still match.
+
 ## Validation
 
 When this boundary changes, validate the whole recovery loop:

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1930 files · ~0 words
+- 1931 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6794 nodes · 7588 edges · 1858 communities detected
+- 6818 nodes · 7631 edges · 1858 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1960,64 +1960,64 @@ Cohesion: 0.07
 Nodes (13): formatCompactTextList(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary(), formatReviewReportedSummary(), formatReviewTypeSummary(), formatTimestamp() (+5 more)
 
 ### Community 16 - "Community 16"
+Cohesion: 0.11
+Nodes (27): buildRecoveryBlockers(), buildRecoveryBlockersFromPreview(), buildRecoveryReadiness(), buildTerminalRecoveryPresentation(), classifyTerminalHealth(), defaultBlockerSummary(), deriveRecoveryBlockerFromReason(), deriveRecoveryBlockers() (+19 more)
+
+### Community 17 - "Community 17"
 Cohesion: 0.16
 Nodes (33): asRecord(), cartItemSourceKey(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale() (+25 more)
 
-### Community 17 - "Community 17"
+### Community 18 - "Community 18"
 Cohesion: 0.08
 Nodes (17): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+9 more)
 
-### Community 18 - "Community 18"
+### Community 19 - "Community 19"
 Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
-### Community 19 - "Community 19"
+### Community 20 - "Community 20"
 Cohesion: 0.12
 Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
 
-### Community 20 - "Community 20"
+### Community 21 - "Community 21"
 Cohesion: 0.15
 Nodes (27): buildDiscoveryIndex(), buildGeneratedDoc(), buildKeyFolderIndex(), buildTestIndex(), buildValidationGuide(), buildValidationMap(), collectFolderFacts(), collectRouteGroups() (+19 more)
 
-### Community 21 - "Community 21"
+### Community 22 - "Community 22"
 Cohesion: 0.08
 Nodes (9): buildMissingDraftResult(), formatQueueWorkItemValue(), getApprovalRequestCopy(), handleDecideApprovalRequest(), handleDiscardCycleCountDraft(), handleRefreshCycleCountDraftLineBaseline(), handleSaveCycleCountDraftLine(), handleSubmitCycleCountDraft() (+1 more)
 
-### Community 22 - "Community 22"
+### Community 23 - "Community 23"
 Cohesion: 0.14
 Nodes (24): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+16 more)
 
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.2
 Nodes (28): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftCreatedMessage(), buildCycleCountDraftSavedMessage(), buildCycleCountDraftSubmissionKey(), buildCycleCountDraftSubmittedMessage(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx() (+20 more)
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
+Cohesion: 0.18
+Nodes (26): completed(), executeCallbackCommand(), executeClearStaleDrawerAuthority(), executeRepairTerminalSeed(), executeRetrySync(), executeTerminalRecoveryCommand(), failed(), firstDrawerAuthorityPreconditions() (+18 more)
+
+### Community 26 - "Community 26"
 Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
-### Community 25 - "Community 25"
+### Community 27 - "Community 27"
 Cohesion: 0.15
 Nodes (22): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildInferentialSummaryNote(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem() (+14 more)
 
-### Community 26 - "Community 26"
+### Community 28 - "Community 28"
 Cohesion: 0.15
 Nodes (23): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle(), formatSignedQuantity() (+15 more)
 
-### Community 27 - "Community 27"
-Cohesion: 0.15
-Nodes (21): buildRecoveryReadiness(), buildTerminalRecoveryPresentation(), classifyTerminalHealth(), defaultBlockerSummary(), deriveRecoveryBlockerFromReason(), deriveRecoveryBlockers(), formatAge(), formatStatusLabel() (+13 more)
-
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.1
 Nodes (15): cancelItemAdjustmentWorkflow(), exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff() (+7 more)
 
-### Community 29 - "Community 29"
-Cohesion: 0.2
-Nodes (25): asRecord(), buildPosLocalSyncUploadEvents(), customerInfoFromPayload(), getCompletedSaleItems(), getCompletedServiceLines(), hasLaterCompletedSale(), isSyncablePosLocalEvent(), isUploadDeferredByValidation() (+17 more)
-
 ### Community 30 - "Community 30"
 Cohesion: 0.2
-Nodes (23): completed(), executeCallbackCommand(), executeClearStaleDrawerAuthority(), executeRepairTerminalSeed(), executeRetrySync(), executeTerminalRecoveryCommand(), failed(), getCommandId() (+15 more)
+Nodes (25): asRecord(), buildPosLocalSyncUploadEvents(), customerInfoFromPayload(), getCompletedSaleItems(), getCompletedServiceLines(), hasLaterCompletedSale(), isSyncablePosLocalEvent(), isUploadDeferredByValidation() (+17 more)
 
 ### Community 31 - "Community 31"
 Cohesion: 0.16
@@ -2052,48 +2052,48 @@ Cohesion: 0.15
 Nodes (19): acquireExpenseQuantityPatchHold(), adjustExpenseQuantityPatchHold(), createDefaultExpenseSessionCommandService(), createExpenseInventoryHoldGateway(), createExpenseSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired() (+11 more)
 
 ### Community 39 - "Community 39"
+Cohesion: 0.14
+Nodes (18): buildTerminalHealthSummary(), buildTerminalRecoveryActions(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), buildTerminalRecoveryManualReview(), buildTerminalRecoveryPreview(), dedupeTerminalActions(), deriveTerminalHealth() (+10 more)
+
+### Community 40 - "Community 40"
 Cohesion: 0.09
 Nodes (2): buildCashControlsDashboardSnapshot(), sumDepositsBySession()
 
-### Community 40 - "Community 40"
+### Community 41 - "Community 41"
 Cohesion: 0.19
 Nodes (22): buildEventMessage(), buildNextEvidence(), buildNextSaleEvidence(), buildReviewPriority(), buildWorkItemPriority(), createOrReusePendingCheckoutItem(), createProvisionalCatalogAnchors(), findMatchingPendingCheckoutItem() (+14 more)
 
-### Community 41 - "Community 41"
+### Community 42 - "Community 42"
 Cohesion: 0.1
 Nodes (4): listCompletedTransactionsForDay(), listSessionItems(), listTransactionItems(), readAllQueryResults()
 
-### Community 42 - "Community 42"
+### Community 43 - "Community 43"
 Cohesion: 0.15
 Nodes (16): buildGitProcessEnv(), collectCommandsForChangedFiles(), fileExists(), formatMissingPathPrefixError(), getChangedFilesForHarnessReview(), hasAnyHarnessDocs(), loadReviewTarget(), loadReviewTargets() (+8 more)
 
-### Community 43 - "Community 43"
+### Community 44 - "Community 44"
 Cohesion: 0.2
 Nodes (18): acquireInventoryHold(), acquireInventoryHoldsBatch(), adjustInventoryHold(), buildSkuActivityIdempotencyKey(), consumeInventoryHoldsForSession(), getActiveHoldForSessionSku(), listActiveSessionHolds(), markHoldExpired() (+10 more)
 
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.21
 Nodes (21): detectFormat(), extractJsonRows(), flattenJsonRows(), inferProductName(), isRecord(), looksLikeLabel(), normalizeKey(), normalizeLegacyRow() (+13 more)
 
-### Community 45 - "Community 45"
+### Community 46 - "Community 46"
 Cohesion: 0.27
 Nodes (20): asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), asString(), cleanUndefined(), firstDefined() (+12 more)
 
-### Community 46 - "Community 46"
+### Community 47 - "Community 47"
 Cohesion: 0.16
 Nodes (19): automationErrorMessage(), automationIdempotencyKey(), eodDecision(), getLatestDailyOperationsAutomationStatusWithCtx(), getOpeningAutoStartPolicyForApi(), listConfiguredAutomationPolicies(), localDateForPolicy(), openingDecision() (+11 more)
 
-### Community 47 - "Community 47"
+### Community 48 - "Community 48"
 Cohesion: 0.17
 Nodes (17): assertRegisterSessionIdentity(), assertRegisterSessionMatchesTransaction(), assertValidRegisterSessionTransition(), buildClosedRegisterSessionPatch(), buildRegisterSession(), buildRegisterSessionCloseoutPatch(), buildRegisterSessionDepositPatch(), buildRegisterSessionOpeningFloatCorrectionPatch() (+9 more)
 
-### Community 48 - "Community 48"
+### Community 49 - "Community 49"
 Cohesion: 0.18
 Nodes (19): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildSkuActivityEvent(), buildTimeline(), getImpactQuantities() (+11 more)
-
-### Community 49 - "Community 49"
-Cohesion: 0.16
-Nodes (15): buildTerminalHealthSummary(), buildTerminalRecoveryActions(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryManualReview(), buildTerminalRecoveryPreview(), dedupeTerminalActions(), deriveTerminalHealth(), deriveTerminalHealthAttentionReasons() (+7 more)
 
 ### Community 50 - "Community 50"
 Cohesion: 0.21
@@ -2168,192 +2168,192 @@ Cohesion: 0.15
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
 ### Community 68 - "Community 68"
+Cohesion: 0.23
+Nodes (14): acknowledgeTerminalRecoveryCommand(), claimTerminalRecoveryCommand(), containsSecretLikeField(), isActiveCommand(), isEquivalentCommand(), issueTerminalRecoveryCommand(), loadScopedCommand(), normalizeOptionalHealthyStatus() (+6 more)
+
+### Community 69 - "Community 69"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.24
 Nodes (14): cacheAssetRequest(), cacheFirstAsset(), cacheLinkedShellAssets(), cacheModuleDependencies(), isExcluded(), isHtmlResponse(), isJavaScriptLikeResponse(), isPosNavigation() (+6 more)
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.13
 Nodes (2): handleEnterReviewMode(), saveInventoryImportRouteDraft()
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.24
 Nodes (15): buildGeneratedControlId(), captureRemoteAssistCoBrowseFrame(), collectSanitizedSurface(), collectSensitiveRegions(), collectVisibleText(), getControlId(), getControlPriority(), getElementLabel() (+7 more)
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 73 - "Community 73"
+### Community 74 - "Community 74"
 Cohesion: 0.26
 Nodes (13): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget() (+5 more)
 
-### Community 74 - "Community 74"
+### Community 75 - "Community 75"
 Cohesion: 0.23
 Nodes (12): assertValidOpeningBlockerHandling(), assertValidOpeningLocalStartMinutes(), assertValidOperatingTimezoneOffsetMinutes(), getAutomationPolicyWithCtx(), getAutomationRunByIdempotencyKeyWithCtx(), getOpeningAutoStartPolicyConfigWithCtx(), listAutomationPoliciesForStoreActionWithCtx(), listAutomationRunsByIdempotencyKeyWithCtx() (+4 more)
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.33
 Nodes (14): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+6 more)
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.28
 Nodes (14): getRegisterCatalogPrice(), isActiveProvisionalImportSkuForStore(), isTrustedRegisterCatalogSku(), listRegisterCatalog(), listRegisterCatalogAvailability(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow() (+6 more)
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
+Cohesion: 0.14
+Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
+
+### Community 79 - "Community 79"
 Cohesion: 0.17
 Nodes (6): buildServerPricedCheckoutProducts(), calculateItemsSubtotal(), deriveDeliveryOptionFromAddress(), isDeliveryFeeWaived(), normalizeDeliveryOption(), resolveServerDeliveryFee()
 
-### Community 78 - "Community 78"
+### Community 80 - "Community 80"
 Cohesion: 0.15
 Nodes (4): formatCurrency(), formatFinancialLabel(), formatTimelineRange(), formatTimelineTime()
 
-### Community 79 - "Community 79"
+### Community 81 - "Community 81"
 Cohesion: 0.24
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
-### Community 80 - "Community 80"
+### Community 82 - "Community 82"
 Cohesion: 0.17
 Nodes (6): formatLocalStartTime(), formatLocalStartTimeFromParts(), getLocalStartTimeParts(), handleSave(), parseLocalStartMinutes(), updateLocalStartTimePart()
 
-### Community 81 - "Community 81"
+### Community 83 - "Community 83"
+Cohesion: 0.15
+Nodes (4): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onStartRemoteAssist()
+
+### Community 84 - "Community 84"
 Cohesion: 0.18
 Nodes (7): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), useConvexRegisterServiceCatalog(), usePrewarmRegisterCatalogOfflineSnapshots()
 
-### Community 82 - "Community 82"
+### Community 85 - "Community 85"
 Cohesion: 0.22
 Nodes (10): extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isBarcodeShapedInput(), normalizeIdentifier(), parseCatalogSearchInput(), searchByText(), searchRegisterCatalog() (+2 more)
 
-### Community 83 - "Community 83"
+### Community 86 - "Community 86"
 Cohesion: 0.22
 Nodes (10): createApp(), createHandlers(), createRedisClient(), createRedisCluster(), deleteKeysIndividually(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline(), scanNodeForPattern() (+2 more)
 
-### Community 84 - "Community 84"
+### Community 87 - "Community 87"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 85 - "Community 85"
+### Community 88 - "Community 88"
 Cohesion: 0.31
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getOperationalWorkItemStatus() (+5 more)
 
-### Community 86 - "Community 86"
+### Community 89 - "Community 89"
 Cohesion: 0.19
 Nodes (4): formatQuickAddDialogError(), handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
 
-### Community 87 - "Community 87"
+### Community 90 - "Community 90"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 88 - "Community 88"
+### Community 91 - "Community 91"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 89 - "Community 89"
+### Community 92 - "Community 92"
 Cohesion: 0.22
 Nodes (6): buildParticipantIdentity(), getDataPublishRouting(), getParticipantRole(), isAllowedSender(), LiveKitRemoteAssistClient, parseParticipantRole()
 
-### Community 90 - "Community 90"
+### Community 93 - "Community 93"
 Cohesion: 0.26
 Nodes (12): bestFuzzyTokenScore(), compactSearchText(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreCompactFieldContains(), scoreFuzzySearchEntry() (+4 more)
 
-### Community 91 - "Community 91"
+### Community 94 - "Community 94"
 Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
-### Community 92 - "Community 92"
+### Community 95 - "Community 95"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 93 - "Community 93"
-Cohesion: 0.28
-Nodes (11): acknowledgeTerminalRecoveryCommand(), claimTerminalRecoveryCommand(), containsSecretLikeField(), issueTerminalRecoveryCommand(), loadScopedCommand(), normalizeOptionalHealthyStatus(), notFound(), pruneUndefined() (+3 more)
-
-### Community 94 - "Community 94"
+### Community 96 - "Community 96"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 95 - "Community 95"
+### Community 97 - "Community 97"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
 
-### Community 96 - "Community 96"
+### Community 98 - "Community 98"
 Cohesion: 0.15
 Nodes (0):
 
-### Community 97 - "Community 97"
+### Community 99 - "Community 99"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 98 - "Community 98"
+### Community 100 - "Community 100"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 99 - "Community 99"
+### Community 101 - "Community 101"
 Cohesion: 0.29
 Nodes (10): applyTheme(), emitThemeChange(), getStorage(), getStoredThemeMode(), getSystemTheme(), getThemeSnapshot(), initializeAthenaTheme(), isThemeMode() (+2 more)
 
-### Community 100 - "Community 100"
+### Community 102 - "Community 102"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 101 - "Community 101"
+### Community 103 - "Community 103"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
 
-### Community 102 - "Community 102"
+### Community 104 - "Community 104"
 Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
 
-### Community 103 - "Community 103"
+### Community 105 - "Community 105"
 Cohesion: 0.31
 Nodes (12): collectFilesUnder(), collectProofSnapshot(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof(), hashValidationWiring(), normalizeRepoPath(), readPrAthenaScript(), recordPrePushValidationProof() (+4 more)
 
-### Community 104 - "Community 104"
+### Community 106 - "Community 106"
 Cohesion: 0.33
 Nodes (11): buildFingerprintPayload(), getSkuDisplayName(), getSkuDisplaySku(), getSkuPrice(), hasOwnValue(), hasUnsupportedManualFields(), isSkuAvailableForAddition(), isWholeQuantity() (+3 more)
 
-### Community 105 - "Community 105"
+### Community 107 - "Community 107"
 Cohesion: 0.2
 Nodes (4): formatProductLineMeta(), formatServiceLabel(), formatServiceLineMeta(), formatStoredAmount()
 
-### Community 106 - "Community 106"
-Cohesion: 0.2
-Nodes (4): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onStartRemoteAssist()
-
-### Community 107 - "Community 107"
+### Community 108 - "Community 108"
 Cohesion: 0.21
 Nodes (5): formatDeposit(), formatMoney(), handleCancelEdit(), handleSaveEdit(), summarizeService()
 
-### Community 108 - "Community 108"
+### Community 109 - "Community 109"
 Cohesion: 0.29
 Nodes (8): isFiniteNumber(), isPointInsideViewport(), isPositiveFiniteNumber(), isRecord(), isValidViewport(), validateKeyEvent(), validatePointerEvent(), validateRemoteAssistControlEvent()
 
-### Community 109 - "Community 109"
+### Community 110 - "Community 110"
 Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
-### Community 110 - "Community 110"
+### Community 111 - "Community 111"
 Cohesion: 0.29
 Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
-### Community 111 - "Community 111"
+### Community 112 - "Community 112"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.22
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
-
-### Community 114 - "Community 114"
-Cohesion: 0.2
-Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
 
 ### Community 115 - "Community 115"
 Cohesion: 0.33
@@ -2449,19 +2449,19 @@ Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalize
 
 ### Community 138 - "Community 138"
 Cohesion: 0.39
-Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 139 - "Community 139"
 Cohesion: 0.39
-Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
+Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
 ### Community 140 - "Community 140"
-Cohesion: 0.22
-Nodes (0):
+Cohesion: 0.39
+Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
 ### Community 141 - "Community 141"
-Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Cohesion: 0.22
+Nodes (0):
 
 ### Community 142 - "Community 142"
 Cohesion: 0.5
@@ -3204,36 +3204,36 @@ Cohesion: 0.5
 Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 327 - "Community 327"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (3): createVersionChecker(), shouldAutoReloadForCurrentRoute(), shouldAutoReloadForPath()
 
 ### Community 328 - "Community 328"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 329 - "Community 329"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 330 - "Community 330"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 331 - "Community 331"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 332 - "Community 332"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 333 - "Community 333"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 334 - "Community 334"
-Cohesion: 0.5
-Nodes (3): createVersionChecker(), shouldAutoReloadForCurrentRoute(), shouldAutoReloadForPath()
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 335 - "Community 335"
 Cohesion: 0.4

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,9 +7,9 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1930
-- Graph nodes: 6794
-- Graph edges: 7588
+- Code files discovered: 1931
+- Graph nodes: 6818
+- Graph edges: 7631
 - Communities: 1858
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -19,9 +19,9 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 ## Graph Hotspots
 - `storefrontJourneyEvents.ts` (45 edges, Community 9) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 9) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `getStoreConfigV2()` (17 edges, Community 45) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `checkoutSession.ts` (14 edges, Community 72) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
-- `storeConfig.ts` (14 edges, Community 45) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `getStoreConfigV2()` (17 edges, Community 46) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
+- `checkoutSession.ts` (14 edges, Community 73) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `storeConfig.ts` (14 edges, Community 46) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -17,11 +17,11 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 - [validation-map.json](../../../packages/valkey-proxy-server/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `app.js` (14 edges, Community 83) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.js` (14 edges, Community 86) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `app.test.js` (6 edges, Community 151) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
-- `createRedisClient()` (4 edges, Community 83) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `createRedisCluster()` (3 edges, Community 83) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `deleteKeysIndividually()` (3 edges, Community 83) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisClient()` (4 edges, Community 86) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisCluster()` (3 edges, Community 86) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `deleteKeysIndividually()` (3 edges, Community 86) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from "vitest";
+
+import type { Doc, Id } from "../../../_generated/dataModel";
+import type { QueryCtx } from "../../../_generated/server";
+import { getTerminalHealthSummary } from "./terminals";
+
+const now = 2_000_000;
+const storeId = "store-1" as Id<"store">;
+const terminalId = "terminal-1" as Id<"posTerminal">;
+
+describe("terminal health queries", () => {
+  it("includes latest terminal recovery command lifecycle metadata in the health preview", async () => {
+    const ctx = buildQueryCtx({
+      posTerminal: [
+        {
+          _id: terminalId,
+          _creationTime: now - 50_000,
+          browserInfo: {
+            userAgent: "Mozilla/5.0",
+          },
+          displayName: "Front register",
+          fingerprintHash: "fingerprint",
+          registeredAt: now - 50_000,
+          registeredByUserId: "user-1" as Id<"athenaUser">,
+          status: "active",
+          storeId,
+        } satisfies Doc<"posTerminal">,
+      ],
+      posTerminalRuntimeStatus: [
+        {
+          _id: "runtime-1" as Id<"posTerminalRuntimeStatus">,
+          _creationTime: now - 2_000,
+          appSessionRecovery: {
+            status: "ready",
+          },
+          browserInfo: {
+            online: true,
+            userAgent: "Mozilla/5.0",
+          },
+          localStore: {
+            available: true,
+            terminalSeedReady: true,
+          },
+          receivedAt: now - 1_000,
+          reportedAt: now - 1_000,
+          snapshots: {},
+          source: "sync-runtime",
+          staffAuthority: {
+            status: "ready",
+          },
+          storeId,
+          sync: {
+            failedEventCount: 0,
+            localOnlyEventCount: 0,
+            pendingEventCount: 0,
+            reviewEventCount: 0,
+            status: "idle",
+            uploadableEventCount: 0,
+          },
+          terminalId,
+          terminalIntegrity: {
+            observedAt: now - 1_000,
+            status: "healthy",
+          },
+        } satisfies Doc<"posTerminalRuntimeStatus">,
+      ],
+      posTerminalRecoveryCommand: [
+        {
+          _id: "command-old" as Id<"posTerminalRecoveryCommand">,
+          _creationTime: now - 20_000,
+          commandContext: {
+            reason: "Old sync retry.",
+          },
+          commandType: "retry_sync",
+          expectedEvidence: {
+            syncStatus: "idle",
+          },
+          expiresAt: now + 5_000,
+          issuedAt: now - 20_000,
+          issuedByUserId: "user-1" as Id<"athenaUser">,
+          status: "completed",
+          storeId,
+          terminalId,
+          verificationStatus: "verified",
+        } satisfies Doc<"posTerminalRecoveryCommand">,
+        {
+          _id: "command-latest" as Id<"posTerminalRecoveryCommand">,
+          _creationTime: now - 5_000,
+          acknowledgement: {
+            acknowledgedAt: now - 4_000,
+            message: "Terminal setup repair completed locally.",
+            result: "completed",
+          },
+          commandContext: {
+            expectedBlockerType: "terminal_seed",
+            reason: "Terminal setup data needs repair.",
+          },
+          commandType: "repair_terminal_seed",
+          expectedEvidence: {
+            terminalIntegrityStatus: "healthy",
+          },
+          expiresAt: now + 5_000,
+          issuedAt: now - 5_000,
+          issuedByUserId: "user-1" as Id<"athenaUser">,
+          status: "completed",
+          storeId,
+          terminalId,
+          verificationStatus: "runtime_verification_ready",
+        } satisfies Doc<"posTerminalRecoveryCommand">,
+      ],
+    });
+
+    const summary = await getTerminalHealthSummary(ctx, {
+      now,
+      storeId,
+      terminalId,
+    });
+
+    expect(summary?.recoveryPreview?.commandStatus).toEqual({
+      commandId: "command-latest",
+      label: "Terminal setup repair",
+      latestAcknowledgement: "Terminal setup repair completed locally.",
+      status: "completed",
+      verificationStatus: "runtime_verification_ready",
+    });
+  });
+
+  it("projects stale pending recovery commands as expired in the health preview", async () => {
+    const ctx = buildQueryCtx({
+      posTerminal: [buildTerminal()],
+      posTerminalRecoveryCommand: [
+        {
+          _id: "command-expired" as Id<"posTerminalRecoveryCommand">,
+          _creationTime: now - 20_000,
+          commandContext: {
+            reason: "Terminal setup data needs repair.",
+          },
+          commandType: "repair_terminal_seed",
+          expectedEvidence: {
+            terminalIntegrityStatus: "healthy",
+          },
+          expiresAt: now - 1,
+          issuedAt: now - 20_000,
+          issuedByUserId: "user-1" as Id<"athenaUser">,
+          status: "pending",
+          storeId,
+          terminalId,
+          verificationStatus: "waiting_for_acknowledgement",
+        } satisfies Doc<"posTerminalRecoveryCommand">,
+      ],
+      posTerminalRuntimeStatus: [buildRuntimeStatus()],
+    });
+
+    const summary = await getTerminalHealthSummary(ctx, {
+      now,
+      storeId,
+      terminalId,
+    });
+
+    expect(summary?.recoveryPreview?.commandStatus).toEqual(
+      expect.objectContaining({
+        commandId: "command-expired",
+        status: "expired",
+      }),
+    );
+  });
+});
+
+type TestTable =
+  | "posLocalSyncConflict"
+  | "posLocalSyncCursor"
+  | "posLocalSyncEvent"
+  | "posTerminal"
+  | "posTerminalRecoveryCommand"
+  | "posTerminalRuntimeStatus";
+
+function buildQueryCtx(
+  records: Partial<Record<TestTable, Array<Record<string, unknown>>>>,
+) {
+  return {
+    db: {
+      get(table: TestTable, id: string) {
+        return Promise.resolve(
+          records[table]?.find((record) => record._id === id) ?? null,
+        );
+      },
+      query(table: TestTable) {
+        return buildQuery(records[table] ?? []);
+      },
+    },
+  } as unknown as QueryCtx;
+}
+
+function buildTerminal(): Doc<"posTerminal"> {
+  return {
+    _id: terminalId,
+    _creationTime: now - 50_000,
+    browserInfo: {
+      userAgent: "Mozilla/5.0",
+    },
+    displayName: "Front register",
+    fingerprintHash: "fingerprint",
+    registeredAt: now - 50_000,
+    registeredByUserId: "user-1" as Id<"athenaUser">,
+    status: "active",
+    storeId,
+  };
+}
+
+function buildRuntimeStatus(): Doc<"posTerminalRuntimeStatus"> {
+  return {
+    _id: "runtime-1" as Id<"posTerminalRuntimeStatus">,
+    _creationTime: now - 2_000,
+    appSessionRecovery: {
+      status: "ready",
+    },
+    browserInfo: {
+      online: true,
+      userAgent: "Mozilla/5.0",
+    },
+    localStore: {
+      available: true,
+      terminalSeedReady: true,
+    },
+    receivedAt: now - 1_000,
+    reportedAt: now - 1_000,
+    snapshots: {},
+    source: "sync-runtime",
+    staffAuthority: {
+      status: "ready",
+    },
+    storeId,
+    sync: {
+      failedEventCount: 0,
+      localOnlyEventCount: 0,
+      pendingEventCount: 0,
+      reviewEventCount: 0,
+      status: "idle",
+      uploadableEventCount: 0,
+    },
+    terminalId,
+    terminalIntegrity: {
+      observedAt: now - 1_000,
+      status: "healthy",
+    },
+  };
+}
+
+function buildQuery(records: Array<Record<string, unknown>>) {
+  const chain = {
+    collect: () => Promise.resolve(records),
+    first: () => Promise.resolve(records[0] ?? null),
+    order: () => chain,
+    take: (count: number) => Promise.resolve(records.slice(0, count)),
+    unique: () => Promise.resolve(records[0] ?? null),
+    withIndex: () => chain,
+  };
+
+  return chain;
+}

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.ts
@@ -13,6 +13,7 @@ import {
 import {
   getTerminalRecoverySourceEvent,
   listTerminalRecoveryConflictsForRepair,
+  createTerminalRecoveryCommandRepository,
 } from "../../infrastructure/repositories/terminalRecoveryRepository";
 import {
   buildTerminalCloudRepairPreview,
@@ -108,6 +109,13 @@ export type TerminalRecoveryPreview = {
     safeConflictIds: Array<Id<"posLocalSyncConflict">>;
     skippedConflictIds: Array<Id<"posLocalSyncConflict">>;
   };
+  commandStatus: {
+    commandId?: Id<"posTerminalRecoveryCommand">;
+    label: string;
+    latestAcknowledgement?: string;
+    status: Doc<"posTerminalRecoveryCommand">["status"];
+    verificationStatus: Doc<"posTerminalRecoveryCommand">["verificationStatus"];
+  } | null;
   terminalActions: Array<{
     commandType: TerminalRecoveryCommandType;
     expectedEvidence: TerminalRecoveryExpectedEvidence;
@@ -291,6 +299,11 @@ async function buildTerminalRecoveryPreview(
     args.runtimeStatus.browserInfo?.online !== false;
   const cloudRepair = await buildTerminalRecoveryCloudRepairPreview(ctx, args);
   const terminalActions = buildTerminalRecoveryActions(args);
+  const commandStatus = await buildTerminalRecoveryCommandStatus(ctx, {
+    now: args.now,
+    storeId: args.storeId,
+    terminalId: args.terminalId,
+  });
   const manualReview = buildTerminalRecoveryManualReview({
     attentionReasons: args.attentionReasons,
     skippedConflictIds: cloudRepair.skippedConflictIds,
@@ -320,9 +333,75 @@ async function buildTerminalRecoveryPreview(
       freshRuntimeRequiredForAbleToTransactNow: true,
     },
     cloudRepair,
+    commandStatus,
     terminalActions,
     manualReview,
   };
+}
+
+async function buildTerminalRecoveryCommandStatus(
+  ctx: QueryCtx,
+  args: {
+    now: number;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  },
+): Promise<TerminalRecoveryPreview["commandStatus"]> {
+  const commands =
+    await createTerminalRecoveryCommandRepository(ctx).listCommandsForTerminal({
+      storeId: args.storeId,
+      terminalId: args.terminalId,
+    });
+  const latestCommand = commands
+    .filter(
+      (command) =>
+        command.storeId === args.storeId &&
+        command.terminalId === args.terminalId,
+    )
+    .sort((left, right) => right.issuedAt - left.issuedAt)
+    .at(0);
+  if (!latestCommand) {
+    return null;
+  }
+
+  return {
+    commandId: latestCommand._id,
+    label: getTerminalRecoveryCommandLabel(latestCommand.commandType),
+    latestAcknowledgement: latestCommand.acknowledgement?.message,
+    status: getTerminalRecoveryCommandStatusForPreview(latestCommand, args.now),
+    verificationStatus: latestCommand.verificationStatus,
+  };
+}
+
+function getTerminalRecoveryCommandStatusForPreview(
+  command: Doc<"posTerminalRecoveryCommand">,
+  now: number,
+) {
+  if (
+    command.expiresAt <= now &&
+    (command.status === "pending" || command.status === "claimed")
+  ) {
+    return "expired" as const;
+  }
+
+  return command.status;
+}
+
+function getTerminalRecoveryCommandLabel(commandType: TerminalRecoveryCommandType) {
+  switch (commandType) {
+    case "repair_terminal_seed":
+      return "Terminal setup repair";
+    case "clear_stale_drawer_authority":
+      return "Drawer authority repair";
+    case "refresh_staff_authority":
+      return "Staff authority refresh";
+    case "refresh_snapshots":
+      return "Snapshot refresh";
+    case "retry_sync":
+      return "Sync retry";
+    case "report_diagnostics":
+      return "Diagnostics request";
+  }
 }
 
 async function buildTerminalRecoveryCloudRepairPreview(

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.test.ts
@@ -99,6 +99,240 @@ describe("terminal command service", () => {
     expect(repository.insertCommand).not.toHaveBeenCalled();
   });
 
+  it("returns an equivalent active command instead of inserting duplicate work", async () => {
+    const existingCommand = buildCommand({
+      commandType: "repair_terminal_seed",
+      commandContext: {
+        expectedBlockerType: "terminal_seed",
+        reason: "Terminal setup data needs repair.",
+      },
+      expectedEvidence: {
+        terminalIntegrityStatus: "healthy",
+      },
+      status: "claimed",
+    });
+    const repository = buildRepository({
+      commands: [existingCommand],
+    });
+
+    const result = await issueTerminalRecoveryCommand(repository, {
+      commandType: "repair_terminal_seed",
+      expectedEvidence: {
+        terminalIntegrityStatus: "healthy",
+      },
+      issuedAt: now,
+      issuedByUserId: "user-2" as Id<"athenaUser">,
+      commandContext: {
+        reason: "Terminal setup data needs repair.",
+        expectedBlockerType: "terminal_seed",
+      },
+      storeId,
+      terminalId,
+    });
+
+    expect(result).toEqual({
+      kind: "ok",
+      data: existingCommand,
+    });
+    expect(repository.insertCommand).not.toHaveBeenCalled();
+  });
+
+  it("returns an equivalent command waiting for runtime verification instead of inserting duplicate work", async () => {
+    const existingCommand = buildCommand({
+      commandType: "repair_terminal_seed",
+      commandContext: {
+        expectedBlockerType: "terminal_seed",
+        reason: "Terminal setup data needs repair.",
+      },
+      expectedEvidence: {
+        terminalIntegrityStatus: "healthy",
+      },
+      status: "completed",
+      verificationStatus: "runtime_verification_ready",
+    });
+    const repository = buildRepository({
+      commands: [existingCommand],
+    });
+
+    const result = await issueTerminalRecoveryCommand(repository, {
+      commandType: "repair_terminal_seed",
+      expectedEvidence: {
+        terminalIntegrityStatus: "healthy",
+      },
+      issuedAt: now,
+      issuedByUserId: "user-2" as Id<"athenaUser">,
+      commandContext: {
+        reason: "Terminal setup data needs repair.",
+        expectedBlockerType: "terminal_seed",
+      },
+      storeId,
+      terminalId,
+    });
+
+    expect(result).toEqual({
+      kind: "ok",
+      data: existingCommand,
+    });
+    expect(repository.insertCommand).not.toHaveBeenCalled();
+  });
+
+  it("replaces equivalent expired commands with fresh pending work", async () => {
+    const repository = buildRepository({
+      commands: [
+        buildCommand({
+          expiresAt: now - 1,
+          commandType: "clear_stale_drawer_authority",
+          commandContext: {
+            cloudRegisterSessionId: "cloud-register-1",
+            localRegisterSessionId: "local-register-1",
+            reason: "Stale drawer authority blocks sales.",
+          },
+          expectedEvidence: {
+            drawerAuthorityStatus: "healthy",
+            localRegisterSessionId: "local-register-1",
+          },
+        }),
+      ],
+    });
+
+    const result = await issueTerminalRecoveryCommand(repository, {
+      commandType: "clear_stale_drawer_authority",
+      expectedEvidence: {
+        drawerAuthorityStatus: "healthy",
+        localRegisterSessionId: "local-register-1",
+      },
+      issuedAt: now,
+      issuedByUserId: "user-2" as Id<"athenaUser">,
+      commandContext: {
+        localRegisterSessionId: "local-register-1",
+        cloudRegisterSessionId: "cloud-register-1",
+        reason: "Stale drawer authority blocks sales.",
+      },
+      storeId,
+      terminalId,
+    });
+
+    expect(repository.patchCommand).toHaveBeenCalledWith("command-1", {
+      status: "expired",
+    });
+    expect(repository.insertCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandType: "clear_stale_drawer_authority",
+        status: "pending",
+      }),
+    );
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        _id: "command-2",
+        status: "pending",
+      },
+    });
+  });
+
+  it("replaces equivalent expired claimed commands with fresh pending work", async () => {
+    const repository = buildRepository({
+      commands: [
+        buildCommand({
+          expiresAt: now - 1,
+          commandType: "repair_terminal_seed",
+          commandContext: {
+            expectedBlockerType: "terminal_seed",
+            reason: "Terminal setup data needs repair.",
+          },
+          expectedEvidence: {
+            terminalIntegrityStatus: "healthy",
+          },
+          status: "claimed",
+        }),
+      ],
+    });
+
+    const result = await issueTerminalRecoveryCommand(repository, {
+      commandType: "repair_terminal_seed",
+      expectedEvidence: {
+        terminalIntegrityStatus: "healthy",
+      },
+      issuedAt: now,
+      issuedByUserId: "user-2" as Id<"athenaUser">,
+      commandContext: {
+        expectedBlockerType: "terminal_seed",
+        reason: "Terminal setup data needs repair.",
+      },
+      storeId,
+      terminalId,
+    });
+
+    expect(repository.patchCommand).toHaveBeenCalledWith("command-1", {
+      status: "expired",
+    });
+    expect(repository.insertCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandType: "repair_terminal_seed",
+        status: "pending",
+      }),
+    );
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        _id: "command-2",
+        status: "pending",
+      },
+    });
+  });
+
+  it("replaces equivalent expired commands that were waiting for runtime verification", async () => {
+    const repository = buildRepository({
+      commands: [
+        buildCommand({
+          expiresAt: now - 1,
+          commandType: "repair_terminal_seed",
+          commandContext: {
+            expectedBlockerType: "terminal_seed",
+            reason: "Terminal setup data needs repair.",
+          },
+          expectedEvidence: {
+            terminalIntegrityStatus: "healthy",
+          },
+          status: "completed",
+          verificationStatus: "runtime_verification_ready",
+        }),
+      ],
+    });
+
+    const result = await issueTerminalRecoveryCommand(repository, {
+      commandType: "repair_terminal_seed",
+      expectedEvidence: {
+        terminalIntegrityStatus: "healthy",
+      },
+      issuedAt: now,
+      issuedByUserId: "user-2" as Id<"athenaUser">,
+      commandContext: {
+        expectedBlockerType: "terminal_seed",
+        reason: "Terminal setup data needs repair.",
+      },
+      storeId,
+      terminalId,
+    });
+
+    expect(repository.patchCommand).toHaveBeenCalledWith("command-1", {
+      status: "expired",
+    });
+    expect(repository.insertCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        commandType: "repair_terminal_seed",
+        status: "pending",
+      }),
+    );
+    expect(result).toMatchObject({
+      kind: "ok",
+      data: {
+        _id: "command-2",
+        status: "pending",
+      },
+    });
+  });
+
   it("redacts and bounds acknowledgement messages before audit persistence", async () => {
     const repository = buildRepository({
       commands: [
@@ -349,8 +583,9 @@ function buildRepository(seed: {
     }),
     insertCommand: vi.fn(
       async (input: Omit<Doc<"posTerminalRecoveryCommand">, "_id" | "_creationTime">) => {
+        const commandId = `command-${commands.length + 1}` as Id<"posTerminalRecoveryCommand">;
         const command = {
-          _id: "command-1" as Id<"posTerminalRecoveryCommand">,
+          _id: commandId,
           _creationTime: input.issuedAt,
           ...input,
         };

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.ts
@@ -71,14 +71,37 @@ export async function issueTerminalRecoveryCommand(
     });
   }
 
+  const commandContext = pruneUndefined(args.commandContext);
+  const expectedEvidence = pruneUndefined(args.expectedEvidence);
+  const existingCommands = await repository.listCommandsForTerminal({
+    storeId: args.storeId,
+    terminalId: args.terminalId,
+  });
+  for (const command of existingCommands) {
+    if (!isEquivalentCommand(command, {
+      commandContext,
+      commandType: args.commandType,
+      expectedEvidence,
+    })) {
+      continue;
+    }
+    if (command.expiresAt <= args.issuedAt && isActiveCommand(command)) {
+      await repository.patchCommand(command._id, { status: "expired" });
+      continue;
+    }
+    if (isActiveCommand(command)) {
+      return ok(command);
+    }
+  }
+
   const input = {
     storeId: args.storeId,
     terminalId: args.terminalId,
     commandType: args.commandType,
     status: "pending" as const,
     verificationStatus: "waiting_for_acknowledgement" as const,
-    commandContext: pruneUndefined(args.commandContext),
-    expectedEvidence: pruneUndefined(args.expectedEvidence),
+    commandContext,
+    expectedEvidence,
     issuedByUserId: args.issuedByUserId,
     issuedAt: args.issuedAt,
     expiresAt: args.issuedAt + COMMAND_TTL_MS,
@@ -351,6 +374,31 @@ function notFound(): CommandResult<never> {
   });
 }
 
+function isEquivalentCommand(
+  command: Doc<"posTerminalRecoveryCommand">,
+  target: {
+    commandContext: TerminalRecoveryCommandPayload;
+    commandType: TerminalRecoveryCommandType;
+    expectedEvidence: TerminalRecoveryExpectedEvidence;
+  },
+) {
+  return (
+    command.commandType === target.commandType &&
+    stableStringify(command.commandContext) ===
+      stableStringify(target.commandContext) &&
+    stableStringify(command.expectedEvidence) ===
+      stableStringify(target.expectedEvidence)
+  );
+}
+
+function isActiveCommand(command: Doc<"posTerminalRecoveryCommand">) {
+  return (
+    command.status === "pending" ||
+    command.status === "claimed" ||
+    command.verificationStatus === "runtime_verification_ready"
+  );
+}
+
 function containsSecretLikeField(value: unknown): boolean {
   if (value === null || value === undefined) {
     return false;
@@ -374,4 +422,18 @@ function pruneUndefined<T extends Record<string, unknown>>(value: T): T {
   return Object.fromEntries(
     Object.entries(value).filter((entry) => entry[1] !== undefined),
   ) as T;
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .filter((entry) => entry[1] !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
 }

--- a/packages/athena-webapp/convex/pos/application/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminals.test.ts
@@ -24,6 +24,7 @@ import {
   upsertLatestRuntimeStatus,
 } from "../infrastructure/repositories/terminalRepository";
 import {
+  createTerminalRecoveryCommandRepository,
   getTerminalRecoverySourceEvent,
   listTerminalRecoveryConflictsForRepair,
 } from "../infrastructure/repositories/terminalRecoveryRepository";
@@ -76,6 +77,7 @@ vi.mock("../infrastructure/repositories/terminalRepository", () => ({
 }));
 
 vi.mock("../infrastructure/repositories/terminalRecoveryRepository", () => ({
+  createTerminalRecoveryCommandRepository: vi.fn(),
   getTerminalRecoverySourceEvent: vi.fn(),
   listTerminalRecoveryConflictsForRepair: vi.fn(),
 }));
@@ -510,6 +512,9 @@ describe("terminal health summaries", () => {
     vi.mocked(resolveTerminalRegisterSessionActionTarget).mockResolvedValue(null);
     vi.mocked(listTerminalRecoveryConflictsForRepair).mockResolvedValue([]);
     vi.mocked(getTerminalRecoverySourceEvent).mockResolvedValue(null);
+    vi.mocked(createTerminalRecoveryCommandRepository).mockReturnValue({
+      listCommandsForTerminal: vi.fn().mockResolvedValue([]),
+    } as never);
   });
 
   afterEach(() => {

--- a/packages/athena-webapp/convex/pos/public/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.test.ts
@@ -449,7 +449,10 @@ describe("POS terminal public mutations", () => {
     );
   });
 
-  it("accepts redacted runtime status from an authorized store member", async () => {
+  it("accepts redacted runtime status from active terminal proof without Athena user auth", async () => {
+    mocks.requireAuthenticatedAthenaUserWithCtx.mockRejectedValue(
+      new Error("not signed in"),
+    );
     const ctx = buildCtx({
       terminal: {
         _id: "terminal-1",
@@ -508,14 +511,7 @@ describe("POS terminal public mutations", () => {
         receivedAt: 200,
       },
     });
-    expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(
-      ctx,
-      expect.objectContaining({
-        allowedRoles: ["full_admin", "pos_only"],
-        organizationId: "org-1",
-        userId: "athena-user-1",
-      }),
-    );
+    expect(mocks.requireOrganizationMemberRoleWithCtx).not.toHaveBeenCalled();
     expect(mocks.submitTerminalRuntimeStatusCommand).toHaveBeenCalledWith(
       ctx,
       expect.objectContaining({
@@ -775,13 +771,7 @@ describe("POS terminal public mutations", () => {
 
   it("skips Remote Assist enrollment when the store is missing", async () => {
     const ctx = buildCtx({
-      store: [
-        {
-          _id: "store-1",
-          organizationId: "org-1",
-        },
-        null,
-      ],
+      store: null,
       terminal: {
         _id: "terminal-1",
         storeId: "store-1",
@@ -915,11 +905,19 @@ describe("POS terminal public mutations", () => {
     expect(mocks.submitTerminalRuntimeStatusCommand).not.toHaveBeenCalled();
   });
 
-  it("does not inspect terminal credentials when runtime status store membership is denied", async () => {
-    mocks.requireOrganizationMemberRoleWithCtx.mockRejectedValue(
-      new Error("denied"),
+  it("does not require Athena user auth before inspecting terminal runtime proof", async () => {
+    mocks.requireAuthenticatedAthenaUserWithCtx.mockRejectedValue(
+      new Error("not signed in"),
     );
-    const ctx = buildCtx();
+    const ctx = buildCtx({
+      terminal: {
+        _id: "terminal-1",
+        storeId: "store-1",
+        status: "active",
+        registeredByUserId: "athena-user-2",
+        syncSecretHash: SYNC_SECRET_HASH,
+      },
+    });
 
     const result = await getHandler(submitTerminalRuntimeStatus)(ctx as never, {
       storeId: "store-1",
@@ -928,16 +926,10 @@ describe("POS terminal public mutations", () => {
       status: buildRuntimeStatus(),
     });
 
-    expect(result).toEqual({
-      kind: "user_error",
-      error: {
-        code: "authorization_failed",
-        message: "You do not have access to update this POS terminal status.",
-      },
-    });
-    expect(ctx.db.get).toHaveBeenCalledWith("store", "store-1");
-    expect(ctx.db.get).not.toHaveBeenCalledWith("posTerminal", "terminal-1");
-    expect(mocks.submitTerminalRuntimeStatusCommand).not.toHaveBeenCalled();
+    expect(result.kind).toBe("ok");
+    expect(mocks.requireOrganizationMemberRoleWithCtx).not.toHaveBeenCalled();
+    expect(ctx.db.get).toHaveBeenCalledWith("posTerminal", "terminal-1");
+    expect(mocks.submitTerminalRuntimeStatusCommand).toHaveBeenCalled();
   });
 
   it("requires store membership before listing terminal health summaries", async () => {
@@ -1107,8 +1099,11 @@ describe("POS terminal public mutations", () => {
       service: mocks.acknowledgeTerminalRecoveryCommandService,
     },
   ])(
-    "allows POS store members to $action recovery commands with the active sync secret",
+    "allows terminal runtime to $action recovery commands with only active sync-secret proof",
     async ({ handler, service }) => {
+      mocks.requireAuthenticatedAthenaUserWithCtx.mockRejectedValue(
+        new Error("not signed in"),
+      );
       const ctx = buildCtx({
         terminal: {
           _id: "terminal-1",
@@ -1128,18 +1123,41 @@ describe("POS terminal public mutations", () => {
         message: "Done.",
       });
 
-      expect(mocks.requireOrganizationMemberRoleWithCtx).toHaveBeenCalledWith(
-        ctx,
-        expect.objectContaining({
-          allowedRoles: ["full_admin", "pos_only"],
-          organizationId: "org-1",
-          userId: "athena-user-1",
-        }),
-      );
+      expect(mocks.requireOrganizationMemberRoleWithCtx).not.toHaveBeenCalled();
       expect(service).toHaveBeenCalled();
       expect(result.kind).toBe("ok");
     },
   );
+
+  it("does not let terminal runtime proof issue terminal recovery commands", async () => {
+    mocks.requireAuthenticatedAthenaUserWithCtx.mockRejectedValue(
+      new Error("not signed in"),
+    );
+    const ctx = buildCtx();
+
+    const result = await getHandler(issueTerminalRecoveryCommand)(ctx as never, {
+      storeId: "store-1",
+      terminalId: "terminal-1",
+      commandType: "repair_terminal_seed",
+      commandContext: {
+        expectedBlockerType: "terminal_seed",
+        reason: "Terminal setup data needs repair.",
+      },
+      expectedEvidence: {
+        terminalIntegrityStatus: "healthy",
+      },
+    });
+
+    expect(result).toEqual({
+      kind: "user_error",
+      error: {
+        code: "authorization_failed",
+        message:
+          "You do not have access to issue POS terminal recovery commands.",
+      },
+    });
+    expect(mocks.issueTerminalRecoveryCommandService).not.toHaveBeenCalled();
+  });
 
   it("rejects recovery command listing when the terminal sync secret is wrong", async () => {
     const ctx = buildCtx({

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -322,6 +322,16 @@ const terminalHealthSummaryReturnValidator = v.object({
         safeConflictIds: v.array(v.id("posLocalSyncConflict")),
         skippedConflictIds: v.array(v.id("posLocalSyncConflict")),
       }),
+      commandStatus: v.union(
+        v.object({
+          commandId: v.optional(v.id("posTerminalRecoveryCommand")),
+          label: v.string(),
+          latestAcknowledgement: v.optional(v.string()),
+          status: posTerminalRecoveryCommandStatusValidator,
+          verificationStatus: posTerminalRecoveryVerificationStatusValidator,
+        }),
+        v.null(),
+      ),
       terminalActions: v.array(
         v.object({
           commandType: posTerminalRecoveryCommandTypeValidator,
@@ -620,22 +630,6 @@ export const submitTerminalRuntimeStatus = mutation({
   },
   returns: commandResultValidator(runtimeStatusWriteResultValidator),
   handler: async (ctx, args) => {
-    let athenaUser;
-    try {
-      athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
-      await requireTerminalStoreAccess(ctx, {
-        allowedRoles: ["full_admin", "pos_only"],
-        failureMessage:
-          "You do not have access to update this POS terminal status.",
-        storeId: args.storeId,
-        userId: athenaUser._id,
-      });
-    } catch {
-      return userError({
-        code: "authorization_failed",
-        message: "You do not have access to update this POS terminal status.",
-      });
-    }
     const terminal = await requireActiveTerminalSyncSecret(ctx, {
       storeId: args.storeId,
       syncSecretHash: args.syncSecretHash,
@@ -975,14 +969,6 @@ export const listTerminalRecoveryCommands = query({
   },
   returns: commandResultValidator(v.array(terminalRecoveryCommandReturnValidator)),
   handler: async (ctx, args) => {
-    const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
-    await requireTerminalStoreAccess(ctx, {
-      allowedRoles: ["full_admin", "pos_only"],
-      failureMessage:
-        "You do not have access to list POS terminal recovery commands.",
-      storeId: args.storeId,
-      userId: athenaUser._id,
-    });
     const terminal = await requireActiveTerminalSyncSecret(ctx, args);
     if (!terminal) {
       return userError({
@@ -1015,14 +1001,6 @@ export const claimTerminalRecoveryCommand = mutation({
   },
   returns: commandResultValidator(terminalRecoveryCommandReturnValidator),
   handler: async (ctx, args) => {
-    const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
-    await requireTerminalStoreAccess(ctx, {
-      allowedRoles: ["full_admin", "pos_only"],
-      failureMessage:
-        "You do not have access to claim POS terminal recovery commands.",
-      storeId: args.storeId,
-      userId: athenaUser._id,
-    });
     const terminal = await requireActiveTerminalSyncSecret(ctx, args);
     if (!terminal) {
       return userError({
@@ -1059,14 +1037,6 @@ export const acknowledgeTerminalRecoveryCommand = mutation({
   },
   returns: commandResultValidator(terminalRecoveryCommandReturnValidator),
   handler: async (ctx, args) => {
-    const athenaUser = await requireAuthenticatedAthenaUserWithCtx(ctx);
-    await requireTerminalStoreAccess(ctx, {
-      allowedRoles: ["full_admin", "pos_only"],
-      failureMessage:
-        "You do not have access to acknowledge POS terminal recovery commands.",
-      storeId: args.storeId,
-      userId: athenaUser._id,
-    });
     const terminal = await requireActiveTerminalSyncSecret(ctx, args);
     if (!terminal) {
       return userError({

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -22,7 +22,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/stockOps`](../../convex/stockOps) — Stock-adjustment, procurement, replenishment, receiving, and vendor flows layered over inventory state. Currently 14 file(s); key children: access.test.ts, access.ts, adjustments.test.ts, adjustments.ts, cycleCountDrafts.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 6 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCases.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 11 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 526 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 527 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 9 file(s); key children: README.md, SUMMARY.md, pos, prod.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -101,6 +101,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`convex/pos/application/posSessionTracing.test.ts`](../../convex/pos/application/posSessionTracing.test.ts)
 - [`convex/pos/application/queries/listRegisterCatalog.test.ts`](../../convex/pos/application/queries/listRegisterCatalog.test.ts)
 - [`convex/pos/application/queries/searchCatalog.test.ts`](../../convex/pos/application/queries/searchCatalog.test.ts)
+- [`convex/pos/application/queries/terminals.test.ts`](../../convex/pos/application/queries/terminals.test.ts)
 - [`convex/pos/application/sessionCommands.test.ts`](../../convex/pos/application/sessionCommands.test.ts)
 - [`convex/pos/application/sync/ingestLocalEvents.test.ts`](../../convex/pos/application/sync/ingestLocalEvents.test.ts)
 - [`convex/pos/application/sync/projectLocalEvents.test.ts`](../../convex/pos/application/sync/projectLocalEvents.test.ts)

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
@@ -593,14 +593,32 @@ describe("POSTerminalDetailViewContent", () => {
             },
           ],
           recovery: {
+            cloudRepair: {
+              preconditionHash: "terminal-cloud-repair:abc",
+              safeConflictIds: ["conflict-1"],
+              skippedConflictIds: [],
+            },
             commandStatus: {
               label: "Terminal repair command waiting for checkout station.",
-              status: "pending",
+              status: "available",
               verificationStatus: "waiting_for_check_in",
             },
             readiness: {
               status: "needs_cloud_repair",
             },
+            terminalActions: [
+              {
+                commandContext: {
+                  expectedBlockerType: "authorization_failed",
+                  reason: "Terminal integrity requires repair.",
+                },
+                commandType: "repair_terminal_seed",
+                expectedEvidence: {
+                  terminalIntegrityStatus: "healthy",
+                },
+                reason: "Terminal integrity requires local repair.",
+              },
+            ],
             verification: {
               status: "waiting_for_check_in",
               summary:
@@ -637,9 +655,13 @@ describe("POSTerminalDetailViewContent", () => {
       }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /send terminal repair command/i }),
+      screen.getByRole("button", { name: /send terminal setup repair/i }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/pending/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Terminal repair command waiting for checkout station. / Available",
+      ),
+    ).toBeInTheDocument();
     expect(screen.getAllByText("Waiting For Check In").length).toBeGreaterThan(
       0,
     );
@@ -648,6 +670,210 @@ describe("POSTerminalDetailViewContent", () => {
         /register_opened|already open|authorization_failed|sync secret/i,
       ),
     ).not.toBeInTheDocument();
+  });
+
+  it("issues cloud and terminal recovery actions from displayed metadata", async () => {
+    const onResolveTerminalCloudRepair = vi.fn(async () => ({
+      data: { resolvedCount: 1 },
+      kind: "ok" as const,
+    }));
+    const onIssueTerminalRecoveryCommand = vi.fn(async () => ({
+      data: { _id: "command-1" },
+      kind: "ok" as const,
+    }));
+
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          attentionReasons: [],
+          recovery: {
+            cloudRepair: {
+              preconditionHash: "terminal-cloud-repair:abc",
+              safeConflictIds: ["conflict-1"],
+              skippedConflictIds: [],
+            },
+            readiness: "needs_terminal_action",
+            terminalActions: [
+              {
+                commandContext: {
+                  expectedBlockerType: "authorization_failed",
+                  reason: "Terminal integrity requires repair.",
+                },
+                commandType: "repair_terminal_seed",
+                expectedEvidence: {
+                  terminalIntegrityStatus: "healthy",
+                },
+                reason: "Terminal integrity requires local repair.",
+              },
+              {
+                commandContext: {
+                  cloudRegisterSessionId: "cloud-session-1",
+                  expectedBlockerType: "cloud_closed",
+                  localRegisterSessionId: "local-session-1",
+                  reason: "Drawer authority requires terminal-local repair.",
+                },
+                commandType: "clear_stale_drawer_authority",
+                expectedEvidence: {
+                  drawerAuthorityStatus: "healthy",
+                  localRegisterSessionId: "local-session-1",
+                },
+                reason: "Drawer authority requires terminal-local repair.",
+              },
+            ],
+          },
+        }}
+        isLoading={false}
+        onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
+        onResolveTerminalCloudRepair={onResolveTerminalCloudRepair}
+        orgUrlSlug="wigclub"
+        storeUrlSlug="osu"
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /resolve duplicate drawer attempts/i,
+      }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /send terminal setup repair/i,
+      }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /send drawer authority repair/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(onResolveTerminalCloudRepair).toHaveBeenCalledWith({
+        action: expect.objectContaining({
+          expectedPreconditionHash: "terminal-cloud-repair:abc",
+          kind: "cloud_repair",
+        }),
+        terminalId: "terminal-1",
+      });
+      expect(onIssueTerminalRecoveryCommand).toHaveBeenCalledWith({
+        action: expect.objectContaining({
+          commandType: "repair_terminal_seed",
+          expectedEvidence: { terminalIntegrityStatus: "healthy" },
+          kind: "terminal_command",
+        }),
+        terminalId: "terminal-1",
+      });
+      expect(onIssueTerminalRecoveryCommand).toHaveBeenCalledWith({
+        action: expect.objectContaining({
+          commandContext: expect.objectContaining({
+            cloudRegisterSessionId: "cloud-session-1",
+            localRegisterSessionId: "local-session-1",
+          }),
+          commandType: "clear_stale_drawer_authority",
+          expectedEvidence: {
+            drawerAuthorityStatus: "healthy",
+            localRegisterSessionId: "local-session-1",
+          },
+          kind: "terminal_command",
+        }),
+        terminalId: "terminal-1",
+      });
+    });
+    expect(mocks.toastSuccess).toHaveBeenCalledWith("Cloud repair requested.");
+    expect(mocks.toastSuccess).toHaveBeenCalledWith("Terminal command queued.");
+  });
+
+  it("disables duplicate recovery command clicks while a command is pending", () => {
+    const onIssueTerminalRecoveryCommand = vi.fn();
+
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          attentionReasons: [],
+          recovery: {
+            commandStatus: {
+              label: "Terminal command queued.",
+              status: "pending",
+              verificationStatus: "waiting_for_acknowledgement",
+            },
+            terminalActions: [
+              {
+                commandContext: {
+                  expectedBlockerType: "authorization_failed",
+                },
+                commandType: "repair_terminal_seed",
+                expectedEvidence: {
+                  terminalIntegrityStatus: "healthy",
+                },
+                reason: "Terminal integrity requires local repair.",
+              },
+            ],
+          },
+        }}
+        isLoading={false}
+        onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
+        orgUrlSlug="wigclub"
+        storeUrlSlug="osu"
+      />,
+    );
+
+    const commandButton = screen.getByRole("button", {
+      name: /send terminal setup repair/i,
+    });
+
+    expect(commandButton).toBeDisabled();
+    expect(
+      screen.getByText("Command is queued for this checkout station."),
+    ).toBeInTheDocument();
+    fireEvent.click(commandButton);
+    expect(onIssueTerminalRecoveryCommand).not.toHaveBeenCalled();
+  });
+
+  it("shows normalized recovery action failures", async () => {
+    const onResolveTerminalCloudRepair = vi.fn(async () => ({
+      error: {
+        message: "Terminal recovery evidence changed. Preview the repair again.",
+      },
+      kind: "user_error" as const,
+    }));
+
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          attentionReasons: [],
+          recovery: {
+            cloudRepair: {
+              preconditionHash: "terminal-cloud-repair:abc",
+              safeConflictIds: ["conflict-1"],
+              skippedConflictIds: [],
+            },
+          },
+        }}
+        isLoading={false}
+        onResolveTerminalCloudRepair={onResolveTerminalCloudRepair}
+        orgUrlSlug="wigclub"
+        storeUrlSlug="osu"
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /resolve duplicate drawer attempts/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Terminal recovery evidence changed. Refresh terminal health before retrying.",
+      );
+    });
+    expect(
+      screen.getByText(
+        "Terminal recovery evidence changed. Refresh terminal health before retrying.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("does not render auto-repair buttons for manual payment or inventory review blockers", () => {

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
@@ -47,11 +47,13 @@ import {
   getStaffAuthorityLabel,
   getSupportSafeAttentionReasonSummary,
   getTerminalAttentionReasons,
+  isRecoveryActionIssuable,
   type TerminalRecoveryPresentationBlocker,
 } from "./terminalHealthPresentation";
 import type {
   TerminalHealthDetail,
   TerminalHealthAttentionReason,
+  TerminalRecoveryAction,
   TerminalRuntimeStatus,
   TerminalSyncEvent,
   TerminalSyncEvidence,
@@ -132,6 +134,14 @@ const REMOTE_ASSIST_PRESENCE_FRESHNESS_MS = 2 * 60 * 1000;
 type POSTerminalDetailViewContentProps = {
   detail: TerminalHealthDetail | null;
   isLoading: boolean;
+  onIssueTerminalRecoveryCommand?: (args: {
+    action: TerminalRecoveryAction;
+    terminalId: Id<"posTerminal"> | string;
+  }) => Promise<TerminalRecoveryMutationResult>;
+  onResolveTerminalCloudRepair?: (args: {
+    action: TerminalRecoveryAction;
+    terminalId: Id<"posTerminal"> | string;
+  }) => Promise<TerminalRecoveryMutationResult>;
   onResolveRegisterSessionReview?: (args: {
     registerSessionId: Id<"registerSession"> | string;
   }) => Promise<TerminalRegisterSessionReviewResult>;
@@ -159,6 +169,24 @@ type TerminalRegisterSessionReviewResult =
         projectedCount?: number;
         resolvedCount?: number;
       };
+    }
+  | {
+      kind: "user_error";
+      error: {
+        message: string;
+      };
+    }
+  | {
+      kind: "unexpected_error";
+      error: {
+        message: string;
+      };
+    };
+
+type TerminalRecoveryMutationResult =
+  | {
+      kind: "ok";
+      data?: unknown;
     }
   | {
       kind: "user_error";
@@ -857,16 +885,22 @@ function RecoveryMetric({
 function RecoveryBlockerGroup({
   blockers,
   emptyCopy,
+  onIssueTerminalRecoveryCommand,
+  onResolveTerminalCloudRepair,
   onResolveRegisterSessionReview,
   orgUrlSlug,
   storeUrlSlug,
+  terminalId,
   title,
 }: {
   blockers: TerminalRecoveryPresentationBlocker[];
   emptyCopy: string;
+  onIssueTerminalRecoveryCommand?: POSTerminalDetailViewContentProps["onIssueTerminalRecoveryCommand"];
+  onResolveTerminalCloudRepair?: POSTerminalDetailViewContentProps["onResolveTerminalCloudRepair"];
   onResolveRegisterSessionReview?: POSTerminalDetailViewContentProps["onResolveRegisterSessionReview"];
   orgUrlSlug?: string;
   storeUrlSlug?: string;
+  terminalId: Id<"posTerminal"> | string;
   title: string;
 }) {
   return (
@@ -902,9 +936,12 @@ function RecoveryBlockerGroup({
               </div>
               <RecoveryBlockerAction
                 blocker={blocker}
+                onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
+                onResolveTerminalCloudRepair={onResolveTerminalCloudRepair}
                 onResolveRegisterSessionReview={onResolveRegisterSessionReview}
                 orgUrlSlug={orgUrlSlug}
                 storeUrlSlug={storeUrlSlug}
+                terminalId={terminalId}
               />
             </div>
           ))
@@ -916,26 +953,87 @@ function RecoveryBlockerGroup({
 
 function RecoveryBlockerAction({
   blocker,
+  onIssueTerminalRecoveryCommand,
+  onResolveTerminalCloudRepair,
   onResolveRegisterSessionReview,
   orgUrlSlug,
   storeUrlSlug,
+  terminalId,
 }: {
   blocker: TerminalRecoveryPresentationBlocker;
+  onIssueTerminalRecoveryCommand?: POSTerminalDetailViewContentProps["onIssueTerminalRecoveryCommand"];
+  onResolveTerminalCloudRepair?: POSTerminalDetailViewContentProps["onResolveTerminalCloudRepair"];
   onResolveRegisterSessionReview?: POSTerminalDetailViewContentProps["onResolveRegisterSessionReview"];
   orgUrlSlug?: string;
   storeUrlSlug?: string;
+  terminalId: Id<"posTerminal"> | string;
 }) {
   const action = blocker.action;
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
   if (action && ["cloud_repair", "terminal_command"].includes(action.kind)) {
+    const canIssue = isRecoveryActionIssuable(action);
+    const handler =
+      action.kind === "cloud_repair"
+        ? onResolveTerminalCloudRepair
+        : onIssueTerminalRecoveryCommand;
+
+    const submitRecoveryAction = async () => {
+      if (!canIssue || !handler || isSubmitting) {
+        return;
+      }
+
+      setIsSubmitting(true);
+      setErrorMessage("");
+      const result = await handler({ action, terminalId });
+      setIsSubmitting(false);
+
+      if (result.kind === "ok") {
+        toast.success(
+          action.kind === "cloud_repair"
+            ? "Cloud repair requested."
+            : "Terminal command queued.",
+        );
+        return;
+      }
+
+      const message = normalizeRecoveryActionError(result.error.message);
+      setErrorMessage(message);
+      toast.error(message);
+    };
+
     return (
-      <Button disabled size="sm" variant="utility">
-        {action.kind === "terminal_command" ? (
-          <Send aria-hidden="true" />
-        ) : (
-          <Wrench aria-hidden="true" />
-        )}
-        {action.label}
-      </Button>
+      <div className="grid justify-items-start gap-layout-xs">
+        <Button
+          disabled={!canIssue || !handler || isSubmitting}
+          onClick={() => {
+            void submitRecoveryAction();
+          }}
+          size="sm"
+          variant="utility"
+        >
+          {action.kind === "terminal_command" ? (
+            <Send aria-hidden="true" />
+          ) : (
+            <Wrench aria-hidden="true" />
+          )}
+          {isSubmitting ? "Sending..." : action.label}
+        </Button>
+        {action.status && action.status !== "available" ? (
+          <p className="max-w-sm text-xs text-muted-foreground">
+            {getRecoveryActionStatusCopy(action.status)}
+          </p>
+        ) : null}
+        {action.latestAcknowledgement ? (
+          <p className="max-w-sm text-xs text-muted-foreground">
+            {action.latestAcknowledgement}
+          </p>
+        ) : null}
+        {errorMessage ? (
+          <p className="max-w-sm text-xs text-danger">{errorMessage}</p>
+        ) : null}
+      </div>
     );
   }
 
@@ -958,13 +1056,52 @@ function RecoveryBlockerAction({
   return null;
 }
 
+function getRecoveryActionStatusCopy(status: TerminalRecoveryAction["status"]) {
+  switch (status) {
+    case "pending":
+      return "Command is queued for this checkout station.";
+    case "claimed":
+      return "Command is running on this checkout station.";
+    case "completed":
+    case "waiting_for_check_in":
+      return "Command completed locally. Waiting for a fresh check-in before verification.";
+    case "verified":
+      return "Recovery verified by the latest terminal check-in.";
+    case "expired":
+      return "Command expired. Refresh terminal health before sending another command.";
+    case "failed":
+      return "Command did not complete. Refresh terminal health before retrying.";
+    case "blocked":
+      return "Recovery is blocked by current terminal evidence.";
+    default:
+      return formatStatusLabel(status);
+  }
+}
+
+function normalizeRecoveryActionError(message?: string) {
+  if (!message) {
+    return "Recovery action could not be sent. Refresh terminal health and try again.";
+  }
+  if (/authorization|access/i.test(message)) {
+    return "Support permission is required before sending this recovery action.";
+  }
+  if (/precondition|changed/i.test(message)) {
+    return "Terminal recovery evidence changed. Refresh terminal health before retrying.";
+  }
+  return message;
+}
+
 function RecoveryPanel({
   detail,
+  onIssueTerminalRecoveryCommand,
+  onResolveTerminalCloudRepair,
   onResolveRegisterSessionReview,
   orgUrlSlug,
   storeUrlSlug,
 }: {
   detail: TerminalHealthDetail;
+  onIssueTerminalRecoveryCommand?: POSTerminalDetailViewContentProps["onIssueTerminalRecoveryCommand"];
+  onResolveTerminalCloudRepair?: POSTerminalDetailViewContentProps["onResolveTerminalCloudRepair"];
   onResolveRegisterSessionReview?: POSTerminalDetailViewContentProps["onResolveRegisterSessionReview"];
   orgUrlSlug?: string;
   storeUrlSlug?: string;
@@ -1011,17 +1148,21 @@ function RecoveryPanel({
         <RecoveryBlockerGroup
           blockers={recovery.groups.cloudRepair}
           emptyCopy="No cloud-safe repair blockers are reported."
+          onResolveTerminalCloudRepair={onResolveTerminalCloudRepair}
           onResolveRegisterSessionReview={onResolveRegisterSessionReview}
           orgUrlSlug={orgUrlSlug}
           storeUrlSlug={storeUrlSlug}
+          terminalId={detail.terminal._id}
           title="Cloud repair"
         />
         <RecoveryBlockerGroup
           blockers={recovery.groups.terminalRequired}
           emptyCopy="No terminal-required blockers are reported."
+          onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
           onResolveRegisterSessionReview={onResolveRegisterSessionReview}
           orgUrlSlug={orgUrlSlug}
           storeUrlSlug={storeUrlSlug}
+          terminalId={detail.terminal._id}
           title="Terminal required"
         />
         <RecoveryBlockerGroup
@@ -1030,6 +1171,7 @@ function RecoveryPanel({
           onResolveRegisterSessionReview={onResolveRegisterSessionReview}
           orgUrlSlug={orgUrlSlug}
           storeUrlSlug={storeUrlSlug}
+          terminalId={detail.terminal._id}
           title="Manual review"
         />
       </div>
@@ -1438,6 +1580,8 @@ export function POSTerminalDetailViewContent({
   detail,
   isLoading,
   onEndRemoteAssist,
+  onIssueTerminalRecoveryCommand,
+  onResolveTerminalCloudRepair,
   onResolveRegisterSessionReview,
   onStartRemoteAssist,
   orgUrlSlug,
@@ -1521,6 +1665,8 @@ export function POSTerminalDetailViewContent({
               />
               <RecoveryPanel
                 detail={detail}
+                onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
+                onResolveTerminalCloudRepair={onResolveTerminalCloudRepair}
                 onResolveRegisterSessionReview={onResolveRegisterSessionReview}
                 orgUrlSlug={orgUrlSlug}
                 storeUrlSlug={storeUrlSlug}
@@ -1596,6 +1742,12 @@ export function POSTerminalDetailView() {
   const resolveRegisterSessionSyncReview = useMutation(
     api.cashControls.deposits.resolveRegisterSessionSyncReview,
   );
+  const resolveTerminalCloudRepair = useMutation(
+    api.pos.public.terminals.resolveTerminalCloudRepair,
+  );
+  const issueTerminalRecoveryCommand = useMutation(
+    api.pos.public.terminals.issueTerminalRecoveryCommand,
+  );
   const startRemoteAssistSession = useMutation(remoteAssistApi.startSession);
   const endRemoteAssistSession = useMutation(remoteAssistApi.endSupportSession);
 
@@ -1619,6 +1771,65 @@ export function POSTerminalDetailView() {
         storeId: activeStore._id,
       }),
     ) as Promise<TerminalRegisterSessionReviewResult>;
+  }
+
+  async function onResolveTerminalCloudRepair({
+    action,
+    terminalId,
+  }: {
+    action: TerminalRecoveryAction;
+    terminalId: Id<"posTerminal"> | string;
+  }): Promise<TerminalRecoveryMutationResult> {
+    if (!activeStore?._id || !action.expectedPreconditionHash) {
+      return {
+        kind: "user_error",
+        error: {
+          message:
+            "Terminal recovery evidence changed. Refresh terminal health before retrying.",
+        },
+      };
+    }
+
+    return runCommand(() =>
+      resolveTerminalCloudRepair({
+        expectedPreconditionHash: action.expectedPreconditionHash!,
+        storeId: activeStore._id,
+        terminalId: terminalId as Id<"posTerminal">,
+      }),
+    ) as Promise<TerminalRecoveryMutationResult>;
+  }
+
+  async function onIssueTerminalRecoveryCommand({
+    action,
+    terminalId,
+  }: {
+    action: TerminalRecoveryAction;
+    terminalId: Id<"posTerminal"> | string;
+  }): Promise<TerminalRecoveryMutationResult> {
+    if (
+      !activeStore?._id ||
+      !action.commandType ||
+      !action.commandContext ||
+      !action.expectedEvidence
+    ) {
+      return {
+        kind: "user_error",
+        error: {
+          message:
+            "Terminal recovery evidence changed. Refresh terminal health before retrying.",
+        },
+      };
+    }
+
+    return runCommand(() =>
+      issueTerminalRecoveryCommand({
+        commandContext: action.commandContext!,
+        commandType: action.commandType!,
+        expectedEvidence: action.expectedEvidence!,
+        storeId: activeStore._id,
+        terminalId: terminalId as Id<"posTerminal">,
+      }),
+    ) as Promise<TerminalRecoveryMutationResult>;
   }
 
   async function onStartRemoteAssist({
@@ -1685,6 +1896,12 @@ export function POSTerminalDetailView() {
       detail={detail ?? null}
       canStartRemoteAssist={hasFullAdminAccess}
       isLoading={detail === undefined}
+      onIssueTerminalRecoveryCommand={
+        hasFullAdminAccess ? onIssueTerminalRecoveryCommand : undefined
+      }
+      onResolveTerminalCloudRepair={
+        hasFullAdminAccess ? onResolveTerminalCloudRepair : undefined
+      }
       onResolveRegisterSessionReview={onResolveRegisterSessionReview}
       onEndRemoteAssist={onEndRemoteAssist}
       onStartRemoteAssist={onStartRemoteAssist}

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
@@ -58,6 +58,7 @@ describe("terminal health presentation", () => {
         blockers: [
           {
             action: {
+              expectedPreconditionHash: "terminal-cloud-repair:hash",
               kind: "cloud_repair",
               label: "Resolve duplicate drawer attempts",
               status: "available",
@@ -70,6 +71,13 @@ describe("terminal health presentation", () => {
           },
           {
             action: {
+              commandContext: {
+                expectedBlockerType: "terminal_integrity",
+              },
+              commandType: "repair_terminal_seed",
+              expectedEvidence: {
+                terminalIntegrityStatus: "healthy",
+              },
               kind: "terminal_command",
               label: "Send terminal repair command",
               status: "available",
@@ -107,6 +115,157 @@ describe("terminal health presentation", () => {
       "Resolve duplicate drawer attempts",
       "Send terminal repair command",
     ]);
+  });
+
+  it("builds safe recovery actions from raw preview metadata", () => {
+    const presentation = buildTerminalRecoveryPresentation({
+      recovery: {
+        cloudRepair: {
+          preconditionHash: "terminal-cloud-repair:abc",
+          safeConflictIds: ["conflict-1"],
+          skippedConflictIds: [],
+        },
+        manualReview: [
+          {
+            reason: "sale_completed payment allocation requires manager review",
+            source: "cloud_sync",
+            type: "cloud_held",
+          },
+        ],
+        readiness: "needs_terminal_action",
+        terminalActions: [
+          {
+            commandContext: {
+              expectedBlockerType: "authorization_failed",
+              reason: "Terminal integrity requires repair.",
+            },
+            commandType: "repair_terminal_seed",
+            expectedEvidence: {
+              terminalIntegrityStatus: "healthy",
+            },
+            reason: "Terminal integrity requires local repair.",
+          },
+          {
+            commandContext: {
+              cloudRegisterSessionId: "cloud-session-1",
+              expectedBlockerType: "cloud_closed",
+              localRegisterSessionId: "local-session-1",
+              reason: "Drawer authority requires terminal-local repair.",
+            },
+            commandType: "clear_stale_drawer_authority",
+            expectedEvidence: {
+              drawerAuthorityStatus: "healthy",
+              localRegisterSessionId: "local-session-1",
+            },
+            reason: "Drawer authority requires terminal-local repair.",
+          },
+        ],
+      },
+      runtimeStatus: null,
+      syncEvidence: {},
+      terminal: { status: "active" },
+    });
+
+    expect(presentation.readiness.label).toBe("Needs terminal action");
+    expect(presentation.groups.cloudRepair[0]?.action).toEqual(
+      expect.objectContaining({
+        expectedPreconditionHash: "terminal-cloud-repair:abc",
+        kind: "cloud_repair",
+      }),
+    );
+    expect(presentation.groups.terminalRequired.map((blocker) => blocker.action)).toEqual([
+      expect.objectContaining({
+        commandType: "repair_terminal_seed",
+        expectedEvidence: { terminalIntegrityStatus: "healthy" },
+        kind: "terminal_command",
+      }),
+      expect.objectContaining({
+        commandContext: expect.objectContaining({
+          cloudRegisterSessionId: "cloud-session-1",
+          localRegisterSessionId: "local-session-1",
+        }),
+        commandType: "clear_stale_drawer_authority",
+        kind: "terminal_command",
+      }),
+    ]);
+    expect(presentation.groups.manualReview[0]?.summary).toBe(
+      "Manual review required. Use the linked operations or cash-control review before support repairs this terminal.",
+    );
+    expect(presentation.safeActions.map((action) => action.kind)).toEqual([
+      "cloud_repair",
+      "terminal_command",
+      "terminal_command",
+    ]);
+  });
+
+  it("suppresses duplicate recovery actions while command lifecycle is active", () => {
+    const presentation = buildTerminalRecoveryPresentation({
+      recovery: {
+        commandStatus: {
+          label: "Terminal command queued.",
+          status: "pending",
+          verificationStatus: "waiting_for_acknowledgement",
+        },
+        terminalActions: [
+          {
+            commandContext: {
+              expectedBlockerType: "authorization_failed",
+            },
+            commandType: "repair_terminal_seed",
+            expectedEvidence: {
+              terminalIntegrityStatus: "healthy",
+            },
+            reason: "Terminal integrity requires local repair.",
+          },
+        ],
+      },
+      runtimeStatus: null,
+      syncEvidence: {},
+      terminal: { status: "active" },
+    });
+
+    expect(presentation.safeActions).toEqual([]);
+    expect(presentation.groups.terminalRequired[0]?.action).toEqual(
+      expect.objectContaining({
+        status: "pending",
+      }),
+    );
+  });
+
+  it("allows recovery actions after the latest command expires", () => {
+    const presentation = buildTerminalRecoveryPresentation({
+      recovery: {
+        commandStatus: {
+          label: "Terminal command queued.",
+          status: "expired",
+          verificationStatus: "waiting_for_acknowledgement",
+        },
+        terminalActions: [
+          {
+            commandContext: {
+              expectedBlockerType: "authorization_failed",
+            },
+            commandType: "repair_terminal_seed",
+            expectedEvidence: {
+              terminalIntegrityStatus: "healthy",
+            },
+            reason: "Terminal integrity requires local repair.",
+          },
+        ],
+      },
+      runtimeStatus: null,
+      syncEvidence: {},
+      terminal: { status: "active" },
+    });
+
+    expect(presentation.safeActions.map((action) => action.status)).toEqual([
+      "expired",
+    ]);
+    expect(presentation.groups.terminalRequired[0]?.action).toEqual(
+      expect.objectContaining({
+        status: "expired",
+      }),
+    );
   });
 
   it("normalizes duplicate register-open and authorization backend wording in derived recovery copy", () => {
@@ -166,10 +325,7 @@ describe("terminal health presentation", () => {
     expect(presentation.groups.manualReview[0]?.summary).toBe(
       "Manual review required. Use the linked operations or cash-control review before support repairs this terminal.",
     );
-    expect(presentation.safeActions.map((action) => action.kind)).toEqual([
-      "cloud_repair",
-      "terminal_command",
-    ]);
+    expect(presentation.safeActions.map((action) => action.kind)).toEqual([]);
     expect(renderedCopy).not.toMatch(/register_opened|already open|authorization_failed|sync secret/i);
   });
 

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
@@ -7,6 +7,7 @@ import type {
   TerminalRecoveryAction,
   TerminalRecoveryBlocker,
   TerminalRecoveryPreview,
+  TerminalRecoveryActionStatus,
   TerminalRecoveryReadinessStatus,
 } from "./terminalHealthTypes";
 
@@ -383,10 +384,7 @@ export function classifyTerminalHealth(
 export function buildTerminalRecoveryPresentation(
   summary: TerminalHealthClassificationInput,
 ): TerminalRecoveryPresentation {
-  const blockers =
-    summary.recovery?.blockers?.map((blocker, index) =>
-      normalizeBackendRecoveryBlocker(blocker, index),
-    ) ?? deriveRecoveryBlockers(summary);
+  const blockers = buildRecoveryBlockers(summary);
   const groups = {
     cloudRepair: blockers.filter((blocker) => blocker.category === "cloud_repair"),
     manualReview: blockers.filter((blocker) => blocker.category === "manual_review"),
@@ -398,13 +396,7 @@ export function buildTerminalRecoveryPresentation(
   const safeActions = blockers
     .map((blocker) => blocker.action)
     .filter((action): action is TerminalRecoveryAction =>
-      Boolean(
-        action &&
-          ["cloud_repair", "terminal_command"].includes(action.kind) &&
-          !["blocked", "completed", "expired", "failed", "verified"].includes(
-            action.status ?? "available",
-          ),
-      ),
+      Boolean(action && isRecoveryActionIssuable(action)),
     );
 
   return {
@@ -429,6 +421,117 @@ export function buildTerminalRecoveryPresentation(
   };
 }
 
+function buildRecoveryBlockers(
+  summary: TerminalHealthClassificationInput,
+): RecoveryBlockerWithCategory[] {
+  if (summary.recovery?.blockers) {
+    return summary.recovery.blockers.map((blocker, index) =>
+      normalizeBackendRecoveryBlocker(blocker, index),
+    );
+  }
+
+  if (summary.recovery) {
+    return buildRecoveryBlockersFromPreview(summary.recovery);
+  }
+
+  return deriveRecoveryBlockers(summary);
+}
+
+function buildRecoveryBlockersFromPreview(
+  preview: TerminalRecoveryPreview,
+): RecoveryBlockerWithCategory[] {
+  const blockers: RecoveryBlockerWithCategory[] = [];
+  const commandStatus = normalizeActionStatus(preview.commandStatus?.status);
+
+  if ((preview.cloudRepair?.safeConflictIds.length ?? 0) > 0) {
+    blockers.push({
+      action: {
+        expectedPreconditionHash: preview.cloudRepair?.preconditionHash,
+        kind: "cloud_repair",
+        label: "Resolve duplicate drawer attempts",
+        status: commandStatus ?? "available",
+      },
+      category: "cloud_repair",
+      detail: `${preview.cloudRepair?.safeConflictIds.length ?? 0} safe conflict${
+        preview.cloudRepair?.safeConflictIds.length === 1 ? "" : "s"
+      } matched.`,
+      id: "cloud-repair-preview",
+      status: commandStatus ?? "available",
+      summary:
+        "Duplicate drawer-open attempts can be resolved. No sales, payments, or inventory will be changed.",
+      title: "Duplicate drawer-open attempts",
+    });
+  }
+
+  preview.terminalActions?.forEach((action, index) => {
+    blockers.push({
+      action: {
+        commandContext: action.commandContext,
+        commandType: action.commandType,
+        expectedEvidence: action.expectedEvidence,
+        kind: "terminal_command",
+        label: getTerminalCommandActionLabel(action.commandType),
+        status: commandStatus ?? "available",
+      },
+      category: "terminal_required",
+      detail: getExpectedEvidenceSummary(action.expectedEvidence),
+      id: `terminal-action-${action.commandType}-${index}`,
+      status: commandStatus ?? "available",
+      summary: normalizeSupportCopy(action.reason) ?? terminalRequiredSummary("drawer_authority_blocked"),
+      title: getTerminalCommandTitle(action.commandType),
+    });
+  });
+
+  preview.manualReview?.forEach((item, index) => {
+    const normalizedReason = normalizeSupportCopy(item.reason);
+    blockers.push({
+      category: "manual_review",
+      id: `manual-review-${item.type}-${index}`,
+      summary:
+        isUnsafeManualReviewReason(item.reason) || !normalizedReason
+          ? "Manual review required. Use the linked operations or cash-control review before support repairs this terminal."
+          : normalizedReason,
+      title: "Manual review required",
+    });
+  });
+
+  return blockers;
+}
+
+export function isRecoveryActionIssuable(action: TerminalRecoveryAction) {
+  if (!["cloud_repair", "terminal_command"].includes(action.kind)) {
+    return false;
+  }
+
+  if (isRecoveryActionInFlightOrClosed(action.status)) {
+    return false;
+  }
+
+  if (action.kind === "cloud_repair") {
+    return Boolean(action.expectedPreconditionHash);
+  }
+
+  return Boolean(
+    action.commandType &&
+      action.commandContext &&
+      action.expectedEvidence,
+  );
+}
+
+export function isRecoveryActionInFlightOrClosed(
+  status?: TerminalRecoveryActionStatus | null,
+) {
+  return [
+    "blocked",
+    "claimed",
+    "completed",
+    "failed",
+    "pending",
+    "verified",
+    "waiting_for_check_in",
+  ].includes(status ?? "");
+}
+
 type RecoveryBlockerWithCategory = TerminalRecoveryPresentationBlocker & {
   category: "cloud_repair" | "manual_review" | "terminal_required";
 };
@@ -437,7 +540,9 @@ function buildRecoveryReadiness(
   summary: TerminalHealthClassificationInput,
   groups: TerminalRecoveryPresentation["groups"],
 ): TerminalRecoveryReadinessPresentation {
-  const explicitStatus = summary.recovery?.readiness?.status;
+  const readiness = summary.recovery?.readiness;
+  const explicitStatus =
+    typeof readiness === "string" ? readiness : readiness?.status;
   const status =
     explicitStatus ??
     (groups.manualReview.length > 0
@@ -451,7 +556,9 @@ function buildRecoveryReadiness(
   const fallback = getRecoveryReadinessFallback(status);
 
   return {
-    description: normalizeSupportCopy(summary.recovery?.readiness?.summary) ?? fallback.description,
+    description:
+      normalizeSupportCopy(typeof readiness === "string" ? undefined : readiness?.summary) ??
+      fallback.description,
     label: fallback.label,
     status,
     toneClassName: fallback.toneClassName,
@@ -514,6 +621,7 @@ function normalizeBackendRecoveryBlocker(
       ? {
           ...blocker.action,
           label: normalizeSupportCopy(blocker.action.label) ?? blocker.action.label,
+          status: normalizeActionStatus(blocker.action.status),
         }
       : undefined;
 
@@ -533,6 +641,81 @@ function normalizeBackendRecoveryBlocker(
           ? "Terminal action"
           : "Manual review"),
   };
+}
+
+function normalizeActionStatus(status?: TerminalRecoveryActionStatus) {
+  if (status === "runtime_verification_ready") {
+    return "waiting_for_check_in";
+  }
+  if (status === "precondition_failed" || status === "superseded") {
+    return "failed";
+  }
+  return status;
+}
+
+function getTerminalCommandActionLabel(
+  commandType: NonNullable<TerminalRecoveryAction["commandType"]>,
+) {
+  switch (commandType) {
+    case "repair_terminal_seed":
+      return "Send terminal setup repair";
+    case "clear_stale_drawer_authority":
+      return "Send drawer authority repair";
+    case "refresh_staff_authority":
+      return "Send staff authority refresh";
+    case "refresh_snapshots":
+      return "Send snapshot refresh";
+    case "retry_sync":
+      return "Send sync retry";
+    case "report_diagnostics":
+      return "Request diagnostics";
+  }
+}
+
+function getTerminalCommandTitle(
+  commandType: NonNullable<TerminalRecoveryAction["commandType"]>,
+) {
+  switch (commandType) {
+    case "repair_terminal_seed":
+      return "Terminal setup repair";
+    case "clear_stale_drawer_authority":
+      return "Drawer authority repair";
+    case "refresh_staff_authority":
+      return "Staff authority refresh";
+    case "refresh_snapshots":
+      return "Snapshot refresh";
+    case "retry_sync":
+      return "Sync retry";
+    case "report_diagnostics":
+      return "Diagnostics request";
+  }
+}
+
+function getExpectedEvidenceSummary(
+  evidence?: TerminalRecoveryAction["expectedEvidence"],
+) {
+  if (!evidence) {
+    return undefined;
+  }
+
+  const checks = [
+    evidence.terminalIntegrityStatus
+      ? `Terminal integrity ${formatStatusLabel(evidence.terminalIntegrityStatus)}`
+      : null,
+    evidence.drawerAuthorityStatus
+      ? `Drawer authority ${formatStatusLabel(evidence.drawerAuthorityStatus)}`
+      : null,
+    evidence.staffAuthorityStatus
+      ? `Staff authority ${formatStatusLabel(evidence.staffAuthorityStatus)}`
+      : null,
+    evidence.syncStatus ? `Sync ${formatStatusLabel(evidence.syncStatus)}` : null,
+    evidence.terminalSeedReady === true ? "Terminal seed ready" : null,
+    evidence.localStoreAvailable === true ? "Local store available" : null,
+  ].filter(Boolean);
+
+  return checks.length > 0
+    ? `Expected after check-in: ${checks.join(", ")}.`
+    : undefined;
 }
 
 function deriveRecoveryBlockers(

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
@@ -214,11 +214,54 @@ export type TerminalRecoveryActionStatus =
 
 export type TerminalRecoveryAction = {
   commandId?: string;
+  commandContext?: TerminalRecoveryCommandContext;
+  commandType?: TerminalRecoveryCommandType;
+  expectedEvidence?: TerminalRecoveryExpectedEvidence;
+  expectedPreconditionHash?: string;
   expectedVerification?: string;
   kind: TerminalRecoveryActionKind;
   label: string;
   latestAcknowledgement?: string;
   status?: TerminalRecoveryActionStatus;
+};
+
+export type TerminalRecoveryCommandType =
+  | "retry_sync"
+  | "repair_terminal_seed"
+  | "clear_stale_drawer_authority"
+  | "refresh_staff_authority"
+  | "refresh_snapshots"
+  | "report_diagnostics";
+
+export type TerminalRecoveryCommandContext = {
+  cloudRegisterSessionId?: string;
+  expectedBlockerType?: string;
+  expectedConflictIds?: Array<Id<"posLocalSyncConflict">>;
+  expectedTerminalSeedIdentity?: string;
+  localRegisterSessionId?: string;
+  reason?: string;
+};
+
+export type TerminalRecoveryExpectedEvidence = {
+  drawerAuthorityStatus?: "healthy" | "blocked";
+  localRegisterSessionId?: string;
+  localStoreAvailable?: boolean;
+  saleAuthorityStatus?: "ready" | "missing" | "blocked" | "unknown";
+  staffAuthorityStatus?: "ready" | "missing" | "expired" | "unknown";
+  syncStatus?:
+    | "failed"
+    | "idle"
+    | "needs_review"
+    | "pending"
+    | "syncing"
+    | "unavailable"
+    | "unknown";
+  terminalIntegrityStatus?:
+    | "healthy"
+    | "repairing"
+    | "requires_reprovision"
+    | "reset_required";
+  terminalSeedReady?: boolean;
 };
 
 export type TerminalRecoveryBlockerCategory =
@@ -240,6 +283,11 @@ export type TerminalRecoveryBlocker = {
 
 export type TerminalRecoveryPreview = {
   blockers?: TerminalRecoveryBlocker[];
+  cloudRepair?: {
+    preconditionHash: string;
+    safeConflictIds: string[];
+    skippedConflictIds: string[];
+  };
   commandStatus?: {
     commandId?: string;
     label?: string;
@@ -247,10 +295,27 @@ export type TerminalRecoveryPreview = {
     status?: TerminalRecoveryActionStatus;
     verificationStatus?: TerminalRecoveryActionStatus;
   } | null;
+  evidence?: {
+    freshRuntimeRequiredForAbleToTransactNow: true;
+  };
+  manualReview?: Array<{
+    reason: string;
+    source:
+      | "cloud_repair"
+      | TerminalHealthAttentionReason["source"];
+    type: "unsafe_cloud_conflict" | TerminalHealthAttentionReason["type"];
+  }>;
   readiness?: {
-    status: TerminalRecoveryReadinessStatus;
+    status?: TerminalRecoveryReadinessStatus;
     summary?: string;
-  } | null;
+  } | TerminalRecoveryReadinessStatus | null;
+  runtimeFresh?: boolean;
+  terminalActions?: Array<{
+    commandContext: TerminalRecoveryCommandContext;
+    commandType: TerminalRecoveryCommandType;
+    expectedEvidence: TerminalRecoveryExpectedEvidence;
+    reason: string;
+  }>;
   verification?: {
     latestCheckInAt?: number;
     status?: TerminalRecoveryActionStatus;

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.test.ts
@@ -155,6 +155,34 @@ describe("terminalRecoveryCommands", () => {
     expect(JSON.stringify(result)).not.toContain("sync-secret-secret");
   });
 
+  it("returns precondition_failed when terminal seed identity preconditions drift", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+
+    const result = await executeTerminalRecoveryCommand({
+      command: buildCommand({
+        commandContext: {
+          expectedBlockerType: "terminal_seed",
+          expectedTerminalSeedIdentity: "other-terminal",
+        },
+        commandType: "repair_terminal_seed",
+        type: undefined,
+      }),
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    expect(result).toEqual({
+      commandId: "command-1",
+      reason: "precondition_failed",
+      status: "precondition_failed",
+      type: "repair_terminal_seed",
+    });
+  });
+
   it("leaves terminal integrity blocked when repaired seed persistence fails", async () => {
     const store = {
       writeProvisionedTerminalSeedAndClearTerminalIntegrity: vi.fn(
@@ -287,6 +315,60 @@ describe("terminalRecoveryCommands", () => {
     });
   });
 
+  it("accepts backend-shaped drawer authority command context without a secret payload", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      createLocalId: () => "event-1",
+    });
+    await store.appendEvent({
+      initialSyncStatus: "synced",
+      localRegisterSessionId: "register-local-1",
+      payload: {},
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+      type: "register.opened",
+    });
+    await store.writeDrawerAuthorityState({
+      cloudRegisterSessionId: "register-cloud-1",
+      localRegisterSessionId: "register-local-1",
+      observedAt: 1_500,
+      reason: "cloud_closed",
+      status: "blocked",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+    });
+
+    const result = await executeTerminalRecoveryCommand({
+      command: {
+        _id: "backend-command-1",
+        commandContext: {
+          cloudRegisterSessionId: "register-cloud-1",
+          expectedBlockerType: "cloud_closed",
+          localRegisterSessionId: "register-local-1",
+          reason: "Drawer authority requires terminal-local repair.",
+        },
+        commandType: "clear_stale_drawer_authority",
+        expectedEvidence: {
+          drawerAuthorityStatus: "healthy",
+          localRegisterSessionId: "register-local-1",
+        },
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      },
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    expect(result).toMatchObject({
+      commandId: "backend-command-1",
+      status: "completed",
+      type: "clear_stale_drawer_authority",
+    });
+    expect(JSON.stringify(result)).not.toMatch(/syncSecret|payload|proof/i);
+  });
+
   it("fails closed and keeps drawer authority when preconditions drift", async () => {
     const store = createPosLocalStore({
       adapter: createMemoryPosLocalStorageAdapter(),
@@ -325,7 +407,7 @@ describe("terminalRecoveryCommands", () => {
 
     expect(result).toMatchObject({
       reason: "precondition_failed",
-      status: "failed",
+      status: "precondition_failed",
     });
     await expect(
       store.readDrawerAuthorityState({
@@ -336,6 +418,44 @@ describe("terminalRecoveryCommands", () => {
     ).resolves.toMatchObject({
       ok: true,
       value: expect.objectContaining({ status: "blocked" }),
+    });
+  });
+
+  it("returns precondition_failed when drawer authority is no longer blocked", async () => {
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+    });
+    await store.writeDrawerAuthorityState({
+      cloudRegisterSessionId: "register-cloud-1",
+      localRegisterSessionId: "register-local-1",
+      observedAt: 1_500,
+      reason: "cloud_closed",
+      status: "healthy",
+      storeId: "store-1",
+      terminalId: "local-terminal-1",
+    });
+
+    const result = await executeTerminalRecoveryCommand({
+      command: buildCommand({
+        commandContext: {
+          cloudRegisterSessionId: "register-cloud-1",
+          expectedBlockerType: "cloud_closed",
+          localRegisterSessionId: "register-local-1",
+        },
+        commandType: "clear_stale_drawer_authority",
+        type: undefined,
+      }),
+      store,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+      terminalSeed: seed,
+    });
+
+    expect(result).toEqual({
+      commandId: "command-1",
+      reason: "unsafe_authority_state",
+      status: "precondition_failed",
+      type: "clear_stale_drawer_authority",
     });
   });
 
@@ -474,5 +594,6 @@ describe("terminalRecoveryCommands", () => {
     expect(acknowledgement).not.toMatch(
       /proof-token|sync-secret|secret-value|verifier|rawPayload|1234/i,
     );
+    expect(acknowledgement.length).toBeLessThan(1_000);
   });
 });

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.ts
@@ -41,7 +41,7 @@ export type PosTerminalRecoveryCommandResult = {
     | "terminal_mismatch"
     | "unsupported_command"
     | "unsafe_authority_state";
-  status: "completed" | "failed" | "ignored";
+  status: "completed" | "failed" | "ignored" | "precondition_failed";
   type: string;
 };
 
@@ -88,6 +88,10 @@ export type PosTerminalRecoveryCommandContext = {
 
 type RepairTerminalSeedPayload = {
   seed: PosProvisionedTerminalSeed;
+};
+
+type RepairTerminalSeedContext = {
+  expectedTerminalSeedIdentity?: string;
 };
 
 type ClearStaleDrawerAuthorityPreconditions = {
@@ -169,7 +173,14 @@ async function executeRepairTerminalSeed(
     return failed(context.command, "missing_payload");
   }
   if (!matchesSeedScope(seed, context)) {
-    return failed(context.command, "precondition_failed");
+    return preconditionFailed(context.command);
+  }
+  const repairContext = toRepairTerminalSeedContext(context.command.commandContext);
+  if (
+    repairContext?.expectedTerminalSeedIdentity &&
+    !terminalScopeIds(context).has(repairContext.expectedTerminalSeedIdentity)
+  ) {
+    return preconditionFailed(context.command);
   }
 
   const writeSeed =
@@ -199,9 +210,7 @@ async function executeRepairTerminalSeed(
 async function executeClearStaleDrawerAuthority(
   context: PosTerminalRecoveryCommandContext,
 ): Promise<PosTerminalRecoveryCommandResult> {
-  const preconditions = toClearDrawerAuthorityPreconditions(
-    context.command.preconditions ?? getCommandPayload(context.command),
-  );
+  const preconditions = toClearDrawerAuthorityPreconditions(context.command);
   if (!preconditions) {
     return failed(context.command, "missing_payload");
   }
@@ -226,10 +235,10 @@ async function executeClearStaleDrawerAuthority(
   }
 
   if (!drawerAuthority.value || drawerAuthority.value.status !== "blocked") {
-    return failed(context.command, "unsafe_authority_state");
+    return preconditionFailed(context.command, "unsafe_authority_state");
   }
   if (!matchesDrawerPreconditions(drawerAuthority.value, preconditions)) {
-    return failed(context.command, "precondition_failed");
+    return preconditionFailed(context.command);
   }
 
   const events = await context.store.listEvents();
@@ -246,7 +255,7 @@ async function executeClearStaleDrawerAuthority(
       terminalIds: terminalScopeIds(context),
     })
   ) {
-    return failed(context.command, "precondition_failed");
+    return preconditionFailed(context.command);
   }
 
   const clear = await clearDrawerAuthorityState({
@@ -420,7 +429,41 @@ function toRepairTerminalSeedPayload(
   return { seed: value.seed };
 }
 
+function toRepairTerminalSeedContext(
+  value: unknown,
+): RepairTerminalSeedContext | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  if (
+    value.expectedTerminalSeedIdentity !== undefined &&
+    typeof value.expectedTerminalSeedIdentity !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    ...(typeof value.expectedTerminalSeedIdentity === "string"
+      ? { expectedTerminalSeedIdentity: value.expectedTerminalSeedIdentity }
+      : {}),
+  };
+}
+
 function toClearDrawerAuthorityPreconditions(
+  command: PosTerminalRecoveryCommand,
+): ClearStaleDrawerAuthorityPreconditions | null {
+  const value =
+    firstDrawerAuthorityPreconditions(command.preconditions) ??
+    firstDrawerAuthorityPreconditions(command.commandContext) ??
+    firstDrawerAuthorityPreconditions(command.payload);
+  if (!value) {
+    return null;
+  }
+
+  return value;
+}
+
+function firstDrawerAuthorityPreconditions(
   value: unknown,
 ): ClearStaleDrawerAuthorityPreconditions | null {
   if (!isRecord(value)) {
@@ -509,6 +552,18 @@ function failed(
   };
 }
 
+function preconditionFailed(
+  command: PosTerminalRecoveryCommand,
+  reason: "precondition_failed" | "unsafe_authority_state" = "precondition_failed",
+): PosTerminalRecoveryCommandResult {
+  return {
+    commandId: getCommandId(command),
+    reason,
+    status: "precondition_failed",
+    type: getCommandType(command) ?? "unknown_command",
+  };
+}
+
 function getCommandId(command: PosTerminalRecoveryCommand) {
   return command.commandId ?? command._id ?? "unknown-command";
 }
@@ -533,6 +588,7 @@ function redactDiagnostics(
 }
 
 function safeRecoveryMessage(value: unknown) {
+  const maxLength = 240;
   const message =
     value instanceof Error
       ? value.message
@@ -549,7 +605,8 @@ function safeRecoveryMessage(value: unknown) {
       /\b(staffProofToken|staff proof|proof-token|syncSecretHash|syncSecret|sync secret|verifier|PIN|pin|rawPayload|raw payload|payload)\b(?:\s*[:=]?\s*[^.,;]*)?/gi,
       "$1 [redacted]",
     )
-    .replace(/[A-Za-z0-9_-]{24,}/g, "[redacted]");
+    .replace(/[A-Za-z0-9_-]{24,}/g, "[redacted]")
+    .slice(0, maxLength);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -3822,6 +3822,57 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     expect(retry).toHaveBeenCalled();
   });
 
+  it("acknowledges safe recovery precondition drift distinctly", async () => {
+    const command = buildRecoveryCommand({
+      commandContext: {
+        cloudRegisterSessionId: "register-cloud-1",
+        expectedBlockerType: "cloud_closed",
+        localRegisterSessionId: "register-local-1",
+      },
+      commandType: "clear_stale_drawer_authority",
+    });
+    const commandResult = { kind: "ok", data: [command] };
+    mocks.listTerminalRecoveryCommands.mockImplementation((args) =>
+      args === "skip" ? undefined : commandResult,
+    );
+    mocks.claimTerminalRecoveryCommand.mockResolvedValue({
+      kind: "ok",
+      data: command,
+    });
+    const store = {
+      ...buildRecoveryCommandStore(),
+      clearDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
+      readDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: null,
+      })),
+    };
+
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        mode: "status-only",
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.acknowledgeTerminalRecoveryCommand).toHaveBeenCalledWith({
+        commandId: "command-1",
+        message: undefined,
+        result: "precondition_failed",
+        storeId: "store-1",
+        syncSecretHash: "sync-secret-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+    expect(store.clearDrawerAuthorityState).not.toHaveBeenCalled();
+  });
+
   it("reschedules a recovery command after a claim failure", async () => {
     const command = buildRecoveryCommand();
     const commandResult = { kind: "ok", data: [command] };

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -81,9 +81,9 @@ export type PosLocalRuntimeSyncDebug = {
   checkInPublishStatus?:
     | "accepted"
     | "failed"
-  | "not_ready"
-  | "pending"
-  | "rejected";
+    | "not_ready"
+    | "pending"
+    | "rejected";
   terminalRecoveryCommandAttemptedAt?: number;
   terminalRecoveryCommandCompletedAt?: number;
   terminalRecoveryCommandMessage?: string;
@@ -91,7 +91,8 @@ export type PosLocalRuntimeSyncDebug = {
     | "completed"
     | "failed"
     | "ignored"
-    | "pending";
+    | "pending"
+    | "precondition_failed";
   appSessionUnverifiedEventCount?: number;
   cloudValidationUncertainEventCount?: number;
   deferredUploadEventCount?: number;
@@ -1434,7 +1435,7 @@ function toTerminalRecoveryCommandAckResult(
   result: PosTerminalRecoveryCommandResult,
 ) {
   if (result.status === "completed") return "completed" as const;
-  if (result.reason === "precondition_failed") {
+  if (result.status === "precondition_failed" || result.reason === "precondition_failed") {
     return "precondition_failed" as const;
   }
   return "failed" as const;


### PR DESCRIPTION
## Summary
- split terminal runtime auth from support user auth so active terminals can list, claim, ack, and report recovery status with terminal sync-secret proof only
- enable Terminal Health safe action buttons for cloud repair and allow-listed terminal-local recovery commands
- harden command dedupe, expiry, acknowledgement redaction, runtime verification metadata, and terminal-local precondition handling
- update recovery docs and generated graph/harness artifacts

Linear: V26-737, V26-738, V26-739, V26-740, V26-741

## Validation
- Internal subagent review loop: security, correctness, testing, and project standards approved unanimously after fixes
- `bun run --filter '@athena/webapp' test -- convex/pos/application/terminals.test.ts convex/pos/application/queries/terminals.test.ts convex/pos/application/terminalRecovery/terminalCommandService.test.ts convex/pos/public/terminals.test.ts src/lib/pos/infrastructure/local/terminalRecoveryCommands.test.ts src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts src/components/pos/terminals/terminalHealthPresentation.test.ts src/components/pos/terminals/POSTerminalDetailView.test.tsx`\n- `bun run pr:athena`\n