### PR TITLE
[V26-742,V26-743]: Refactor pr:athena proof ladder

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,15 +210,20 @@ Use `bun run harness:test -- --dry-run` to print the selected files without exec
 The repo pins Bun via `package.json` (`bun@1.1.29` today), and GitHub Actions reads that same repo-declared version so CI and local harness runs stay aligned.
 
 `pre-commit:generated-artifacts` automatically runs `bun run harness:generate` and `bun run graphify:rebuild`, then stages the tracked generated harness docs and graphify outputs before the commit is finalized, so the pushed ref includes refreshed generated artifacts.
-`bun run pr:athena` starts with that same generated-artifact repair step before the blocking harness checks, so deterministic generated-doc drift is repaired locally instead of failing as stale docs.
+`bun run pr:athena:prepare` starts with that same generated-artifact repair step, then blocks before the heavy validation ladder if unstaged or untracked files would prevent a reusable proof. Stage intended new files explicitly, or remove unrelated local files, before running the full gate.
+`bun run pr:athena:validate` runs the heavy validation ladder without recording proof, and `bun run pr:athena:record-proof` records the reusable pre-push proof for the current clean or staged-only tree.
+The default `bun run pr:athena` command composes those three steps in order.
 `pre-push:review` starts with `bun run graphify:check` before the rest of the local validation suite. If tracked graphify artifacts are stale, the hook runs `bun run graphify:rebuild` once, reruns `bun run graphify:check`, and then stops so you can review and commit the repaired graphify artifacts before pushing again.
 If `harness:self-review` or `harness:review` gets blocked by stale generated harness docs, the hook runs `bun run harness:generate` once, retries the blocked step on the repaired tree, and:
+
 - Blocks so you can review, commit, and push the repaired generated docs instead of sending a stale ref to CI.
 
-After a clean `bun run pr:athena`, the repo records a git-private proof for the
-current branch head and `origin/main`. `pre-push:review` reuses that proof only
-when the head, base, clean working tree, Bun version, command wiring, and
-validation fingerprint still match; otherwise it reruns and prints the reason.
+After a clean or staged-only `bun run pr:athena`, the repo records a git-private
+proof for the validated tree and `origin/main`. `pre-push:review` reuses that
+proof only when the pushed tree, base, clean working tree, Bun version, command
+wiring, and validation fingerprint still match; otherwise it reruns and prints
+the reason. If `origin/main` or the base diff cannot be read, the hook blocks
+instead of treating the changed-file set as empty.
 
 List runtime behavior scenarios with `bun run harness:behavior --list`.
 Bundled scenarios include:

--- a/docs/harness.md
+++ b/docs/harness.md
@@ -112,10 +112,14 @@ Freshness sensors catch stale generated artifacts.
   `graphify:rebuild`, then stages tracked source changes and generated outputs.
 - `pre-push:review` can attempt a narrow repair once, then blocks so the repaired
   files are reviewed and committed before push.
-- `pr:athena` records a git-private proof after the final graphify check only
-  when the branch head, `origin/main`, validation wiring, Bun version, and
-  working tree are clean and current. A later `pre-push:review` may reuse that
-  proof instead of rerunning the whole local suite.
+- `pr:athena:prepare` runs generated-artifact repair, stages tracked changes
+  only, then blocks before heavy validation if unstaged or untracked files would
+  prevent reusable proof recording.
+- `pr:athena:validate` runs the heavy local PR ladder without recording proof.
+- `pr:athena:record-proof` records a git-private proof only when the branch
+  head or staged index, `origin/main`, validation wiring, Bun version, and
+  working tree state can be reused safely. A later `pre-push:review` may reuse
+  that proof instead of rerunning the whole local suite.
 
 The important behavior is fail-closed repair. The harness may refresh files, but
 it does not silently push repaired evidence past review.
