### PR TITLE
Serialize terminal runtime status check-ins

### DIFF
--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -2964,6 +2964,89 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     expect(mocks.reportTerminalRuntimeStatus).toHaveBeenCalledTimes(1);
   });
 
+  it("queues changed runtime check-ins while a previous publish is in flight", async () => {
+    const firstPublish = deferred<{
+      kind: "ok";
+      data: Record<string, never>;
+    }>();
+    const secondPublish = deferred<{
+      kind: "ok";
+      data: Record<string, never>;
+    }>();
+    mocks.reportTerminalRuntimeStatus
+      .mockReturnValueOnce(firstPublish.promise)
+      .mockReturnValueOnce(secondPublish.promise);
+    const store = {
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [],
+      })),
+      readProvisionedTerminalSeed: vi.fn(async () => ({
+        ok: true,
+        value: {
+          cloudTerminalId: "terminal-cloud-1",
+          displayName: "Front",
+          provisionedAt: 1,
+          schemaVersion: 1,
+          syncSecretHash: "sync-secret-1",
+          storeId: "store-1",
+          terminalId: "local-terminal-1",
+        },
+      })),
+    };
+
+    const storeFactory = () => store as never;
+    const { rerender } = renderHook(
+      ({ staffProfileId }) =>
+        usePosLocalSyncRuntimeStatus({
+          mode: "status-only",
+          staffProfileId,
+          storeFactory,
+          storeId: "store-1",
+          terminalId: "terminal-cloud-1",
+        }),
+      {
+        initialProps: { staffProfileId: "staff-1" },
+      },
+    );
+
+    await waitFor(() =>
+      expect(mocks.reportTerminalRuntimeStatus).toHaveBeenCalledTimes(1),
+    );
+
+    rerender({ staffProfileId: "staff-2" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mocks.reportTerminalRuntimeStatus).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      firstPublish.resolve({
+        kind: "ok",
+        data: {},
+      });
+    });
+
+    await waitFor(() =>
+      expect(mocks.reportTerminalRuntimeStatus).toHaveBeenCalledTimes(2),
+    );
+    expect(mocks.reportTerminalRuntimeStatus).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        status: expect.objectContaining({
+          staffAuthority: expect.objectContaining({
+            staffProfileId: "staff-2",
+          }),
+        }),
+      }),
+    );
+
+    await act(async () => {
+      secondPublish.resolve({
+        kind: "ok",
+        data: {},
+      });
+    });
+  });
+
   it("exposes missing check-in publish prerequisites in debug state", async () => {
     const store = {
       listEvents: vi.fn(async () => ({

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -193,12 +193,22 @@ export function usePosLocalSyncRuntimeStatus(input: {
     [input.appSessionRecovery],
   );
   const lastRuntimeStatusSignatureRef = useRef<string | null>(null);
+  const runtimeStatusPublishInFlightRef = useRef(false);
+  const queuedRuntimeStatusSignatureRef = useRef<string | null>(null);
+  const isRuntimeStatusPublisherMountedRef = useRef(true);
   const observedRecoveryCommandIdsRef = useRef<Set<string>>(new Set());
   const requestRetry = useCallback(() => {
     setRefreshToken((current) => current + 1);
     setManualRetryToken((current) => current + 1);
     onRetrySync?.();
   }, [onRetrySync]);
+
+  useEffect(
+    () => () => {
+      isRuntimeStatusPublisherMountedRef.current = false;
+    },
+    [],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -857,7 +867,12 @@ export function usePosLocalSyncRuntimeStatus(input: {
       terminalId: checkInTerminalId,
     });
     if (signature === lastRuntimeStatusSignatureRef.current) return;
+    if (runtimeStatusPublishInFlightRef.current) {
+      queuedRuntimeStatusSignatureRef.current = signature;
+      return;
+    }
     lastRuntimeStatusSignatureRef.current = signature;
+    runtimeStatusPublishInFlightRef.current = true;
 
     const attemptedAt = Date.now();
     setDebug((current) =>
@@ -996,6 +1011,18 @@ export function usePosLocalSyncRuntimeStatus(input: {
             checkInPublishStatus: "failed",
           }),
         );
+      })
+      .finally(() => {
+        runtimeStatusPublishInFlightRef.current = false;
+        const queuedSignature = queuedRuntimeStatusSignatureRef.current;
+        queuedRuntimeStatusSignatureRef.current = null;
+        if (
+          queuedSignature &&
+          queuedSignature !== lastRuntimeStatusSignatureRef.current &&
+          isRuntimeStatusPublisherMountedRef.current
+        ) {
+          setRuntimeStatusObservationToken((current) => current + 1);
+        }
       });
 
     return () => {


### PR DESCRIPTION
## Summary
- serialize POS terminal runtime status publishes in the browser runtime
- queue the latest changed status while a previous check-in is in flight
- add regression coverage for the overlapping publish case that can trigger Convex document retry conflicts

## Root cause
The POS runtime could start overlapping `reportTerminalRuntimeStatus` mutations for the same terminal. Convex stores one latest `posTerminalRuntimeStatus` document per terminal via read-then-patch, so overlapping check-ins can keep changing that document during retries and surface a Convex document-conflict error.

## Validation
- `bun run --filter '@athena/webapp' test -- src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`
- `bun run --filter '@athena/webapp' lint:frontend:changed`
- `bun run graphify:rebuild && bun run graphify:check`
- pre-push validation suite passed