@@ -251,17 +255,32 @@ For merge-ready Athena work, the broad command is:
 bun run pr:athena
 ```
 
-That command repairs generated artifacts first, then runs the main repo ladder:
-Convex audits, architecture checks, coverage, harness tests, generated-doc
-checks, review sensors, audit, scorecard, and graphify freshness.
+That command composes three explicit phases:
 
-After the final `graphify:check`, `pr:athena` records a worktree-local proof for
-the current `HEAD` and `origin/main`. `pre-push:review` reuses that proof only
-when the pushed head, base SHA, clean working tree, Bun version, `pr:athena`
-script, and validation wiring fingerprint still match. Any dirty file,
-generated-artifact repair, rebase, advanced `origin/main`, changed hook, changed
-harness script, or missing proof makes pre-push run the full validation suite
-normally and prints the reason.
+```sh
+bun run pr:athena:prepare
+bun run pr:athena:validate
+bun run pr:athena:record-proof
+```
+
+`pr:athena:prepare` repairs generated artifacts and stages tracked changes, then
+stops before the heavy ladder if unstaged or untracked files remain. It does not
+stage new files automatically; stage intended new files explicitly and rerun the
+prepare step before spending the full validation cycle.
+
+`pr:athena:validate` runs the main repo ladder: Convex audits, architecture
+checks, coverage, harness tests, generated-doc checks, review sensors, audit,
+scorecard, and graphify freshness.
+
+After the final `graphify:check`, `pr:athena:record-proof` records a
+worktree-local proof for the current clean tree or staged index and
+`origin/main`. `pre-push:review` reuses that proof only when the pushed tree,
+base SHA, clean working tree, Bun version, `pr:athena` script, and validation
+wiring fingerprint still match. Any dirty file, generated-artifact repair,
+rebase, advanced `origin/main`, changed hook, changed harness script, or missing
+proof makes pre-push run the full validation suite normally and prints the
+reason. If `origin/main` or the base diff cannot be read, the hook blocks
+instead of treating the changed-file set as empty.
 
 For harness-only changes, useful focused commands are:
 

--- a/docs/plans/2026-06-13-001-refactor-pr-athena-proof-ladder-plan.html
+++ b/docs/plans/2026-06-13-001-refactor-pr-athena-proof-ladder-plan.html
@@ -1,0 +1,244 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Refactor PR Athena Proof Ladder</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --ink: #1f2933;
+        --muted: #5f6b7a;
+        --line: #d9dee7;
+        --panel: #f7f9fc;
+        --accent: #0f766e;
+        --warn: #9a3412;
+      }
+      body {
+        margin: 0;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        color: var(--ink);
+        background: #ffffff;
+        line-height: 1.55;
+      }
+      main {
+        max-width: 1040px;
+        margin: 0 auto;
+        padding: 40px 24px 56px;
+      }
+      header {
+        border-bottom: 1px solid var(--line);
+        margin-bottom: 28px;
+        padding-bottom: 20px;
+      }
+      h1 {
+        margin: 0 0 8px;
+        font-size: 34px;
+        line-height: 1.15;
+        letter-spacing: 0;
+      }
+      h2 {
+        margin-top: 32px;
+        padding-top: 18px;
+        border-top: 1px solid var(--line);
+        font-size: 21px;
+        letter-spacing: 0;
+      }
+      h3 {
+        margin-top: 22px;
+        font-size: 17px;
+        letter-spacing: 0;
+      }
+      .meta,
+      .muted {
+        color: var(--muted);
+      }
+      .summary {
+        background: var(--panel);
+        border-left: 4px solid var(--accent);
+        padding: 14px 16px;
+        margin: 18px 0 0;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 14px;
+      }
+      .unit,
+      .callout {
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 14px 16px;
+        background: #fff;
+      }
+      .unit h3 {
+        margin-top: 0;
+      }
+      code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        font-size: 0.94em;
+        background: #eef2f7;
+        padding: 1px 4px;
+        border-radius: 4px;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 12px;
+      }
+      th,
+      td {
+        border: 1px solid var(--line);
+        padding: 10px 12px;
+        text-align: left;
+        vertical-align: top;
+      }
+      th {
+        background: var(--panel);
+      }
+      .warn {
+        color: var(--warn);
+        font-weight: 600;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <p class="meta">
+          Plan type: refactor · Status: active · Date: 2026-06-13 · Source:
+          <code>2026-06-13-001-refactor-pr-athena-proof-ladder-plan.md</code>
+        </p>
+        <h1>Refactor PR Athena Proof Ladder</h1>
+        <p class="summary">
+          Split the Athena PR gate into explicit prepare, validate, and
+          proof-recording commands so agents validate the exact tree they intend
+          to commit.
+        </p>
+      </header>
+
+      <section>
+        <h2>Problem</h2>
+        <p>
+          Recent delivery sessions showed <code>bun run pr:athena</code> can
+          pass the heavy ladder while intended new files remain untracked. The
+          proof then fails to record, so <code>git push</code> repeats expensive
+          pre-push validation.
+        </p>
+      </section>
+
+      <section>
+        <h2>Core Requirements</h2>
+        <ul>
+          <li>Keep <code>pr:athena</code> as the safe composed default.</li>
+          <li>
+            Add independent <code>pr:athena:prepare</code>,
+            <code>pr:athena:validate</code>, and
+            <code>pr:athena:record-proof</code> commands.
+          </li>
+          <li>
+            Block before heavy validation when unstaged or untracked files would
+            prevent proof reuse.
+          </li>
+          <li>Never auto-stage arbitrary untracked files.</li>
+          <li>Preserve fail-closed pre-push proof evaluation.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Implementation Units</h2>
+        <div class="grid">
+          <article class="unit">
+            <h3>U1. Split Commands And Add Prepare Guard</h3>
+            <p>
+              Update root command wiring and add a testable prepare guard around
+              generated-artifact repair and mixed-tree detection.
+            </p>
+            <p>
+              <strong>Primary files:</strong> <code>package.json</code>,
+              <code>scripts/pre-push-validation-proof.ts</code>, optional
+              <code>scripts/pr-athena-prepare.ts</code>, related script tests.
+            </p>
+            <p><strong>Posture:</strong> test-first.</p>
+          </article>
+          <article class="unit">
+            <h3>U2. Refresh Harness Documentation And Durable Learning</h3>
+            <p>
+              Update harness docs, add a solution note, and rebuild graphify so
+              future agents follow the new ladder.
+            </p>
+            <p>
+              <strong>Primary files:</strong> <code>docs/harness.md</code>,
+              <code>README.md</code>,
+              <code
+                >docs/solutions/harness/pr-athena-prepare-validate-proof-2026-06-13.md</code
+              >, <code>graphify-out/</code>.
+            </p>
+            <p><strong>Posture:</strong> sensor-only.</p>
+          </article>
+        </div>
+      </section>
+
+      <section>
+        <h2>Key Decisions</h2>
+        <ul>
+          <li>
+            Prepare should stage tracked files only and list untracked files for
+            explicit staging or removal.
+          </li>
+          <li>
+            Validation can run independently, but the default
+            <code>pr:athena</code> path remains prepare, validate, record proof.
+          </li>
+          <li>Proof reuse remains fingerprint-based and fail-closed.</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Risks</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Risk</th>
+              <th>Mitigation</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Prepare blocks a manual exploratory validation run.</td>
+              <td>
+                Keep <code>pr:athena:validate</code> available for advanced
+                manual use.
+              </td>
+            </tr>
+            <tr>
+              <td>Command split drifts from docs.</td>
+              <td>
+                Add package-script tests, update <code>docs/harness.md</code>,
+                and add a solution note.
+              </td>
+            </tr>
+            <tr>
+              <td>Proof reuse becomes too permissive.</td>
+              <td>
+                Do not weaken existing pre-push proof evaluation semantics.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section>
+        <h2>Verification Strategy</h2>
+        <p>
+          Run focused script tests around preparation and proof recording first,
+          then regenerate graphify and run the repo PR gate from the fully
+          staged intended tree.
+        </p>
+        <p class="warn">
+          The final proof should be reusable by pre-push only when the pushed
+          commit has the same validated tree.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/plans/2026-06-13-001-refactor-pr-athena-proof-ladder-plan.md
+++ b/docs/plans/2026-06-13-001-refactor-pr-athena-proof-ladder-plan.md
@@ -1,0 +1,221 @@
+---
+title: Refactor PR Athena Proof Ladder
+type: refactor
+status: active
+date: 2026-06-13
+---
+
+# Refactor PR Athena Proof Ladder
+
+## Summary
+
+Split the Athena PR gate into explicit prepare, validate, and proof-recording commands so agents validate the exact tree they intend to commit. Add a preparation guard that refreshes generated artifacts, stages tracked changes only, and blocks before the heavy ladder if unstaged or untracked files would make the proof non-reusable.
+
+---
+
+## Problem Frame
+
+Recent delivery sessions showed `bun run pr:athena` can pass the heavy validation ladder while intended new files remain untracked. Because proof recording refuses mixed unstaged or untracked states, the later `git push` falls through to the full pre-push suite and repeats the same expensive checks.
+
+---
+
+## Requirements
+
+- R1. `pr:athena` remains the safe default command and still runs generated-artifact preparation, the full validation ladder, and proof recording.
+- R2. The validation ladder can be invoked independently as `pr:athena:validate` without preparation or proof recording.
+- R3. Proof recording can be invoked independently as `pr:athena:record-proof`.
+- R4. A new preparation command refreshes generated artifacts and blocks before heavy validation if unstaged or untracked files remain.
+- R5. The preparation command stages tracked changes only and never auto-stages arbitrary untracked files.
+- R6. Pre-push proof reuse remains fail-closed and continues to reject stale, dirty, or mismatched trees.
+- R7. Harness docs, script tests, and solution notes reflect the new validation ladder so future agents use it correctly.
+
+---
+
+## Scope Boundaries
+
+- Do not weaken `pre-push:review` proof evaluation or make it heuristic-based.
+- Do not bypass pre-push validation when no current proof exists.
+- Do not auto-stage untracked feature files; the tool should list them and make the operator or agent stage the intended set explicitly.
+- Do not change package-level test selection, CI workflow semantics, or GitHub required checks beyond script-name/docs alignment.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `package.json` owns the root command wiring for `pre-push:review` and `pr:athena`.
+- `scripts/pre-commit-generated-artifacts.ts` already refreshes harness docs, Convex generated API files, graphify artifacts, and stages tracked changes with `git add --update -- .`.
+- `scripts/pre-push-validation-proof.ts` owns proof recording and reuse evaluation. It already supports staged-index proof recording when the worktree has no unstaged or untracked files.
+- `scripts/pre-push-validation-proof.test.ts` covers clean proof reuse, staged-index proof reuse after commit, rejection of untracked files, and stale proof reasons.
+- `scripts/pre-push-review.ts` consumes proof evaluation before running expensive pre-push validation.
+- `docs/harness.md` documents generated-artifact repair, `pr:athena`, and pre-push proof reuse.
+- `README.md` also summarizes the Athena PR gate and may need wording updates alongside `docs/harness.md`.
+
+### Institutional Learnings
+
+- `docs/solutions/harness/generated-artifact-repair-full-tracked-diff-2026-05-02.md`: generated repair should stage the full tracked diff with `git add --update -- .`, not `git add .` or `git add -A`.
+- `docs/solutions/harness/repo-validation-rerun-policy-2026-05-07.md`: rerun avoidance must remain proof-based and fail closed when any proof input is stale or dirty.
+- `docs/solutions/harness/compound-solution-gate-2026-05-05.md`: validation-gate changes should carry durable solution documentation.
+
+### External References
+
+- None. This is repo-local harness behavior with strong existing patterns.
+
+---
+
+## Key Technical Decisions
+
+- Split command ownership without changing the default gate: `pr:athena` should compose preparation, validation, and proof recording so existing usage stays safe.
+- Put the mixed-tree guard in a repo harness script rather than shell-only package JSON: this keeps behavior testable and lets diagnostics list the blocking paths.
+- Keep untracked handling manual: the prepare command should explain which files must be staged or removed, not decide whether new files belong in the commit.
+- Preserve staged-index proof semantics: after preparation and explicit staging, the proof may describe the index tree that the next commit will contain.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- Should untracked files be auto-staged by prepare? No. Existing generated-artifact staging intentionally stages tracked files only to avoid pulling unrelated local files into commits.
+- Should pre-push reuse become less strict? No. Reuse remains proof-based and fail-closed.
+
+### Deferred to Implementation
+
+- Exact CLI diagnostic wording: choose concise operator-facing wording while implementing and lock it with tests.
+- Whether the helper lives in a new script or extends `pre-push-validation-proof.ts`: pick the smallest testable shape once implementation starts.
+
+---
+
+## Implementation Units
+
+- U1. **Split Commands And Add Prepare Guard**
+
+**Goal:** Add explicit `pr:athena:prepare`, `pr:athena:validate`, and `pr:athena:record-proof` commands while keeping `pr:athena` as the composed safe default.
+
+**Requirements:** R1, R2, R3, R4, R5, R6
+
+**Dependencies:** None
+
+**Files:**
+
+- Modify: `package.json`
+- Modify or create: `scripts/pre-push-validation-proof.ts`
+- Modify or create: `scripts/pr-athena-prepare.ts`
+- Test: `scripts/pre-push-validation-proof.test.ts`
+- Test if new script is created: `scripts/pr-athena-prepare.test.ts`
+
+**Approach:**
+
+- Extract the current heavy command body into `pr:athena:validate`.
+- Add `pr:athena:record-proof` as a direct wrapper around existing proof recording.
+- Add `pr:athena:prepare` before validation. It should run the existing generated-artifact repair flow, then inspect git status for unstaged or untracked residue.
+- Block with actionable diagnostics when residue remains, making clear that intended new files must be staged explicitly before running the heavy ladder.
+- Keep `pr:athena` as `prepare && validate && record-proof`.
+
+**Execution note:** Test-first. Start with failing harness-script tests for clean, staged-only, unstaged, and untracked states before changing command wiring.
+
+**Patterns to follow:**
+
+- `scripts/pre-commit-generated-artifacts.ts` for tracked-only staging.
+- `scripts/pre-push-validation-proof.ts` for git status inspection and proof diagnostics.
+- `scripts/pre-push-review.test.ts` for command orchestration tests with stubbed runners.
+
+**Test scenarios:**
+
+- Happy path: clean tree after generated-artifact repair lets `pr:athena:prepare` pass.
+- Happy path: tracked modified files are staged by generated-artifact repair and prepare passes when no untracked files remain.
+- Edge case: staged-only tree passes prepare so later proof can record the staged index.
+- Error path: unstaged tracked residue after repair blocks before validation and lists the file.
+- Error path: untracked residue blocks before validation and lists the file without staging it.
+- Integration: `package.json` exposes `pr:athena:prepare`, `pr:athena:validate`, `pr:athena:record-proof`, and keeps `pr:athena` composed in the expected order.
+
+**Verification:**
+
+- Script tests prove the mixed-tree guard fires before the heavy ladder.
+- Existing proof tests still pass, including staged-index proof reuse and dirty-tree rejection.
+- `pr:athena` still ends by recording proof only after the validation ladder succeeds.
+
+---
+
+- U2. **Refresh Harness Documentation And Durable Learning**
+
+**Goal:** Update repo guidance so future agents run the split commands correctly and understand why prepare blocks on untracked files.
+
+**Requirements:** R7
+
+**Dependencies:** U1
+
+**Files:**
+
+- Modify: `docs/harness.md`
+- Modify: `README.md`
+- Modify if docs wording assertions change: `scripts/pre-push-review.test.ts`
+- Create or modify: `docs/solutions/harness/pr-athena-prepare-validate-proof-2026-06-13.md`
+- Modify if generated docs change: `graphify-out/GRAPH_REPORT.md`
+- Modify if generated docs change: `graphify-out/graph.json`
+- Modify if generated docs change: `graphify-out/wiki/index.md`
+
+**Approach:**
+
+- Update `docs/harness.md` and `README.md` with the new command split and the expected delivery sequence.
+- Add a solution note that captures the session-discovered failure mode: heavy validation can be wasted when untracked files prevent proof recording.
+- Rebuild graphify after code/docs edits per repo instructions.
+
+**Execution note:** Sensor-only for docs and generated graph artifacts; behavior is covered by U1 tests.
+
+**Patterns to follow:**
+
+- `docs/solutions/harness/repo-validation-rerun-policy-2026-05-07.md`
+- `docs/solutions/harness/generated-artifact-repair-full-tracked-diff-2026-05-02.md`
+
+**Test scenarios:**
+
+- Test expectation: none for prose docs and graph artifacts. The relevant proof behavior is covered in U1.
+
+**Verification:**
+
+- Documentation names the split commands and the staged/untracked contract.
+- Existing docs assertions still reflect the command names and proof contract.
+- Graphify artifacts are current.
+- The full repo gate can reuse proof on push when the branch commit matches the validated tree.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Root package scripts, generated-artifact repair, proof recording, and pre-push proof reuse become a more explicit ladder.
+- **Error propagation:** Prepare failures should exit non-zero with actionable diagnostics before expensive validation starts.
+- **State lifecycle risks:** The proof file remains git-private and worktree-local; no tracked proof state is introduced.
+- **API surface parity:** This changes root CLI script names only; no runtime app API changes.
+- **Integration coverage:** Package-script wiring plus proof/prepare tests are required because shell composition mistakes would otherwise be hard to see.
+- **Unchanged invariants:** Pre-push stays fail-closed, generated repair stages tracked files only, and untracked files are never auto-staged.
+
+---
+
+## Risks & Dependencies
+
+| Risk                                                                                     | Mitigation                                                                                                               |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Prepare blocks legitimate workflows that intentionally validate before staging new files | Make diagnostics clear and keep `pr:athena:validate` available for advanced manual validation without proof assumptions. |
+| Command split drifts from docs                                                           | Update `docs/harness.md`, add tests around package script wiring, and add a solution note.                               |
+| Proof reuse becomes too permissive                                                       | Do not change pre-push evaluation semantics; only tighten when proof recording happens.                                  |
+
+---
+
+## Documentation / Operational Notes
+
+- Linear tickets should be executed as a coordinated batch because the code, docs, and graphify artifacts all touch shared repo-generated state.
+- The final branch should run focused script tests first, then the repo PR gate after the intended tree is staged.
+
+---
+
+## Sources & References
+
+- Related code: `package.json`
+- Related code: `scripts/pre-commit-generated-artifacts.ts`
+- Related code: `scripts/pre-push-validation-proof.ts`
+- Related code: `scripts/pre-push-review.ts`
+- Related docs: `docs/harness.md`
+- Related learning: `docs/solutions/harness/generated-artifact-repair-full-tracked-diff-2026-05-02.md`
+- Related learning: `docs/solutions/harness/repo-validation-rerun-policy-2026-05-07.md`

--- a/docs/solutions/harness/pr-athena-prepare-validate-proof-2026-06-13.md
+++ b/docs/solutions/harness/pr-athena-prepare-validate-proof-2026-06-13.md
@@ -1,0 +1,56 @@
+---
+title: PR Athena Should Prepare The Proof Tree Before Heavy Validation
+date: 2026-06-13
+category: harness
+module: repo
+problem_type: validation_noise
+component: pr-athena
+resolution_type: explicit_prepare_validate_record_ladder
+severity: medium
+tags:
+  - harness
+  - pr-validation
+  - pre-push
+  - generated-artifacts
+---
+
+# PR Athena Should Prepare The Proof Tree Before Heavy Validation
+
+## Problem
+
+`bun run pr:athena` can spend a full validation cycle and still fail to record a
+reusable pre-push proof when intended new files are left untracked or tracked
+files remain unstaged. The next `git push` then falls through to
+`pre-push:review`, which repeats the expensive validation suite for the same
+logical change.
+
+The waste is easy to miss because the heavy gate itself can pass. The proof
+recording step is intentionally stricter: proof reuse is valid only for a clean
+tree or a staged index that will become the pushed commit.
+
+## Solution
+
+Make the ladder explicit:
+
+- `pr:athena:prepare` repairs generated artifacts, stages tracked changes only,
+  and blocks before heavy validation if unstaged or untracked files remain.
+- `pr:athena:validate` runs the expensive repo validation ladder.
+- `pr:athena:record-proof` records the reusable pre-push proof.
+- `pr:athena` composes those three steps in order.
+
+This keeps the default command safe while giving advanced operators separate
+entry points. It also moves the common failure earlier, before coverage,
+harness, browser, and graphify checks consume time.
+
+## Prevention
+
+- Keep generated-artifact staging tracked-only. Do not replace it with
+  `git add .` or `git add -A`.
+- Do not auto-stage untracked files from `pr:athena:prepare`; list them and make
+  the operator or agent stage the intended set explicitly.
+- Preserve staged-index proof support. Requiring a fully clean tree would break
+  the useful path where a staged index is validated and then committed.
+- Keep `pre-push:review` fail-closed. If proof is missing, stale, dirty, or
+  fingerprint-mismatched, pre-push should rerun and print the reason.
+- Do not turn base-ref or `git diff origin/main...HEAD` failures into an empty
+  changed-file set; block with an actionable fetch/base-ref error instead.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6818 nodes · 7631 edges · 1858 communities detected
+- 6824 nodes · 7644 edges · 1858 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1920,16 +1920,16 @@ Cohesion: 0.06
 Nodes (24): asRecord(), createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), normalizeCashierPresenceRecord(), normalizeDrawerAuthorityState(), normalizeLocalEventPayload(), normalizePendingCheckoutItemDefinedPayload(), normalizePendingCheckoutItemLocalMetadata() (+16 more)
 
 ### Community 6 - "Community 6"
+Cohesion: 0.1
+Nodes (46): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectHarnessSafetySignalFindings(), collectHarnessScriptTestUpdateFindings(), createOutput() (+38 more)
+
+### Community 7 - "Community 7"
 Cohesion: 0.08
 Nodes (43): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents(), buildWeekMetricForDate(), buildWeekMetrics(), compareDailyOperationsTimelineEvents() (+35 more)
 
-### Community 7 - "Community 7"
-Cohesion: 0.1
-Nodes (37): canonicalize(), canonicalJson(), createLocalSyncIngestionService(), ingestLocalEventsWithCtx(), isNonEmptyString(), isNonNegativeFiniteNumber(), isOptionalBoolean(), isOptionalNonEmptyString() (+29 more)
-
 ### Community 8 - "Community 8"
 Cohesion: 0.1
-Nodes (45): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectHarnessSafetySignalFindings(), collectHarnessScriptTestUpdateFindings(), createOutput() (+37 more)
+Nodes (37): canonicalize(), canonicalJson(), createLocalSyncIngestionService(), ingestLocalEventsWithCtx(), isNonEmptyString(), isNonNegativeFiniteNumber(), isOptionalBoolean(), isOptionalNonEmptyString() (+29 more)
 
 ### Community 9 - "Community 9"
 Cohesion: 0.09
@@ -2140,184 +2140,184 @@ Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
 ### Community 61 - "Community 61"
+Cohesion: 0.23
+Nodes (17): assertPrAthenaProofReady(), collectFilesUnder(), collectProofSnapshot(), collectUnstagedFiles(), collectUntrackedFiles(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof(), formatPathList() (+9 more)
+
+### Community 62 - "Community 62"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.13
 Nodes (4): DailyCloseHistoryView(), getDailyCloseHistoryApi(), getHistoryRecordSnapshot(), normalizeHistorySnapshot()
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.23
 Nodes (13): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), buildValidationMetadataMetrics(), getReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), isSaleAuthorityReady(), mapSyncStatus() (+5 more)
 
-### Community 64 - "Community 64"
+### Community 65 - "Community 65"
 Cohesion: 0.14
 Nodes (5): getBlockedPosTerminalShellCopy(), getPosHubRouteParams(), getRouteParamsForPattern(), getStoreWorkspaceRouteParams(), PosTerminalBlockedShell()
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.15
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.23
 Nodes (14): acknowledgeTerminalRecoveryCommand(), claimTerminalRecoveryCommand(), containsSecretLikeField(), isActiveCommand(), isEquivalentCommand(), issueTerminalRecoveryCommand(), loadScopedCommand(), normalizeOptionalHealthyStatus() (+6 more)
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
-### Community 70 - "Community 70"
+### Community 71 - "Community 71"
 Cohesion: 0.24
 Nodes (14): cacheAssetRequest(), cacheFirstAsset(), cacheLinkedShellAssets(), cacheModuleDependencies(), isExcluded(), isHtmlResponse(), isJavaScriptLikeResponse(), isPosNavigation() (+6 more)
 
-### Community 71 - "Community 71"
+### Community 72 - "Community 72"
 Cohesion: 0.13
 Nodes (2): handleEnterReviewMode(), saveInventoryImportRouteDraft()
 
-### Community 72 - "Community 72"
+### Community 73 - "Community 73"
 Cohesion: 0.24
 Nodes (15): buildGeneratedControlId(), captureRemoteAssistCoBrowseFrame(), collectSanitizedSurface(), collectSensitiveRegions(), collectVisibleText(), getControlId(), getControlPriority(), getElementLabel() (+7 more)
 
-### Community 73 - "Community 73"
+### Community 74 - "Community 74"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 74 - "Community 74"
+### Community 75 - "Community 75"
 Cohesion: 0.26
 Nodes (13): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget() (+5 more)
 
-### Community 75 - "Community 75"
+### Community 76 - "Community 76"
 Cohesion: 0.23
 Nodes (12): assertValidOpeningBlockerHandling(), assertValidOpeningLocalStartMinutes(), assertValidOperatingTimezoneOffsetMinutes(), getAutomationPolicyWithCtx(), getAutomationRunByIdempotencyKeyWithCtx(), getOpeningAutoStartPolicyConfigWithCtx(), listAutomationPoliciesForStoreActionWithCtx(), listAutomationRunsByIdempotencyKeyWithCtx() (+4 more)
 
-### Community 76 - "Community 76"
+### Community 77 - "Community 77"
 Cohesion: 0.33
 Nodes (14): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+6 more)
 
-### Community 77 - "Community 77"
+### Community 78 - "Community 78"
 Cohesion: 0.28
 Nodes (14): getRegisterCatalogPrice(), isActiveProvisionalImportSkuForStore(), isTrustedRegisterCatalogSku(), listRegisterCatalog(), listRegisterCatalogAvailability(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow() (+6 more)
 
-### Community 78 - "Community 78"
+### Community 79 - "Community 79"
 Cohesion: 0.14
 Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
 
-### Community 79 - "Community 79"
+### Community 80 - "Community 80"
 Cohesion: 0.17
 Nodes (6): buildServerPricedCheckoutProducts(), calculateItemsSubtotal(), deriveDeliveryOptionFromAddress(), isDeliveryFeeWaived(), normalizeDeliveryOption(), resolveServerDeliveryFee()
 
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.15
 Nodes (4): formatCurrency(), formatFinancialLabel(), formatTimelineRange(), formatTimelineTime()
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.24
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.17
 Nodes (6): formatLocalStartTime(), formatLocalStartTimeFromParts(), getLocalStartTimeParts(), handleSave(), parseLocalStartMinutes(), updateLocalStartTimePart()
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.15
 Nodes (4): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onStartRemoteAssist()
 
-### Community 84 - "Community 84"
+### Community 85 - "Community 85"
 Cohesion: 0.18
 Nodes (7): mapProductByIdResult(), useConvexProductIdLookup(), useConvexRegisterCatalog(), useConvexRegisterCatalogAvailability(), useConvexRegisterCatalogAvailabilityState(), useConvexRegisterServiceCatalog(), usePrewarmRegisterCatalogOfflineSnapshots()
 
-### Community 85 - "Community 85"
+### Community 86 - "Community 86"
 Cohesion: 0.22
 Nodes (10): extractIdentifierFromUrl(), findExactMatches(), firstNonEmpty(), isBarcodeShapedInput(), normalizeIdentifier(), parseCatalogSearchInput(), searchByText(), searchRegisterCatalog() (+2 more)
 
-### Community 86 - "Community 86"
+### Community 87 - "Community 87"
 Cohesion: 0.22
 Nodes (10): createApp(), createHandlers(), createRedisClient(), createRedisCluster(), deleteKeysIndividually(), invalidateAcrossCluster(), invalidateAcrossClusterWithPipeline(), scanNodeForPattern() (+2 more)
 
-### Community 87 - "Community 87"
+### Community 88 - "Community 88"
 Cohesion: 0.35
 Nodes (12): assertRoleConfiguration(), buildRoleAssignmentDrafts(), buildStaffFullName(), buildStaffProfileResult(), createStaffProfileWithCtx(), ensureLinkedUserAvailable(), getStaffProfileByIdWithCtx(), normalizeOptionalString() (+4 more)
 
-### Community 88 - "Community 88"
+### Community 89 - "Community 89"
 Cohesion: 0.31
 Nodes (13): advancePurchaseOrderToOrderedCommandWithCtx(), advancePurchaseOrderToOrderedWithCtx(), assertValidPurchaseOrderStatusTransition(), buildPurchaseOrderNumber(), calculatePurchaseOrderTotals(), createPurchaseOrderCommandWithCtx(), createPurchaseOrderWithCtx(), getOperationalWorkItemStatus() (+5 more)
 
-### Community 89 - "Community 89"
+### Community 90 - "Community 90"
 Cohesion: 0.19
 Nodes (4): formatQuickAddDialogError(), handleAttachBarcode(), handleQuickAddSubmit(), validateQuickAddLookupCode()
 
-### Community 90 - "Community 90"
+### Community 91 - "Community 91"
 Cohesion: 0.18
 Nodes (5): handleSave(), hasReceivingAccountDetails(), normalizePrimaryAccounts(), toPatchReceivingAccounts(), trimToUndefined()
 
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.18
 Nodes (5): isOverpayPaymentMethod(), isValidEmail(), isValidPhone(), validateCustomer(), validatePaymentAmount()
 
-### Community 92 - "Community 92"
+### Community 93 - "Community 93"
 Cohesion: 0.22
 Nodes (6): buildParticipantIdentity(), getDataPublishRouting(), getParticipantRole(), isAllowedSender(), LiveKitRemoteAssistClient, parseParticipantRole()
 
-### Community 93 - "Community 93"
+### Community 94 - "Community 94"
 Cohesion: 0.26
 Nodes (12): bestFuzzyTokenScore(), compactSearchText(), createFuzzySearchEntry(), isProbablySameToken(), levenshteinDistance(), normalizeFuzzySearchText(), scoreCompactFieldContains(), scoreFuzzySearchEntry() (+4 more)
 
-### Community 94 - "Community 94"
+### Community 95 - "Community 95"
 Cohesion: 0.26
 Nodes (12): deleteHeadBranch(), enablePullRequestAutoMerge(), encodeGitRefPath(), ghJson(), HelpRequested, mergePullRequest(), parseArgs(), parseMergeMethod() (+4 more)
 
-### Community 95 - "Community 95"
+### Community 96 - "Community 96"
 Cohesion: 0.26
 Nodes (10): createCustomer(), fullNameFromParts(), guestResult(), linkToGuest(), linkToStoreFrontUser(), posCustomerResult(), resolveGuestMatch(), resolvePosCustomerSelection() (+2 more)
 
-### Community 96 - "Community 96"
+### Community 97 - "Community 97"
 Cohesion: 0.21
 Nodes (6): buildServiceCase(), createServiceCaseWithCtx(), deriveServiceCasePaymentStatus(), listServiceCaseAllocationsWithCtx(), listServiceCaseLineItemsWithCtx(), syncServiceCaseFinancialsWithCtx()
 
-### Community 97 - "Community 97"
+### Community 98 - "Community 98"
 Cohesion: 0.29
 Nodes (12): assertDistinctReceivingLineItems(), assertReceivablePurchaseOrderStatus(), assertReceivingLineQuantities(), buildReceivingBatchSourceId(), calculatePurchaseOrderReceivingStatus(), calculateReceivingBatchTotals(), listPurchaseOrderLineItems(), mapReceivePurchaseOrderBatchError() (+4 more)
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.15
 Nodes (0):
 
-### Community 99 - "Community 99"
+### Community 100 - "Community 100"
 Cohesion: 0.17
 Nodes (2): formatRegisterLabel(), getRegisterLabel()
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
 Cohesion: 0.38
 Nodes (12): base64ToBytes(), bytesToBase64(), createLocalPinVerifier(), cryptoRefDecrypt(), derivePinHash(), deriveWrappingKey(), getCrypto(), isLocalPinVerifierMetadata() (+4 more)
 
-### Community 101 - "Community 101"
+### Community 102 - "Community 102"
 Cohesion: 0.29
 Nodes (10): applyTheme(), emitThemeChange(), getStorage(), getStoredThemeMode(), getSystemTheme(), getThemeSnapshot(), initializeAthenaTheme(), isThemeMode() (+2 more)
 
-### Community 102 - "Community 102"
+### Community 103 - "Community 103"
 Cohesion: 0.29
 Nodes (12): createReview(), deleteReview(), getBaseUrl(), getReviewByOrderItem(), getReviewsByProductId(), getReviewsByProductSkuId(), getUserReviews(), getUserReviewsForProduct() (+4 more)
 
-### Community 103 - "Community 103"
+### Community 104 - "Community 104"
 Cohesion: 0.28
 Nodes (11): buildCoverageReport(), checkSourceThresholds(), emptySummary(), formatMetric(), parseLcovSummary(), percentage(), pickMetric(), printCoverageReport() (+3 more)
 
-### Community 104 - "Community 104"
+### Community 105 - "Community 105"
 Cohesion: 0.26
 Nodes (11): collectConvexSourceModules(), collectConvexSourceModulesFromDir(), readCommandStdout(), readGeneratedConvexApiModules(), refreshAthenaConvexGeneratedApi(), resolveSupportedConvexNodeBin(), runPreCommitGeneratedArtifacts(), stageTrackedGeneratedArtifacts() (+3 more)
-
-### Community 105 - "Community 105"
-Cohesion: 0.31
-Nodes (12): collectFilesUnder(), collectProofSnapshot(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof(), hashValidationWiring(), normalizeRepoPath(), readPrAthenaScript(), recordPrePushValidationProof() (+4 more)
 
 ### Community 106 - "Community 106"
 Cohesion: 0.33

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1931
-- Graph nodes: 6818
-- Graph edges: 7631
+- Graph nodes: 6824
+- Graph edges: 7644
 - Communities: 1858
 
 ## Graph Hotspots
@@ -18,9 +18,9 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - `dailyClose.ts` (65 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `projectLocalEvents.ts` (52 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `usePosLocalSyncRuntime.ts` (48 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
-- `dailyOperations.ts` (46 edges, Community 6) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
-- `harness-inferential-review.ts` (46 edges, Community 8) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
-- `ingestLocalEvents.ts` (46 edges, Community 7) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
+- `harness-inferential-review.ts` (47 edges, Community 6) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
+- `dailyOperations.ts` (46 edges, Community 7) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
+- `ingestLocalEvents.ts` (46 edges, Community 8) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 
 ## Registered Packages
 - [Athena Webapp](packages/athena-webapp.md)

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -20,7 +20,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - `storefrontJourneyEvents.ts` (45 edges, Community 9) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 9) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 46) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `checkoutSession.ts` (14 edges, Community 73) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `checkoutSession.ts` (14 edges, Community 74) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 - `storeConfig.ts` (14 edges, Community 46) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -17,11 +17,11 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 - [validation-map.json](../../../packages/valkey-proxy-server/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `app.js` (14 edges, Community 86) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `app.js` (14 edges, Community 87) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `app.test.js` (6 edges, Community 151) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
-- `createRedisClient()` (4 edges, Community 86) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `createRedisCluster()` (3 edges, Community 86) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `deleteKeysIndividually()` (3 edges, Community 86) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisClient()` (4 edges, Community 87) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `createRedisCluster()` (3 edges, Community 87) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
+- `deleteKeysIndividually()` (3 edges, Community 87) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
     "workflow:check": "bun scripts/github-workflows-check.ts",
     "pre-commit:generated-artifacts": "bun scripts/pre-commit-generated-artifacts.ts",
     "pre-push:review": "bun scripts/pre-push-review.ts",
-    "pr:athena": "bun run pre-commit:generated-artifacts && bun run compound:check && bun run workflow:check && bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run --filter '@athena/webapp' lint:frontend:changed && bun run architecture:check && bun run test:coverage && bun run harness:test && bun run harness:check && bun run harness:review --base origin/main --repo-validation-provided-by pr:athena && bun run harness:inferential-review && bun run harness:audit && bun run harness:scorecard && bun run graphify:check && bun scripts/pre-push-validation-proof.ts record-pr-athena",
+    "pr:athena": "bun run pr:athena:prepare && bun run pr:athena:validate && bun run pr:athena:record-proof",
+    "pr:athena:prepare": "bun run pre-commit:generated-artifacts && bun scripts/pre-push-validation-proof.ts prepare-pr-athena",
+    "pr:athena:validate": "bun run compound:check && bun run workflow:check && bun run --filter '@athena/webapp' audit:convex && bun run --filter '@athena/webapp' lint:convex:changed && bun run --filter '@athena/webapp' lint:frontend:changed && bun run architecture:check && bun run test:coverage && bun run harness:test && bun run harness:check && bun run harness:review --base origin/main --repo-validation-provided-by pr:athena && bun run harness:inferential-review && bun run harness:audit && bun run harness:scorecard && bun run graphify:check",
+    "pr:athena:record-proof": "bun scripts/pre-push-validation-proof.ts record-pr-athena",
     "test": "bun run --filter '@athena/webapp' test && bun run --filter '@athena/storefront-webapp' test",
     "test:coverage:scripts": "bun scripts/root-scripts-coverage.ts",
     "test:coverage": "bun scripts/coverage-toolchain-parity.ts --repair && bun run --filter '@athena/webapp' test:coverage && bun run --filter '@athena/storefront-webapp' test:coverage && bun run test:coverage:scripts && bun scripts/coverage-summary.ts"

--- a/scripts/harness-inferential-review.test.ts
+++ b/scripts/harness-inferential-review.test.ts
@@ -18,7 +18,7 @@ async function write(relativePath: string, contents: string, rootDir: string) {
 
 async function createFixtureRepo() {
   const rootDir = await mkdtemp(
-    path.join(tmpdir(), "athena-harness-inferential-review-")
+    path.join(tmpdir(), "athena-harness-inferential-review-"),
   );
   tempRoots.push(rootDir);
 
@@ -32,9 +32,9 @@ async function createFixtureRepo() {
         },
       },
       null,
-      2
+      2,
     ),
-    rootDir
+    rootDir,
   );
 
   await write(
@@ -57,7 +57,7 @@ async function createFixtureRepo() {
       "      - name: Graphify check",
       "        run: bun run graphify:check",
     ].join("\n"),
-    rootDir
+    rootDir,
   );
 
   await write(
@@ -71,7 +71,7 @@ async function createFixtureRepo() {
       "- `bun run harness:inferential-review` is the inferential harness gate.",
       "- Inferential findings are blocking and exit non-zero with remediation guidance.",
     ].join("\n"),
-    rootDir
+    rootDir,
   );
 
   await write(
@@ -85,7 +85,7 @@ async function createFixtureRepo() {
       "- `bun run harness:inferential-review` is the inferential harness gate.",
       "- Inferential findings are blocking and exit non-zero with remediation guidance.",
     ].join("\n"),
-    rootDir
+    rootDir,
   );
 
   await write(
@@ -97,23 +97,23 @@ async function createFixtureRepo() {
       "  return harnessInferentialReviewStub;",
       "}",
     ].join("\n"),
-    rootDir
+    rootDir,
   );
 
   await write(
     "scripts/harness-inferential-review.test.ts",
     [
-      "import { describe, expect, it } from \"vitest\";",
+      'import { describe, expect, it } from "vitest";',
       "",
-      "import { runHarnessInferentialReviewStub } from \"./harness-inferential-review\";",
+      'import { runHarnessInferentialReviewStub } from "./harness-inferential-review";',
       "",
-      "describe(\"runHarnessInferentialReviewStub\", () => {",
-      "  it(\"returns the stubbed value\", () => {",
+      'describe("runHarnessInferentialReviewStub", () => {',
+      '  it("returns the stubbed value", () => {',
       "    expect(runHarnessInferentialReviewStub()).toBe(true);",
       "  });",
       "});",
     ].join("\n"),
-    rootDir
+    rootDir,
   );
 
   return rootDir;
@@ -121,9 +121,9 @@ async function createFixtureRepo() {
 
 afterEach(async () => {
   await Promise.all(
-    tempRoots.splice(0).map((rootDir) =>
-      rm(rootDir, { recursive: true, force: true })
-    )
+    tempRoots
+      .splice(0)
+      .map((rootDir) => rm(rootDir, { recursive: true, force: true })),
   );
 });
 
@@ -140,9 +140,9 @@ describe("runHarnessInferentialReview", () => {
           },
         },
         null,
-        2
+        2,
       ),
-      rootDir
+      rootDir,
     );
 
     const result = await runHarnessInferentialReview(rootDir, {
@@ -173,9 +173,9 @@ describe("runHarnessInferentialReview", () => {
           },
         },
         null,
-        2
+        2,
       ),
-      rootDir
+      rootDir,
     );
 
     const result = await runHarnessInferentialReview(rootDir, {
@@ -190,7 +190,7 @@ describe("runHarnessInferentialReview", () => {
         id: "missing-pr-athena-review-step",
         severity: "high",
         filePath: "package.json",
-      })
+      }),
     );
   });
 
@@ -205,9 +205,9 @@ describe("runHarnessInferentialReview", () => {
           },
         },
         null,
-        2
+        2,
       ),
-      rootDir
+      rootDir,
     );
 
     const result = await runHarnessInferentialReview(rootDir, {
@@ -222,14 +222,14 @@ describe("runHarnessInferentialReview", () => {
         id: "missing-pr-athena-review-step",
         severity: "high",
         filePath: "package.json",
-      })
+      }),
     );
     expect(result.machine.findings).toContainEqual(
       expect.objectContaining({
         id: "missing-pr-athena-inferential-step",
         severity: "high",
         filePath: "package.json",
-      })
+      }),
     );
   });
 
@@ -245,9 +245,9 @@ describe("runHarnessInferentialReview", () => {
           },
         },
         null,
-        2
+        2,
       ),
-      rootDir
+      rootDir,
     );
 
     const result = await runHarnessInferentialReview(rootDir, {
@@ -272,9 +272,41 @@ describe("runHarnessInferentialReview", () => {
           },
         },
         null,
-        2
+        2,
       ),
-      rootDir
+      rootDir,
+    );
+
+    const result = await runHarnessInferentialReview(rootDir, {
+      getChangedFiles: async () => ["package.json"],
+      nowIso: () => "2026-04-12T05:00:00.000Z",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.machine.status).toBe("pass");
+    expect(result.machine.findings).toEqual([]);
+  });
+
+  it("accepts harness review and inferential review through pr:athena subcommands", async () => {
+    const rootDir = await createFixtureRepo();
+    await write(
+      "package.json",
+      JSON.stringify(
+        {
+          scripts: {
+            "pr:athena":
+              "bun run pr:athena:prepare && bun run pr:athena:validate && bun run pr:athena:record-proof",
+            "pr:athena:prepare": "bun run pre-commit:generated-artifacts",
+            "pr:athena:validate":
+              "bun run harness:check && bun run harness:review --base origin/main --repo-validation-provided-by pr:athena && bun run harness:inferential-review && bun run harness:audit && bun run graphify:check",
+            "pr:athena:record-proof":
+              "bun scripts/pre-push-validation-proof.ts record-pr-athena",
+          },
+        },
+        null,
+        2,
+      ),
+      rootDir,
     );
 
     const result = await runHarnessInferentialReview(rootDir, {
@@ -299,9 +331,9 @@ describe("runHarnessInferentialReview", () => {
           },
         },
         null,
-        2
+        2,
       ),
-      rootDir
+      rootDir,
     );
 
     const result = await runHarnessInferentialReview(rootDir, {
@@ -316,7 +348,7 @@ describe("runHarnessInferentialReview", () => {
         id: "missing-pr-athena-review-step",
         severity: "high",
         filePath: "package.json",
-      })
+      }),
     );
   });
 
@@ -336,7 +368,9 @@ describe("runHarnessInferentialReview", () => {
       severity: "medium",
       filePath: "scripts/harness-inferential-review.ts",
     });
-    expect(result.humanReport).toContain("Harness script changed without test update");
+    expect(result.humanReport).toContain(
+      "Harness script changed without test update",
+    );
   });
 
   it("fails when scripts/harness-app-registry.ts changes without scripts/harness-app-registry.test.ts", async () => {
@@ -354,9 +388,11 @@ describe("runHarnessInferentialReview", () => {
         id: "missing-harness-script-test-update-scripts-harness-app-registry-ts",
         severity: "medium",
         filePath: "scripts/harness-app-registry.ts",
-      })
+      }),
     );
-    expect(result.humanReport).toContain("scripts/harness-app-registry.test.ts");
+    expect(result.humanReport).toContain(
+      "scripts/harness-app-registry.test.ts",
+    );
   });
 
   it("fails when the PR workflow omits semantic shadow mode on inferential review", async () => {
@@ -379,7 +415,7 @@ describe("runHarnessInferentialReview", () => {
         "      - name: Graphify check",
         "        run: bun run graphify:check",
       ].join("\n"),
-      rootDir
+      rootDir,
     );
 
     const result = await runHarnessInferentialReview(rootDir, {
@@ -394,7 +430,7 @@ describe("runHarnessInferentialReview", () => {
         id: "missing-ci-shadow-semantic-mode",
         severity: "high",
         filePath: ".github/workflows/athena-pr-tests.yml",
-      })
+      }),
     );
   });
 
@@ -418,7 +454,7 @@ describe("runHarnessInferentialReview", () => {
         "      - name: Graphify check",
         "        run: bun run graphify:check",
       ].join("\n"),
-      rootDir
+      rootDir,
     );
 
     const result = await runHarnessInferentialReview(rootDir, {
@@ -433,7 +469,7 @@ describe("runHarnessInferentialReview", () => {
         id: "missing-ci-review-step",
         severity: "high",
         filePath: ".github/workflows/athena-pr-tests.yml",
-      })
+      }),
     );
   });
 
@@ -459,7 +495,7 @@ describe("runHarnessInferentialReview", () => {
         "      - name: Graphify check",
         "        run: bun run graphify:check",
       ].join("\n"),
-      rootDir
+      rootDir,
     );
 
     const result = await runHarnessInferentialReview(rootDir, {
@@ -494,7 +530,7 @@ describe("runHarnessInferentialReview", () => {
         "      - name: Graphify check",
         "        run: bun run graphify:check",
       ].join("\n"),
-      rootDir
+      rootDir,
     );
 
     const result = await runHarnessInferentialReview(rootDir, {
@@ -528,7 +564,7 @@ describe("runHarnessInferentialReview", () => {
         "      - name: Graphify check",
         "        run: bun run graphify:check",
       ].join("\n"),
-      rootDir
+      rootDir,
     );
 
     const result = await runHarnessInferentialReview(rootDir, {
@@ -543,7 +579,7 @@ describe("runHarnessInferentialReview", () => {
         id: "missing-ci-review-step",
         severity: "high",
         filePath: ".github/workflows/athena-pr-tests.yml",
-      })
+      }),
     );
   });
 
@@ -571,7 +607,7 @@ describe("runHarnessInferentialReview", () => {
         "      - name: Graphify check",
         "        run: bun run graphify:check",
       ].join("\n"),
-      rootDir
+      rootDir,
     );
 
     const result = await runHarnessInferentialReview(rootDir, {
@@ -586,7 +622,7 @@ describe("runHarnessInferentialReview", () => {
         id: "missing-ci-review-step",
         severity: "high",
         filePath: ".github/workflows/athena-pr-tests.yml",
-      })
+      }),
     );
   });
 
@@ -670,7 +706,9 @@ describe("runHarnessInferentialReview", () => {
       },
     ]);
     expect(result.humanReport).toContain("Provider/runtime failure");
-    expect(result.humanReport).toContain("Confirm provider configuration and connectivity");
+    expect(result.humanReport).toContain(
+      "Confirm provider configuration and connectivity",
+    );
   });
 
   it("records semantic shadow errors without making the command blocking", async () => {
@@ -709,7 +747,9 @@ describe("runHarnessInferentialReview", () => {
     expect(result.exitCode).toBe(0);
     expect(result.machine.status).toBe("skipped");
     expect(result.machine.summary).toContain("No harness-critical files");
-    expect(result.humanReport).toContain("No harness-critical files are in scope.");
+    expect(result.humanReport).toContain(
+      "No harness-critical files are in scope.",
+    );
   });
 
   it("writes machine-readable output with additive shadow data via the default artifact path", async () => {
@@ -735,7 +775,7 @@ describe("runHarnessInferentialReview", () => {
     });
 
     const saved = JSON.parse(
-      await readFile(path.join(rootDir, result.machineOutputPath), "utf8")
+      await readFile(path.join(rootDir, result.machineOutputPath), "utf8"),
     ) as {
       status: string;
       providerName: string;
@@ -769,10 +809,10 @@ describe("runHarnessInferentialReview", () => {
       await readFile(
         path.join(
           rootDir,
-          "artifacts/harness-inferential-review/history/2026-04-12T05-00-00-000Z.json"
+          "artifacts/harness-inferential-review/history/2026-04-12T05-00-00-000Z.json",
         ),
-        "utf8"
-      )
+        "utf8",
+      ),
     ) as {
       status: string;
       reviewMode?: string;
@@ -791,7 +831,11 @@ describe("runHarnessInferentialReview", () => {
 describe("parseHarnessInferentialReviewArgs", () => {
   it("accepts --persist-history", () => {
     expect(
-      parseHarnessInferentialReviewArgs(["--base", "origin/main", "--persist-history"])
+      parseHarnessInferentialReviewArgs([
+        "--base",
+        "origin/main",
+        "--persist-history",
+      ]),
     ).toMatchObject({
       baseRef: "origin/main",
       persistHistory: true,

--- a/scripts/harness-inferential-review.ts
+++ b/scripts/harness-inferential-review.ts
@@ -86,12 +86,12 @@ type InferentialReviewOptions = {
   baseRef?: string;
   getChangedFiles?: (rootDir: string, baseRef: string) => Promise<string[]>;
   runProvider?: (
-    input: InferentialProviderInput
+    input: InferentialProviderInput,
   ) => Promise<InferentialProviderResult>;
   semanticMode?: InferentialShadowMode;
   persistHistory?: boolean;
   runSemanticAnalysis?: (
-    input: InferentialProviderInput
+    input: InferentialProviderInput,
   ) => Promise<InferentialSemanticAnalysisResult>;
   machineOutputPath?: string;
   nowIso?: () => string;
@@ -111,7 +111,9 @@ function normalizeRepoPath(repoPath: string) {
 
 function sortUnique(entries: string[]) {
   return [
-    ...new Set(entries.map((entry) => normalizeRepoPath(entry).trim()).filter(Boolean)),
+    ...new Set(
+      entries.map((entry) => normalizeRepoPath(entry).trim()).filter(Boolean),
+    ),
   ].sort((left, right) => left.localeCompare(right));
 }
 
@@ -143,8 +145,8 @@ async function runCommand(
   command: string[],
   spawn: (
     command: string[],
-    options: { cwd: string; stdout: "pipe"; stderr: "pipe" }
-  ) => SpawnedProcess = Bun.spawn
+    options: { cwd: string; stdout: "pipe"; stderr: "pipe" },
+  ) => SpawnedProcess = Bun.spawn,
 ) {
   const process = spawn(command, {
     cwd: rootDir,
@@ -167,7 +169,7 @@ async function runCommand(
 
 export async function getChangedFilesForInferentialReview(
   rootDir: string,
-  baseRef: string
+  baseRef: string,
 ) {
   const refCheck = await runCommand(rootDir, [
     "git",
@@ -204,21 +206,21 @@ export async function getChangedFilesForInferentialReview(
   if (baseDiff.exitCode !== 0) {
     throw new Error(
       baseDiff.stderr.trim() ||
-        `Unable to compute changed files against ${baseRef}.`
+        `Unable to compute changed files against ${baseRef}.`,
     );
   }
 
   if (trackedDiff.exitCode !== 0) {
     throw new Error(
       trackedDiff.stderr.trim() ||
-        "Unable to compute tracked working-tree changes."
+        "Unable to compute tracked working-tree changes.",
     );
   }
 
   if (untrackedDiff.exitCode !== 0) {
     throw new Error(
       untrackedDiff.stderr.trim() ||
-        "Unable to compute untracked working-tree changes."
+        "Unable to compute untracked working-tree changes.",
     );
   }
 
@@ -260,7 +262,7 @@ function buildFinding(
   title: string,
   filePath: string,
   rationale: string,
-  remediation: string
+  remediation: string,
 ): InferentialFinding {
   return {
     id,
@@ -283,27 +285,47 @@ function escapeRegExp(value: string) {
 function buildShellCommandPattern(commandBody: string) {
   return new RegExp(
     `(?:^|&&|\\|\\||;)\\s*${commandBody}(?=\\s*(?:&&|\\|\\||;|$))`,
-    "i"
+    "i",
   );
 }
 
 function hasHarnessReviewCommand(value: string, baseRef: string) {
   const pattern = buildShellCommandPattern(
-    `bun\\s+run\\s+harness:review\\s+--base(?:\\s+|=)${escapeRegExp(baseRef)}(?:\\s+--repo-validation-provided-by\\s+pr:athena)?(?:\\s+--validation-provided-by\\s+athena-pr-tests)?`
+    `bun\\s+run\\s+harness:review\\s+--base(?:\\s+|=)${escapeRegExp(baseRef)}(?:\\s+--repo-validation-provided-by\\s+pr:athena)?(?:\\s+--validation-provided-by\\s+athena-pr-tests)?`,
   );
   return pattern.test(value);
 }
 
 function hasHarnessInferentialCommand(value: string) {
   return buildShellCommandPattern(
-    "bun\\s+run\\s+harness:inferential-review"
+    "bun\\s+run\\s+harness:inferential-review",
   ).test(value);
 }
 
-function extractWorkflowJobSection(
-  workflowContents: string,
-  jobName: string
+function expandPackageScriptChain(
+  scripts: Record<string, string> | undefined,
+  scriptName: string,
+  seen = new Set<string>(),
 ) {
+  const script = scripts?.[scriptName] ?? "";
+  if (!script || seen.has(scriptName)) {
+    return script;
+  }
+
+  seen.add(scriptName);
+  const childScripts = [...script.matchAll(/\bbun\s+run\s+([@\w:./-]+)/g)]
+    .map((match) => match[1])
+    .filter((name) => scripts?.[name]);
+
+  return [
+    script,
+    ...childScripts.map((name) =>
+      expandPackageScriptChain(scripts, name, seen),
+    ),
+  ].join(" && ");
+}
+
+function extractWorkflowJobSection(workflowContents: string, jobName: string) {
   const lines = workflowContents.split(/\r?\n/);
   let inJobsBlock = false;
   let insideTargetJob = false;
@@ -334,10 +356,7 @@ function extractWorkflowJobSection(
   return section.join("\n");
 }
 
-function extractWorkflowRunCommands(
-  workflowContents: string,
-  jobName: string
-) {
+function extractWorkflowRunCommands(workflowContents: string, jobName: string) {
   const jobSection = extractWorkflowJobSection(workflowContents, jobName);
   if (!jobSection) {
     return [];
@@ -355,7 +374,7 @@ function workflowJobHasEnvSetting(
   workflowContents: string,
   jobName: string,
   key: string,
-  value: string
+  value: string,
 ) {
   const jobSection = extractWorkflowJobSection(workflowContents, jobName);
   if (!jobSection) {
@@ -377,7 +396,11 @@ function slugifyForFindingId(value: string) {
 
 function isHarnessScriptSourceFile(filePath: string) {
   const normalized = normalizeRepoPath(filePath);
-  return normalized.startsWith("scripts/harness-") && normalized.endsWith(".ts") && !normalized.endsWith(".test.ts");
+  return (
+    normalized.startsWith("scripts/harness-") &&
+    normalized.endsWith(".ts") &&
+    !normalized.endsWith(".test.ts")
+  );
 }
 
 function toHarnessScriptTestPath(filePath: string) {
@@ -393,7 +416,7 @@ function createReducedSignalFinding(
   title: string,
   severity: InferentialSeverity,
   missingSignals: string[],
-  remediation: string
+  remediation: string,
 ): InferentialFinding {
   return buildFinding(
     `reduced-safety-signals-${slugifyForFindingId(filePath)}`,
@@ -401,13 +424,13 @@ function createReducedSignalFinding(
     title,
     filePath,
     `This file is missing safety or wiring signal(s): ${formatMissingSignals(missingSignals)}.`,
-    remediation
+    remediation,
   );
 }
 
 async function collectHarnessScriptTestUpdateFindings(
   rootDir: string,
-  changedFiles: string[]
+  changedFiles: string[],
 ) {
   const changedFileSet = new Set(sortUnique(changedFiles));
   const findings: InferentialFinding[] = [];
@@ -422,7 +445,9 @@ async function collectHarnessScriptTestUpdateFindings(
       continue;
     }
 
-    const testFileExists = await fileExists(path.join(rootDir, matchingTestFile));
+    const testFileExists = await fileExists(
+      path.join(rootDir, matchingTestFile),
+    );
     findings.push(
       buildFinding(
         `missing-harness-script-test-update-${slugifyForFindingId(changedFile)}`,
@@ -434,8 +459,8 @@ async function collectHarnessScriptTestUpdateFindings(
           : `This harness-critical script changed, but the expected sibling test file ${matchingTestFile} is missing.`,
         testFileExists
           ? `Update ${matchingTestFile} alongside the script change so the regression coverage stays deterministic.`
-          : `Create ${matchingTestFile} alongside the script change so the regression coverage stays deterministic.`
-      )
+          : `Create ${matchingTestFile} alongside the script change so the regression coverage stays deterministic.`,
+      ),
     );
   }
 
@@ -444,7 +469,7 @@ async function collectHarnessScriptTestUpdateFindings(
 
 async function collectHarnessSafetySignalFindings(
   rootDir: string,
-  changedFiles: string[]
+  changedFiles: string[],
 ) {
   const changedFileSet = new Set(sortUnique(changedFiles));
   const findings: InferentialFinding[] = [];
@@ -517,7 +542,7 @@ async function collectHarnessSafetySignalFindings(
     }
 
     const missingSignals = rule.requiredSignals.filter(
-      (signal) => !includesCaseInsensitive(contents, signal)
+      (signal) => !includesCaseInsensitive(contents, signal),
     );
 
     if (missingSignals.length === 0) {
@@ -530,8 +555,8 @@ async function collectHarnessSafetySignalFindings(
         rule.title,
         rule.severity,
         missingSignals,
-        rule.remediation
-      )
+        rule.remediation,
+      ),
     );
   }
 
@@ -539,16 +564,16 @@ async function collectHarnessSafetySignalFindings(
 }
 
 async function runDeterministicSemanticAnalysis(
-  input: InferentialProviderInput
+  input: InferentialProviderInput,
 ): Promise<InferentialDeterministicAnalysisResult> {
   const findings = [
     ...(await collectHarnessScriptTestUpdateFindings(
       input.rootDir,
-      input.changedFiles
+      input.changedFiles,
     )),
     ...(await collectHarnessSafetySignalFindings(
       input.rootDir,
-      input.changedFiles
+      input.changedFiles,
     )),
   ];
 
@@ -558,10 +583,12 @@ async function runDeterministicSemanticAnalysis(
 }
 
 function resolveSemanticMode(
-  optionMode?: InferentialShadowMode
+  optionMode?: InferentialShadowMode,
 ): InferentialShadowMode {
   const rawMode =
-    optionMode ?? process.env.HARNESS_INFERENTIAL_SEMANTIC_MODE ?? DEFAULT_SEMANTIC_MODE;
+    optionMode ??
+    process.env.HARNESS_INFERENTIAL_SEMANTIC_MODE ??
+    DEFAULT_SEMANTIC_MODE;
 
   return rawMode === "shadow" ? "shadow" : "off";
 }
@@ -590,7 +617,7 @@ async function buildSemanticPrompt(input: InferentialProviderInput) {
         `FILE: ${filePath}`,
         "CONTENT:",
         contents ? truncateForPrompt(contents) : "[missing]",
-      ].join("\n")
+      ].join("\n"),
     );
   }
 
@@ -599,7 +626,7 @@ async function buildSemanticPrompt(input: InferentialProviderInput) {
     "Return JSON only with this exact shape:",
     '{"summary":"string","findings":[{"id":"string","severity":"high|medium|low","title":"string","filePath":"string","rationale":"string","remediation":"string"}]}',
     "Only report likely semantic or operational issues that a deterministic rule might miss.",
-    "If there are no likely issues, return {\"summary\":\"No semantic issues detected.\",\"findings\":[]}.",
+    'If there are no likely issues, return {"summary":"No semantic issues detected.","findings":[]}.',
     `Base ref: ${input.baseRef}`,
     `Changed files (${input.changedFiles.length}): ${input.changedFiles.join(", ")}`,
     `Target files (${input.targetFiles.length}): ${input.targetFiles.join(", ")}`,
@@ -654,9 +681,7 @@ function extractJsonPayload(responseText: string) {
   throw new Error("Semantic provider response did not include JSON output.");
 }
 
-function normalizeSemanticFinding(
-  value: unknown
-): InferentialFinding | null {
+function normalizeSemanticFinding(value: unknown): InferentialFinding | null {
   if (typeof value !== "object" || value === null) {
     return null;
   }
@@ -727,7 +752,7 @@ function parseSemanticResponse(responseText: string) {
 }
 
 async function runAnthropicSemanticAnalysis(
-  input: InferentialProviderInput
+  input: InferentialProviderInput,
 ): Promise<InferentialSemanticAnalysisResult> {
   const model =
     process.env.HARNESS_INFERENTIAL_ANTHROPIC_MODEL?.trim() ||
@@ -766,7 +791,7 @@ async function runAnthropicSemanticAnalysis(
 }
 
 export async function runDeterministicInferentialProvider(
-  input: InferentialProviderInput
+  input: InferentialProviderInput,
 ): Promise<InferentialProviderResult> {
   const findings: InferentialFinding[] = [];
   const reviewBaseRef = "origin/main";
@@ -774,15 +799,15 @@ export async function runDeterministicInferentialProvider(
   const packageJsonPath = path.join(input.rootDir, "package.json");
   const workflowPath = path.join(
     input.rootDir,
-    ".github/workflows/athena-pr-tests.yml"
+    ".github/workflows/athena-pr-tests.yml",
   );
   const athenaTestingDocPath = path.join(
     input.rootDir,
-    "packages/athena-webapp/docs/agent/testing.md"
+    "packages/athena-webapp/docs/agent/testing.md",
   );
   const storefrontTestingDocPath = path.join(
     input.rootDir,
-    "packages/storefront-webapp/docs/agent/testing.md"
+    "packages/storefront-webapp/docs/agent/testing.md",
   );
 
   const packageJsonContents = await readUtf8OrNull(packageJsonPath);
@@ -794,8 +819,8 @@ export async function runDeterministicInferentialProvider(
         "Missing repo package.json",
         "package.json",
         "Inferential gate policy cannot verify pr:athena wiring without package.json.",
-        "Restore package.json and ensure pr:athena includes `bun run harness:inferential-review`."
-      )
+        "Restore package.json and ensure pr:athena includes `bun run harness:inferential-review`.",
+      ),
     );
   } else {
     let prAthenaScript = "";
@@ -804,7 +829,7 @@ export async function runDeterministicInferentialProvider(
       const parsed = JSON.parse(packageJsonContents) as {
         scripts?: Record<string, string>;
       };
-      prAthenaScript = parsed.scripts?.["pr:athena"] ?? "";
+      prAthenaScript = expandPackageScriptChain(parsed.scripts, "pr:athena");
     } catch {
       findings.push(
         buildFinding(
@@ -813,8 +838,8 @@ export async function runDeterministicInferentialProvider(
           "Invalid package.json format",
           "package.json",
           "Inferential gate policy could not parse package.json to inspect pr:athena wiring.",
-          "Fix package.json JSON syntax and ensure pr:athena includes `bun run harness:inferential-review`."
-        )
+          "Fix package.json JSON syntax and ensure pr:athena includes `bun run harness:inferential-review`.",
+        ),
       );
     }
 
@@ -826,8 +851,8 @@ export async function runDeterministicInferentialProvider(
           "pr:athena omits harness review",
           "package.json",
           "Athena preflight does not currently include the harness review gate.",
-          "Add `bun run harness:review --base origin/main` to the `pr:athena` script before final success output."
-        )
+          "Add `bun run harness:review --base origin/main` to the `pr:athena` script before final success output.",
+        ),
       );
     }
 
@@ -839,8 +864,8 @@ export async function runDeterministicInferentialProvider(
           "pr:athena omits inferential review",
           "package.json",
           "Athena preflight does not currently include the inferential review gate.",
-          "Add `bun run harness:inferential-review` to the `pr:athena` script before final success output."
-        )
+          "Add `bun run harness:inferential-review` to the `pr:athena` script before final success output.",
+        ),
       );
     }
   }
@@ -854,12 +879,12 @@ export async function runDeterministicInferentialProvider(
         "Missing Athena PR workflow",
         ".github/workflows/athena-pr-tests.yml",
         "Inferential gate policy cannot verify CI enforcement without the Athena PR workflow file.",
-        "Restore `.github/workflows/athena-pr-tests.yml` and add `run: bun run harness:inferential-review`."
-      )
+        "Restore `.github/workflows/athena-pr-tests.yml` and add `run: bun run harness:inferential-review`.",
+      ),
     );
   } else if (
     !extractWorkflowRunCommands(workflowContents, workflowJobName).some(
-      (command) => hasHarnessReviewCommand(command, reviewBaseRef)
+      (command) => hasHarnessReviewCommand(command, reviewBaseRef),
     )
   ) {
     findings.push(
@@ -869,15 +894,15 @@ export async function runDeterministicInferentialProvider(
         "CI omits harness review",
         ".github/workflows/athena-pr-tests.yml",
         "Athena PR workflow does not enforce the harness review gate as a blocking CI step.",
-        "Add a workflow step with `run: bun run harness:review --base origin/main` in the harness validation job."
-      )
+        "Add a workflow step with `run: bun run harness:review --base origin/main` in the harness validation job.",
+      ),
     );
   }
 
   if (
     workflowContents &&
     !extractWorkflowRunCommands(workflowContents, workflowJobName).some(
-      hasHarnessInferentialCommand
+      hasHarnessInferentialCommand,
     )
   ) {
     findings.push(
@@ -887,8 +912,8 @@ export async function runDeterministicInferentialProvider(
         "CI omits inferential review",
         ".github/workflows/athena-pr-tests.yml",
         "Athena PR workflow does not enforce inferential review as a blocking gate.",
-        "Add a workflow step with `run: bun run harness:inferential-review` in the harness validation job."
-      )
+        "Add a workflow step with `run: bun run harness:inferential-review` in the harness validation job.",
+      ),
     );
   }
 
@@ -898,7 +923,7 @@ export async function runDeterministicInferentialProvider(
       workflowContents,
       workflowJobName,
       "HARNESS_INFERENTIAL_SEMANTIC_MODE",
-      "shadow"
+      "shadow",
     )
   ) {
     findings.push(
@@ -908,8 +933,8 @@ export async function runDeterministicInferentialProvider(
         "CI inferential review is not running in semantic shadow mode",
         ".github/workflows/athena-pr-tests.yml",
         "Athena PR workflow still runs inferential review without the semantic shadow lane enabled, so PR CI cannot collect the new shadow telemetry.",
-        "Set `HARNESS_INFERENTIAL_SEMANTIC_MODE: shadow` on the inferential review workflow step while keeping deterministic inferential findings authoritative."
-      )
+        "Set `HARNESS_INFERENTIAL_SEMANTIC_MODE: shadow` on the inferential review workflow step while keeping deterministic inferential findings authoritative.",
+      ),
     );
   }
 
@@ -933,15 +958,15 @@ export async function runDeterministicInferentialProvider(
           "Missing testing guidance",
           testingDoc.filePath,
           "Inferential gate policy cannot verify agent-facing usage guidance when testing docs are absent.",
-          "Restore the testing doc and document inferential review usage plus failure remediation guidance."
-        )
+          "Restore the testing doc and document inferential review usage plus failure remediation guidance.",
+        ),
       );
       continue;
     }
 
     const hasCommand = includesCaseInsensitive(
       testingDoc.contents,
-      "`bun run harness:inferential-review`"
+      "`bun run harness:inferential-review`",
     );
     const hasFailureGuidance =
       includesCaseInsensitive(testingDoc.contents, "non-zero") &&
@@ -955,8 +980,8 @@ export async function runDeterministicInferentialProvider(
           "Inferential review docs guidance is incomplete",
           testingDoc.filePath,
           "Testing docs must show how to run inferential review and how to interpret blocking failures.",
-          "Document `bun run harness:inferential-review` and state that findings fail with non-zero exit plus remediation guidance."
-        )
+          "Document `bun run harness:inferential-review` and state that findings fail with non-zero exit plus remediation guidance.",
+        ),
       );
     }
   }
@@ -1023,7 +1048,7 @@ function buildHumanReport(output: InferentialMachineOutput) {
     lines.push("Findings:");
     for (const finding of output.findings) {
       lines.push(
-        `- [${finding.severity.toUpperCase()}] ${finding.title} (${finding.filePath})`
+        `- [${finding.severity.toUpperCase()}] ${finding.title} (${finding.filePath})`,
       );
       lines.push(`  Rationale: ${finding.rationale}`);
       lines.push(`  Remediation: ${finding.remediation}`);
@@ -1049,7 +1074,7 @@ function buildHumanReport(output: InferentialMachineOutput) {
     if (output.shadow.findings.length > 0) {
       for (const finding of output.shadow.findings) {
         lines.push(
-          `- [${finding.severity.toUpperCase()}] ${finding.title} (${finding.filePath})`
+          `- [${finding.severity.toUpperCase()}] ${finding.title} (${finding.filePath})`,
         );
         lines.push(`  Rationale: ${finding.rationale}`);
         lines.push(`  Remediation: ${finding.remediation}`);
@@ -1072,11 +1097,14 @@ function buildHumanReport(output: InferentialMachineOutput) {
 async function writeMachineOutput(
   rootDir: string,
   machineOutputPath: string,
-  output: InferentialMachineOutput
+  output: InferentialMachineOutput,
 ) {
   const absoluteOutputPath = path.join(rootDir, machineOutputPath);
   await mkdir(path.dirname(absoluteOutputPath), { recursive: true });
-  await writeFile(`${absoluteOutputPath}`, `${JSON.stringify(output, null, 2)}\n`);
+  await writeFile(
+    `${absoluteOutputPath}`,
+    `${JSON.stringify(output, null, 2)}\n`,
+  );
 }
 
 function toHistoryFileStamp(generatedAt: string) {
@@ -1086,13 +1114,13 @@ function toHistoryFileStamp(generatedAt: string) {
 async function writeHistorySnapshot(
   rootDir: string,
   machineOutputPath: string,
-  output: InferentialMachineOutput
+  output: InferentialMachineOutput,
 ) {
   const absoluteHistoryPath = path.join(
     rootDir,
     path.dirname(machineOutputPath),
     "history",
-    `${toHistoryFileStamp(output.generatedAt)}.json`
+    `${toHistoryFileStamp(output.generatedAt)}.json`,
   );
 
   await mkdir(path.dirname(absoluteHistoryPath), { recursive: true });
@@ -1152,7 +1180,7 @@ function createProviderFailure(
   changedFiles: string[],
   targetFiles: string[],
   generatedAt: string,
-  reviewMode: InferentialReviewMode
+  reviewMode: InferentialReviewMode,
 ): InferentialMachineOutput {
   return createOutput({
     status: "error",
@@ -1181,7 +1209,7 @@ function createRuntimeFailure(
   changedFiles: string[],
   targetFiles: string[],
   generatedAt: string,
-  reviewMode: InferentialReviewMode
+  reviewMode: InferentialReviewMode,
 ): InferentialMachineOutput {
   return createOutput({
     status: "error",
@@ -1206,7 +1234,7 @@ function createRuntimeFailure(
 
 export async function runHarnessInferentialReview(
   rootDir: string,
-  options: InferentialReviewOptions = {}
+  options: InferentialReviewOptions = {},
 ): Promise<HarnessInferentialReviewResult> {
   const baseRef = options.baseRef ?? DEFAULT_BASE_REF;
   const machineOutputPath =
@@ -1239,7 +1267,7 @@ export async function runHarnessInferentialReview(
       changedFiles,
       targetFiles,
       nowIso(),
-      reviewMode
+      reviewMode,
     );
     const humanReport = buildHumanReport(machine);
     await writeMachineOutput(rootDir, machineOutputPath, machine);
@@ -1254,7 +1282,8 @@ export async function runHarnessInferentialReview(
   if (targetFiles.length === 0) {
     machine = createOutput({
       status: "skipped",
-      summary: "No harness-critical files are in scope. Inferential review skipped.",
+      summary:
+        "No harness-critical files are in scope. Inferential review skipped.",
       baseRef,
       changedFiles,
       targetFiles,
@@ -1289,7 +1318,7 @@ export async function runHarnessInferentialReview(
       changedFiles,
       targetFiles,
       nowIso(),
-      reviewMode
+      reviewMode,
     );
   }
 
@@ -1331,7 +1360,7 @@ export async function runHarnessInferentialReview(
         changedFiles,
         targetFiles,
         nowIso(),
-        reviewMode
+        reviewMode,
       );
     }
   }
@@ -1391,7 +1420,7 @@ export async function runHarnessInferentialReview(
       changedFiles,
       targetFiles,
       nowIso(),
-      reviewMode
+      reviewMode,
     );
     const runtimeReport = buildHumanReport(machine);
     await writeMachineOutput(rootDir, machineOutputPath, machine);
@@ -1414,7 +1443,7 @@ export async function runHarnessInferentialReview(
         changedFiles,
         targetFiles,
         nowIso(),
-        reviewMode
+        reviewMode,
       );
       const runtimeReport = buildHumanReport(machine);
       await writeMachineOutput(rootDir, machineOutputPath, machine);
@@ -1452,7 +1481,9 @@ type ParsedCliArgs = {
   help: boolean;
 };
 
-export function parseHarnessInferentialReviewArgs(argv: string[]): ParsedCliArgs {
+export function parseHarnessInferentialReviewArgs(
+  argv: string[],
+): ParsedCliArgs {
   let baseRef = DEFAULT_BASE_REF;
   let persistHistory = false;
 
@@ -1480,7 +1511,7 @@ export function parseHarnessInferentialReviewArgs(argv: string[]): ParsedCliArgs
       const value = argv[index + 1];
       if (!value || value.startsWith("--")) {
         throw new Error(
-          "Missing value for --base. Usage: bun run harness:inferential-review --base origin/main"
+          "Missing value for --base. Usage: bun run harness:inferential-review --base origin/main",
         );
       }
       baseRef = value;
@@ -1492,7 +1523,7 @@ export function parseHarnessInferentialReviewArgs(argv: string[]): ParsedCliArgs
       const value = arg.slice("--base=".length).trim();
       if (!value) {
         throw new Error(
-          "Missing value for --base. Usage: bun run harness:inferential-review --base origin/main"
+          "Missing value for --base. Usage: bun run harness:inferential-review --base origin/main",
         );
       }
       baseRef = value;
@@ -1500,7 +1531,7 @@ export function parseHarnessInferentialReviewArgs(argv: string[]): ParsedCliArgs
     }
 
     throw new Error(
-      `Unknown argument: ${arg}. Usage: bun run harness:inferential-review [--base <ref>]`
+      `Unknown argument: ${arg}. Usage: bun run harness:inferential-review [--base <ref>]`,
     );
   }
 
@@ -1516,7 +1547,7 @@ if (import.meta.main) {
     const parsed = parseHarnessInferentialReviewArgs(Bun.argv.slice(2));
     if (parsed.help) {
       console.log(
-        "Usage: bun run harness:inferential-review [--base <ref>] [--persist-history]"
+        "Usage: bun run harness:inferential-review [--base <ref>] [--persist-history]",
       );
       process.exit(0);
     }

--- a/scripts/pre-push-review.test.ts
+++ b/scripts/pre-push-review.test.ts
@@ -10,6 +10,12 @@ const ATHENA_GENERATED_DOC_PATHS = [
   "packages/athena-webapp/docs/agent/test-index.md",
   "packages/athena-webapp/docs/agent/key-folder-index.md",
 ] as const;
+const EXPIRED_PROOF_OPTIONS = {
+  evaluatePrePushValidationProof: async () => ({
+    reusable: false as const,
+    reason: "test proof disabled",
+  }),
+};
 
 describe("pre-push review wiring", () => {
   it("exports testable helpers for pre-push orchestration", () => {
@@ -36,11 +42,11 @@ describe("pre-push review wiring", () => {
         return {
           exited: Promise.resolve(0),
           stdout: new Response(
-            "packages/athena-webapp/src/main.tsx\npackages/storefront-webapp/src/router.tsx\n"
+            "packages/athena-webapp/src/main.tsx\npackages/storefront-webapp/src/router.tsx\n",
           ).body,
           stderr: new Response("").body,
         };
-      }
+      },
     );
 
     expect(files).toEqual([
@@ -53,23 +59,54 @@ describe("pre-push review wiring", () => {
     ]);
   });
 
-  it("falls back cleanly when origin/main is not reachable", async () => {
-    const files = await prePushReview.getChangedFilesVsOriginMain(
-      ROOT_DIR,
-      () => ({
+  it("fails closed when origin/main is not reachable", async () => {
+    await expect(
+      prePushReview.getChangedFilesVsOriginMain(ROOT_DIR, () => ({
         exited: Promise.resolve(1),
         stdout: new Response("").body,
         stderr: new Response("missing ref").body,
-      })
+      })),
+    ).rejects.toThrow(
+      "origin/main is not reachable; cannot select targeted pre-push validations",
+    );
+  });
+
+  it("fails closed when origin/main diff cannot be computed", async () => {
+    const commands: string[][] = [];
+
+    await expect(
+      prePushReview.getChangedFilesVsOriginMain(ROOT_DIR, (command) => {
+        commands.push(command);
+
+        if (command[1] === "rev-parse") {
+          return {
+            exited: Promise.resolve(0),
+            stdout: new Response("").body,
+            stderr: new Response("").body,
+          };
+        }
+
+        return {
+          exited: Promise.resolve(1),
+          stdout: new Response("").body,
+          stderr: new Response("bad revision").body,
+        };
+      }),
+    ).rejects.toThrow(
+      "git diff against origin/main failed; cannot select targeted pre-push validations",
     );
 
-    expect(files).toEqual([]);
+    expect(commands).toEqual([
+      ["git", "rev-parse", "--verify", "origin/main"],
+      ["git", "diff", "--name-only", "origin/main...HEAD"],
+    ]);
   });
 
   it("runs graphify check before self-review, architecture checks, harness review, and inferential review", async () => {
     const steps: string[] = [];
 
     await prePushReview.runPrePushReview(ROOT_DIR, {
+      ...EXPIRED_PROOF_OPTIONS,
       getChangedFiles: async () => {
         steps.push("changed-files");
         return ["packages/athena-webapp/src/main.tsx"];
@@ -153,7 +190,7 @@ describe("pre-push review wiring", () => {
 
     expect(steps).toEqual([]);
     expect(logs).toContain(
-      "[pre-push] Reusing current pr:athena validation proof for tree tree-sha."
+      "[pre-push] Reusing current pr:athena validation proof for tree tree-sha.",
     );
   });
 
@@ -161,6 +198,7 @@ describe("pre-push review wiring", () => {
     const steps: string[] = [];
 
     await prePushReview.runPrePushReview(ROOT_DIR, {
+      ...EXPIRED_PROOF_OPTIONS,
       getChangedFiles: async () => {
         steps.push("changed-files");
         return ["scripts/harness-check.test.ts"];
@@ -179,7 +217,10 @@ describe("pre-push review wiring", () => {
       },
       runHarnessReview: async (_rootDir, options) => {
         steps.push(`harness:review:${options.baseRef}`);
-        const files = await options.getChangedFiles?.(ROOT_DIR, options.baseRef);
+        const files = await options.getChangedFiles?.(
+          ROOT_DIR,
+          options.baseRef,
+        );
         steps.push(`files:${files?.join(",") ?? ""}`);
       },
       runHarnessInferentialReview: async () => {
@@ -207,6 +248,7 @@ describe("pre-push review wiring", () => {
     const steps: string[] = [];
 
     await prePushReview.runPrePushReview(ROOT_DIR, {
+      ...EXPIRED_PROOF_OPTIONS,
       getChangedFiles: async () => {
         steps.push("changed-files");
         return ["packages/athena-webapp/src/main.tsx"];
@@ -225,7 +267,10 @@ describe("pre-push review wiring", () => {
       },
       runHarnessReview: async (_rootDir, options) => {
         steps.push(`harness:review:${options.baseRef}`);
-        const files = await options.getChangedFiles?.(ROOT_DIR, options.baseRef);
+        const files = await options.getChangedFiles?.(
+          ROOT_DIR,
+          options.baseRef,
+        );
         steps.push(`files:${files?.join(",") ?? ""}`);
       },
       runHarnessInferentialReview: async () => {
@@ -250,10 +295,11 @@ describe("pre-push review wiring", () => {
     ]);
   });
 
-  it("preserves the non-blocking origin/main fallback when handing off to harness review", async () => {
+  it("preserves an injected empty changed-file set when handing off to harness review", async () => {
     const steps: string[] = [];
 
     await prePushReview.runPrePushReview(ROOT_DIR, {
+      ...EXPIRED_PROOF_OPTIONS,
       getChangedFiles: async () => {
         steps.push("changed-files-fallback");
         return [];
@@ -269,7 +315,10 @@ describe("pre-push review wiring", () => {
       },
       runHarnessReview: async (_rootDir, options) => {
         steps.push(`harness:review:${options.baseRef}`);
-        const files = await options.getChangedFiles?.(ROOT_DIR, options.baseRef);
+        const files = await options.getChangedFiles?.(
+          ROOT_DIR,
+          options.baseRef,
+        );
         steps.push(`files:${files?.join(",") ?? ""}`);
       },
       runHarnessInferentialReview: async () => {
@@ -301,6 +350,7 @@ describe("pre-push review wiring", () => {
 
     await expect(
       prePushReview.runPrePushReview(ROOT_DIR, {
+        ...EXPIRED_PROOF_OPTIONS,
         getChangedFiles: async () => {
           steps.push("changed-files");
           return ["packages/athena-webapp/src/main.tsx"];
@@ -316,7 +366,7 @@ describe("pre-push review wiring", () => {
                 "[graphify check] Graphify artifacts are stale:",
                 "- graphify-out/GRAPH_REPORT.md",
                 "Run `bun run graphify:rebuild` from repo root to refresh tracked graphify artifacts.",
-              ].join("\n")
+              ].join("\n"),
             );
           }
         },
@@ -342,9 +392,9 @@ describe("pre-push review wiring", () => {
           warn() {},
           error() {},
         },
-      } as any)
+      } as any),
     ).rejects.toThrow(
-      "Tracked graphify artifacts were auto-repaired locally. Review and commit the repaired files, then push again."
+      "Tracked graphify artifacts were auto-repaired locally. Review and commit the repaired files, then push again.",
     );
 
     expect(steps).toEqual([
@@ -364,6 +414,7 @@ describe("pre-push review wiring", () => {
 
     await expect(
       prePushReview.runPrePushReview(ROOT_DIR, {
+        ...EXPIRED_PROOF_OPTIONS,
         getChangedFiles: async () => {
           steps.push("changed-files");
           return ["packages/athena-webapp/src/main.tsx"];
@@ -390,9 +441,9 @@ describe("pre-push review wiring", () => {
           warn() {},
           error() {},
         },
-      } as any)
+      } as any),
     ).rejects.toThrow(
-      "Tracked graphify artifacts were auto-repaired locally. Review and commit the repaired files, then push again."
+      "Tracked graphify artifacts were auto-repaired locally. Review and commit the repaired files, then push again.",
     );
 
     expect(steps).toEqual([
@@ -415,16 +466,14 @@ describe("pre-push review wiring", () => {
 
       await expect(
         prePushReview.runPrePushReview(ROOT_DIR, {
+          ...EXPIRED_PROOF_OPTIONS,
           getChangedFiles: async () => {
             steps.push("changed-files:base");
             return ["packages/athena-webapp/src/main.tsx"];
           },
           getChangedFilesForRepairedTree: async () => {
             steps.push("changed-files:repaired");
-            return [
-              "packages/athena-webapp/src/main.tsx",
-              generatedDocPath,
-            ];
+            return ["packages/athena-webapp/src/main.tsx", generatedDocPath];
           },
           getLocalChangedFiles: async () =>
             generatedDocsPending ? [generatedDocPath] : [],
@@ -453,7 +502,7 @@ describe("pre-push review wiring", () => {
           },
           runHarnessReview: async (rootDir, options) => {
             reviewChangedFiles.push(
-              (await options.getChangedFiles?.(rootDir, options.baseRef)) ?? []
+              (await options.getChangedFiles?.(rootDir, options.baseRef)) ?? [],
             );
             steps.push(`harness:review:${options.baseRef}`);
           },
@@ -465,9 +514,9 @@ describe("pre-push review wiring", () => {
             warn() {},
             error() {},
           },
-        } as any)
+        } as any),
       ).rejects.toThrow(
-        "Generated harness docs were auto-repaired locally. Review and commit the repaired files, then push again."
+        "Generated harness docs were auto-repaired locally. Review and commit the repaired files, then push again.",
       );
 
       expect(steps).toEqual([
@@ -482,7 +531,7 @@ describe("pre-push review wiring", () => {
       expect(reviewChangedFiles).toEqual([
         ["packages/athena-webapp/src/main.tsx", generatedDocPath],
       ]);
-    }
+    },
   );
 
   it("blocks when harness:self-review reports non-repairable blockers", async () => {
@@ -490,6 +539,7 @@ describe("pre-push review wiring", () => {
 
     await expect(
       prePushReview.runPrePushReview(ROOT_DIR, {
+        ...EXPIRED_PROOF_OPTIONS,
         getChangedFiles: async () => {
           steps.push("changed-files");
           return [];
@@ -500,7 +550,9 @@ describe("pre-push review wiring", () => {
         runHarnessSelfReview: async () => {
           steps.push("harness:self-review");
           return {
-            blockers: ["Harness review coverage gap: packages/athena-webapp/src/unmapped.ts"],
+            blockers: [
+              "Harness review coverage gap: packages/athena-webapp/src/unmapped.ts",
+            ],
           };
         },
         validateHarnessDocs: async () => [],
@@ -521,7 +573,7 @@ describe("pre-push review wiring", () => {
           warn() {},
           error() {},
         },
-      } as any)
+      } as any),
     ).rejects.toThrow("harness:self-review blocked");
 
     expect(steps).toEqual(["graphify:check", "harness:self-review"]);
@@ -535,6 +587,7 @@ describe("pre-push review wiring", () => {
 
     await expect(
       prePushReview.runPrePushReview(ROOT_DIR, {
+        ...EXPIRED_PROOF_OPTIONS,
         getChangedFiles: async () => {
           steps.push("changed-files:base");
           return ["packages/athena-webapp/src/main.tsx"];
@@ -563,7 +616,7 @@ describe("pre-push review wiring", () => {
         runHarnessReview: async (rootDir, options) => {
           reviewRuns += 1;
           reviewChangedFiles.push(
-            (await options.getChangedFiles?.(rootDir, options.baseRef)) ?? []
+            (await options.getChangedFiles?.(rootDir, options.baseRef)) ?? [],
           );
           steps.push(`harness:review:${options.baseRef}:${reviewRuns}`);
           if (reviewRuns === 1) {
@@ -585,9 +638,9 @@ describe("pre-push review wiring", () => {
           warn() {},
           error() {},
         },
-      } as any)
+      } as any),
     ).rejects.toThrow(
-      "Generated harness docs were auto-repaired locally. Review and commit the repaired files, then push again."
+      "Generated harness docs were auto-repaired locally. Review and commit the repaired files, then push again.",
     );
 
     expect(steps).toEqual([
@@ -615,6 +668,7 @@ describe("pre-push review wiring", () => {
 
     await expect(
       prePushReview.runPrePushReview(ROOT_DIR, {
+        ...EXPIRED_PROOF_OPTIONS,
         getChangedFiles: async () => {
           steps.push("changed-files:base");
           return ["packages/athena-webapp/src/main.tsx"];
@@ -641,7 +695,7 @@ describe("pre-push review wiring", () => {
         },
         runHarnessReview: async (rootDir, options) => {
           reviewChangedFiles.push(
-            (await options.getChangedFiles?.(rootDir, options.baseRef)) ?? []
+            (await options.getChangedFiles?.(rootDir, options.baseRef)) ?? [],
           );
           steps.push(`harness:review:${options.baseRef}`);
         },
@@ -653,9 +707,9 @@ describe("pre-push review wiring", () => {
           warn() {},
           error() {},
         },
-      } as any)
+      } as any),
     ).rejects.toThrow(
-      "Generated harness docs were auto-repaired locally. Review and commit the repaired files, then push again."
+      "Generated harness docs were auto-repaired locally. Review and commit the repaired files, then push again.",
     );
 
     expect(steps).toEqual([
@@ -678,45 +732,46 @@ describe("pre-push review wiring", () => {
     const warnings: string[] = [];
     const reviewChangedFiles: string[][] = [];
 
-      await expect(
-        prePushReview.runPrePushReview(ROOT_DIR, {
-          getChangedFilesForRepairedTree: async () => {
-            throw new Error("Base ref check failed for origin/main: missing ref");
+    await expect(
+      prePushReview.runPrePushReview(ROOT_DIR, {
+        ...EXPIRED_PROOF_OPTIONS,
+        getChangedFilesForRepairedTree: async () => {
+          throw new Error("Base ref check failed for origin/main: missing ref");
+        },
+        getLocalChangedFiles: async () => {
+          steps.push("changed-files:local");
+          return ["packages/athena-webapp/docs/agent/test-index.md"];
+        },
+        runGraphifyCheck: async () => {
+          steps.push("graphify:check");
+        },
+        runHarnessSelfReview: async () => {
+          steps.push("harness:self-review");
+          return { blockers: [] };
+        },
+        runArchitectureCheck: async () => {
+          steps.push("architecture:check");
+        },
+        runHarnessReview: async (rootDir, options) => {
+          reviewChangedFiles.push(
+            (await options.getChangedFiles?.(rootDir, options.baseRef)) ?? [],
+          );
+          steps.push(`harness:review:${options.baseRef}`);
+        },
+        runHarnessInferentialReview: async () => {
+          steps.push("harness:inferential-review");
+        },
+        logger: {
+          log() {},
+          warn(message: string) {
+            warnings.push(message);
           },
-          getLocalChangedFiles: async () => {
-            steps.push("changed-files:local");
-            return ["packages/athena-webapp/docs/agent/test-index.md"];
-          },
-          runGraphifyCheck: async () => {
-            steps.push("graphify:check");
-          },
-          runHarnessSelfReview: async () => {
-            steps.push("harness:self-review");
-            return { blockers: [] };
-          },
-          runArchitectureCheck: async () => {
-            steps.push("architecture:check");
-          },
-          runHarnessReview: async (rootDir, options) => {
-            reviewChangedFiles.push(
-              (await options.getChangedFiles?.(rootDir, options.baseRef)) ?? []
-            );
-            steps.push(`harness:review:${options.baseRef}`);
-          },
-          runHarnessInferentialReview: async () => {
-            steps.push("harness:inferential-review");
-          },
-          logger: {
-            log() {},
-            warn(message: string) {
-              warnings.push(message);
-            },
-            error() {},
-          },
-        } as any)
-      ).rejects.toThrow(
-        "Generated harness docs were auto-repaired locally. Review and commit the repaired files, then push again."
-      );
+          error() {},
+        },
+      } as any),
+    ).rejects.toThrow(
+      "Generated harness docs were auto-repaired locally. Review and commit the repaired files, then push again.",
+    );
 
     expect(steps).toEqual([
       "graphify:check",
@@ -730,15 +785,14 @@ describe("pre-push review wiring", () => {
     expect(reviewChangedFiles).toEqual([
       ["packages/athena-webapp/docs/agent/test-index.md"],
     ]);
-    expect(warnings[0]).toContain(
-      "Falling back to local working tree changes"
-    );
+    expect(warnings[0]).toContain("Falling back to local working tree changes");
   });
 
   it("does not pass the base ref into default-style changed-file helpers", async () => {
     const observedSpawnTypes: string[] = [];
 
     await prePushReview.runPrePushReview(ROOT_DIR, {
+      ...EXPIRED_PROOF_OPTIONS,
       getChangedFiles: (async (_rootDir: string, spawn = Bun.spawn) => {
         observedSpawnTypes.push(typeof spawn);
         return [];
@@ -764,7 +818,7 @@ describe("pre-push review wiring", () => {
   it("keeps the husky pre-push hook pointed at the repo review script", async () => {
     const hookContents = await readFile(
       path.join(ROOT_DIR, ".husky/pre-push"),
-      "utf8"
+      "utf8",
     );
 
     expect(hookContents).toContain("bun run pre-push:review");
@@ -773,7 +827,7 @@ describe("pre-push review wiring", () => {
   it("keeps the husky pre-commit hook pointed at the generated-artifact repair script", async () => {
     const hookContents = await readFile(
       path.join(ROOT_DIR, ".husky/pre-commit"),
-      "utf8"
+      "utf8",
     );
 
     expect(hookContents).toContain("bun run pre-commit:generated-artifacts");
@@ -784,7 +838,7 @@ describe("repo harness ergonomics", () => {
   it("schedules a recurring harness drift check in GitHub Actions", async () => {
     const workflow = await readFile(
       path.join(ROOT_DIR, ".github/workflows/athena-pr-tests.yml"),
-      "utf8"
+      "utf8",
     );
 
     expect(workflow).toContain("schedule:");
@@ -794,9 +848,11 @@ describe("repo harness ergonomics", () => {
     expect(workflow).toContain("fetch-depth: 0");
     expect(workflow).toContain("run: bun run workflow:check");
     expect(workflow).toContain("run: bun run compound:check");
-    expect(workflow).toContain("run: bun run harness:self-review --base origin/main");
     expect(workflow).toContain(
-      "run: bun run harness:review --base origin/main --validation-provided-by athena-pr-tests"
+      "run: bun run harness:self-review --base origin/main",
+    );
+    expect(workflow).toContain(
+      "run: bun run harness:review --base origin/main --validation-provided-by athena-pr-tests",
     );
     expect(workflow).toContain("run: bun run harness:test");
     expect(workflow).toContain("name: Athena and Storefront Webapp Validation");
@@ -804,59 +860,83 @@ describe("repo harness ergonomics", () => {
     expect(workflow).toContain("athena-webapp-validation:");
     expect(workflow).toContain("storefront-webapp-validation-context:");
     expect(workflow).toContain("needs: athena-webapp-validation");
-    expect(workflow).toContain("Confirm consolidated storefront validation coverage");
+    expect(workflow).toContain(
+      "Confirm consolidated storefront validation coverage",
+    );
     expect(workflow).toContain("run: bun run test:coverage");
     expect(workflow).toContain("run: bun run --filter '@athena/webapp' build");
     expect(workflow).toContain(
-      "run: bun run --filter '@athena/storefront-webapp' build"
+      "run: bun run --filter '@athena/storefront-webapp' build",
     );
     expect(workflow).toContain(
-      "run: bun run --filter '@athena/webapp' lint:frontend:changed"
+      "run: bun run --filter '@athena/webapp' lint:frontend:changed",
     );
-    expect(workflow).not.toContain("run: bun run --filter '@athena/webapp' test");
+    expect(workflow).not.toContain(
+      "run: bun run --filter '@athena/webapp' test",
+    );
     expect(workflow).not.toContain("test-storefront-webapp:");
     expect(workflow).not.toContain("cargo install ripgrep");
     expect(workflow).toContain(
-      "run: python3 -m pip install -r .graphify-requirements.txt"
+      "run: python3 -m pip install -r .graphify-requirements.txt",
     );
     expect(workflow).toContain("run: bunx playwright install chromium");
     expect(workflow).toContain("run: bun run harness:audit");
     expect(workflow).toContain("HARNESS_INFERENTIAL_SEMANTIC_MODE: shadow");
     expect(workflow).toContain("run: bun run harness:inferential-review");
-    expect(workflow).toContain("run: bun run harness:inferential-review --persist-history");
-    expect(workflow).toContain("bun run harness:runtime-trends --persist-history");
+    expect(workflow).toContain(
+      "run: bun run harness:inferential-review --persist-history",
+    );
+    expect(workflow).toContain(
+      "bun run harness:runtime-trends --persist-history",
+    );
     expect(workflow).toContain("runtime_behavior_report_lines:");
     expect(workflow).toContain("actions/upload-artifact@v4");
     expect(workflow).toContain("run: bun run graphify:check");
   });
 
-  it("includes harness implementation, audit, and graphify checks in the local pr:athena command", async () => {
+  it("includes prepare, validate, and proof recording in the local pr:athena command chain", async () => {
     const packageJson = JSON.parse(
-      await readFile(path.join(ROOT_DIR, "package.json"), "utf8")
+      await readFile(path.join(ROOT_DIR, "package.json"), "utf8"),
     ) as {
       scripts?: Record<string, string>;
     };
 
-    expect(packageJson.scripts?.["pr:athena"]).toContain(
-      "bun run pre-commit:generated-artifacts"
+    expect(packageJson.scripts?.["pr:athena"]).toBe(
+      "bun run pr:athena:prepare && bun run pr:athena:validate && bun run pr:athena:record-proof",
     );
-    expect(packageJson.scripts?.["pr:athena"]).toContain("bun run compound:check");
-    expect(packageJson.scripts?.["pr:athena"]).toContain("bun run workflow:check");
-    expect(packageJson.scripts?.["pr:athena"]).toContain("bun run harness:test");
-    expect(packageJson.scripts?.["pr:athena"]).toContain(
-      "bun run harness:review --base origin/main --repo-validation-provided-by pr:athena"
+    expect(packageJson.scripts?.["pr:athena:prepare"]).toContain(
+      "bun run pre-commit:generated-artifacts",
     );
-    expect(packageJson.scripts?.["pr:athena"]).toContain(
-      "bun scripts/pre-push-validation-proof.ts record-pr-athena"
+    expect(packageJson.scripts?.["pr:athena:prepare"]).toContain(
+      "bun scripts/pre-push-validation-proof.ts prepare-pr-athena",
     );
-    expect(packageJson.scripts?.["pr:athena"]).toContain(
-      "bun run --filter '@athena/webapp' lint:frontend:changed"
+    expect(packageJson.scripts?.["pr:athena:validate"]).toContain(
+      "bun run compound:check",
     );
-    expect(packageJson.scripts?.["pr:athena"]).toContain("bun run harness:audit");
-    expect(packageJson.scripts?.["pr:athena"]).toContain(
-      "bun run harness:inferential-review"
+    expect(packageJson.scripts?.["pr:athena:validate"]).toContain(
+      "bun run workflow:check",
     );
-    expect(packageJson.scripts?.["pr:athena"]).toContain("bun run graphify:check");
+    expect(packageJson.scripts?.["pr:athena:validate"]).toContain(
+      "bun run harness:test",
+    );
+    expect(packageJson.scripts?.["pr:athena:validate"]).toContain(
+      "bun run harness:review --base origin/main --repo-validation-provided-by pr:athena",
+    );
+    expect(packageJson.scripts?.["pr:athena:record-proof"]).toBe(
+      "bun scripts/pre-push-validation-proof.ts record-pr-athena",
+    );
+    expect(packageJson.scripts?.["pr:athena:validate"]).toContain(
+      "bun run --filter '@athena/webapp' lint:frontend:changed",
+    );
+    expect(packageJson.scripts?.["pr:athena:validate"]).toContain(
+      "bun run harness:audit",
+    );
+    expect(packageJson.scripts?.["pr:athena:validate"]).toContain(
+      "bun run harness:inferential-review",
+    );
+    expect(packageJson.scripts?.["pr:athena:validate"]).toContain(
+      "bun run graphify:check",
+    );
   });
 
   it("documents harness implementation tests as a repo-level command", async () => {
@@ -873,20 +953,28 @@ describe("repo harness ergonomics", () => {
     const readme = await readFile(path.join(ROOT_DIR, "README.md"), "utf8");
 
     expect(readme).toContain(
-      "`pre-commit:generated-artifacts` automatically runs `bun run harness:generate` and `bun run graphify:rebuild`"
+      "`pre-commit:generated-artifacts` automatically runs `bun run harness:generate` and `bun run graphify:rebuild`",
     );
     expect(readme).toContain(
-      "`bun run pr:athena` starts with that same generated-artifact repair step"
+      "`bun run pr:athena:prepare` starts with that same generated-artifact repair step",
     );
     expect(readme).toContain(
-      "If `harness:self-review` or `harness:review` gets blocked by stale generated harness docs"
+      "`bun run pr:athena:validate` runs the heavy validation ladder",
     );
     expect(readme).toContain(
-      "Blocks so you can review, commit, and push the repaired generated docs instead of sending a stale ref to CI."
+      "`bun run pr:athena:record-proof` records the reusable pre-push proof",
     );
-    expect(readme).toContain("`pre-push:review` starts with `bun run graphify:check`");
     expect(readme).toContain(
-      "runs `bun run graphify:rebuild` once, reruns `bun run graphify:check`, and then stops"
+      "If `harness:self-review` or `harness:review` gets blocked by stale generated harness docs",
+    );
+    expect(readme).toContain(
+      "Blocks so you can review, commit, and push the repaired generated docs instead of sending a stale ref to CI.",
+    );
+    expect(readme).toContain(
+      "`pre-push:review` starts with `bun run graphify:check`",
+    );
+    expect(readme).toContain(
+      "runs `bun run graphify:rebuild` once, reruns `bun run graphify:check`, and then stops",
     );
     expect(readme).toContain("bun run graphify:check");
     expect(readme).toContain("bun run graphify:rebuild");
@@ -908,13 +996,13 @@ describe("repo harness ergonomics", () => {
 
   it("wires a repo-level pre-commit generated-artifact repair command", async () => {
     const packageJson = JSON.parse(
-      await readFile(path.join(ROOT_DIR, "package.json"), "utf8")
+      await readFile(path.join(ROOT_DIR, "package.json"), "utf8"),
     ) as {
       scripts?: Record<string, string>;
     };
 
     expect(packageJson.scripts?.["pre-commit:generated-artifacts"]).toBe(
-      "bun scripts/pre-commit-generated-artifacts.ts"
+      "bun scripts/pre-commit-generated-artifacts.ts",
     );
   });
 
@@ -925,7 +1013,7 @@ describe("repo harness ergonomics", () => {
     ]);
 
     expect(JSON.parse(packageJson).scripts?.prepare).toBe(
-      "sh scripts/configure-git-hooks.sh"
+      "sh scripts/configure-git-hooks.sh",
     );
     expect(configureHooksScript).toContain("git config core.hooksPath .husky");
   });
@@ -933,7 +1021,10 @@ describe("repo harness ergonomics", () => {
   it("pins Bun in package.json and keeps GitHub Actions aligned with that repo version", async () => {
     const [packageJsonText, workflow] = await Promise.all([
       readFile(path.join(ROOT_DIR, "package.json"), "utf8"),
-      readFile(path.join(ROOT_DIR, ".github/workflows/athena-pr-tests.yml"), "utf8"),
+      readFile(
+        path.join(ROOT_DIR, ".github/workflows/athena-pr-tests.yml"),
+        "utf8",
+      ),
     ]);
 
     expect(JSON.parse(packageJsonText)).toMatchObject({

--- a/scripts/pre-push-review.ts
+++ b/scripts/pre-push-review.ts
@@ -17,7 +17,7 @@ import {
 const ROOT_DIR = process.cwd();
 const BASE_REF = "origin/main";
 const GENERATED_HARNESS_DOC_PATHS = new Set(
-  HARNESS_APP_REGISTRY.flatMap((app) => app.harnessDocs.generatedDocs)
+  HARNESS_APP_REGISTRY.flatMap((app) => app.harnessDocs.generatedDocs),
 );
 const TRACKED_GRAPHIFY_ARTIFACT_PATHS = new Set(TRACKED_GRAPHIFY_ARTIFACTS);
 const REPAIRED_DOCS_COMMIT_BLOCKER =
@@ -41,7 +41,7 @@ type PrePushReviewOptions = {
   getChangedFiles?: (rootDir: string) => Promise<string[]>;
   getChangedFilesForRepairedTree?: (
     rootDir: string,
-    baseRef: string
+    baseRef: string,
   ) => Promise<string[]>;
   getLocalChangedFiles?: (rootDir: string) => Promise<string[]>;
   runGraphifyCheck?: (rootDir: string) => Promise<void>;
@@ -51,17 +51,20 @@ type PrePushReviewOptions = {
   runHarnessGenerate?: (rootDir: string) => Promise<void>;
   runHarnessImplementationTests?: (rootDir: string) => Promise<void>;
   runHarnessSelfReview?: (
-    rootDir: string
+    rootDir: string,
   ) => Promise<HarnessSelfReviewSummary | void>;
   runHarnessReview?: (
     rootDir: string,
     options: {
       baseRef: string;
-      getChangedFiles?: (rootDir: string, baseRef?: string) => Promise<string[]>;
-    }
+      getChangedFiles?: (
+        rootDir: string,
+        baseRef?: string,
+      ) => Promise<string[]>;
+    },
   ) => Promise<void>;
   evaluatePrePushValidationProof?: (
-    rootDir: string
+    rootDir: string,
   ) => Promise<PrePushValidationProofEvaluation>;
   validateHarnessDocs?: (rootDir: string) => Promise<string[]>;
   logger?: PrePushReviewLogger;
@@ -73,7 +76,10 @@ function normalizeRepoPath(repoPath: string) {
 
 export async function getChangedFilesVsOriginMain(
   rootDir: string,
-  spawn: (command: string[], options: { cwd: string; stdout: "pipe"; stderr: "pipe" }) => SpawnedProcess = Bun.spawn
+  spawn: (
+    command: string[],
+    options: { cwd: string; stdout: "pipe"; stderr: "pipe" },
+  ) => SpawnedProcess = Bun.spawn,
 ): Promise<string[]> {
   const refCheck = spawn(["git", "rev-parse", "--verify", BASE_REF], {
     cwd: rootDir,
@@ -83,27 +89,37 @@ export async function getChangedFilesVsOriginMain(
   const refExitCode = await refCheck.exited;
 
   if (refExitCode !== 0) {
-    console.warn(
-      `[pre-push] Warning: ${BASE_REF} not reachable. Skipping targeted validations.`
+    const stderr = await new Response(refCheck.stderr).text();
+    throw new Error(
+      [
+        `[pre-push] ${BASE_REF} is not reachable; cannot select targeted pre-push validations.`,
+        stderr.trim() || `git rev-parse --verify ${BASE_REF} failed`,
+        `Run \`git fetch origin ${BASE_REF.replace("origin/", "")}\` and retry.`,
+      ].join("\n"),
     );
-    return [];
   }
 
-  const proc = spawn(
-    ["git", "diff", "--name-only", `${BASE_REF}...HEAD`],
-    { cwd: rootDir, stdout: "pipe", stderr: "pipe" }
-  );
+  const proc = spawn(["git", "diff", "--name-only", `${BASE_REF}...HEAD`], {
+    cwd: rootDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
 
-  const [output, exitCode] = await Promise.all([
+  const [output, stderr, exitCode] = await Promise.all([
     new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
     proc.exited,
   ]);
 
   if (exitCode !== 0) {
-    console.warn(
-      `[pre-push] Warning: git diff failed. Skipping targeted validations.`
+    throw new Error(
+      [
+        `[pre-push] git diff against ${BASE_REF} failed; cannot select targeted pre-push validations.`,
+        stderr.trim() ||
+          output.trim() ||
+          `git diff --name-only ${BASE_REF}...HEAD failed`,
+      ].join("\n"),
     );
-    return [];
   }
 
   return output
@@ -125,7 +141,7 @@ export async function runArchitectureCheck(rootDir: string): Promise<void> {
 }
 
 export async function runHarnessSelfReview(
-  rootDir: string
+  rootDir: string,
 ): Promise<HarnessSelfReviewSummary> {
   return runStructuredHarnessSelfReview(rootDir, { baseRef: BASE_REF });
 }
@@ -134,7 +150,9 @@ export async function runHarnessGenerate(rootDir: string): Promise<void> {
   await writeGeneratedHarnessDocs(rootDir);
 }
 
-export async function runHarnessImplementationTests(rootDir: string): Promise<void> {
+export async function runHarnessImplementationTests(
+  rootDir: string,
+): Promise<void> {
   const proc = Bun.spawn(["bun", "run", "harness:test"], {
     cwd: rootDir,
     stdout: "inherit",
@@ -146,7 +164,9 @@ export async function runHarnessImplementationTests(rootDir: string): Promise<vo
   }
 }
 
-export async function runHarnessInferentialReview(rootDir: string): Promise<void> {
+export async function runHarnessInferentialReview(
+  rootDir: string,
+): Promise<void> {
   const proc = Bun.spawn(["bun", "run", "harness:inferential-review"], {
     cwd: rootDir,
     stdout: "inherit",
@@ -167,7 +187,9 @@ function collectRepairableHarnessDocErrors(errors: string[]) {
       continue;
     }
 
-    const missingFileMatch = error.match(/^Missing required harness file: (.+)$/);
+    const missingFileMatch = error.match(
+      /^Missing required harness file: (.+)$/,
+    );
     if (
       missingFileMatch?.[1] &&
       GENERATED_HARNESS_DOC_PATHS.has(missingFileMatch[1])
@@ -177,7 +199,7 @@ function collectRepairableHarnessDocErrors(errors: string[]) {
     }
 
     const generatedDocMatch = error.match(
-      /^(?:Broken markdown link in|Missing referenced path in) ([^:]+):/
+      /^(?:Broken markdown link in|Missing referenced path in) ([^:]+):/,
     );
     if (
       generatedDocMatch?.[1] &&
@@ -204,10 +226,11 @@ function isRepairableGraphifyDrift(error: unknown) {
 
 export async function runPrePushReview(
   rootDir: string,
-  options: PrePushReviewOptions = {}
+  options: PrePushReviewOptions = {},
 ) {
   const logger = options.logger ?? console;
-  const getChangedFiles = options.getChangedFiles ?? getChangedFilesVsOriginMain;
+  const getChangedFiles =
+    options.getChangedFiles ?? getChangedFilesVsOriginMain;
   const getChangedFilesForRepairedTree =
     options.getChangedFilesForRepairedTree ??
     ((nextRootDir: string, baseRef: string) =>
@@ -238,14 +261,14 @@ export async function runPrePushReview(
   const proofEvaluation = await evaluateValidationProof(rootDir);
   if (proofEvaluation.reusable) {
     logger.log(
-      `[pre-push] Reusing current pr:athena validation proof for tree ${proofEvaluation.proof.validatedTreeSha}.`
+      `[pre-push] Reusing current pr:athena validation proof for tree ${proofEvaluation.proof.validatedTreeSha}.`,
     );
     logger.log("[pre-push] All checks passed.");
     return;
   }
 
   logger.log(
-    `[pre-push] pr:athena proof not reusable: ${proofEvaluation.reason}. Running validation suite.`
+    `[pre-push] pr:athena proof not reusable: ${proofEvaluation.reason}. Running validation suite.`,
   );
 
   const loadChangedFiles = () => {
@@ -272,7 +295,7 @@ export async function runPrePushReview(
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         logger.warn(
-          `[pre-push] Warning: unable to diff repaired generated docs against ${BASE_REF}. Falling back to local working tree changes. (${message})`
+          `[pre-push] Warning: unable to diff repaired generated docs against ${BASE_REF}. Falling back to local working tree changes. (${message})`,
         );
         return getLocalChangedFiles(rootDir);
       }
@@ -283,9 +306,10 @@ export async function runPrePushReview(
 
   const getPendingGeneratedHarnessDocs = async () => {
     const localChangedFiles = await getLocalChangedFiles(rootDir);
-    const normalizedLocalChangedFiles = localChangedFiles.map(normalizeRepoPath);
-    const pendingGeneratedDocs = normalizedLocalChangedFiles.filter((filePath) =>
-      GENERATED_HARNESS_DOC_PATHS.has(filePath)
+    const normalizedLocalChangedFiles =
+      localChangedFiles.map(normalizeRepoPath);
+    const pendingGeneratedDocs = normalizedLocalChangedFiles.filter(
+      (filePath) => GENERATED_HARNESS_DOC_PATHS.has(filePath),
     );
 
     if (pendingGeneratedDocs.length > 0) {
@@ -297,9 +321,9 @@ export async function runPrePushReview(
 
   const getPendingGraphifyArtifacts = async () => {
     const localChangedFiles = await getLocalChangedFiles(rootDir);
-    return localChangedFiles.map(normalizeRepoPath).filter((filePath) =>
-      TRACKED_GRAPHIFY_ARTIFACT_PATHS.has(filePath)
-    );
+    return localChangedFiles
+      .map(normalizeRepoPath)
+      .filter((filePath) => TRACKED_GRAPHIFY_ARTIFACT_PATHS.has(filePath));
   };
 
   const maybeRepairGeneratedHarnessDocs = async (reason: string) => {
@@ -308,7 +332,7 @@ export async function runPrePushReview(
     }
 
     const repairableErrors = collectRepairableHarnessDocErrors(
-      await validateHarnessDocsStep(rootDir)
+      await validateHarnessDocsStep(rootDir),
     );
     if (repairableErrors.length === 0) {
       return false;
@@ -323,7 +347,7 @@ export async function runPrePushReview(
 
   const maybeRepairGraphifyArtifacts = async (
     reason: string,
-    error: unknown
+    error: unknown,
   ) => {
     if (repairedGraphifyArtifacts || !isRepairableGraphifyDrift(error)) {
       return false;
@@ -343,7 +367,7 @@ export async function runPrePushReview(
   } catch (error) {
     const repaired = await maybeRepairGraphifyArtifacts(
       "repairable graphify drift detected after graphify:check failed",
-      error
+      error,
     );
     if (!repaired) {
       throw error;
@@ -356,7 +380,7 @@ export async function runPrePushReview(
   let selfReviewResult = await runSelfReview(rootDir);
   if ((selfReviewResult?.blockers?.length ?? 0) > 0) {
     const repaired = await maybeRepairGeneratedHarnessDocs(
-      "repairable harness doc drift detected after harness:self-review"
+      "repairable harness doc drift detected after harness:self-review",
     );
     if (repaired) {
       selfReviewResult = await runSelfReview(rootDir);
@@ -364,7 +388,7 @@ export async function runPrePushReview(
   }
   if ((selfReviewResult?.blockers?.length ?? 0) > 0) {
     throw new Error(
-      formatBlockerList("harness:self-review", selfReviewResult.blockers ?? [])
+      formatBlockerList("harness:self-review", selfReviewResult.blockers ?? []),
     );
   }
 
@@ -378,10 +402,12 @@ export async function runPrePushReview(
 
   if (repoValidation.matchedFiles.length > 0) {
     logger.log(
-      "[pre-push] Step 4/6: harness:test skipped (repo harness validations run inside harness:review)"
+      "[pre-push] Step 4/6: harness:test skipped (repo harness validations run inside harness:review)",
     );
   } else {
-    logger.log("[pre-push] Step 4/6: harness:test skipped (no harness-owned changes)");
+    logger.log(
+      "[pre-push] Step 4/6: harness:test skipped (no harness-owned changes)",
+    );
   }
 
   // runHarnessReview internally runs harness:check first, then targeted per-surface scripts
@@ -393,7 +419,7 @@ export async function runPrePushReview(
     });
   } catch (error) {
     const repaired = await maybeRepairGeneratedHarnessDocs(
-      "repairable harness doc drift detected after harness:review failed"
+      "repairable harness doc drift detected after harness:review failed",
     );
     if (!repaired) {
       throw error;
@@ -406,11 +432,12 @@ export async function runPrePushReview(
   }
 
   const finalChangedFiles = await loadChangedFiles();
-  const finalRepoValidation = collectHarnessRepoValidationSelection(finalChangedFiles);
+  const finalRepoValidation =
+    collectHarnessRepoValidationSelection(finalChangedFiles);
 
   if (finalRepoValidation.matchedFiles.length > 0) {
     logger.log(
-      "[pre-push] Step 6/6: harness:inferential-review skipped (repo harness validations already ran in harness:review)"
+      "[pre-push] Step 6/6: harness:inferential-review skipped (repo harness validations already ran in harness:review)",
     );
   } else {
     logger.log("[pre-push] Step 6/6: harness:inferential-review");
@@ -421,7 +448,7 @@ export async function runPrePushReview(
 
   if (pendingGeneratedHarnessDocs.length > 0) {
     logger.log(
-      "\n[pre-push] Generated harness docs were repaired and revalidated locally."
+      "\n[pre-push] Generated harness docs were repaired and revalidated locally.",
     );
     throw new Error(REPAIRED_DOCS_COMMIT_BLOCKER);
   }
@@ -430,7 +457,7 @@ export async function runPrePushReview(
 
   if (repairedGraphifyArtifacts || pendingGraphifyArtifacts.length > 0) {
     logger.log(
-      "\n[pre-push] Tracked graphify artifacts were repaired and revalidated locally."
+      "\n[pre-push] Tracked graphify artifacts were repaired and revalidated locally.",
     );
     throw new Error(REPAIRED_GRAPHIFY_COMMIT_BLOCKER);
   }

--- a/scripts/pre-push-validation-proof.test.ts
+++ b/scripts/pre-push-validation-proof.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import {
+  assertPrAthenaProofReady,
   evaluatePrePushValidationProof,
   recordPrePushValidationProof,
 } from "./pre-push-validation-proof";
@@ -31,18 +32,30 @@ async function createFixtureRoot() {
         },
       },
       null,
-      2
-    )
+      2,
+    ),
   );
   await write(rootDir, ".husky/pre-push", "bun run pre-push:review\n");
-  await write(rootDir, "scripts/pre-push-review.ts", "export const prePush = true;\n");
+  await write(
+    rootDir,
+    "scripts/pre-push-review.ts",
+    "export const prePush = true;\n",
+  );
   await write(
     rootDir,
     "scripts/pre-push-validation-proof.ts",
-    "export const proof = true;\n"
+    "export const proof = true;\n",
   );
-  await write(rootDir, "scripts/harness-review.ts", "export const review = true;\n");
-  await write(rootDir, "scripts/harness-repo-validation.ts", "export const repo = true;\n");
+  await write(
+    rootDir,
+    "scripts/harness-review.ts",
+    "export const review = true;\n",
+  );
+  await write(
+    rootDir,
+    "scripts/harness-repo-validation.ts",
+    "export const repo = true;\n",
+  );
 
   return rootDir;
 }
@@ -55,6 +68,7 @@ function createSpawn(outputs: {
   status?: string;
   untrackedFiles?: string;
   unstagedDiffExitCode?: number;
+  unstagedFiles?: string;
   bunVersion?: string;
 }) {
   const next = {
@@ -65,13 +79,17 @@ function createSpawn(outputs: {
     status: "",
     untrackedFiles: "",
     unstagedDiffExitCode: 0,
+    unstagedFiles: "",
     bunVersion: "1.1.29",
     ...outputs,
   };
 
   return (command: string[]) => {
     let output = "";
-    if (command.join(" ") === "git rev-parse --git-path codex/pre-push-pr-athena-proof.json") {
+    if (
+      command.join(" ") ===
+      "git rev-parse --git-path codex/pre-push-pr-athena-proof.json"
+    ) {
       output = "proof.json";
     } else if (command.join(" ") === "git rev-parse --verify HEAD") {
       output = next.headSha;
@@ -85,7 +103,9 @@ function createSpawn(outputs: {
       command.join(" ") === "git status --porcelain --untracked-files=all"
     ) {
       output = next.status;
-    } else if (command.join(" ") === "git ls-files --others --exclude-standard") {
+    } else if (
+      command.join(" ") === "git ls-files --others --exclude-standard"
+    ) {
       output = next.untrackedFiles;
     } else if (command.join(" ") === "git diff --quiet") {
       return {
@@ -93,6 +113,8 @@ function createSpawn(outputs: {
         stdout: new Response("").body,
         stderr: new Response("").body,
       };
+    } else if (command.join(" ") === "git diff --name-only") {
+      output = next.unstagedFiles;
     } else if (command.join(" ") === "bun --version") {
       output = next.bunVersion;
     } else {
@@ -108,10 +130,86 @@ function createSpawn(outputs: {
 }
 
 afterEach(async () => {
-  await Promise.all(tempRoots.splice(0).map((rootDir) => rm(rootDir, { recursive: true })));
+  await Promise.all(
+    tempRoots.splice(0).map((rootDir) => rm(rootDir, { recursive: true })),
+  );
 });
 
 describe("pre-push validation proof", () => {
+  it("prepares a clean tree for pr:athena proof recording", async () => {
+    const rootDir = await createFixtureRoot();
+    const logs: string[] = [];
+
+    await expect(
+      assertPrAthenaProofReady(rootDir, {
+        spawn: createSpawn({}),
+        logger: {
+          log(message: string) {
+            logs.push(message);
+          },
+        },
+      }),
+    ).resolves.toMatchObject({
+      ready: true,
+      mode: "clean",
+      stagedFiles: [],
+    });
+    expect(logs).toContain(
+      "[pr:athena] Prepare complete: working tree is clean.",
+    );
+  });
+
+  it("prepares a staged-only tree for pr:athena staged-index proof recording", async () => {
+    const rootDir = await createFixtureRoot();
+
+    await expect(
+      assertPrAthenaProofReady(rootDir, {
+        spawn: createSpawn({
+          headTreeSha: "tree-before",
+          indexTreeSha: "tree-after",
+          status: "M  scripts/pre-push-review.ts",
+        }),
+        logger: { log() {} },
+      }),
+    ).resolves.toMatchObject({
+      ready: true,
+      mode: "staged-index",
+      stagedFiles: ["scripts/pre-push-review.ts"],
+    });
+  });
+
+  it("blocks pr:athena prepare when unstaged tracked files remain", async () => {
+    const rootDir = await createFixtureRoot();
+
+    await expect(
+      assertPrAthenaProofReady(rootDir, {
+        spawn: createSpawn({
+          status: " M scripts/pre-push-review.ts",
+          unstagedFiles: "scripts/pre-push-review.ts",
+        }),
+        logger: { log() {} },
+      }),
+    ).rejects.toThrow(
+      /Unstaged tracked files:\n  - scripts\/pre-push-review.ts/,
+    );
+  });
+
+  it("blocks pr:athena prepare when untracked files remain", async () => {
+    const rootDir = await createFixtureRoot();
+
+    await expect(
+      assertPrAthenaProofReady(rootDir, {
+        spawn: createSpawn({
+          status: "M  scripts/pre-push-review.ts\n?? tmp.txt",
+          untrackedFiles: "tmp.txt",
+        }),
+        logger: { log() {} },
+      }),
+    ).rejects.toThrow(
+      /Untracked files:\n  - tmp.txt\nStage intended new files explicitly/,
+    );
+  });
+
   it("records and reuses a clean same-head pr:athena proof", async () => {
     const rootDir = await createFixtureRoot();
     const spawn = createSpawn({});
@@ -123,7 +221,7 @@ describe("pre-push validation proof", () => {
     expect(recorded.recorded).toBe(true);
 
     await expect(
-      evaluatePrePushValidationProof(rootDir, { spawn })
+      evaluatePrePushValidationProof(rootDir, { spawn }),
     ).resolves.toMatchObject({
       reusable: true,
       proof: {
@@ -162,7 +260,7 @@ describe("pre-push validation proof", () => {
           headTreeSha: "tree-after",
           indexTreeSha: "tree-after",
         }),
-      })
+      }),
     ).resolves.toMatchObject({
       reusable: true,
       proof: {
@@ -185,7 +283,7 @@ describe("pre-push validation proof", () => {
           unstagedDiffExitCode: 1,
         }),
         logger: { log() {}, warn() {} },
-      })
+      }),
     ).resolves.toMatchObject({
       recorded: false,
       reason: "working tree has unstaged or untracked changes",
@@ -204,7 +302,7 @@ describe("pre-push validation proof", () => {
           untrackedFiles: "tmp.txt",
         }),
         logger: { log() {}, warn() {} },
-      })
+      }),
     ).resolves.toMatchObject({
       recorded: false,
       reason: "working tree has unstaged or untracked changes",
@@ -221,7 +319,7 @@ describe("pre-push validation proof", () => {
     await expect(
       evaluatePrePushValidationProof(rootDir, {
         spawn: createSpawn({ status: " M scripts/pre-push-review.ts" }),
-      })
+      }),
     ).resolves.toMatchObject({
       reusable: false,
       reason: "working tree is not clean",
@@ -247,7 +345,7 @@ describe("pre-push validation proof", () => {
           headTreeSha: "tree-other",
           indexTreeSha: "tree-other",
         }),
-      })
+      }),
     ).resolves.toMatchObject({
       reusable: false,
       reason: "HEAD tree changed since pr:athena recorded its proof",
@@ -264,7 +362,7 @@ describe("pre-push validation proof", () => {
     await expect(
       evaluatePrePushValidationProof(rootDir, {
         spawn: createSpawn({ baseSha: "base-b" }),
-      })
+      }),
     ).resolves.toMatchObject({
       reusable: false,
       reason: "origin/main changed since pr:athena recorded its proof",
@@ -281,13 +379,13 @@ describe("pre-push validation proof", () => {
     await write(
       rootDir,
       "scripts/harness-review.ts",
-      "export const review = 'changed';\n"
+      "export const review = 'changed';\n",
     );
 
     await expect(
       evaluatePrePushValidationProof(rootDir, {
         spawn: createSpawn({}),
-      })
+      }),
     ).resolves.toMatchObject({
       reusable: false,
       reason: "validation wiring changed since proof recording",

--- a/scripts/pre-push-validation-proof.ts
+++ b/scripts/pre-push-validation-proof.ts
@@ -14,10 +14,11 @@ type SpawnedProcess = {
 
 type CommandRunner = (
   command: string[],
-  options: { cwd: string; stdout: "pipe"; stderr: "pipe" }
+  options: { cwd: string; stdout: "pipe"; stderr: "pipe" },
 ) => SpawnedProcess;
 
 type ProofLogger = Pick<Console, "log" | "warn">;
+type PrepareLogger = Pick<Console, "log">;
 
 export type PrePushValidationProof = {
   schemaVersion: typeof PRE_PUSH_VALIDATION_PROOF_SCHEMA_VERSION;
@@ -60,15 +61,15 @@ function normalizeRepoPath(repoPath: string) {
 }
 
 function sortUniquePaths(paths: string[]) {
-  return [...new Set(paths.map((entry) => normalizeRepoPath(entry)).filter(Boolean))].sort(
-    (left, right) => left.localeCompare(right)
-  );
+  return [
+    ...new Set(paths.map((entry) => normalizeRepoPath(entry)).filter(Boolean)),
+  ].sort((left, right) => left.localeCompare(right));
 }
 
 async function runCommand(
   rootDir: string,
   command: string[],
-  spawn: CommandRunner = Bun.spawn
+  spawn: CommandRunner = Bun.spawn,
 ) {
   const proc = spawn(command, {
     cwd: rootDir,
@@ -82,7 +83,9 @@ async function runCommand(
   ]);
 
   if (exitCode !== 0) {
-    throw new Error(stderr.trim() || stdout.trim() || `${command.join(" ")} failed`);
+    throw new Error(
+      stderr.trim() || stdout.trim() || `${command.join(" ")} failed`,
+    );
   }
 
   return stdout.trim();
@@ -91,7 +94,7 @@ async function runCommand(
 async function runExitCodeCommand(
   rootDir: string,
   command: string[],
-  spawn: CommandRunner = Bun.spawn
+  spawn: CommandRunner = Bun.spawn,
 ) {
   const proc = spawn(command, {
     cwd: rootDir,
@@ -107,10 +110,122 @@ async function runExitCodeCommand(
   return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
 }
 
+function parsePorcelainPaths(status: string) {
+  return status
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line) => line.slice(3).trim())
+    .filter(Boolean);
+}
+
+function formatPathList(paths: string[]) {
+  return paths.map((repoPath) => `  - ${repoPath}`).join("\n");
+}
+
+async function collectUnstagedFiles(
+  rootDir: string,
+  spawn: CommandRunner = Bun.spawn,
+) {
+  const proc = spawn(["git", "diff", "--name-only"], {
+    cwd: rootDir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  if (exitCode !== 0) {
+    throw new Error(
+      stderr.trim() || stdout.trim() || "git diff --name-only failed",
+    );
+  }
+
+  return stdout
+    .split("\n")
+    .map((line) => normalizeRepoPath(line.trim()))
+    .filter(Boolean);
+}
+
+async function collectUntrackedFiles(
+  rootDir: string,
+  spawn: CommandRunner = Bun.spawn,
+) {
+  const output = await runCommand(
+    rootDir,
+    ["git", "ls-files", "--others", "--exclude-standard"],
+    spawn,
+  );
+
+  return output
+    .split("\n")
+    .map((line) => normalizeRepoPath(line.trim()))
+    .filter(Boolean);
+}
+
+export async function assertPrAthenaProofReady(
+  rootDir: string,
+  options: ProofRuntimeOptions & { logger?: PrepareLogger } = {},
+) {
+  const spawn = options.spawn ?? Bun.spawn;
+  const [status, unstagedFiles, untrackedFiles] = await Promise.all([
+    runCommand(
+      rootDir,
+      ["git", "status", "--porcelain", "--untracked-files=all"],
+      spawn,
+    ),
+    collectUnstagedFiles(rootDir, spawn),
+    collectUntrackedFiles(rootDir, spawn),
+  ]);
+
+  if (unstagedFiles.length > 0 || untrackedFiles.length > 0) {
+    const sections = [
+      "pr:athena prepare blocked before heavy validation because the current tree cannot record a reusable pre-push proof.",
+    ];
+
+    if (unstagedFiles.length > 0) {
+      sections.push(
+        `Unstaged tracked files:\n${formatPathList(unstagedFiles)}`,
+      );
+    }
+
+    if (untrackedFiles.length > 0) {
+      sections.push(
+        [
+          "Untracked files:",
+          formatPathList(untrackedFiles),
+          "Stage intended new files explicitly, or remove unrelated files, then rerun `bun run pr:athena:prepare`.",
+        ].join("\n"),
+      );
+    } else {
+      sections.push(
+        "Stage intended tracked changes, or restore unrelated edits, then rerun `bun run pr:athena:prepare`.",
+      );
+    }
+
+    throw new Error(sections.join("\n\n"));
+  }
+
+  const stagedFiles = parsePorcelainPaths(status);
+  const logger = options.logger ?? console;
+  if (stagedFiles.length > 0) {
+    logger.log(
+      `[pr:athena] Prepare complete: ${stagedFiles.length} staged file(s) ready for staged-index proof.`,
+    );
+    return { ready: true as const, mode: "staged-index" as const, stagedFiles };
+  }
+
+  logger.log("[pr:athena] Prepare complete: working tree is clean.");
+  return { ready: true as const, mode: "clean" as const, stagedFiles };
+}
+
 async function collectFilesUnder(
   rootDir: string,
   relativeDir: string,
-  options: ProofRuntimeOptions
+  options: ProofRuntimeOptions,
 ) {
   const fsReaddir = options.readdir ?? readdir;
   const files: string[] = [];
@@ -145,7 +260,7 @@ async function collectFilesUnder(
 
 async function collectValidationFingerprintPaths(
   rootDir: string,
-  options: ProofRuntimeOptions = {}
+  options: ProofRuntimeOptions = {},
 ) {
   return sortUniquePaths([
     "package.json",
@@ -161,19 +276,24 @@ async function collectValidationFingerprintPaths(
     "scripts/coverage-toolchain-parity.ts",
     ...(await collectFilesUnder(rootDir, "scripts", options)).filter(
       (filePath) =>
-        /^scripts\/(?:harness-|graphify-|pre-commit-generated-artifacts)/.test(filePath)
+        /^scripts\/(?:harness-|graphify-|pre-commit-generated-artifacts)/.test(
+          filePath,
+        ),
     ),
   ]);
 }
 
 async function hashValidationWiring(
   rootDir: string,
-  options: ProofRuntimeOptions = {}
+  options: ProofRuntimeOptions = {},
 ) {
   const fsReadFile = options.readFile ?? readFile;
   const hasher = createHash("sha256");
 
-  for (const repoPath of await collectValidationFingerprintPaths(rootDir, options)) {
+  for (const repoPath of await collectValidationFingerprintPaths(
+    rootDir,
+    options,
+  )) {
     hasher.update(`${repoPath}\0`);
     try {
       const contents = await fsReadFile(path.join(rootDir, repoPath));
@@ -187,10 +307,13 @@ async function hashValidationWiring(
   return hasher.digest("hex");
 }
 
-async function readPrAthenaScript(rootDir: string, options: ProofRuntimeOptions = {}) {
+async function readPrAthenaScript(
+  rootDir: string,
+  options: ProofRuntimeOptions = {},
+) {
   const fsReadFile = options.readFile ?? readFile;
   const packageJson = JSON.parse(
-    await fsReadFile(path.join(rootDir, "package.json"), "utf8")
+    await fsReadFile(path.join(rootDir, "package.json"), "utf8"),
   ) as { scripts?: Record<string, string> };
 
   const prAthenaScript = packageJson.scripts?.["pr:athena"]?.trim();
@@ -204,7 +327,7 @@ async function readPrAthenaScript(rootDir: string, options: ProofRuntimeOptions 
 async function collectProofSnapshot(
   rootDir: string,
   options: ProofRuntimeOptions = {},
-  mode: ProofSnapshotMode = "evaluate"
+  mode: ProofSnapshotMode = "evaluate",
 ): Promise<ProofSnapshot> {
   const spawn = options.spawn ?? Bun.spawn;
   const [
@@ -219,23 +342,36 @@ async function collectProofSnapshot(
     prAthenaScript,
     validationFingerprint,
   ] = await Promise.all([
-    runCommand(rootDir, ["git", "rev-parse", "--git-path", PROOF_GIT_PATH], spawn),
+    runCommand(
+      rootDir,
+      ["git", "rev-parse", "--git-path", PROOF_GIT_PATH],
+      spawn,
+    ),
     runCommand(rootDir, ["git", "rev-parse", "--verify", "HEAD"], spawn),
     runCommand(rootDir, ["git", "rev-parse", "--verify", "HEAD^{tree}"], spawn),
     runCommand(rootDir, ["git", "write-tree"], spawn),
-    runCommand(rootDir, ["git", "rev-parse", "--verify", PR_ATHENA_PROOF_BASE_REF], spawn),
+    runCommand(
+      rootDir,
+      ["git", "rev-parse", "--verify", PR_ATHENA_PROOF_BASE_REF],
+      spawn,
+    ),
     runCommand(
       rootDir,
       ["git", "status", "--porcelain", "--untracked-files=all"],
-      spawn
+      spawn,
     ),
-    runCommand(rootDir, ["git", "ls-files", "--others", "--exclude-standard"], spawn),
+    runCommand(
+      rootDir,
+      ["git", "ls-files", "--others", "--exclude-standard"],
+      spawn,
+    ),
     runCommand(rootDir, ["bun", "--version"], spawn),
     readPrAthenaScript(rootDir, options),
     hashValidationWiring(rootDir, options),
   ]);
 
-  let recordedStatusMode: PrePushValidationProof["recordedStatusMode"] = "clean";
+  let recordedStatusMode: PrePushValidationProof["recordedStatusMode"] =
+    "clean";
   let validatedTreeSha = headTreeSha;
 
   if (status.trim()) {
@@ -246,11 +382,11 @@ async function collectProofSnapshot(
     const unstagedDiff = await runExitCodeCommand(
       rootDir,
       ["git", "diff", "--quiet"],
-      spawn
+      spawn,
     );
     if (unstagedDiff.exitCode > 1) {
       throw new Error(
-        unstagedDiff.stderr || unstagedDiff.stdout || "git diff --quiet failed"
+        unstagedDiff.stderr || unstagedDiff.stdout || "git diff --quiet failed",
       );
     }
 
@@ -302,7 +438,7 @@ function validateProofShape(value: unknown): value is PrePushValidationProof {
 
 export async function evaluatePrePushValidationProof(
   rootDir: string,
-  options: ProofRuntimeOptions = {}
+  options: ProofRuntimeOptions = {},
 ): Promise<PrePushValidationProofEvaluation> {
   let snapshot: ProofSnapshot;
   try {
@@ -333,11 +469,20 @@ export async function evaluatePrePushValidationProof(
   }
 
   const comparisons: Array<[keyof PrePushValidationProof, string]> = [
-    ["validatedTreeSha", "HEAD tree changed since pr:athena recorded its proof"],
-    ["baseSha", `${PR_ATHENA_PROOF_BASE_REF} changed since pr:athena recorded its proof`],
+    [
+      "validatedTreeSha",
+      "HEAD tree changed since pr:athena recorded its proof",
+    ],
+    [
+      "baseSha",
+      `${PR_ATHENA_PROOF_BASE_REF} changed since pr:athena recorded its proof`,
+    ],
     ["bunVersion", "Bun version changed since pr:athena recorded its proof"],
     ["prAthenaScript", "pr:athena command changed since proof recording"],
-    ["validationFingerprint", "validation wiring changed since proof recording"],
+    [
+      "validationFingerprint",
+      "validation wiring changed since proof recording",
+    ],
   ];
 
   for (const [field, reason] of comparisons) {
@@ -359,7 +504,7 @@ export async function evaluatePrePushValidationProof(
 
 export async function recordPrePushValidationProof(
   rootDir: string,
-  options: ProofRuntimeOptions & { logger?: ProofLogger } = {}
+  options: ProofRuntimeOptions & { logger?: ProofLogger } = {},
 ) {
   const logger = options.logger ?? console;
 
@@ -368,12 +513,14 @@ export async function recordPrePushValidationProof(
     const { proofPath, ...proof } = snapshot;
     await mkdir(path.dirname(proofPath), { recursive: true });
     await writeFile(proofPath, `${JSON.stringify(proof, null, 2)}\n`, "utf8");
-    logger.log(`[pr:athena] Recorded current pre-push validation proof at ${proofPath}.`);
+    logger.log(
+      `[pr:athena] Recorded current pre-push validation proof at ${proofPath}.`,
+    );
     return { recorded: true as const, proofPath, proof };
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     logger.warn(
-      `[pr:athena] Did not record pre-push validation proof: ${reason}. pre-push will run normally.`
+      `[pr:athena] Did not record pre-push validation proof: ${reason}. pre-push will run normally.`,
     );
 
     try {
@@ -382,8 +529,8 @@ export async function recordPrePushValidationProof(
         await runCommand(
           rootDir,
           ["git", "rev-parse", "--git-path", PROOF_GIT_PATH],
-          options.spawn ?? Bun.spawn
-        )
+          options.spawn ?? Bun.spawn,
+        ),
       );
       await rm(proofPath, { force: true });
     } catch {
@@ -397,9 +544,14 @@ export async function recordPrePushValidationProof(
 if (import.meta.main) {
   const [command] = Bun.argv.slice(2);
 
+  if (command === "prepare-pr-athena") {
+    await assertPrAthenaProofReady(process.cwd());
+    process.exit(0);
+  }
+
   if (command !== "record-pr-athena") {
     console.error(
-      "Usage: bun scripts/pre-push-validation-proof.ts record-pr-athena"
+      "Usage: bun scripts/pre-push-validation-proof.ts <prepare-pr-athena|record-pr-athena>",
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- split `pr:athena` into explicit prepare, validate, and record-proof phases
- add a pre-heavy-validation prepare gate that only allows clean or staged-only trees so reusable proof recording is not silently lost
- teach harness inferential review to inspect chained `pr:athena` scripts and document the new ladder contract

## Validation
- `bun test scripts/pre-push-validation-proof.test.ts scripts/pre-push-review.test.ts scripts/harness-inferential-review.test.ts`
- `bun run harness:test`
- `bun run graphify:rebuild`
- `bun run graphify:check`
- `bun scripts/validate-plan-html.ts docs/plans/2026-06-13-001-refactor-pr-athena-proof-ladder-plan.html`
- `bun run pr:athena`
- pre-push on `git push` reused the recorded `pr:athena` proof for tree `732007e9bcac2584643bc131842791ec3b3b1853`

## Linear
- V26-742
- V26-743