### PR TITLE
Align POS terminal recovery readiness

### DIFF
--- a/docs/deployment/vps-production.md
+++ b/docs/deployment/vps-production.md
@@ -181,15 +181,20 @@ scripts/deploy-vps.sh athena-local
 scripts/deploy-vps.sh storefront-local
 scripts/deploy-vps.sh valkey-proxy
 scripts/deploy-vps.sh qa
+scripts/deploy-vps.sh convex-athena-local
+scripts/deploy-vps.sh convex-storefront-local
 scripts/deploy-vps.sh full-prod
 scripts/deploy-vps.sh full-prod-local
 scripts/deploy-vps.sh all
 scripts/deploy-vps.sh check-git
 ```
 
-`athena`, `storefront`, `full-prod`, and `all` are local-build production deploy
-paths. They build static bundles from the local checkout before uploading them
-to the VPS. `full-prod-local` remains as an explicit alias for older runbooks.
+`athena`, `storefront`, `convex-athena-local`, `convex-storefront-local`,
+`full-prod`, and `all` are local-build production deploy paths. They build
+static bundles from the local checkout before uploading them to the VPS. Use
+`convex-athena-local` or `convex-storefront-local` when a change needs Convex
+plus exactly one static app build, but does not need the Valkey proxy
+redeployed. `full-prod-local` remains as an explicit alias for older runbooks.
 Use `athena-remote` only when you intentionally want the VPS checkout to build
 the Athena admin app.
 

--- a/docs/solutions/architecture/athena-pos-terminal-recovery-readiness-boundary-2026-06-14.md
+++ b/docs/solutions/architecture/athena-pos-terminal-recovery-readiness-boundary-2026-06-14.md
@@ -1,0 +1,247 @@
+---
+title: Athena POS Terminal Recovery Readiness Boundary
+date: 2026-06-14
+category: architecture
+module: athena-webapp
+problem_type: pos_terminal_recovery_readiness_boundary
+component: pos
+symptoms:
+  - "Terminal Health can label a terminal healthy while Support Recovery still shows a repair state from an older command"
+  - "Staff authority expiry and cleanly closed drawers can be presented as support blockers even though normal cashier action resolves them"
+  - "Terminal roster and terminal detail can disagree because they derive recovery state from different evidence"
+  - "Register-session review actions can toast success while older review evidence remains visible"
+root_cause: terminal_health_mixed_sales_readiness_support_recovery_and_historical_command_status
+resolution_type: readiness_boundary_and_recovery_preview_alignment
+severity: high
+tags:
+  - pos
+  - terminal-health
+  - support-recovery
+  - cash-controls
+  - local-first
+  - remote-commands
+---
+
+# Athena POS Terminal Recovery Readiness Boundary
+
+## Problem
+
+Terminal Health is a support surface, but it consumes evidence from several
+different domains:
+
+- live terminal runtime check-ins,
+- cloud sync cursors and conflicts,
+- local drawer and staff authority,
+- register-session state,
+- remote recovery command acknowledgements, and
+- Cash Controls review evidence.
+
+When those domains are collapsed into a single "healthy" or "blocked" posture,
+the UI becomes contradictory. A terminal can be healthy for support purposes
+while still needing a cashier to sign in. A drawer can be cleanly closed in the
+cloud while stale local drawer-authority evidence still says `cloud_closed`.
+A remote repair command can fail its precondition because the terminal evidence
+already changed, but the old command can continue to read as the current problem.
+
+The result is especially confusing on production terminals after support sends
+remote commands: the terminal may be able to proceed through the normal POS
+lifecycle while Support Recovery still foregrounds the last command outcome.
+
+## Decision
+
+Keep three concepts separate and derive each one from the right source:
+
+1. **Sales readiness** answers whether the checkout station is ready for the
+   next POS action. It can include normal operator next steps such as opening a
+   drawer or signing in.
+2. **Support recovery** answers whether support has current repair or review
+   work to do. Historical command status is not current work once no blocker or
+   safe action remains.
+3. **Diagnostic evidence** explains what the latest terminal check-in reported.
+   It is useful for support but should not automatically become a sales blocker.
+
+The terminal roster and terminal detail must use the same recovery preview and
+presentation helpers. The list card is not allowed to re-derive a weaker
+readiness state from partial evidence when the detail query has already
+normalized the recovery state.
+
+## Solution
+
+Align the backend preview, frontend presentation, and local runtime reporting
+around the same readiness boundary:
+
+- Build terminal roster rows with the same recovery preview used by terminal
+  detail.
+- Normalize support runtime evidence before deriving attention reasons, so a
+  cleanly closed drawer does not keep a stale drawer-authority repair alive.
+- Publish app-shell and active register-session evidence in terminal runtime
+  check-ins.
+- Hide verified terminal repair actions from the current support work queue.
+- Show command failure reasons and next steps only while current support work is
+  still present.
+- Classify register-session review items with structured review kind and action
+  policy, while preserving compatibility for older summary-only conflicts.
+- Scope closeout review actions to the visible conflict ids so success reflects
+  a real mutation of the intended review evidence.
+- Render initial roster metrics as `-` until data arrives.
+
+## Source Of Truth
+
+The cloud query builds a `TerminalRecoveryPreview` from:
+
+- the latest terminal runtime status,
+- cloud sync evidence,
+- active register-session lookup,
+- current attention reasons,
+- safe cloud repair candidates, and
+- the latest terminal recovery command.
+
+The frontend then passes that preview through
+`buildTerminalRecoveryPresentation`. UI components should not infer support
+recovery groups directly from raw attention reasons unless no preview exists.
+
+Runtime check-in remains the verification source. A command acknowledgement says
+the terminal ran a local helper; a fresh runtime check-in says whether the
+expected evidence actually changed.
+
+## State Rules
+
+Use these rules when changing Terminal Health or POS runtime reporting:
+
+- `able_to_transact_now` requires fresh runtime evidence, active register
+  session evidence, and sale authority.
+- `drawer_open` is an operational state, not a support repair state. It means
+  the drawer is open and the next POS step is a cashier sign-in or sale action.
+- `healthy_idle` means no current support blocker is visible. It does not mean a
+  drawer is already open or a cashier is already signed in.
+- `needs_terminal_action` is only for terminal-side repair commands that are
+  still relevant. Do not use it for normal cashier sign-in.
+- `needs_cloud_repair` is only for cloud-safe conflicts that can be repaired
+  without touching sales, payments, inventory, closeouts, variances, or manager
+  review facts.
+- `needs_manual_review` is for business-fact review that belongs in Cash
+  Controls or Operations.
+
+Staff authority deserves special handling. `ready` is displayed with a check.
+`expired` is displayed as expired evidence, but it should not create Support
+Recovery work by itself because a cashier signing in at the terminal refreshes
+it through the normal POS lifecycle.
+
+Drawer authority also deserves special handling. A `blocked` drawer authority
+with reason `cloud_closed` should not be treated as support-blocked when the
+matching cloud register session is closed for the same store and terminal. That
+is a clean drawer lifecycle, so support should not offer drawer repair.
+
+## Remote Command Outcomes
+
+Remote commands are scoped, allow-listed, and verified by later terminal
+evidence. The UI should present command state only while it helps the operator
+or support user act.
+
+Current command states:
+
+- `pending` means the command is queued for the checkout station.
+- `claimed` means the checkout station is running it.
+- `completed` means the station finished the local helper.
+- `runtime_verification_ready` means the local helper completed and the next
+  check-in should verify the evidence.
+- `verified` means the next check-in matched the expected evidence.
+- `precondition_failed` means the command expected a stale blocker that was no
+  longer present or no longer matched safely.
+
+Do not use an old `precondition_failed` command as the headline if the latest
+runtime evidence has no current blocker. If current support work exists, show the
+failure reason and the next safe action. If no current support work exists, show
+that no support action is needed.
+
+## Register Session Review Compatibility
+
+Older review records were created before review items carried structured
+`reviewKind` and `actionPolicy` metadata. The resolution path must classify both
+old and new evidence, then choose behavior by review kind:
+
+- `register_closeout_variance` can be approved or rejected.
+- `duplicate_register_closeout` is reject-only because the register is already
+  closed; applying it would double-apply closeout facts.
+- `register_not_open_sale` can be approved or rejected when the local register
+  session matches.
+- `staff_access` can be approved or rejected when it is the only automatic staff
+  access review.
+- `service_customer_attribution` remains reject-only until the missing business
+  attribution is repaired elsewhere.
+- `server_rejected` can be overridden or rejected through manager review.
+- `unknown` is reject-only.
+
+Actioning a review must mutate the underlying conflict records, not only show a
+toast. When the UI scopes an action to one visible closeout review item, it
+passes the target conflict ids so duplicate or stale review evidence cannot be
+mistaken for the item the user approved or rejected.
+
+## App Shell And Local Diagnostics
+
+App shell readiness is diagnostic evidence. The terminal should report whether
+the app shell is ready in runtime status, but missing app-shell evidence should
+not outrank drawer, cashier, sync, and register-session readiness.
+
+The roster should show `-` for aggregate metric cards until data arrives. A
+temporary zero implies there are truly zero terminals, zero pending sync events,
+or zero review items, which is not true during the initial query gap.
+
+## UI Rules
+
+- The roster and detail pages must use shared recovery preview semantics.
+- "Support recovery" should mean support work, not normal cashier action.
+- Do not surface raw backend conflict ids in operator-facing copy.
+- Show only the active register session for a terminal, and link it to Cash
+  Controls with the app's link-out affordance.
+- Keep local data copy operational. Prefer labels like "Products and stock" and
+  "Register details" over internal terms like "availability snapshot" or
+  "register read model".
+- Avoid showing verified terminal actions as available actions. Verification
+  should remove the action from the support work queue.
+
+## Prevention
+
+- Do not add support recovery copy by reading raw command status alone. First
+  decide whether current blockers or safe actions still exist.
+- Do not let staff authority expiry create a support repair action unless there
+  is separate evidence that a terminal-side refresh command is actually needed.
+- Do not treat `cloud_closed` drawer authority as blocked when the matching
+  cloud register session is cleanly closed for the same terminal.
+- Do not add a roster-only readiness derivation that bypasses
+  `TerminalRecoveryPreview`.
+- Do not action register-session review items by summary text alone when a
+  structured `reviewKind` or target conflict id is available.
+- Do not expose backend identifiers or raw conflict text in operator-facing
+  copy.
+
+## Validation
+
+When this boundary changes, cover both the server preview and the UI
+presentation. The durable test set should include:
+
+- `convex/pos/application/queries/terminals.test.ts`
+- `convex/pos/application/commands/terminals.test.ts`
+- `convex/pos/application/terminals.test.ts`
+- `convex/pos/infrastructure/repositories/terminalRepository.test.ts`
+- `src/components/pos/terminals/terminalHealthPresentation.test.ts`
+- `src/components/pos/terminals/POSTerminalDetailView.test.tsx`
+- `src/components/pos/terminals/POSTerminalHealthView.test.tsx`
+- `src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts`
+- `src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`
+- `src/lib/pos/infrastructure/local/terminalRecoveryCommands.test.ts`
+- `src/offline/posAppShellReadiness.test.ts`
+- `convex/cashControls/deposits.test.ts`
+- `convex/pos/application/sync/registerSessionSyncReview` coverage through
+  deposits and register-session view tests
+- `src/components/cash-controls/RegisterSessionView.test.tsx`
+
+Run `bun run graphify:rebuild` after code or solution-doc changes, then run the
+focused tests and `bun run pr:athena` before merging.
+
+## Related
+
+- [Athena POS Remote Terminal Health Recovery](./athena-pos-remote-terminal-health-recovery-2026-06-11.md)
+- [Athena POS Local Staff Authority](./athena-pos-local-staff-authority-2026-05-14.md)
+- [Athena POS Drawer Authority Replacement Recovery](../logic-errors/athena-pos-drawer-authority-replacement-recovery-2026-06-06.md)
+- [Athena POS Register Sync Closeout Review Recovery](../logic-errors/athena-pos-register-sync-closeout-review-recovery-2026-05-23.md)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1931 files · ~0 words
+- 1933 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6824 nodes · 7644 edges · 1858 communities detected
+- 6866 nodes · 7718 edges · 1860 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1868,6 +1868,8 @@
 - [[_COMMUNITY_Community 1855|Community 1855]]
 - [[_COMMUNITY_Community 1856|Community 1856]]
 - [[_COMMUNITY_Community 1857|Community 1857]]
+- [[_COMMUNITY_Community 1858|Community 1858]]
+- [[_COMMUNITY_Community 1859|Community 1859]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1879,7 +1881,7 @@
 7. `DataTableViewOptions()` - 16 edges
 8. `createConflict()` - 15 edges
 9. `importInventoryRowsWithCtx()` - 14 edges
-10. `validatePendingCheckoutItemDefinedPayload()` - 14 edges
+10. `submitTerminalRuntimeStatus()` - 14 edges
 
 ## Surprising Connections (you probably didn't know these)
 - `getAmountPaidForOrder()` --calls--> `getDiscountValue()`  [EXTRACTED]
@@ -1913,7 +1915,7 @@ Nodes (50): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(),
 
 ### Community 4 - "Community 4"
 Cohesion: 0.06
-Nodes (24): assertPosLocalStoreOk(), clearAcceptedTerminalIntegrityState(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents() (+16 more)
+Nodes (25): assertPosLocalStoreOk(), clearAcceptedTerminalIntegrityState(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents() (+17 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.06
@@ -1940,36 +1942,36 @@ Cohesion: 0.07
 Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
 
 ### Community 11 - "Community 11"
+Cohesion: 0.1
+Nodes (33): buildRecoveryBlockers(), buildRecoveryBlockersFromPreview(), buildRecoveryReadiness(), buildTerminalRecoveryPresentation(), classifyTerminalHealth(), defaultBlockerSummary(), deriveRecoveryBlockerFromReason(), deriveRecoveryBlockers() (+25 more)
+
+### Community 12 - "Community 12"
+Cohesion: 0.07
+Nodes (22): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+14 more)
+
+### Community 13 - "Community 13"
 Cohesion: 0.08
 Nodes (22): cleanInventoryMetadataValue(), formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels() (+14 more)
 
-### Community 12 - "Community 12"
+### Community 14 - "Community 14"
 Cohesion: 0.13
 Nodes (35): buildFinalTrustedQuantitiesByRowNumber(), buildProvisionalSkuPatch(), buildSkuInsert(), buildSkuPatch(), finalizeProvisionalImportRowsForAppliedImport(), findExistingSku(), findOrCreateCategory(), findOrCreateProduct() (+27 more)
 
-### Community 13 - "Community 13"
+### Community 15 - "Community 15"
 Cohesion: 0.12
 Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
 
-### Community 14 - "Community 14"
+### Community 16 - "Community 16"
 Cohesion: 0.12
 Nodes (32): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+24 more)
 
-### Community 15 - "Community 15"
-Cohesion: 0.07
-Nodes (13): formatCompactTextList(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary(), formatReviewReportedSummary(), formatReviewTypeSummary(), formatTimestamp() (+5 more)
-
-### Community 16 - "Community 16"
-Cohesion: 0.11
-Nodes (27): buildRecoveryBlockers(), buildRecoveryBlockersFromPreview(), buildRecoveryReadiness(), buildTerminalRecoveryPresentation(), classifyTerminalHealth(), defaultBlockerSummary(), deriveRecoveryBlockerFromReason(), deriveRecoveryBlockers() (+19 more)
-
 ### Community 17 - "Community 17"
-Cohesion: 0.16
-Nodes (33): asRecord(), cartItemSourceKey(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale() (+25 more)
+Cohesion: 0.07
+Nodes (16): formatCompactTextList(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary(), formatReviewReportedSummary(), formatReviewTypeSummary(), formatTimestamp() (+8 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.08
-Nodes (17): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+9 more)
+Cohesion: 0.16
+Nodes (33): asRecord(), cartItemSourceKey(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale() (+25 more)
 
 ### Community 19 - "Community 19"
 Cohesion: 0.15
@@ -1988,72 +1990,72 @@ Cohesion: 0.08
 Nodes (9): buildMissingDraftResult(), formatQueueWorkItemValue(), getApprovalRequestCopy(), handleDecideApprovalRequest(), handleDiscardCycleCountDraft(), handleRefreshCycleCountDraftLineBaseline(), handleSaveCycleCountDraftLine(), handleSubmitCycleCountDraft() (+1 more)
 
 ### Community 23 - "Community 23"
+Cohesion: 0.18
+Nodes (27): completed(), executeCallbackCommand(), executeClearStaleDrawerAuthority(), executeRepairTerminalSeed(), executeRetrySync(), executeTerminalRecoveryCommand(), failed(), firstDrawerAuthorityPreconditions() (+19 more)
+
+### Community 24 - "Community 24"
 Cohesion: 0.14
 Nodes (24): assertStaffProfileReadyForCredential(), authenticateStaffCredentialForApprovalWithCtx(), authenticateStaffCredentialForTerminalWithCtx(), authenticateStaffCredentialWithCtx(), createStaffCredentialWithCtx(), getActiveRolesForStaffProfile(), getCredentialById(), getCredentialByUsername() (+16 more)
 
-### Community 24 - "Community 24"
+### Community 25 - "Community 25"
+Cohesion: 0.12
+Nodes (22): buildTerminalHealthSummary(), buildTerminalRecoveryActions(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), buildTerminalRecoveryManualReview(), buildTerminalRecoveryPreview(), dedupeTerminalActions(), deriveTerminalHealth() (+14 more)
+
+### Community 26 - "Community 26"
 Cohesion: 0.2
 Nodes (28): buildActiveCycleCountDraftsSubmissionKey(), buildCycleCountDraftCreatedMessage(), buildCycleCountDraftSavedMessage(), buildCycleCountDraftSubmissionKey(), buildCycleCountDraftSubmittedMessage(), createCycleCountDraftWithCtx(), discardCycleCountDraftCommandWithCtx(), ensureCycleCountDraftCommandWithCtx() (+20 more)
 
-### Community 25 - "Community 25"
-Cohesion: 0.18
-Nodes (26): completed(), executeCallbackCommand(), executeClearStaleDrawerAuthority(), executeRepairTerminalSeed(), executeRetrySync(), executeTerminalRecoveryCommand(), failed(), firstDrawerAuthorityPreconditions() (+18 more)
-
-### Community 26 - "Community 26"
+### Community 27 - "Community 27"
 Cohesion: 0.16
 Nodes (25): asArray(), asBoolean(), asMtnMomoSetupStatus(), asNumber(), asOptionalArray(), asRecord(), assignOrDelete(), asString() (+17 more)
 
-### Community 27 - "Community 27"
+### Community 28 - "Community 28"
 Cohesion: 0.15
 Nodes (22): buildDocumentationStatus(), buildEmptyHistoryMetric(), buildGraphifyStatus(), buildInferentialSummaryNote(), buildSummary(), collectHarnessScorecard(), countMissingSnippets(), createFileSystem() (+14 more)
 
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.15
 Nodes (23): applyStockAdjustmentBatchWithCtx(), assertDistinctStockAdjustmentLineItems(), buildResolvedStockAdjustmentStatus(), buildStockAdjustmentDecisionEventType(), buildStockAdjustmentOperationalEventMessage(), buildStockAdjustmentSourceId(), buildStockAdjustmentTitle(), formatSignedQuantity() (+15 more)
 
-### Community 29 - "Community 29"
+### Community 30 - "Community 30"
+Cohesion: 0.15
+Nodes (19): buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsExpenseSearch(), buildOperationsTransactionSearch(), getDailyOperationsMetricLabels(), getLocalDateFromOperatingDate(), getLocalOperatingDate(), getLocalOperatingDateRange() (+11 more)
+
+### Community 31 - "Community 31"
 Cohesion: 0.1
 Nodes (15): cancelItemAdjustmentWorkflow(), exitCorrectionWorkflow(), formatCorrectionEventType(), formatCorrectionHistoryChange(), formatCorrectionHistoryTitle(), formatPaymentMethodLabel(), getCorrectionHistoryChangeParts(), isManagerStaff() (+7 more)
 
-### Community 30 - "Community 30"
+### Community 32 - "Community 32"
 Cohesion: 0.2
 Nodes (25): asRecord(), buildPosLocalSyncUploadEvents(), customerInfoFromPayload(), getCompletedSaleItems(), getCompletedServiceLines(), hasLaterCompletedSale(), isSyncablePosLocalEvent(), isUploadDeferredByValidation() (+17 more)
 
-### Community 31 - "Community 31"
+### Community 33 - "Community 33"
 Cohesion: 0.16
 Nodes (19): createDefaultSessionCommandService(), createPosSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired(), pendingCheckoutItemMatchesLine(), registerSessionMatchesIdentity(), resolveRegisterSessionBinding() (+11 more)
 
-### Community 32 - "Community 32"
-Cohesion: 0.16
-Nodes (18): buildDailyCloseSearch(), buildDailyOperationsSearch(), buildOperationsTransactionSearch(), getDailyOperationsMetricLabels(), getLocalDateFromOperatingDate(), getLocalOperatingDate(), getLocalOperatingDateRange(), getLocalOperatingDateRangeFromSearch() (+10 more)
-
-### Community 33 - "Community 33"
+### Community 34 - "Community 34"
 Cohesion: 0.12
 Nodes (18): ancestorChain(), collectRawMoneyParses(), collectRawMoneyParsesFromSource(), collectRawNumericHelperNames(), collectSourceFiles(), collectStorefrontDirectMoneyFormats(), containsDisallowedRawNumericParse(), containsTerm() (+10 more)
 
-### Community 34 - "Community 34"
+### Community 35 - "Community 35"
 Cohesion: 0.19
 Nodes (23): assertCompoundSolutionCheck(), collectChangedFiles(), collectCompoundSolutionFindings(), collectExistingFiles(), collectMarkdownContents(), collectSourceLineChanges(), countFileLines(), extractFrontmatter() (+15 more)
 
-### Community 35 - "Community 35"
+### Community 36 - "Community 36"
 Cohesion: 0.15
 Nodes (19): appendListSection(), buildMarkdownBundle(), collectCoverage(), evaluateGraphifyFreshness(), fileExists(), formatValidationCommand(), getChangedFilesFromGit(), isLocalGeneratedArtifactPath() (+11 more)
 
-### Community 36 - "Community 36"
+### Community 37 - "Community 37"
 Cohesion: 0.13
 Nodes (18): buildCartSummary(), buildSessionOperationsRow(), expirePosSessionNow(), hasCustomerSnapshotValue(), isUsableRegisterSession(), loadPosSessionItems(), loadSessionCustomer(), loadSessionOperator() (+10 more)
 
-### Community 37 - "Community 37"
+### Community 38 - "Community 38"
 Cohesion: 0.19
 Nodes (23): adjustRegisterSessionExpectedCashForSettlement(), adjustTransactionItems(), applyApprovedAdjustment(), applyInventoryDeltas(), assertPayloadMatchesPlan(), buildAdjustmentApprovalRequirement(), buildServerAdjustmentPlan(), consumeItemAdjustmentApprovalProof() (+15 more)
 
-### Community 38 - "Community 38"
+### Community 39 - "Community 39"
 Cohesion: 0.15
 Nodes (19): acquireExpenseQuantityPatchHold(), adjustExpenseQuantityPatchHold(), createDefaultExpenseSessionCommandService(), createExpenseInventoryHoldGateway(), createExpenseSessionCommandService(), failure(), isActiveRegisterSession(), isSessionExpired() (+11 more)
-
-### Community 39 - "Community 39"
-Cohesion: 0.14
-Nodes (18): buildTerminalHealthSummary(), buildTerminalRecoveryActions(), buildTerminalRecoveryCloudRepairPreview(), buildTerminalRecoveryCommandStatus(), buildTerminalRecoveryManualReview(), buildTerminalRecoveryPreview(), dedupeTerminalActions(), deriveTerminalHealth() (+10 more)
 
 ### Community 40 - "Community 40"
 Cohesion: 0.09
@@ -2096,144 +2098,144 @@ Cohesion: 0.18
 Nodes (19): assertIdempotentReplayMatches(), assertProductSkuBelongsToStore(), assertSkuActivityArgs(), buildActiveReservationEntries(), buildAvailabilityWarnings(), buildSkuActivityEvent(), buildTimeline(), getImpactQuantities() (+11 more)
 
 ### Community 50 - "Community 50"
+Cohesion: 0.24
+Nodes (18): assertRegisterNumberIsAvailable(), cleanActiveRegisterSession(), cleanAppSessionRecovery(), cleanAppShell(), cleanBrowserInfo(), cleanDiagnosticMessage(), cleanDrawerAuthority(), cleanOptionalString() (+10 more)
+
+### Community 51 - "Community 51"
 Cohesion: 0.21
 Nodes (18): bytesToHex(), findAthenaUserByEmail(), findAuthUserByEmail(), formatRecoveryCode(), generateRecoveryCode(), getCredentialForStore(), getFailureAuditBucket(), hashPosRecoveryCode() (+10 more)
 
-### Community 51 - "Community 51"
+### Community 52 - "Community 52"
 Cohesion: 0.1
 Nodes (4): handleChange(), isSkuReserved(), parseVariantInputValue(), shouldDisable()
 
-### Community 52 - "Community 52"
+### Community 53 - "Community 53"
+Cohesion: 0.13
+Nodes (11): getLatestRuntimeStatusForTerminal(), getTerminalByFingerprint(), getTerminalSyncEvidence(), isActionableRejectedSyncEvent(), isActionableTerminalReviewSyncEvent(), mapTerminalRecord(), omitUndefined(), resolveRegisterSessionActionTarget() (+3 more)
+
+### Community 54 - "Community 54"
 Cohesion: 0.15
 Nodes (11): checkIfItemsHaveChanged(), createOnlineOrder(), createPatchObject(), findBestValuePromoCode(), handleExistingSession(), handleOrderCreation(), handlePlaceOrder(), listSessionItems() (+3 more)
 
-### Community 53 - "Community 53"
+### Community 55 - "Community 55"
+Cohesion: 0.11
+Nodes (4): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onStartRemoteAssist()
+
+### Community 56 - "Community 56"
 Cohesion: 0.15
 Nodes (10): capitalizeFirstLetter(), capitalizeWords(), cn(), currencyFormatter(), formatDate(), getErrorForField(), getProductName(), getRelativeTime() (+2 more)
 
-### Community 54 - "Community 54"
+### Community 57 - "Community 57"
 Cohesion: 0.21
 Nodes (16): commandForPort(), defaultCommand(), isProcessAlive(), isReachable(), listPreviews(), optionsFromEnv(), pruneState(), readState() (+8 more)
 
-### Community 55 - "Community 55"
-Cohesion: 0.25
-Nodes (16): assertRegisterNumberIsAvailable(), cleanAppSessionRecovery(), cleanBrowserInfo(), cleanDiagnosticMessage(), cleanDrawerAuthority(), cleanOptionalString(), cleanSaleAuthority(), cleanTerminalIntegrity() (+8 more)
-
-### Community 56 - "Community 56"
-Cohesion: 0.14
-Nodes (11): getLatestRuntimeStatusForTerminal(), getTerminalByFingerprint(), getTerminalSyncEvidence(), isActionableRejectedSyncEvent(), isActionableTerminalReviewSyncEvent(), mapTerminalRecord(), omitUndefined(), resolveRegisterSessionActionTarget() (+3 more)
-
-### Community 57 - "Community 57"
+### Community 58 - "Community 58"
 Cohesion: 0.17
 Nodes (13): buildSkuContinuityContextById(), deriveContinuityStatus(), getPlannedActionAt(), getStartOfCurrentDay(), hasLateInbound(), hasRelatedPurchaseOrderContext(), hasStalePlannedAction(), isInboundStatus() (+5 more)
 
-### Community 58 - "Community 58"
+### Community 59 - "Community 59"
 Cohesion: 0.18
 Nodes (11): getTransactionById(), listMixedServiceLinesForTransaction(), listStaffNames(), loadCorrectionEvents(), loadCustomerProfile(), loadPendingItemAdjustmentApprovals(), normalizeAdjustmentLineItem(), normalizeAdjustmentMetadata() (+3 more)
 
-### Community 59 - "Community 59"
+### Community 60 - "Community 60"
 Cohesion: 0.11
 Nodes (0):
 
-### Community 60 - "Community 60"
+### Community 61 - "Community 61"
 Cohesion: 0.22
 Nodes (16): buildDegreeIndex(), buildHotspotLines(), buildPackagePage(), buildRootIndexPage(), collectRepoCodeFiles(), compareHotspots(), countCommunities(), fileExists() (+8 more)
 
-### Community 61 - "Community 61"
+### Community 62 - "Community 62"
 Cohesion: 0.23
 Nodes (17): assertPrAthenaProofReady(), collectFilesUnder(), collectProofSnapshot(), collectUnstagedFiles(), collectUntrackedFiles(), collectValidationFingerprintPaths(), evaluatePrePushValidationProof(), formatPathList() (+9 more)
 
-### Community 62 - "Community 62"
+### Community 63 - "Community 63"
 Cohesion: 0.12
 Nodes (1): DataTableViewOptions()
 
-### Community 63 - "Community 63"
+### Community 64 - "Community 64"
 Cohesion: 0.13
 Nodes (4): DailyCloseHistoryView(), getDailyCloseHistoryApi(), getHistoryRecordSnapshot(), normalizeHistorySnapshot()
 
-### Community 64 - "Community 64"
+### Community 65 - "Community 65"
 Cohesion: 0.23
 Nodes (13): buildPosTerminalRuntimeCopyDiagnostics(), buildPosTerminalRuntimeStatus(), buildSyncMetrics(), buildValidationMetadataMetrics(), getReviewDiagnosticsEvents(), getTerminalIntegrityLabel(), isSaleAuthorityReady(), mapSyncStatus() (+5 more)
 
-### Community 65 - "Community 65"
+### Community 66 - "Community 66"
 Cohesion: 0.14
 Nodes (5): getBlockedPosTerminalShellCopy(), getPosHubRouteParams(), getRouteParamsForPattern(), getStoreWorkspaceRouteParams(), PosTerminalBlockedShell()
 
-### Community 66 - "Community 66"
+### Community 67 - "Community 67"
 Cohesion: 0.19
 Nodes (13): compareSnapshots(), fileExists(), formatArtifactList(), formatDetailLines(), formatError(), formatHarnessJanitorReport(), readUtf8OrNull(), runCheckStep() (+5 more)
 
-### Community 67 - "Community 67"
+### Community 68 - "Community 68"
 Cohesion: 0.21
 Nodes (14): buildNumericTrendStats(), buildRegressionWarnings(), buildRuntimeTrendOutput(), buildScenarioTrend(), collectHarnessRuntimeTrends(), formatMs(), formatPercent(), parseHarnessBehaviorReportLines() (+6 more)
 
-### Community 68 - "Community 68"
+### Community 69 - "Community 69"
 Cohesion: 0.15
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
-### Community 69 - "Community 69"
+### Community 70 - "Community 70"
+Cohesion: 0.13
+Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
+
+### Community 71 - "Community 71"
 Cohesion: 0.23
 Nodes (14): acknowledgeTerminalRecoveryCommand(), claimTerminalRecoveryCommand(), containsSecretLikeField(), isActiveCommand(), isEquivalentCommand(), issueTerminalRecoveryCommand(), loadScopedCommand(), normalizeOptionalHealthyStatus() (+6 more)
 
-### Community 70 - "Community 70"
+### Community 72 - "Community 72"
 Cohesion: 0.27
 Nodes (15): assertValidOnlineOrderStatusTransition(), getOnlineOrderPaymentAmount(), getOnlineOrderPaymentMethodLabel(), getOnlineOrderStatusEventType(), getStoreOrganizationId(), isPaymentOnDeliveryOrder(), recordOnlineOrderCreatedEvent(), recordOnlineOrderFulfillmentMovement() (+7 more)
 
-### Community 71 - "Community 71"
+### Community 73 - "Community 73"
 Cohesion: 0.24
 Nodes (14): cacheAssetRequest(), cacheFirstAsset(), cacheLinkedShellAssets(), cacheModuleDependencies(), isExcluded(), isHtmlResponse(), isJavaScriptLikeResponse(), isPosNavigation() (+6 more)
 
-### Community 72 - "Community 72"
+### Community 74 - "Community 74"
 Cohesion: 0.13
 Nodes (2): handleEnterReviewMode(), saveInventoryImportRouteDraft()
 
-### Community 73 - "Community 73"
+### Community 75 - "Community 75"
 Cohesion: 0.24
 Nodes (15): buildGeneratedControlId(), captureRemoteAssistCoBrowseFrame(), collectSanitizedSurface(), collectSensitiveRegions(), collectVisibleText(), getControlId(), getControlPriority(), getElementLabel() (+7 more)
 
-### Community 74 - "Community 74"
+### Community 76 - "Community 76"
 Cohesion: 0.21
 Nodes (14): CheckoutSessionError, createCheckoutSession(), defaultCheckoutActionMessage(), getActiveCheckoutSession(), getBaseUrl(), getCheckoutActionErrorMessage(), getCheckoutErrorMessageFromPayload(), getCheckoutSession() (+6 more)
 
-### Community 75 - "Community 75"
+### Community 77 - "Community 77"
 Cohesion: 0.26
 Nodes (13): addGroupedError(), collectLiveSurfaceEntries(), fileExists(), formatGroupedErrors(), formatMissingValidationPathError(), hasAnyHarnessDocs(), inferGroupFromError(), loadAuditTarget() (+5 more)
 
-### Community 76 - "Community 76"
+### Community 78 - "Community 78"
 Cohesion: 0.23
 Nodes (12): assertValidOpeningBlockerHandling(), assertValidOpeningLocalStartMinutes(), assertValidOperatingTimezoneOffsetMinutes(), getAutomationPolicyWithCtx(), getAutomationRunByIdempotencyKeyWithCtx(), getOpeningAutoStartPolicyConfigWithCtx(), listAutomationPoliciesForStoreActionWithCtx(), listAutomationRunsByIdempotencyKeyWithCtx() (+4 more)
 
-### Community 77 - "Community 77"
+### Community 79 - "Community 79"
 Cohesion: 0.33
 Nodes (14): adjustRegisterSessionExpectedCashForPaymentCorrection(), applyPaymentMethodCorrection(), buildPaymentMethodCorrectionApprovalRequirement(), consumePaymentMethodCorrectionApprovalProof(), correctTransactionCustomer(), correctTransactionPaymentMethod(), createPaymentMethodCorrectionApprovalRequest(), getPaymentMethodCashContribution() (+6 more)
 
-### Community 78 - "Community 78"
+### Community 80 - "Community 80"
 Cohesion: 0.28
 Nodes (14): getRegisterCatalogPrice(), isActiveProvisionalImportSkuForStore(), isTrustedRegisterCatalogSku(), listRegisterCatalog(), listRegisterCatalogAvailability(), listRegisterCatalogAvailabilitySnapshot(), listScopedRegisterCatalogSkus(), mapSkuToRegisterCatalogRow() (+6 more)
 
-### Community 79 - "Community 79"
-Cohesion: 0.14
-Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
-
-### Community 80 - "Community 80"
+### Community 81 - "Community 81"
 Cohesion: 0.17
 Nodes (6): buildServerPricedCheckoutProducts(), calculateItemsSubtotal(), deriveDeliveryOptionFromAddress(), isDeliveryFeeWaived(), normalizeDeliveryOption(), resolveServerDeliveryFee()
 
-### Community 81 - "Community 81"
+### Community 82 - "Community 82"
 Cohesion: 0.15
 Nodes (4): formatCurrency(), formatFinancialLabel(), formatTimelineRange(), formatTimelineTime()
 
-### Community 82 - "Community 82"
+### Community 83 - "Community 83"
 Cohesion: 0.24
 Nodes (9): clearPaymentEditing(), handleCancelEdit(), handleClearPayments(), handleRemovePayment(), handleSaveEdit(), handleStartEdit(), resetPaymentCollectionControls(), setPaymentEditing() (+1 more)
 
-### Community 83 - "Community 83"
+### Community 84 - "Community 84"
 Cohesion: 0.17
 Nodes (6): formatLocalStartTime(), formatLocalStartTimeFromParts(), getLocalStartTimeParts(), handleSave(), parseLocalStartMinutes(), updateLocalStartTimePart()
-
-### Community 84 - "Community 84"
-Cohesion: 0.15
-Nodes (4): handleEndRemoteAssist(), handleStartRemoteAssist(), onEndRemoteAssist(), onStartRemoteAssist()
 
 ### Community 85 - "Community 85"
 Cohesion: 0.18
@@ -2340,48 +2342,48 @@ Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
 ### Community 111 - "Community 111"
-Cohesion: 0.29
-Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
-
-### Community 112 - "Community 112"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 113 - "Community 113"
+### Community 112 - "Community 112"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 114 - "Community 114"
+### Community 113 - "Community 113"
 Cohesion: 0.22
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
-### Community 115 - "Community 115"
+### Community 114 - "Community 114"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 116 - "Community 116"
+### Community 115 - "Community 115"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 117 - "Community 117"
+### Community 116 - "Community 116"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
 
-### Community 118 - "Community 118"
+### Community 117 - "Community 117"
 Cohesion: 0.25
 Nodes (5): blocked(), evaluateLocalPosReadiness(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
-### Community 119 - "Community 119"
+### Community 118 - "Community 118"
 Cohesion: 0.2
 Nodes (2): runSharedRecovery(), runWithTimeout()
 
-### Community 120 - "Community 120"
+### Community 119 - "Community 119"
 Cohesion: 0.18
 Nodes (0):
 
-### Community 121 - "Community 121"
+### Community 120 - "Community 120"
 Cohesion: 0.24
 Nodes (5): collectOfflineAppShellDiagnostics(), expectPosRegisterRouteChunksCached(), formatRuntimeSignals(), getPosAppShellCachedUrls(), waitForRenderedAppShell()
+
+### Community 121 - "Community 121"
+Cohesion: 0.29
+Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
 ### Community 122 - "Community 122"
 Cohesion: 0.18
@@ -2449,19 +2451,19 @@ Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalize
 
 ### Community 138 - "Community 138"
 Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
 ### Community 139 - "Community 139"
 Cohesion: 0.39
-Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
-
-### Community 140 - "Community 140"
-Cohesion: 0.39
 Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 141 - "Community 141"
+### Community 140 - "Community 140"
 Cohesion: 0.22
 Nodes (0):
+
+### Community 141 - "Community 141"
+Cohesion: 0.39
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 142 - "Community 142"
 Cohesion: 0.5
@@ -2593,191 +2595,191 @@ Nodes (0):
 
 ### Community 174 - "Community 174"
 Cohesion: 0.46
-Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
+Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
 
 ### Community 175 - "Community 175"
+Cohesion: 0.46
+Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
+
+### Community 176 - "Community 176"
 Cohesion: 0.43
 Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
 
-### Community 176 - "Community 176"
+### Community 177 - "Community 177"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 177 - "Community 177"
+### Community 178 - "Community 178"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 178 - "Community 178"
+### Community 179 - "Community 179"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.33
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.33
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 187 - "Community 187"
+### Community 188 - "Community 188"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 189 - "Community 189"
 Cohesion: 0.48
 Nodes (6): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), isDuplicateRegisterOpenConflict(), skipped()
 
-### Community 188 - "Community 188"
+### Community 190 - "Community 190"
 Cohesion: 0.48
 Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
 
-### Community 189 - "Community 189"
+### Community 191 - "Community 191"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 192 - "Community 192"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 190 - "Community 190"
+### Community 193 - "Community 193"
 Cohesion: 0.33
 Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
 
-### Community 191 - "Community 191"
+### Community 194 - "Community 194"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 192 - "Community 192"
+### Community 195 - "Community 195"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 193 - "Community 193"
-Cohesion: 0.33
-Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
-
-### Community 194 - "Community 194"
-Cohesion: 0.38
-Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
-
-### Community 195 - "Community 195"
-Cohesion: 0.57
-Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
 ### Community 196 - "Community 196"
 Cohesion: 0.33
-Nodes (2): appendTransition(), applyOnlineOrderUpdate()
+Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
 ### Community 197 - "Community 197"
 Cohesion: 0.38
-Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
+Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
 ### Community 198 - "Community 198"
+Cohesion: 0.57
+Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
+
+### Community 199 - "Community 199"
+Cohesion: 0.33
+Nodes (2): appendTransition(), applyOnlineOrderUpdate()
+
+### Community 200 - "Community 200"
+Cohesion: 0.38
+Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
+
+### Community 201 - "Community 201"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
 
-### Community 199 - "Community 199"
+### Community 202 - "Community 202"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 200 - "Community 200"
+### Community 203 - "Community 203"
 Cohesion: 0.33
 Nodes (2): handlePinChange(), normalizeOtpCode()
 
-### Community 201 - "Community 201"
+### Community 204 - "Community 204"
 Cohesion: 0.33
 Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
-### Community 202 - "Community 202"
+### Community 205 - "Community 205"
 Cohesion: 0.33
 Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
 
-### Community 203 - "Community 203"
+### Community 206 - "Community 206"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
-### Community 204 - "Community 204"
+### Community 207 - "Community 207"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 205 - "Community 205"
+### Community 208 - "Community 208"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 206 - "Community 206"
+### Community 209 - "Community 209"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
-
-### Community 207 - "Community 207"
-Cohesion: 0.29
-Nodes (0):
-
-### Community 208 - "Community 208"
-Cohesion: 0.33
-Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
-
-### Community 209 - "Community 209"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 210 - "Community 210"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 211 - "Community 211"
-Cohesion: 0.52
-Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
+Cohesion: 0.33
+Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
 
 ### Community 212 - "Community 212"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 213 - "Community 213"
-Cohesion: 0.43
-Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 214 - "Community 214"
 Cohesion: 0.52
-Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
+Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
 ### Community 215 - "Community 215"
 Cohesion: 0.33
-Nodes (2): overwriteFreshGraphifyArtifacts(), write()
+Nodes (2): getProductName(), sortProduct()
 
 ### Community 216 - "Community 216"
-Cohesion: 0.38
-Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
+Cohesion: 0.43
+Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
 ### Community 217 - "Community 217"
-Cohesion: 0.33
-Nodes (1): ValkeyClient
+Cohesion: 0.52
+Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
 ### Community 218 - "Community 218"
 Cohesion: 0.33
-Nodes (0):
+Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
 ### Community 219 - "Community 219"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.38
+Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
 ### Community 220 - "Community 220"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ValkeyClient
 
 ### Community 221 - "Community 221"
 Cohesion: 0.33
@@ -2788,76 +2790,76 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 223 - "Community 223"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 224 - "Community 224"
 Cohesion: 0.4
 Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
-### Community 224 - "Community 224"
+### Community 225 - "Community 225"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.4
 Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.4
 Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
-
-### Community 240 - "Community 240"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 241 - "Community 241"
 Cohesion: 0.33
@@ -2865,27 +2867,27 @@ Nodes (0):
 
 ### Community 242 - "Community 242"
 Cohesion: 0.33
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 243 - "Community 243"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 244 - "Community 244"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 245 - "Community 245"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 245 - "Community 245"
+### Community 246 - "Community 246"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 246 - "Community 246"
-Cohesion: 0.33
-Nodes (0):
-
 ### Community 247 - "Community 247"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 248 - "Community 248"
 Cohesion: 0.33
@@ -2900,120 +2902,120 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 251 - "Community 251"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 252 - "Community 252"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 253 - "Community 253"
-Cohesion: 0.33
-Nodes (0):
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 254 - "Community 254"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 255 - "Community 255"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 256 - "Community 256"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 257 - "Community 257"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 256 - "Community 256"
+### Community 258 - "Community 258"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 257 - "Community 257"
+### Community 259 - "Community 259"
 Cohesion: 0.33
 Nodes (0):
-
-### Community 258 - "Community 258"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 259 - "Community 259"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 260 - "Community 260"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 261 - "Community 261"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
+
+### Community 262 - "Community 262"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 261 - "Community 261"
+### Community 263 - "Community 263"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 262 - "Community 262"
+### Community 264 - "Community 264"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
-
-### Community 263 - "Community 263"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 264 - "Community 264"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
 
 ### Community 265 - "Community 265"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 266 - "Community 266"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
 
 ### Community 267 - "Community 267"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 268 - "Community 268"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 268 - "Community 268"
+### Community 269 - "Community 269"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 269 - "Community 269"
+### Community 270 - "Community 270"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 270 - "Community 270"
+### Community 271 - "Community 271"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 271 - "Community 271"
+### Community 272 - "Community 272"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 272 - "Community 272"
+### Community 273 - "Community 273"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 273 - "Community 273"
+### Community 274 - "Community 274"
 Cohesion: 0.5
 Nodes (2): createAuthorizedRegisterDepositCtx(), createQueryCtx()
 
-### Community 274 - "Community 274"
+### Community 275 - "Community 275"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
-
-### Community 275 - "Community 275"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 276 - "Community 276"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 277 - "Community 277"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 278 - "Community 278"
 Cohesion: 0.6
 Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
-### Community 278 - "Community 278"
+### Community 279 - "Community 279"
 Cohesion: 0.7
 Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
-
-### Community 279 - "Community 279"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 280 - "Community 280"
 Cohesion: 0.4
@@ -3024,16 +3026,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 282 - "Community 282"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 283 - "Community 283"
 Cohesion: 0.7
 Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
-### Community 283 - "Community 283"
+### Community 284 - "Community 284"
 Cohesion: 0.6
 Nodes (3): isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult()
-
-### Community 284 - "Community 284"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 285 - "Community 285"
 Cohesion: 0.4
@@ -3048,32 +3050,32 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 288 - "Community 288"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 289 - "Community 289"
 Cohesion: 0.6
 Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
 
-### Community 289 - "Community 289"
+### Community 290 - "Community 290"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 290 - "Community 290"
+### Community 291 - "Community 291"
 Cohesion: 0.7
 Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
-### Community 291 - "Community 291"
+### Community 292 - "Community 292"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 292 - "Community 292"
+### Community 293 - "Community 293"
 Cohesion: 0.6
 Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
-### Community 293 - "Community 293"
+### Community 294 - "Community 294"
 Cohesion: 0.5
 Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
-
-### Community 294 - "Community 294"
-Cohesion: 0.4
-Nodes (0):
 
 ### Community 295 - "Community 295"
 Cohesion: 0.4
@@ -3084,12 +3086,12 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 297 - "Community 297"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
-
-### Community 298 - "Community 298"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 298 - "Community 298"
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 299 - "Community 299"
 Cohesion: 0.4
@@ -3108,16 +3110,16 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 303 - "Community 303"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
-
-### Community 304 - "Community 304"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 305 - "Community 305"
+### Community 304 - "Community 304"
 Cohesion: 0.5
-Nodes (2): buildTerminalOfflineReadiness(), getAppSessionReadinessInput()
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
+
+### Community 305 - "Community 305"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 306 - "Community 306"
 Cohesion: 0.4
@@ -3140,52 +3142,52 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 311 - "Community 311"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 312 - "Community 312"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 312 - "Community 312"
+### Community 313 - "Community 313"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 313 - "Community 313"
+### Community 314 - "Community 314"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 314 - "Community 314"
+### Community 315 - "Community 315"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 315 - "Community 315"
+### Community 316 - "Community 316"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 316 - "Community 316"
-Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 317 - "Community 317"
 Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 318 - "Community 318"
 Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 319 - "Community 319"
 Cohesion: 0.6
-Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 320 - "Community 320"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
 ### Community 321 - "Community 321"
-Cohesion: 0.7
-Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
-
-### Community 322 - "Community 322"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 322 - "Community 322"
+Cohesion: 0.7
+Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
 ### Community 323 - "Community 323"
 Cohesion: 0.4
@@ -3200,88 +3202,88 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 326 - "Community 326"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 327 - "Community 327"
 Cohesion: 0.5
-Nodes (3): createVersionChecker(), shouldAutoReloadForCurrentRoute(), shouldAutoReloadForPath()
+Nodes (2): completePendingAuthSync(), sleep()
 
 ### Community 328 - "Community 328"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (3): createVersionChecker(), shouldAutoReloadForCurrentRoute(), shouldAutoReloadForPath()
 
 ### Community 329 - "Community 329"
-Cohesion: 0.7
-Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 330 - "Community 330"
 Cohesion: 0.7
-Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
+Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
 ### Community 331 - "Community 331"
 Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
+Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
 ### Community 332 - "Community 332"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 333 - "Community 333"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 334 - "Community 334"
-Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
-
-### Community 335 - "Community 335"
 Cohesion: 0.4
 Nodes (0):
+
+### Community 335 - "Community 335"
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 336 - "Community 336"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 337 - "Community 337"
-Cohesion: 0.6
-Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
-
-### Community 338 - "Community 338"
 Cohesion: 0.4
 Nodes (0):
 
+### Community 338 - "Community 338"
+Cohesion: 0.6
+Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+
 ### Community 339 - "Community 339"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 340 - "Community 340"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 340 - "Community 340"
+### Community 341 - "Community 341"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 341 - "Community 341"
+### Community 342 - "Community 342"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 342 - "Community 342"
+### Community 343 - "Community 343"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 343 - "Community 343"
+### Community 344 - "Community 344"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 344 - "Community 344"
+### Community 345 - "Community 345"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 345 - "Community 345"
+### Community 346 - "Community 346"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
-
-### Community 346 - "Community 346"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 347 - "Community 347"
 Cohesion: 0.5
@@ -3292,12 +3294,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 349 - "Community 349"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
-
-### Community 350 - "Community 350"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 350 - "Community 350"
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
 
 ### Community 351 - "Community 351"
 Cohesion: 0.5
@@ -3308,72 +3310,72 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 353 - "Community 353"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 354 - "Community 354"
 Cohesion: 0.67
 Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
-### Community 354 - "Community 354"
+### Community 355 - "Community 355"
 Cohesion: 0.83
 Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
-### Community 355 - "Community 355"
+### Community 356 - "Community 356"
 Cohesion: 0.67
 Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
-### Community 356 - "Community 356"
+### Community 357 - "Community 357"
 Cohesion: 0.67
 Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
-### Community 357 - "Community 357"
+### Community 358 - "Community 358"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 358 - "Community 358"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 359 - "Community 359"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 360 - "Community 360"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 361 - "Community 361"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 362 - "Community 362"
 Cohesion: 0.83
 Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
-### Community 362 - "Community 362"
+### Community 363 - "Community 363"
 Cohesion: 0.67
 Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
-### Community 363 - "Community 363"
+### Community 364 - "Community 364"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 364 - "Community 364"
+### Community 365 - "Community 365"
 Cohesion: 0.83
 Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
-### Community 365 - "Community 365"
+### Community 366 - "Community 366"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 366 - "Community 366"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 367 - "Community 367"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
 
 ### Community 368 - "Community 368"
 Cohesion: 0.83
-Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
 
 ### Community 369 - "Community 369"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
 ### Community 370 - "Community 370"
 Cohesion: 0.5
@@ -3384,20 +3386,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 372 - "Community 372"
-Cohesion: 0.67
-Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 373 - "Community 373"
 Cohesion: 0.67
-Nodes (2): buildRepository(), buildSession()
+Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
 ### Community 374 - "Community 374"
 Cohesion: 0.67
-Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
+Nodes (2): buildRepository(), buildSession()
 
 ### Community 375 - "Community 375"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
 ### Community 376 - "Community 376"
 Cohesion: 0.5
@@ -3408,28 +3410,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 378 - "Community 378"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 379 - "Community 379"
 Cohesion: 0.67
 Nodes (2): expectIndex(), getTableIndexes()
 
-### Community 379 - "Community 379"
+### Community 380 - "Community 380"
 Cohesion: 0.83
 Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
-### Community 380 - "Community 380"
+### Community 381 - "Community 381"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 381 - "Community 381"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 382 - "Community 382"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 383 - "Community 383"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 384 - "Community 384"
 Cohesion: 0.5
@@ -3444,20 +3446,20 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 387 - "Community 387"
-Cohesion: 0.67
-Nodes (2): countGroupedAnalytics(), groupAnalytics()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 388 - "Community 388"
 Cohesion: 0.67
-Nodes (2): handleSubmit(), navigationTargetForRedirect()
+Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
 ### Community 389 - "Community 389"
 Cohesion: 0.67
-Nodes (2): getPosRouteScope(), Login()
+Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
 ### Community 390 - "Community 390"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): getPosRouteScope(), Login()
 
 ### Community 391 - "Community 391"
 Cohesion: 0.5
@@ -3480,16 +3482,16 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 396 - "Community 396"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 397 - "Community 397"
 Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 398 - "Community 398"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 399 - "Community 399"
 Cohesion: 0.5
@@ -3500,12 +3502,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 401 - "Community 401"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
-
-### Community 402 - "Community 402"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 402 - "Community 402"
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 403 - "Community 403"
 Cohesion: 0.5
@@ -3516,120 +3518,120 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 405 - "Community 405"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
-
-### Community 406 - "Community 406"
 Cohesion: 0.5
 Nodes (0):
+
+### Community 406 - "Community 406"
+Cohesion: 0.67
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 407 - "Community 407"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 408 - "Community 408"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 409 - "Community 409"
 Cohesion: 0.67
 Nodes (2): getRiskStyles(), RiskIndicators()
 
-### Community 409 - "Community 409"
+### Community 410 - "Community 410"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 410 - "Community 410"
-Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 411 - "Community 411"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 412 - "Community 412"
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+
+### Community 413 - "Community 413"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 413 - "Community 413"
+### Community 414 - "Community 414"
 Cohesion: 0.67
 Nodes (2): extractTraceId(), runCommand()
 
-### Community 414 - "Community 414"
+### Community 415 - "Community 415"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 415 - "Community 415"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 416 - "Community 416"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 417 - "Community 417"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 418 - "Community 418"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 419 - "Community 419"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 420 - "Community 420"
 Cohesion: 0.67
 Nodes (2): mapActiveSessionDto(), normalizeCartItems()
 
-### Community 420 - "Community 420"
+### Community 421 - "Community 421"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 421 - "Community 421"
+### Community 422 - "Community 422"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 422 - "Community 422"
+### Community 423 - "Community 423"
 Cohesion: 0.83
 Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 423 - "Community 423"
+### Community 424 - "Community 424"
 Cohesion: 0.83
 Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
-### Community 424 - "Community 424"
+### Community 425 - "Community 425"
 Cohesion: 0.83
 Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
-### Community 425 - "Community 425"
+### Community 426 - "Community 426"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 426 - "Community 426"
+### Community 427 - "Community 427"
 Cohesion: 0.67
 Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
-### Community 427 - "Community 427"
+### Community 428 - "Community 428"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 428 - "Community 428"
+### Community 429 - "Community 429"
 Cohesion: 0.83
 Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
-### Community 429 - "Community 429"
+### Community 430 - "Community 430"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 430 - "Community 430"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 431 - "Community 431"
 Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 432 - "Community 432"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 433 - "Community 433"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 434 - "Community 434"
 Cohesion: 0.5
@@ -3660,59 +3662,59 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 441 - "Community 441"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 442 - "Community 442"
 Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Nodes (2): useOptionalStoreContext(), useStoreContext()
 
 ### Community 443 - "Community 443"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 444 - "Community 444"
 Cohesion: 0.83
 Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
 
-### Community 444 - "Community 444"
+### Community 445 - "Community 445"
 Cohesion: 0.5
 Nodes (0):
-
-### Community 445 - "Community 445"
-Cohesion: 0.83
-Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 446 - "Community 446"
 Cohesion: 0.83
-Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
+Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
 ### Community 447 - "Community 447"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
 ### Community 448 - "Community 448"
-Cohesion: 0.67
-Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 449 - "Community 449"
 Cohesion: 0.67
-Nodes (2): shutdown(), stopValkeyRuntimeServer()
+Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
 ### Community 450 - "Community 450"
+Cohesion: 0.67
+Nodes (2): shutdown(), stopValkeyRuntimeServer()
+
+### Community 451 - "Community 451"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 451 - "Community 451"
+### Community 452 - "Community 452"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
-
-### Community 452 - "Community 452"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 453 - "Community 453"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 454 - "Community 454"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 455 - "Community 455"
@@ -3720,12 +3722,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 456 - "Community 456"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
-
-### Community 457 - "Community 457"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 457 - "Community 457"
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 458 - "Community 458"
 Cohesion: 0.67
@@ -3760,12 +3762,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 466 - "Community 466"
-Cohesion: 1.0
-Nodes (2): buildCtx(), createDb()
-
-### Community 467 - "Community 467"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 467 - "Community 467"
+Cohesion: 1.0
+Nodes (2): buildCtx(), createDb()
 
 ### Community 468 - "Community 468"
 Cohesion: 0.67
@@ -3780,12 +3782,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 471 - "Community 471"
-Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
-
-### Community 472 - "Community 472"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 472 - "Community 472"
+Cohesion: 1.0
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 473 - "Community 473"
 Cohesion: 0.67
@@ -3793,11 +3795,11 @@ Nodes (0):
 
 ### Community 474 - "Community 474"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 475 - "Community 475"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): PosServerError
 
 ### Community 476 - "Community 476"
 Cohesion: 0.67
@@ -3812,12 +3814,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 479 - "Community 479"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
-
-### Community 480 - "Community 480"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 480 - "Community 480"
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 481 - "Community 481"
 Cohesion: 0.67
@@ -3840,12 +3842,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 486 - "Community 486"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
-
-### Community 487 - "Community 487"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 487 - "Community 487"
+Cohesion: 1.0
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 488 - "Community 488"
 Cohesion: 0.67
@@ -3860,40 +3862,40 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 491 - "Community 491"
-Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 492 - "Community 492"
 Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 493 - "Community 493"
 Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 494 - "Community 494"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 495 - "Community 495"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 496 - "Community 496"
-Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 497 - "Community 497"
 Cohesion: 1.0
-Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 498 - "Community 498"
-Cohesion: 0.67
-Nodes (1): View()
+Cohesion: 1.0
+Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
 ### Community 499 - "Community 499"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): View()
 
 ### Community 500 - "Community 500"
 Cohesion: 0.67
@@ -3908,12 +3910,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 503 - "Community 503"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
-
-### Community 504 - "Community 504"
 Cohesion: 0.67
 Nodes (0):
+
+### Community 504 - "Community 504"
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 505 - "Community 505"
 Cohesion: 0.67
@@ -3924,16 +3926,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 507 - "Community 507"
+Cohesion: 0.67
+Nodes (0):
+
+### Community 508 - "Community 508"
 Cohesion: 1.0
 Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
-### Community 508 - "Community 508"
-Cohesion: 0.67
-Nodes (1): FadeIn()
-
 ### Community 509 - "Community 509"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): FadeIn()
 
 ### Community 510 - "Community 510"
 Cohesion: 0.67
@@ -3945,15 +3947,15 @@ Nodes (0):
 
 ### Community 512 - "Community 512"
 Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Nodes (0):
 
 ### Community 513 - "Community 513"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (1): VideoPlayer()
 
 ### Community 514 - "Community 514"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 515 - "Community 515"
 Cohesion: 0.67
@@ -9327,6 +9329,14 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1858 - "Community 1858"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1859 - "Community 1859"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
@@ -9662,2133 +9672,2137 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 793`** (2 nodes): `POSSettingsView.test.tsx`, `waitForFingerprintEffect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 794`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 795`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 796`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 797`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 798`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 799`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 800`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 801`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 802`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
+- **Thin community `Community 803`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 804`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 805`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 806`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 807`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 808`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 809`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 810`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 811`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 812`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 813`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 814`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 815`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 816`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 817`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 818`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 819`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 820`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 821`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 822`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 823`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 824`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 825`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 826`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 827`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 828`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 829`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 830`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 831`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 832`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 833`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 834`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 835`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 836`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 837`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 838`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 839`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 840`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 841`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 842`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 843`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 844`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 845`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 846`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 847`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 848`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 849`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 850`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 851`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 852`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 853`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 854`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 855`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 856`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 857`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 858`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 859`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 860`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 861`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 862`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 863`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 864`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 865`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 866`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 867`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 868`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 869`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 870`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 871`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 872`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 873`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 874`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 875`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 876`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 877`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 878`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 879`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 880`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 881`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 882`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 883`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 884`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 885`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 886`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 887`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 888`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 889`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 890`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 891`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 892`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 893`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 894`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 895`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 896`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 897`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 898`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 899`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
+- **Thin community `Community 900`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 901`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 902`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 903`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 904`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 905`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 906`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 907`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 908`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 909`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 910`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 911`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 912`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 913`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 914`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 915`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 916`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 917`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 918`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 919`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 920`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 921`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 922`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 923`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 924`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 925`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 926`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 927`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 928`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 929`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 930`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 931`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 932`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 933`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 934`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 935`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 936`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 937`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 938`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 939`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 940`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 941`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 942`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 943`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 944`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 945`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 946`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 947`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 948`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 949`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 950`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 951`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 952`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 953`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 954`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 955`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 956`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 957`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 958`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 959`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 960`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 961`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 962`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 963`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 964`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 965`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 966`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 967`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 968`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 969`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 970`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 971`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 972`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 973`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 974`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 975`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 976`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 977`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 978`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 979`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 980`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 981`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 982`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 983`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 984`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 985`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 986`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 987`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 988`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 989`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 990`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 991`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 992`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 993`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 994`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 995`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 996`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 997`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 998`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 999`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1000`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1001`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1002`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1003`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1004`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1005`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1006`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1007`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1008`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1009`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1010`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1011`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1012`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1013`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1014`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1015`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1016`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1017`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1018`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1019`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1020`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1021`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1022`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1023`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1024`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1025`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1026`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1027`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1028`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1029`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1030`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1031`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1032`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1033`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1034`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1035`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1036`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1037`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1038`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1039`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1040`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1041`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1042`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1043`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1044`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1045`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1046`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1047`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1048`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1049`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1050`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1051`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1052`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1053`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1054`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1055`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1056`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1057`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1058`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1059`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1060`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1061`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1062`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1063`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `api.js`
+- **Thin community `Community 1064`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1065`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1066`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `server.js`
+- **Thin community `Community 1067`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `app.ts`
+- **Thin community `Community 1068`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1069`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1070`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1071`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1072`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `auth.ts`
+- **Thin community `Community 1073`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1074`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1075`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1076`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `countries.ts`
+- **Thin community `Community 1077`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `email.ts`
+- **Thin community `Community 1078`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1079`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `payment.ts`
+- **Thin community `Community 1080`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1081`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `crons.ts`
+- **Thin community `Community 1082`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1083`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `internal.ts`
+- **Thin community `Community 1084`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1085`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1086`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1087`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1088`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1089`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1090`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1091`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1092`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1093`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1094`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1095`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `env.ts`
+- **Thin community `Community 1096`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1097`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `auth.ts`
+- **Thin community `Community 1098`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1099`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `colors.ts`
+- **Thin community `Community 1100`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `index.ts`
+- **Thin community `Community 1101`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1102`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `products.ts`
+- **Thin community `Community 1103`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `storefrontHidden.test.ts`
+- **Thin community `Community 1104`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `stores.ts`
+- **Thin community `Community 1105`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `bag.ts`
+- **Thin community `Community 1106`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `guest.ts`
+- **Thin community `Community 1107`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `index.ts`
+- **Thin community `Community 1108`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1109`** (1 nodes): `me.ts`
+- **Thin community `Community 1109`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `offers.ts`
+- **Thin community `Community 1110`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1111`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1112`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1113`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1114`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1115`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1116`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1117`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1118`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1119`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `user.ts`
+- **Thin community `Community 1120`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1121`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `index.ts`
+- **Thin community `Community 1122`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1123`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `http.ts`
+- **Thin community `Community 1124`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1125`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1126`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1127`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `categories.ts`
+- **Thin community `Community 1128`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `colors.ts`
+- **Thin community `Community 1129`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1130`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 1131`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1132`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1133`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1134`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1135`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `pos.ts`
+- **Thin community `Community 1136`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1137`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1138`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1139`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1140`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1141`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1142`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1143`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1144`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1145`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1146`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1147`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1148`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1149`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1150`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1151`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1152`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `types.ts`
+- **Thin community `Community 1153`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1154`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1155`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1156`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1157`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1158`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1159`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `dto.ts`
+- **Thin community `Community 1160`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1161`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1162`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1163`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `types.ts`
+- **Thin community `Community 1164`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1165`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1166`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1167`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `customers.ts`
+- **Thin community `Community 1168`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `register.ts`
+- **Thin community `Community 1169`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `sync.ts`
+- **Thin community `Community 1170`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1171`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1172`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1173`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `schema.ts`
+- **Thin community `Community 1174`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `automation.ts`
+- **Thin community `Community 1175`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1176`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `index.ts`
+- **Thin community `Community 1177`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1178`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1179`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1180`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1181`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1182`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `category.ts`
+- **Thin community `Community 1183`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `color.ts`
+- **Thin community `Community 1184`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1185`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1186`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `index.ts`
+- **Thin community `Community 1187`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1188`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1189`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1190`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1191`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `organization.ts`
+- **Thin community `Community 1192`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1193`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `product.ts`
+- **Thin community `Community 1194`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1195`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1196`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `store.ts`
+- **Thin community `Community 1197`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1198`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `index.ts`
+- **Thin community `Community 1199`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1200`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1201`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1202`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1203`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1204`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1205`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1206`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `index.ts`
+- **Thin community `Community 1207`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1208`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1209`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1210`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1211`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1212`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1213`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1214`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1215`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1216`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1217`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1218`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `customer.ts`
+- **Thin community `Community 1219`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1220`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1221`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1222`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1223`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `index.ts`
+- **Thin community `Community 1224`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1225`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1226`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1227`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1228`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1229`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1230`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1231`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1232`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1233`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1234`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1235`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1236`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1237`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1238`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1239`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1240`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1241`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1242`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1243`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `index.ts`
+- **Thin community `Community 1244`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1245`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1246`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `index.ts`
+- **Thin community `Community 1247`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1248`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1249`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1250`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1251`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1252`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1253`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `index.ts`
+- **Thin community `Community 1254`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1255`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1255`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1256`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1257`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1258`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1259`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1260`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `bag.ts`
+- **Thin community `Community 1261`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1262`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1263`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1264`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `guest.ts`
+- **Thin community `Community 1265`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `index.ts`
+- **Thin community `Community 1266`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `offer.ts`
+- **Thin community `Community 1267`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1268`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1269`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `review.ts`
+- **Thin community `Community 1270`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1271`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1272`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1273`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1274`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1275`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1276`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1277`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1278`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1279`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `bag.ts`
+- **Thin community `Community 1280`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1281`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `customer.ts`
+- **Thin community `Community 1282`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `guest.ts`
+- **Thin community `Community 1283`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1284`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1285`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1286`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1287`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `payment.ts`
+- **Thin community `Community 1288`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1289`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1290`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1291`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `users.ts`
+- **Thin community `Community 1292`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `payment.ts`
+- **Thin community `Community 1293`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1294`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1295`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1296`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1297`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1298`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `index.ts`
+- **Thin community `Community 1299`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1300`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1301`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1302`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1303`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `auth.ts`
+- **Thin community `Community 1304`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1305`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1306`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1307`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1308`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1309`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1310`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1311`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1312`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1313`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1314`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1315`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1316`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1317`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1318`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1319`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1320`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `constants.ts`
+- **Thin community `Community 1321`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1322`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1323`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1324`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `types.ts`
+- **Thin community `Community 1325`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1326`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1327`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1328`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1329`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1330`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1330`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1331`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1331`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1332`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1333`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1334`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1335`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1336`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1337`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1338`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1339`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1340`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1341`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1342`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1343`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1344`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1345`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1345`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1346`** (1 nodes): `constants.ts`
+- **Thin community `Community 1346`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1347`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1348`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1349`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `data.ts`
+- **Thin community `Community 1350`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1351`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1352`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1353`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1354`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1355`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1356`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1357`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1358`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1359`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `constants.ts`
+- **Thin community `Community 1360`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1361`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1362`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1363`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `data.ts`
+- **Thin community `Community 1364`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1365`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1366`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1367`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1368`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1369`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1370`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1371`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1372`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1373`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1374`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1375`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1376`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `constants.ts`
+- **Thin community `Community 1377`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1378`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1379`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1380`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1381`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1382`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1383`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1384`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1385`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1386`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1387`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1388`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1389`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1390`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1391`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1392`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 1393`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1394`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1395`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1396`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1397`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1398`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1399`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1400`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1401`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1402`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1403`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1404`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1405`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1406`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1407`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1408`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1409`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `constants.ts`
+- **Thin community `Community 1410`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1411`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1412`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1413`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `data.ts`
+- **Thin community `Community 1414`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1415`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1416`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `constants.ts`
+- **Thin community `Community 1417`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1418`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1418`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1419`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1419`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1420`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1420`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1421`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `data.ts`
+- **Thin community `Community 1422`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1423`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `constants.ts`
+- **Thin community `Community 1424`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1425`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1425`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1426`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1426`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1427`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1427`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1428`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1428`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1429`** (1 nodes): `data.ts`
+- **Thin community `Community 1429`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1430`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1430`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1431`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1432`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1433`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1434`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1435`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1436`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1437`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1438`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1439`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1440`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1441`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1442`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1443`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1444`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1445`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1446`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1447`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1448`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1449`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1450`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1451`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1452`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1453`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1454`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1455`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `POSTerminalHealthView.test.tsx`
+- **Thin community `Community 1456`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1457`** (1 nodes): `POSTerminalHealthView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1458`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1459`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `types.ts`
+- **Thin community `Community 1460`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1461`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1462`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1463`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1464`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1465`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1466`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1467`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1468`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1469`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1470`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1471`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1472`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1473`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1474`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1475`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1476`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1477`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `data.ts`
+- **Thin community `Community 1478`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1479`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1480`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1481`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1482`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1483`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1484`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1485`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1486`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1487`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1488`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1489`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1490`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `constants.ts`
+- **Thin community `Community 1491`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1492`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1493`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1494`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `data.ts`
+- **Thin community `Community 1495`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `types.ts`
+- **Thin community `Community 1496`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1497`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 1498`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 1499`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 1500`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 1501`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `index.ts`
+- **Thin community `Community 1502`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1503`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1504`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1505`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1506`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `index.tsx`
+- **Thin community `Community 1507`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1508`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1509`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1510`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1511`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1512`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1513`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1514`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1515`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `index.tsx`
+- **Thin community `Community 1516`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1517`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1518`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1519`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `button.tsx`
+- **Thin community `Community 1520`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1521`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `card.tsx`
+- **Thin community `Community 1522`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1523`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1524`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `command.tsx`
+- **Thin community `Community 1525`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1526`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1527`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1528`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `form.tsx`
+- **Thin community `Community 1529`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1530`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1531`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `input.tsx`
+- **Thin community `Community 1532`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1533`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1534`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1535`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1536`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1537`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1538`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `select.tsx`
+- **Thin community `Community 1539`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1540`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1541`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `sidebar.test.tsx`
+- **Thin community `Community 1542`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1543`** (1 nodes): `sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `table.tsx`
+- **Thin community `Community 1544`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1545`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1546`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1547`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1548`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1549`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1550`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1551`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1552`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `constants.ts`
+- **Thin community `Community 1553`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1554`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1555`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1556`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `data.ts`
+- **Thin community `Community 1557`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1558`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1559`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1560`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1561`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1562`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1562`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1563`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1563`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1564`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1565`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1566`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1567`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1568`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `index.ts`
+- **Thin community `Community 1569`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1570`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1571`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1572`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1573`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1574`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1575`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1576`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1577`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1578`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1579`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1580`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `aws.ts`
+- **Thin community `Community 1581`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `constants.ts`
+- **Thin community `Community 1582`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `countries.ts`
+- **Thin community `Community 1583`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1584`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1585`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1586`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1587`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1588`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1589`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1590`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `dto.ts`
+- **Thin community `Community 1591`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `ports.ts`
+- **Thin community `Community 1592`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `constants.ts`
+- **Thin community `Community 1593`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1594`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1595`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `index.ts`
+- **Thin community `Community 1596`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1597`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `types.ts`
+- **Thin community `Community 1598`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1599`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1600`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1601`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1602`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1603`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1604`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1605`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1606`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 1607`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1608`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1609`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1610`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 1611`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 1612`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `index.ts`
+- **Thin community `Community 1613`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 1614`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `category.ts`
+- **Thin community `Community 1615`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `product.ts`
+- **Thin community `Community 1616`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `store.ts`
+- **Thin community `Community 1617`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1618`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `user.ts`
+- **Thin community `Community 1619`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1620`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1621`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1622`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1623`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1624`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1625`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1626`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1627`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1628`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1629`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `index.tsx`
+- **Thin community `Community 1630`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `index.tsx`
+- **Thin community `Community 1631`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1632`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1633`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1634`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1635`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1636`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1637`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `index.tsx`
+- **Thin community `Community 1638`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1639`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1640`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1640`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1641`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `home.tsx`
+- **Thin community `Community 1642`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1643`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1644`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1645`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `index.tsx`
+- **Thin community `Community 1646`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `review.tsx`
+- **Thin community `Community 1647`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1648`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1649`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `index.tsx`
+- **Thin community `Community 1650`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1651`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1652`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1653`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `index.tsx`
+- **Thin community `Community 1654`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1655`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1656`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1657`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1658`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1659`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1660`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `index.tsx`
+- **Thin community `Community 1661`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1662`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1663`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1663`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1664`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1665`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1666`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1667`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1668`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1669`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1670`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `index.tsx`
+- **Thin community `Community 1671`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1672`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1673`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `new.tsx`
+- **Thin community `Community 1674`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1675`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1676`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1677`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1678`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `index.tsx`
+- **Thin community `Community 1679`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `new.tsx`
+- **Thin community `Community 1680`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1681`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1682`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1683`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1684`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1685`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `index.tsx`
+- **Thin community `Community 1686`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1687`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1688`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1688`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1689`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `index.tsx`
+- **Thin community `Community 1690`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1691`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1692`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1693`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1694`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1695`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1696`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1697`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1698`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1699`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1700`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1701`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1702`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1703`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1704`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1705`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1706`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1707`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1708`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1709`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1710`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1711`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1712`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1713`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1714`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `setup.ts`
+- **Thin community `Community 1715`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1716`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `types.ts`
+- **Thin community `Community 1717`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1718`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1719`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1720`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1721`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1722`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `types.ts`
+- **Thin community `Community 1723`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1724`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1725`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1726`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1727`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1728`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1729`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1730`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1731`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1732`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `schema.ts`
+- **Thin community `Community 1733`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1734`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1735`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1736`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1737`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1738`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1739`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1740`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1741`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1742`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `types.ts`
+- **Thin community `Community 1743`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1744`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1745`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1746`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1747`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1748`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1749`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1750`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `constants.ts`
+- **Thin community `Community 1751`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1752`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `About.tsx`
+- **Thin community `Community 1753`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1754`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1755`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1756`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1757`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1758`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1759`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1760`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1761`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1762`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1763`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `types.ts`
+- **Thin community `Community 1764`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1765`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1766`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1767`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1768`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1769`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1770`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1771`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1772`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1773`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1774`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1775`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `button.tsx`
+- **Thin community `Community 1776`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `card.tsx`
+- **Thin community `Community 1777`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1778`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `command.tsx`
+- **Thin community `Community 1779`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1780`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1781`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1782`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `form.tsx`
+- **Thin community `Community 1783`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1784`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1785`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1786`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1787`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `input.tsx`
+- **Thin community `Community 1788`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `label.tsx`
+- **Thin community `Community 1789`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1790`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1791`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1792`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `index.ts`
+- **Thin community `Community 1793`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `types.ts`
+- **Thin community `Community 1794`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1795`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1796`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1797`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1798`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `select.tsx`
+- **Thin community `Community 1799`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1800`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1801`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `table.tsx`
+- **Thin community `Community 1802`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1803`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1804`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1805`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1806`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1807`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `config.ts`
+- **Thin community `Community 1808`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1809`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1810`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1811`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1812`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `constants.ts`
+- **Thin community `Community 1813`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `countries.ts`
+- **Thin community `Community 1814`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1815`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1816`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1817`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1818`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `index.ts`
+- **Thin community `Community 1819`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `store.ts`
+- **Thin community `Community 1820`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `bag.ts`
+- **Thin community `Community 1821`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1822`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `category.ts`
+- **Thin community `Community 1823`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `organization.ts`
+- **Thin community `Community 1824`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `product.ts`
+- **Thin community `Community 1825`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `store.ts`
+- **Thin community `Community 1826`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1827`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `user.ts`
+- **Thin community `Community 1828`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `states.ts`
+- **Thin community `Community 1829`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1830`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1831`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1832`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1833`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1834`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1835`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1836`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `index.tsx`
+- **Thin community `Community 1837`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1838`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1839`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1840`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1841`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1842`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1843`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1844`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `index.tsx`
+- **Thin community `Community 1845`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1846`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1847`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1848`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1849`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1850`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `index.js`
+- **Thin community `Community 1851`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1852`** (1 nodes): `vitest.setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1853`** (1 nodes): `index.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1854`** (1 nodes): `harness-app-registry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1855`** (1 nodes): `athena-runtime-app.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1856`** (1 nodes): `storefront-runtime-api.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1857`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1858`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1859`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,17 +7,17 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1931
-- Graph nodes: 6824
-- Graph edges: 7644
-- Communities: 1858
+- Code files discovered: 1933
+- Graph nodes: 6866
+- Graph edges: 7718
+- Communities: 1860
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (87 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `useRegisterViewModel.ts` (72 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `dailyClose.ts` (65 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `projectLocalEvents.ts` (52 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
-- `usePosLocalSyncRuntime.ts` (48 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
+- `usePosLocalSyncRuntime.ts` (49 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
 - `harness-inferential-review.ts` (47 edges, Community 6) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `dailyOperations.ts` (46 edges, Community 7) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 - `ingestLocalEvents.ts` (46 edges, Community 8) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -21,7 +21,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - `useRegisterViewModel.ts` (72 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `dailyClose.ts` (65 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `projectLocalEvents.ts` (52 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
-- `usePosLocalSyncRuntime.ts` (48 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
+- `usePosLocalSyncRuntime.ts` (49 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -20,7 +20,7 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - `storefrontJourneyEvents.ts` (45 edges, Community 9) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `createJourneyEvent()` (40 edges, Community 9) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 46) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
-- `checkoutSession.ts` (14 edges, Community 74) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
+- `checkoutSession.ts` (14 edges, Community 76) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 - `storeConfig.ts` (14 edges, Community 46) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 
 ## Navigation

--- a/manage-athena-versions.sh
+++ b/manage-athena-versions.sh
@@ -135,7 +135,7 @@ fi
 # Handle deployment operations
 if [ "$OPERATION" = "deploy" ]; then
   # Select app to deploy
-  APP=$(printf "athena-webapp\nathena-webapp local build\nstorefront\nstorefront local build\nconvex\nfull-deploy\nfull-deploy local builds\nvalkey-proxy\nqa\nall" | fzf --prompt="Select app to deploy: ")
+  APP=$(printf "athena-webapp\nathena-webapp local build\nstorefront\nstorefront local build\nconvex\nconvex + athena local build\nconvex + storefront local build\nfull-deploy\nfull-deploy local builds\nvalkey-proxy\nqa\nall" | fzf --prompt="Select app to deploy: ")
   if [ -z "$APP" ]; then
     echo "No app selected. Aborting."
     exit 1
@@ -156,6 +156,12 @@ if [ "$OPERATION" = "deploy" ]; then
       ;;
     "convex")
       deploy_vps convex-prod
+      ;;
+    "convex + athena local build")
+      deploy_vps convex-athena-local
+      ;;
+    "convex + storefront local build")
+      deploy_vps convex-storefront-local
       ;;
     "full-deploy")
       deploy_vps full-prod

--- a/packages/athena-webapp/convex/cashControls/deposits.test.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.test.ts
@@ -20,6 +20,10 @@ import {
   recordRegisterSessionDeposit,
   resolveRegisterSessionSyncReview,
 } from "./deposits";
+import {
+  buildRegisterSessionLocalSyncStatus,
+  classifyRegisterSessionSyncReview,
+} from "../pos/application/sync/registerSessionSyncReview";
 
 function getSource(relativePath: string) {
   return readFileSync(new URL(relativePath, import.meta.url), "utf8");
@@ -208,6 +212,83 @@ function createAuthorizedRegisterDepositCtx(
 describe("cash control deposits", () => {
   beforeEach(() => {
     mockedAuthServer.getAuthUserId.mockResolvedValue("auth_user_1");
+  });
+
+  it("classifies register-session sync reviews with action policy at the source", () => {
+    expect(
+      classifyRegisterSessionSyncReview({
+        conflictType: "permission",
+        details: {
+          countedCash: 45000,
+          expectedCash: 50000,
+          variance: -5000,
+        },
+        localEventId: "local-register-closed-1",
+        status: "needs_review",
+        summary: "Synced register closeout has a variance.",
+      }),
+    ).toEqual({
+      actionPolicy: "apply_or_reject",
+      conflictType: "permission",
+      reviewKind: "register_closeout_variance",
+    });
+    expect(
+      classifyRegisterSessionSyncReview({
+        conflictType: "permission",
+        details: {},
+        localEventId: "event_closeout",
+        status: "needs_review",
+        summary: "Register session is not open for synced POS closeout.",
+      }),
+    ).toEqual({
+      actionPolicy: "reject_only",
+      conflictType: "permission",
+      reviewKind: "duplicate_register_closeout",
+    });
+    expect(
+      classifyRegisterSessionSyncReview({
+        conflictType: "server_rejected",
+        details: {},
+        localEventId: "event_1",
+        status: "rejected",
+        summary: "Server rejected synced register activity for this drawer.",
+      }),
+    ).toEqual({
+      actionPolicy: "override_or_reject",
+      conflictType: "server_rejected",
+      reviewKind: "server_rejected",
+    });
+  });
+
+  it("projects sync review classification into register-session local sync status", () => {
+    expect(
+      buildRegisterSessionLocalSyncStatus([
+        {
+          _id: "sync_conflict_closeout",
+          conflictType: "permission",
+          createdAt: 1,
+          details: {
+            countedCash: 45000,
+            expectedCash: 50000,
+            variance: -5000,
+          },
+          localEventId: "local-register-closed-1",
+          sequence: 2,
+          status: "needs_review",
+          summary: "Synced register closeout has a variance.",
+        },
+      ]),
+    ).toEqual({
+      status: "needs_review",
+      reconciliationItems: [
+        expect.objectContaining({
+          actionPolicy: "apply_or_reject",
+          id: "sync_conflict_closeout",
+          reviewKind: "register_closeout_variance",
+          type: "register_closeout",
+        }),
+      ],
+    });
   });
 
   it("builds a stable session-scoped submission target for idempotent deposit writes", () => {
@@ -2002,6 +2083,191 @@ describe("cash control deposits", () => {
     );
   });
 
+  it("applies reviewed synced closeouts when the review summary was normalized", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx({
+      operationalEvent: [],
+      posLocalSyncConflict: [
+        {
+          _id: "sync_conflict_closeout",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "local-register-closed-1",
+          sequence: 2,
+          conflictType: "permission",
+          status: "needs_review",
+          summary: "Synced register closeout has a variance.",
+          details: {
+            countedCash: 45000,
+            expectedCash: 50000,
+            variance: -5000,
+          },
+          createdAt: 1,
+        },
+        {
+          _id: "sync_conflict_service",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "local-sale-1",
+          sequence: 3,
+          conflictType: "permission",
+          status: "needs_review",
+          summary: "Service line is missing customer attribution.",
+          details: {},
+          createdAt: 2,
+        },
+      ],
+      posLocalSyncEvent: [
+        {
+          _id: "sync_event_closeout",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "local-register-closed-1",
+          sequence: 2,
+          eventType: "register_closed",
+          occurredAt: 2,
+          staffProfileId: "staff_1",
+          payload: {
+            countedCash: 45000,
+            notes: "Short drawer",
+          },
+          status: "conflicted",
+          submittedAt: 4,
+          acceptedAt: 4,
+        },
+        {
+          _id: "sync_event_service",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localEventId: "local-sale-1",
+          sequence: 3,
+          eventType: "sale_completed",
+          occurredAt: 3,
+          staffProfileId: "staff_1",
+          payload: {},
+          status: "conflicted",
+          submittedAt: 5,
+          acceptedAt: 5,
+        },
+      ],
+      posLocalSyncMapping: [
+        {
+          _id: "sync_mapping_1",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "local-register-1",
+          localIdKind: "registerSession",
+          localId: "local-register-1",
+          cloudTable: "registerSession",
+          cloudId: "session_open",
+        },
+      ],
+      registerSession: [
+        {
+          _id: "session_open",
+          closeoutRecords: [],
+          expectedCash: 50000,
+          openedAt: 1,
+          openingFloat: 50000,
+          organizationId: "org_1",
+          registerNumber: "1",
+          status: "active",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+        },
+      ],
+      posTerminal: [
+        {
+          _id: "terminal_1",
+          registerNumber: "1",
+          registeredByUserId: "athena_user_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+      staffProfile: [
+        {
+          _id: "manager_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+        {
+          _id: "staff_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+      staffRoleAssignment: [
+        {
+          _id: "role_1",
+          organizationId: "org_1",
+          role: "manager",
+          staffProfileId: "manager_1",
+          status: "active",
+          storeId: "store_1",
+        },
+        {
+          _id: "role_2",
+          organizationId: "org_1",
+          role: "cashier",
+          staffProfileId: "staff_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+    });
+
+    const result = await getHandler(resolveRegisterSessionSyncReview)(
+      ctx as never,
+      {
+        actorStaffProfileId: "manager_1" as Id<"staffProfile">,
+        registerSessionId: "session_open" as Id<"registerSession">,
+        reviewConflictIds: [
+          "sync_conflict_closeout" as Id<"posLocalSyncConflict">,
+        ],
+        storeId: "store_1" as Id<"store">,
+      },
+    );
+
+    expect(result).toEqual(
+      ok({
+        action: "resolved",
+        projectedCount: 0,
+        registerSession: expect.objectContaining({
+          _id: "session_open",
+          status: "closed",
+        }),
+        resolvedCount: 1,
+      }),
+    );
+    expect(ctx.tables.get("posLocalSyncEvent")).toEqual([
+      expect.objectContaining({
+        _id: "sync_event_closeout",
+        projectedAt: expect.any(Number),
+        status: "projected",
+      }),
+      expect.objectContaining({
+        _id: "sync_event_service",
+        status: "conflicted",
+      }),
+    ]);
+    expect(ctx.tables.get("posLocalSyncConflict")).toEqual([
+      expect.objectContaining({
+        _id: "sync_conflict_closeout",
+        status: "resolved",
+      }),
+      expect.objectContaining({
+        _id: "sync_conflict_service",
+        status: "needs_review",
+      }),
+    ]);
+  });
+
   it("explains that already-closed synced closeouts must be rejected", async () => {
     const ctx = createAuthorizedRegisterDepositCtx({
       posLocalSyncConflict: [
@@ -2105,6 +2371,233 @@ describe("cash control deposits", () => {
         status: "conflicted",
       }),
     ]);
+  });
+
+  it("clears duplicate synced closeout reviews after manager rejection", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx({
+      posLocalSyncConflict: [
+        {
+          _id: "sync_conflict_closeout",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "session_closed",
+          localEventId: "event_closeout",
+          sequence: 2,
+          conflictType: "permission",
+          status: "needs_review",
+          summary: "Register session is not open for synced POS closeout.",
+          details: {
+            localRegisterSessionId: "session_closed",
+            status: "closed",
+          },
+          createdAt: 1,
+        },
+        {
+          _id: "sync_conflict_closeout_shadow",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "session_closed",
+          localEventId: "event_closeout",
+          sequence: 2,
+          conflictType: "permission",
+          status: "needs_review",
+          summary: "Register session is not open for synced POS closeout.",
+          details: {
+            localRegisterSessionId: "session_closed",
+            status: "closed",
+          },
+          createdAt: 2,
+        },
+      ],
+      posLocalSyncEvent: [
+        {
+          _id: "sync_event_closeout",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "session_closed",
+          localEventId: "event_closeout",
+          sequence: 2,
+          eventType: "register_closed",
+          occurredAt: 2,
+          staffProfileId: "staff_1",
+          payload: {
+            countedCash: 50000,
+          },
+          status: "conflicted",
+          submittedAt: 4,
+          acceptedAt: 4,
+        },
+      ],
+      registerSession: [
+        {
+          _id: "session_closed",
+          closeoutRecords: [],
+          countedCash: 50000,
+          expectedCash: 50000,
+          openedAt: 1,
+          openingFloat: 50000,
+          organizationId: "org_1",
+          registerNumber: "1",
+          status: "closed",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          variance: 0,
+        },
+      ],
+      staffProfile: [
+        {
+          _id: "manager_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+        {
+          _id: "staff_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+      staffRoleAssignment: [
+        {
+          _id: "role_1",
+          organizationId: "org_1",
+          role: "manager",
+          staffProfileId: "manager_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+    });
+
+    const result = await getHandler(resolveRegisterSessionSyncReview)(
+      ctx as never,
+      {
+        actorStaffProfileId: "manager_1" as Id<"staffProfile">,
+        decision: "rejected",
+        registerSessionId: "session_closed" as Id<"registerSession">,
+        reviewConflictIds: [
+          "sync_conflict_closeout" as Id<"posLocalSyncConflict">,
+        ],
+        storeId: "store_1" as Id<"store">,
+      },
+    );
+
+    expect(result).toEqual(
+      ok({
+        action: "rejected",
+        projectedCount: 0,
+        registerSession: expect.objectContaining({ _id: "session_closed" }),
+        resolvedCount: 1,
+      }),
+    );
+    expect(ctx.tables.get("posLocalSyncEvent")).toEqual([
+      expect.objectContaining({
+        _id: "sync_event_closeout",
+        rejectionCode: "manager_rejected",
+        rejectionMessage:
+          "Manager rejected synced register activity during cash-controls review.",
+        status: "rejected",
+      }),
+    ]);
+    expect(ctx.tables.get("posLocalSyncConflict")).toEqual([
+      expect.objectContaining({
+        _id: "sync_conflict_closeout",
+        status: "resolved",
+      }),
+      expect.objectContaining({
+        _id: "sync_conflict_closeout_shadow",
+        status: "resolved",
+      }),
+    ]);
+    await expect(
+      listOpenLocalSyncConflictsByRegisterSession(
+        ctx as never,
+        "store_1" as Id<"store">,
+        { includeRejectedEvidence: true },
+      ),
+    ).resolves.toEqual(new Map());
+  });
+
+  it("does not report success when a scoped review id is no longer present", async () => {
+    const ctx = createAuthorizedRegisterDepositCtx({
+      posLocalSyncConflict: [
+        {
+          _id: "sync_conflict_closeout",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "session_closed",
+          localEventId: "event_closeout",
+          sequence: 2,
+          conflictType: "permission",
+          status: "needs_review",
+          summary: "Register session is not open for synced POS closeout.",
+          details: {},
+          createdAt: 1,
+        },
+      ],
+      posLocalSyncEvent: [
+        {
+          _id: "sync_event_closeout",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+          localRegisterSessionId: "session_closed",
+          localEventId: "event_closeout",
+          sequence: 2,
+          eventType: "register_closed",
+          occurredAt: 2,
+          staffProfileId: "staff_1",
+          payload: {},
+          status: "conflicted",
+          submittedAt: 4,
+          acceptedAt: 4,
+        },
+      ],
+      registerSession: [
+        {
+          _id: "session_closed",
+          organizationId: "org_1",
+          registerNumber: "1",
+          status: "closed",
+          storeId: "store_1",
+          terminalId: "terminal_1",
+        },
+      ],
+      staffProfile: [
+        {
+          _id: "manager_1",
+          organizationId: "org_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+      staffRoleAssignment: [
+        {
+          _id: "role_1",
+          organizationId: "org_1",
+          role: "manager",
+          staffProfileId: "manager_1",
+          status: "active",
+          storeId: "store_1",
+        },
+      ],
+    });
+
+    await expect(
+      getHandler(resolveRegisterSessionSyncReview)(ctx as never, {
+        actorStaffProfileId: "manager_1" as Id<"staffProfile">,
+        decision: "rejected",
+        registerSessionId: "session_closed" as Id<"registerSession">,
+        reviewConflictIds: ["stale-review-id"],
+        storeId: "store_1" as Id<"store">,
+      }),
+    ).resolves.toEqual(
+      userError({
+        code: "precondition_failed",
+        message:
+          "This register review changed before the action completed. Refresh the register session and try again.",
+      }),
+    );
   });
 
   it("ignores unmapped local register ids that are not valid cloud session ids", async () => {

--- a/packages/athena-webapp/convex/cashControls/deposits.ts
+++ b/packages/athena-webapp/convex/cashControls/deposits.ts
@@ -21,7 +21,9 @@ import {
 } from "../pos/infrastructure/repositories/transactionRepository";
 import {
   buildRegisterSessionLocalSyncStatus,
+  classifyRegisterSessionSyncReview,
   listOpenLocalSyncConflictsByRegisterSession as listRegisterSessionSyncReviewConflicts,
+  STAFF_ACCESS_SYNC_REVIEW_SUMMARY,
   type RegisterSessionSyncConflict,
 } from "../pos/application/sync/registerSessionSyncReview";
 import { createConvexLocalSyncRepository } from "../pos/infrastructure/repositories/localSyncRepository";
@@ -43,14 +45,6 @@ const RECENT_DEPOSIT_LIMIT = 10;
 const SESSION_LIMIT = 100;
 const STAFF_ROLE_LOOKUP_LIMIT = 20;
 const TIMELINE_LIMIT = 200;
-const REGISTER_NOT_OPEN_SYNC_REVIEW_SUMMARY =
-  "Register was not open before this sale synced.";
-const STAFF_ACCESS_SYNC_REVIEW_SUMMARY =
-  "Staff access changed before this POS history synced.";
-const SERVICE_CUSTOMER_ATTRIBUTION_SYNC_REVIEW_SUMMARY =
-  "Service line is missing customer attribution.";
-const CLOSED_REGISTER_SYNCED_CLOSEOUT_SUMMARY =
-  "Register session is not open for synced POS closeout.";
 
 const userErrorValidator = v.object({
   code: v.union(
@@ -1104,6 +1098,7 @@ export const resolveRegisterSessionSyncReview = mutation({
     actorStaffProfileId: v.optional(v.id("staffProfile")),
     decision: v.optional(v.union(v.literal("approved"), v.literal("rejected"))),
     registerSessionId: v.id("registerSession"),
+    reviewConflictIds: v.optional(v.array(v.string())),
     storeId: v.id("store"),
   },
   returns: registerSessionSyncReviewResultValidator,
@@ -1154,7 +1149,26 @@ export const resolveRegisterSessionSyncReview = mutation({
       args.storeId,
       { includeRejectedEvidence: true },
     );
-    const conflicts = conflictsBySessionId.get(args.registerSessionId) ?? [];
+    const allConflicts = conflictsBySessionId.get(args.registerSessionId) ?? [];
+    const requestedConflictIds = new Set(args.reviewConflictIds ?? []);
+    const conflicts =
+      requestedConflictIds.size > 0
+        ? allConflicts.filter((conflict) =>
+            requestedConflictIds.has(conflict._id) ||
+            requestedConflictIds.has(conflict.localEventId),
+          )
+        : allConflicts;
+    if (
+      requestedConflictIds.size > 0 &&
+      allConflicts.length > 0 &&
+      conflicts.length === 0
+    ) {
+      return userError({
+        code: "precondition_failed",
+        message:
+          "This register review changed before the action completed. Refresh the register session and try again.",
+      });
+    }
     if (conflicts.length === 0) {
       return ok({
         action: "already_resolved",
@@ -1168,6 +1182,11 @@ export const resolveRegisterSessionSyncReview = mutation({
     const localSyncRepository = createConvexLocalSyncRepository(ctx);
     const projectedTransactionIds: string[] = [];
     const resolvedConflictIds = new Set<Id<"posLocalSyncConflict">>();
+    const conflictResolutionKeys: Array<{
+      localEventId: string;
+      storeId: Id<"store">;
+      terminalId: Id<"posTerminal">;
+    }> = [];
     const localEventIds: string[] = [];
     const originalStatuses: string[] = [];
     const sequences: number[] = [];
@@ -1197,6 +1216,11 @@ export const resolveRegisterSessionSyncReview = mutation({
       }
       const hasConflictRecord =
         !(conflict.status === "rejected" && conflict._id === syncEvent._id);
+      conflictResolutionKeys.push({
+        localEventId: syncEvent.localEventId,
+        storeId: args.storeId,
+        terminalId,
+      });
       localEventIds.push(syncEvent.localEventId);
       originalStatuses.push(syncEvent.status);
       sequences.push(syncEvent.sequence);
@@ -1226,27 +1250,26 @@ export const resolveRegisterSessionSyncReview = mutation({
       if (shouldApplyManagerOverride) {
         managerOverrideCount += 1;
       }
+      const review = classifyRegisterSessionSyncReview(conflict);
+      const matchesLocalRegisterSession =
+        !conflict.localRegisterSessionId ||
+        syncEvent.localRegisterSessionId === conflict.localRegisterSessionId;
       const shouldApplyProoflessStaffAccessEvent =
         isProoflessStaffAccessSyncReview(conflict) &&
         (syncEvent.eventType === "register_opened" ||
           syncEvent.eventType === "sale_completed");
       const shouldApplyReviewedSale =
         (syncEvent.eventType === "sale_completed" &&
-          (!conflict.localRegisterSessionId ||
-            syncEvent.localRegisterSessionId ===
-              conflict.localRegisterSessionId) &&
+          matchesLocalRegisterSession &&
           conflict.conflictType === "permission" &&
-          conflict.summary === REGISTER_NOT_OPEN_SYNC_REVIEW_SUMMARY) ||
+          review.reviewKind === "register_not_open_sale") ||
         (shouldApplyManagerOverride &&
           syncEvent.eventType === "sale_completed");
       const shouldApplyReviewedCloseout =
         (syncEvent.eventType === "register_closed" &&
-          (!conflict.localRegisterSessionId ||
-            syncEvent.localRegisterSessionId ===
-              conflict.localRegisterSessionId) &&
+          matchesLocalRegisterSession &&
           conflict.conflictType === "permission" &&
-          conflict.summary ===
-            "Register closeout variance requires manager review before synced closeout can be applied.") ||
+          review.reviewKind === "register_closeout_variance") ||
         (shouldApplyManagerOverride &&
           syncEvent.eventType === "register_closed");
 
@@ -1265,7 +1288,7 @@ export const resolveRegisterSessionSyncReview = mutation({
       ) {
         if (
           syncEvent.eventType === "register_closed" &&
-          conflict.summary === CLOSED_REGISTER_SYNCED_CLOSEOUT_SUMMARY
+          review.reviewKind === "duplicate_register_closeout"
         ) {
           return userError({
             code: "precondition_failed",
@@ -1274,7 +1297,7 @@ export const resolveRegisterSessionSyncReview = mutation({
           });
         }
 
-        if (conflict.summary === SERVICE_CUSTOMER_ATTRIBUTION_SYNC_REVIEW_SUMMARY) {
+        if (review.reviewKind === "service_customer_attribution") {
           return userError({
             code: "precondition_failed",
             message:
@@ -1368,6 +1391,26 @@ export const resolveRegisterSessionSyncReview = mutation({
           .map((mapping) => mapping.cloudId),
       );
     }
+
+    await Promise.all(
+      conflictResolutionKeys.map(async (key) => {
+        const matchingConflicts = await ctx.db
+          .query("posLocalSyncConflict")
+          .withIndex("by_store_terminal_localEvent", (q) =>
+            q
+              .eq("storeId", key.storeId)
+              .eq("terminalId", key.terminalId)
+              .eq("localEventId", key.localEventId),
+          )
+          .take(100);
+
+        for (const conflict of matchingConflicts) {
+          if (conflict.status === "needs_review") {
+            resolvedConflictIds.add(conflict._id);
+          }
+        }
+      }),
+    );
 
     await Promise.all(
       Array.from(resolvedConflictIds).map((conflictId) =>

--- a/packages/athena-webapp/convex/operations/dailyOperations.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.test.ts
@@ -463,6 +463,13 @@ describe("daily operations overview read model", () => {
       adjustmentRefundTotal: 7000,
       itemAdjustmentCount: 1,
       netCashMovementTotal: 43000,
+      paymentTotals: [
+        {
+          amount: 50000,
+          method: "cash",
+          transactionCount: 1,
+        },
+      ],
       salesTotal: 50000,
       transactionCount: 1,
     });

--- a/packages/athena-webapp/convex/operations/dailyOperations.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.ts
@@ -138,6 +138,11 @@ type DailyOperationsCloseSummary = {
   itemAdjustmentCount: number;
   netCashVariance: number;
   netCashMovementTotal: number;
+  paymentTotals: Array<{
+    amount: number;
+    method: string;
+    transactionCount?: number;
+  }>;
   registerVarianceCount: number;
   salesTotal: number;
   transactionCount: number;
@@ -238,6 +243,7 @@ function emptyCloseSummary(): DailyOperationsCloseSummary {
     itemAdjustmentCount: 0,
     netCashVariance: 0,
     netCashMovementTotal: 0,
+    paymentTotals: [],
     registerVarianceCount: 0,
     salesTotal: 0,
     transactionCount: 0,
@@ -1584,6 +1590,7 @@ export async function buildDailyOperationsSnapshotWithCtx(
       itemAdjustmentCount: closeSnapshot.summary.itemAdjustmentCount,
       netCashVariance: closeSnapshot.summary.netCashVariance,
       netCashMovementTotal: closeSnapshot.summary.netCashMovementTotal,
+      paymentTotals: closeSnapshot.summary.paymentTotals ?? [],
       registerVarianceCount: closeSnapshot.summary.registerVarianceCount,
       salesTotal: closeSnapshot.summary.salesTotal,
       transactionCount: closeSnapshot.summary.transactionCount,

--- a/packages/athena-webapp/convex/pos/application/commands/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/commands/terminals.ts
@@ -243,6 +243,10 @@ export type TerminalRuntimeStatusInput = {
   appSessionRecovery?: {
     status: AppSessionRecoveryStatus;
   };
+  appShell?: {
+    observedAt: number;
+    ready: boolean;
+  };
   localStore: {
     available: boolean;
     schemaVersion?: number;
@@ -279,6 +283,16 @@ export type TerminalRuntimeStatusInput = {
     transactionMode?: NonNullable<
       Doc<"posTerminalRuntimeStatus">["saleAuthority"]
     >["transactionMode"];
+  };
+  activeRegisterSession?: {
+    cloudRegisterSessionId?: string;
+    localRegisterSessionId: string;
+    observedAt: number;
+    openedAt?: number;
+    registerNumber?: string;
+    status: NonNullable<
+      Doc<"posTerminalRuntimeStatus">["activeRegisterSession"]
+    >["status"];
   };
   terminalIntegrity?: {
     observedAt: number;
@@ -383,6 +397,7 @@ export async function submitTerminalRuntimeStatus(
     receivedAt,
     source: args.status.source,
     appSessionRecovery,
+    appShell: cleanAppShell(args.status.appShell),
     ...omitUndefined({
       appVersion: cleanOptionalString(args.status.appVersion, 80),
       buildSha: cleanOptionalString(args.status.buildSha, 80),
@@ -431,6 +446,9 @@ export async function submitTerminalRuntimeStatus(
       expiresAt: positiveTimestamp(args.status.staffAuthority.expiresAt),
     }),
     saleAuthority: cleanSaleAuthority(args.status.saleAuthority),
+    activeRegisterSession: cleanActiveRegisterSession(
+      args.status.activeRegisterSession,
+    ),
     snapshots: omitUndefined({
       catalogAgeMs: nonNegativeInteger(args.status.snapshots.catalogAgeMs),
       serviceCatalogAgeMs: nonNegativeInteger(
@@ -443,10 +461,8 @@ export async function submitTerminalRuntimeStatus(
         args.status.snapshots.registerReadModelAgeMs,
       ),
     }),
-    ...omitUndefined({
-      terminalIntegrity: cleanTerminalIntegrity(args.status.terminalIntegrity),
-      drawerAuthority: cleanDrawerAuthority(args.status.drawerAuthority),
-    }),
+    terminalIntegrity: cleanTerminalIntegrity(args.status.terminalIntegrity),
+    drawerAuthority: cleanDrawerAuthority(args.status.drawerAuthority),
   });
 
   return ok({
@@ -507,6 +523,15 @@ function cleanAppSessionRecovery(
     : undefined;
 }
 
+function cleanAppShell(appShell: TerminalRuntimeStatusInput["appShell"]) {
+  if (!appShell) return undefined;
+
+  return {
+    observedAt: positiveTimestamp(appShell.observedAt) ?? Date.now(),
+    ready: appShell.ready === true,
+  };
+}
+
 function cleanOptionalString(value: string | undefined, maxLength: number) {
   const trimmed = value?.trim();
   if (!trimmed) {
@@ -541,6 +566,32 @@ function cleanTerminalIntegrity(
     status: terminalIntegrityStatuses.has(terminalIntegrity.status)
       ? terminalIntegrity.status
       : "reset_required",
+  });
+}
+
+function cleanActiveRegisterSession(
+  activeRegisterSession: TerminalRuntimeStatusInput["activeRegisterSession"],
+) {
+  if (!activeRegisterSession) return undefined;
+
+  return omitUndefined({
+    cloudRegisterSessionId: cleanOptionalString(
+      activeRegisterSession.cloudRegisterSessionId,
+      120,
+    ),
+    localRegisterSessionId:
+      cleanOptionalString(activeRegisterSession.localRegisterSessionId, 120) ??
+      "unknown",
+    observedAt:
+      positiveTimestamp(activeRegisterSession.observedAt) ?? Date.now(),
+    openedAt: positiveTimestamp(activeRegisterSession.openedAt),
+    registerNumber: cleanOptionalString(
+      activeRegisterSession.registerNumber,
+      30,
+    ),
+    status: activeRegisterSessionStatuses.has(activeRegisterSession.status)
+      ? activeRegisterSession.status
+      : "open",
   });
 }
 
@@ -586,6 +637,13 @@ const saleAuthorityTransactionModes = new Set([
   "products_only",
   "services_only",
   undefined,
+]);
+
+const activeRegisterSessionStatuses = new Set([
+  "open",
+  "active",
+  "closing",
+  "closed",
 ]);
 
 const terminalIntegrityReasons = new Set<TerminalIntegrityReason | undefined>([

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.test.ts
@@ -2,13 +2,57 @@ import { describe, expect, it } from "vitest";
 
 import type { Doc, Id } from "../../../_generated/dataModel";
 import type { QueryCtx } from "../../../_generated/server";
-import { getTerminalHealthSummary } from "./terminals";
+import {
+  getTerminalHealthSummary,
+  listTerminalHealthSummaries,
+} from "./terminals";
 
 const now = 2_000_000;
 const storeId = "store-1" as Id<"store">;
 const terminalId = "terminal-1" as Id<"posTerminal">;
 
 describe("terminal health queries", () => {
+  it("treats a closed cloud drawer authority as ready for the next drawer", async () => {
+    const ctx = buildQueryCtx({
+      posTerminal: [buildTerminal()],
+      posTerminalRuntimeStatus: [
+        buildRuntimeStatus({
+          drawerAuthority: {
+            cloudRegisterSessionId: "register-1",
+            localRegisterSessionId: "local-register-1",
+            observedAt: now - 2_000,
+            reason: "cloud_closed",
+            status: "blocked",
+          },
+          saleAuthority: {
+            observedAt: now - 1_000,
+            status: "ready",
+            transactionMode: "products_and_services",
+          },
+        }),
+      ],
+      registerSession: [
+        buildRegisterSession({
+          _id: "register-1" as Id<"registerSession">,
+        }),
+      ],
+    });
+
+    const summary = await getTerminalHealthSummary(ctx, {
+      now,
+      storeId,
+      terminalId,
+    });
+
+    expect(summary?.health).toBe("online");
+    expect(summary?.runtimeStatus?.drawerAuthority).toBeUndefined();
+    expect(summary?.attentionReasons.map((reason) => reason.type)).not.toContain(
+      "drawer_authority_blocked",
+    );
+    expect(summary?.recoveryPreview?.readiness).toBe("healthy_idle");
+    expect(summary?.recoveryPreview?.terminalActions).toEqual([]);
+  });
+
   it("includes latest terminal recovery command lifecycle metadata in the health preview", async () => {
     const ctx = buildQueryCtx({
       posTerminal: [
@@ -118,6 +162,7 @@ describe("terminal health queries", () => {
 
     expect(summary?.recoveryPreview?.commandStatus).toEqual({
       commandId: "command-latest",
+      commandType: "repair_terminal_seed",
       label: "Terminal setup repair",
       latestAcknowledgement: "Terminal setup repair completed locally.",
       status: "completed",
@@ -164,6 +209,258 @@ describe("terminal health queries", () => {
       }),
     );
   });
+
+  it("keeps expired staff authority out of support recovery actions", async () => {
+    const ctx = buildQueryCtx({
+      posTerminal: [buildTerminal()],
+      posTerminalRuntimeStatus: [
+        buildRuntimeStatus({
+          staffAuthority: {
+            status: "expired",
+          },
+        }),
+      ],
+    });
+
+    const summary = await getTerminalHealthSummary(ctx, {
+      now,
+      storeId,
+      terminalId,
+    });
+
+    expect(summary?.recoveryPreview?.readiness).toBe("healthy_idle");
+    expect(summary?.recoveryPreview?.terminalActions).toEqual([]);
+  });
+
+  it("includes recovery preview on terminal health roster summaries", async () => {
+    const ctx = buildQueryCtx({
+      posTerminal: [buildTerminal()],
+      posTerminalRuntimeStatus: [buildRuntimeStatus()],
+    });
+
+    const summaries = await listTerminalHealthSummaries(ctx, {
+      now,
+      storeId,
+    });
+
+    expect(summaries[0]?.recoveryPreview).toEqual(
+      expect.objectContaining({
+        evidence: expect.objectContaining({
+          activeRegisterSession: false,
+        }),
+        readiness: "healthy_idle",
+      }),
+    );
+  });
+
+  it("includes active register-session evidence in recovery preview", async () => {
+    const ctx = buildQueryCtx({
+      posTerminal: [buildTerminal()],
+      posTerminalRuntimeStatus: [buildRuntimeStatus()],
+      registerSession: [
+        buildRegisterSession({
+          status: "open",
+        }),
+      ],
+    });
+
+    const summary = await getTerminalHealthSummary(ctx, {
+      now,
+      storeId,
+      terminalId,
+    });
+
+    expect(summary?.recoveryPreview?.evidence).toEqual(
+      expect.objectContaining({
+        activeRegisterSession: true,
+      }),
+    );
+    expect(summary?.recoveryPreview?.readiness).toBe("drawer_open");
+  });
+
+  it("requires an active register session before reporting able to transact now", async () => {
+    const ctx = buildQueryCtx({
+      posTerminal: [buildTerminal()],
+      posTerminalRuntimeStatus: [
+        buildRuntimeStatus({
+          saleAuthority: {
+            observedAt: now - 1_000,
+            status: "ready",
+            transactionMode: "products_and_services",
+          },
+        }),
+      ],
+    });
+
+    const summary = await getTerminalHealthSummary(ctx, {
+      now,
+      storeId,
+      terminalId,
+    });
+
+    expect(summary?.recoveryPreview?.evidence).toEqual(
+      expect.objectContaining({
+        activeRegisterSession: false,
+      }),
+    );
+    expect(summary?.recoveryPreview?.readiness).toBe("healthy_idle");
+  });
+
+  it("reports able to transact now when the drawer is open and sale authority is ready", async () => {
+    const ctx = buildQueryCtx({
+      posTerminal: [buildTerminal()],
+      posTerminalRuntimeStatus: [
+        buildRuntimeStatus({
+          saleAuthority: {
+            observedAt: now - 1_000,
+            status: "ready",
+            transactionMode: "products_and_services",
+          },
+        }),
+      ],
+      registerSession: [
+        buildRegisterSession({
+          status: "active",
+        }),
+      ],
+    });
+
+    const summary = await getTerminalHealthSummary(ctx, {
+      now,
+      storeId,
+      terminalId,
+    });
+
+    expect(summary?.recoveryPreview?.evidence).toEqual(
+      expect.objectContaining({
+        activeRegisterSession: true,
+      }),
+    );
+    expect(summary?.recoveryPreview?.readiness).toBe("able_to_transact_now");
+  });
+
+  it("uses runtime active drawer evidence for recovery readiness", async () => {
+    const ctx = buildQueryCtx({
+      posTerminal: [buildTerminal()],
+      posTerminalRuntimeStatus: [
+        buildRuntimeStatus({
+          activeRegisterSession: {
+            localRegisterSessionId: "local-register-1",
+            observedAt: now - 1_000,
+            openedAt: now - 20_000,
+            registerNumber: "8",
+            status: "open",
+          },
+        }),
+      ],
+    });
+
+    const summary = await getTerminalHealthSummary(ctx, {
+      now,
+      storeId,
+      terminalId,
+    });
+
+    expect(summary?.recoveryPreview?.evidence).toEqual(
+      expect.objectContaining({
+        activeRegisterSession: true,
+      }),
+    );
+    expect(summary?.recoveryPreview?.readiness).toBe("drawer_open");
+  });
+
+  it("links terminal cards to the active register session for the terminal", async () => {
+    const ctx = buildQueryCtx({
+      posTerminal: [
+        buildTerminal({
+          registerNumber: "8",
+        }),
+      ],
+      posTerminalRuntimeStatus: [buildRuntimeStatus()],
+      registerSession: [
+        buildRegisterSession({
+          _id: "register-closed-latest" as Id<"registerSession">,
+          closedAt: now - 1_000,
+          openedAt: now - 20_000,
+          registerNumber: "8",
+          status: "closed",
+        }),
+        buildRegisterSession({
+          _id: "register-open" as Id<"registerSession">,
+          closeoutRecords: [],
+          closedAt: undefined,
+          openedAt: now - 100_000,
+          registerNumber: "8",
+          status: "open",
+        }),
+      ],
+    });
+
+    const summary = await getTerminalHealthSummary(ctx, {
+      now,
+      storeId,
+      terminalId,
+    });
+
+    expect(summary?.registerSessionLink).toEqual({
+      registerSessionId: "register-open",
+      status: "open",
+    });
+  });
+
+  it("does not link terminal cards to closed register sessions", async () => {
+    const ctx = buildQueryCtx({
+      posTerminal: [buildTerminal()],
+      posTerminalRuntimeStatus: [buildRuntimeStatus()],
+      registerSession: [
+        buildRegisterSession({
+          _id: "register-closed-older" as Id<"registerSession">,
+          closedAt: now - 30_000,
+        }),
+        buildRegisterSession({
+          _id: "register-closed-newer" as Id<"registerSession">,
+          closedAt: now - 1_000,
+        }),
+      ],
+    });
+
+    const summary = await getTerminalHealthSummary(ctx, {
+      now,
+      storeId,
+      terminalId,
+    });
+
+    expect(summary?.registerSessionLink).toBeNull();
+  });
+
+  it("does not link register-number matches that are not bound to the terminal", async () => {
+    const ctx = buildQueryCtx({
+      posTerminal: [
+        buildTerminal({
+          registerNumber: "8",
+        }),
+      ],
+      posTerminalRuntimeStatus: [buildRuntimeStatus()],
+      registerSession: [
+        buildRegisterSession({
+          _id: "register-open-other-terminal" as Id<"registerSession">,
+          closeoutRecords: [],
+          closedAt: undefined,
+          registerNumber: "8",
+          status: "open",
+          terminalId: undefined,
+        }),
+      ],
+    });
+
+    const summary = await getTerminalHealthSummary(ctx, {
+      now,
+      storeId,
+      terminalId,
+    });
+
+    expect(summary?.registerSessionLink).toBeNull();
+  });
 });
 
 type TestTable =
@@ -172,7 +469,8 @@ type TestTable =
   | "posLocalSyncEvent"
   | "posTerminal"
   | "posTerminalRecoveryCommand"
-  | "posTerminalRuntimeStatus";
+  | "posTerminalRuntimeStatus"
+  | "registerSession";
 
 function buildQueryCtx(
   records: Partial<Record<TestTable, Array<Record<string, unknown>>>>,
@@ -191,7 +489,9 @@ function buildQueryCtx(
   } as unknown as QueryCtx;
 }
 
-function buildTerminal(): Doc<"posTerminal"> {
+function buildTerminal(
+  overrides: Partial<Doc<"posTerminal">> = {},
+): Doc<"posTerminal"> {
   return {
     _id: terminalId,
     _creationTime: now - 50_000,
@@ -204,10 +504,13 @@ function buildTerminal(): Doc<"posTerminal"> {
     registeredByUserId: "user-1" as Id<"athenaUser">,
     status: "active",
     storeId,
+    ...overrides,
   };
 }
 
-function buildRuntimeStatus(): Doc<"posTerminalRuntimeStatus"> {
+function buildRuntimeStatus(
+  overrides: Partial<Doc<"posTerminalRuntimeStatus">> = {},
+): Doc<"posTerminalRuntimeStatus"> {
   return {
     _id: "runtime-1" as Id<"posTerminalRuntimeStatus">,
     _creationTime: now - 2_000,
@@ -243,6 +546,31 @@ function buildRuntimeStatus(): Doc<"posTerminalRuntimeStatus"> {
       observedAt: now - 1_000,
       status: "healthy",
     },
+    ...overrides,
+  };
+}
+
+function buildRegisterSession(
+  overrides: Partial<Doc<"registerSession">> = {},
+): Doc<"registerSession"> {
+  return {
+    _id: "register-1" as Id<"registerSession">,
+    _creationTime: now - 10_000,
+    closeoutRecords: [
+      {
+        expectedCash: 0,
+        occurredAt: now - 5_000,
+        type: "closed",
+      },
+    ],
+    closedAt: now - 5_000,
+    expectedCash: 0,
+    openedAt: now - 100_000,
+    openingFloat: 0,
+    status: "closed",
+    storeId,
+    terminalId,
+    ...overrides,
   };
 }
 

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.ts
@@ -1,11 +1,13 @@
 import type { Doc, Id } from "../../../_generated/dataModel";
 import type { QueryCtx } from "../../../_generated/server";
+import { isPosUsableRegisterSessionStatus } from "../../../../shared/registerSessionStatus";
 
 import {
   getLatestRuntimeStatusForTerminal,
   getTerminalByFingerprint as getTerminalByFingerprintRecord,
   getTerminalById,
   getTerminalSyncEvidence,
+  hasActiveRegisterSessionForTerminal,
   listTerminalsForStore,
   resolveTerminalRegisterSessionActionTarget,
   type TerminalSyncEvidence,
@@ -72,7 +74,11 @@ export type TerminalHealthAttentionReason = {
 };
 
 export type TerminalHealthAttentionActionTarget =
-  | { type: "cash_control_register_session"; registerSessionId: Id<"registerSession"> }
+  | {
+      automaticRepairEligible?: boolean;
+      type: "cash_control_register_session";
+      registerSessionId: Id<"registerSession">;
+    }
   | { type: "open_work" }
   | { type: "pos_register" }
   | { type: "pos_settings" };
@@ -95,14 +101,24 @@ export type TerminalHealthSummary = {
   > | null;
   attentionReasons: TerminalHealthAttentionReason[];
   recoveryPreview: TerminalRecoveryPreview | null;
+  registerSessionLink: {
+    registerSessionId: Id<"registerSession">;
+    status: ActiveRegisterSessionLinkStatus;
+  } | null;
   syncEvidence: TerminalSyncEvidence;
 };
+
+type ActiveRegisterSessionLinkStatus = Extract<
+  Doc<"registerSession">["status"],
+  "active" | "open"
+>;
 
 export type TerminalRecoveryPreview = {
   readiness: TerminalRecoveryReadiness;
   runtimeFresh: boolean;
   evidence: {
     freshRuntimeRequiredForAbleToTransactNow: true;
+    activeRegisterSession: boolean;
   };
   cloudRepair: {
     preconditionHash: string;
@@ -111,6 +127,7 @@ export type TerminalRecoveryPreview = {
   };
   commandStatus: {
     commandId?: Id<"posTerminalRecoveryCommand">;
+    commandType: TerminalRecoveryCommandType;
     label: string;
     latestAcknowledgement?: string;
     status: Doc<"posTerminalRecoveryCommand">["status"];
@@ -161,7 +178,7 @@ export async function listTerminalHealthSummaries(
   return Promise.all(
     terminals.map((terminal) =>
       buildTerminalHealthSummary(ctx, {
-        includeSyncEvidence: false,
+        includeSyncEvidence: true,
         terminal,
         now: args.now ?? Date.now(),
       }),
@@ -192,6 +209,78 @@ export async function getTerminalHealthSummary(
 export const listTerminalHealth = listTerminalHealthSummaries;
 export const getTerminalHealthDetail = getTerminalHealthSummary;
 
+async function normalizeRuntimeStatusForSupport(
+  ctx: QueryCtx,
+  args: {
+    runtimeStatus: Doc<"posTerminalRuntimeStatus"> | null;
+    terminal: Doc<"posTerminal">;
+  },
+): Promise<Doc<"posTerminalRuntimeStatus"> | null> {
+  if (!args.runtimeStatus) {
+    return null;
+  }
+
+  if (
+    !(await isCleanlyClosedDrawerAuthority(ctx, {
+      runtimeStatus: args.runtimeStatus,
+      terminal: args.terminal,
+    }))
+  ) {
+    return args.runtimeStatus;
+  }
+
+  return {
+    ...args.runtimeStatus,
+    drawerAuthority: undefined,
+  };
+}
+
+async function isCleanlyClosedDrawerAuthority(
+  ctx: QueryCtx,
+  args: {
+    runtimeStatus: Doc<"posTerminalRuntimeStatus">;
+    terminal: Doc<"posTerminal">;
+  },
+) {
+  const drawerAuthority = args.runtimeStatus.drawerAuthority;
+  if (
+    drawerAuthority?.status !== "blocked" ||
+    drawerAuthority.reason !== "cloud_closed" ||
+    !drawerAuthority.cloudRegisterSessionId
+  ) {
+    return false;
+  }
+
+  const db = ctx.db as {
+    get?: (
+      tableName: "registerSession",
+      id: Id<"registerSession">,
+    ) => Promise<Doc<"registerSession"> | null>;
+    normalizeId?: (
+      tableName: "registerSession",
+      id: string,
+    ) => Id<"registerSession"> | null;
+  } | null;
+  if (!db || typeof db.get !== "function") {
+    return false;
+  }
+
+  const registerSessionId =
+    typeof db.normalizeId === "function"
+      ? db.normalizeId("registerSession", drawerAuthority.cloudRegisterSessionId)
+      : (drawerAuthority.cloudRegisterSessionId as Id<"registerSession">);
+  if (!registerSessionId) {
+    return false;
+  }
+
+  const registerSession = await db.get("registerSession", registerSessionId);
+  return (
+    registerSession?.storeId === args.terminal.storeId &&
+    registerSession.terminalId === args.terminal._id &&
+    registerSession.status === "closed"
+  );
+}
+
 async function buildTerminalHealthSummary(
   ctx: QueryCtx,
   args: {
@@ -200,7 +289,7 @@ async function buildTerminalHealthSummary(
     now: number;
   },
 ): Promise<TerminalHealthSummary> {
-  const [runtimeStatus, syncEvidence] = await Promise.all([
+  const [runtimeStatus, syncEvidence, registerSessionLink] = await Promise.all([
     getLatestRuntimeStatusForTerminal(ctx, {
       storeId: args.terminal.storeId,
       terminalId: args.terminal._id,
@@ -211,12 +300,20 @@ async function buildTerminalHealthSummary(
           terminalId: args.terminal._id,
         })
       : EMPTY_TERMINAL_SYNC_EVIDENCE,
+    getActiveRegisterSessionLink(ctx, {
+      storeId: args.terminal.storeId,
+      terminalId: args.terminal._id,
+    }),
   ]);
+  const supportRuntimeStatus = await normalizeRuntimeStatusForSupport(ctx, {
+    runtimeStatus,
+    terminal: args.terminal,
+  });
   const runtimeAgeMs = runtimeStatus
     ? Math.max(0, args.now - runtimeStatus.receivedAt)
     : null;
   const attentionReasons = deriveTerminalHealthAttentionReasons({
-    runtimeStatus,
+    runtimeStatus: supportRuntimeStatus,
     syncEvidence,
     terminalStatus: args.terminal.status,
   });
@@ -234,7 +331,8 @@ async function buildTerminalHealthSummary(
         attentionReasons: resolvedAttentionReasons,
         now: args.now,
         runtimeAgeMs,
-        runtimeStatus,
+        runtimeStatus: supportRuntimeStatus,
+        registerNumber: args.terminal.registerNumber,
         storeId: args.terminal.storeId,
         syncEvidence,
         terminalId: args.terminal._id,
@@ -255,16 +353,60 @@ async function buildTerminalHealthSummary(
     health: deriveTerminalHealth({
       attentionReasons: resolvedAttentionReasons,
       runtimeAgeMs,
-      runtimeStatus,
+      runtimeStatus: supportRuntimeStatus,
       syncEvidence,
       terminalStatus: args.terminal.status,
     }),
     runtimeAgeMs,
-    runtimeStatus: runtimeStatus ? stripRuntimeStatusIdentity(runtimeStatus) : null,
+    runtimeStatus: supportRuntimeStatus
+      ? stripRuntimeStatusIdentity(supportRuntimeStatus)
+      : null,
     attentionReasons: resolvedAttentionReasons,
     recoveryPreview,
+    registerSessionLink,
     syncEvidence,
   };
+}
+
+async function getActiveRegisterSessionLink(
+  ctx: QueryCtx,
+  args: {
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  },
+): Promise<TerminalHealthSummary["registerSessionLink"]> {
+  if (!ctx.db || typeof ctx.db.query !== "function") {
+    return null;
+  }
+
+  const byTerminal = await ctx.db
+    .query("registerSession")
+    .withIndex("by_terminalId", (q) => q.eq("terminalId", args.terminalId))
+    .order("desc")
+    .take(20);
+  const activeSession = byTerminal
+    .filter(
+      (session) =>
+        session.storeId === args.storeId &&
+        session.terminalId === args.terminalId,
+    )
+    .filter(isActiveRegisterSessionLinkTarget)
+    .sort((left, right) => right.openedAt - left.openedAt)[0];
+
+  return activeSession
+    ? {
+        registerSessionId: activeSession._id,
+        status: activeSession.status,
+      }
+    : null;
+}
+
+function isActiveRegisterSessionLinkTarget(
+  session: Doc<"registerSession">,
+): session is Doc<"registerSession"> & {
+  status: ActiveRegisterSessionLinkStatus;
+} {
+  return isPosUsableRegisterSessionStatus(session.status);
 }
 
 export async function previewTerminalRecovery(
@@ -286,6 +428,7 @@ async function buildTerminalRecoveryPreview(
     now: number;
     runtimeAgeMs: number | null;
     runtimeStatus: Doc<"posTerminalRuntimeStatus"> | null;
+    registerNumber?: string | null;
     storeId: Id<"store">;
     syncEvidence: TerminalSyncEvidence;
     terminalId: Id<"posTerminal">;
@@ -299,6 +442,13 @@ async function buildTerminalRecoveryPreview(
     args.runtimeStatus.browserInfo?.online !== false;
   const cloudRepair = await buildTerminalRecoveryCloudRepairPreview(ctx, args);
   const terminalActions = buildTerminalRecoveryActions(args);
+  const activeRegisterSession =
+    runtimeHasActiveRegisterSession(args.runtimeStatus) ||
+    (await hasActiveRegisterSessionForTerminal(ctx, {
+      registerNumber: args.registerNumber,
+      storeId: args.storeId,
+      terminalId: args.terminalId,
+    }));
   const commandStatus = await buildTerminalRecoveryCommandStatus(ctx, {
     now: args.now,
     storeId: args.storeId,
@@ -316,7 +466,7 @@ async function buildTerminalRecoveryPreview(
     cloudRepair.safeConflictIds.length === 0 &&
     runtimeHasHealthyIdleEvidence(args.runtimeStatus, args.syncEvidence);
   const ableToTransactNow =
-    healthyIdle && runtimeHasSaleAuthority(args.runtimeStatus);
+    activeRegisterSession && healthyIdle && runtimeHasSaleAuthority(args.runtimeStatus);
 
   return {
     readiness: ableToTransactNow
@@ -327,9 +477,12 @@ async function buildTerminalRecoveryPreview(
           ? "needs_terminal_action"
           : cloudRepair.safeConflictIds.length > 0
             ? "needs_cloud_repair"
+            : activeRegisterSession
+              ? "drawer_open"
             : "healthy_idle",
     runtimeFresh,
     evidence: {
+      activeRegisterSession,
       freshRuntimeRequiredForAbleToTransactNow: true,
     },
     cloudRepair,
@@ -366,6 +519,7 @@ async function buildTerminalRecoveryCommandStatus(
 
   return {
     commandId: latestCommand._id,
+    commandType: latestCommand.commandType,
     label: getTerminalRecoveryCommandLabel(latestCommand.commandType),
     latestAcknowledgement: latestCommand.acknowledgement?.message,
     status: getTerminalRecoveryCommandStatusForPreview(latestCommand, args.now),
@@ -497,22 +651,6 @@ function buildTerminalRecoveryActions(args: {
       reason: "Drawer authority requires terminal-local repair.",
     });
   }
-  if (
-    status.staffAuthority.status === "expired" ||
-    status.staffAuthority.status === "missing"
-  ) {
-    actions.push({
-      commandType: "refresh_staff_authority",
-      expectedEvidence: {
-        staffAuthorityStatus: "ready",
-      },
-      commandContext: {
-        expectedBlockerType: "staff_authority",
-        reason: "Staff authority must be refreshed on this terminal.",
-      },
-      reason: "Staff authority must be refreshed on this terminal.",
-    });
-  }
   if (status.sync.status === "failed" || status.sync.status === "unavailable") {
     actions.push({
       commandType: "retry_sync",
@@ -524,6 +662,19 @@ function buildTerminalRecoveryActions(args: {
         reason: "Local sync needs a terminal retry.",
       },
       reason: "Local sync needs a terminal retry.",
+    });
+  }
+  if (status.sync.status === "needs_review" || status.sync.reviewEventCount > 0) {
+    actions.push({
+      commandType: "retry_sync",
+      expectedEvidence: {
+        syncStatus: "idle",
+      },
+      commandContext: {
+        expectedBlockerType: "local_review",
+        reason: "Local review items need a terminal sync retry.",
+      },
+      reason: "Local review items need a terminal sync retry.",
     });
   }
   return dedupeTerminalActions(actions);
@@ -546,7 +697,8 @@ function buildTerminalRecoveryManualReview(args: {
     }));
   for (const conflictId of args.skippedConflictIds) {
     manual.push({
-      reason: `Cloud conflict ${conflictId} needs manual review before repair.`,
+      reason:
+        "A cloud sync conflict needs manual review before support can repair this terminal.",
       source: "cloud_repair" as const,
       type: "unsafe_cloud_conflict" as const,
     });
@@ -562,6 +714,7 @@ function runtimeHasHealthyIdleEvidence(
     !!status &&
     status.localStore.available &&
     status.localStore.terminalSeedReady &&
+    status.staffAuthority.status === "ready" &&
     status.sync.status !== "failed" &&
     status.sync.status !== "needs_review" &&
     status.sync.status !== "unavailable" &&
@@ -581,6 +734,15 @@ function runtimeHasSaleAuthority(status: Doc<"posTerminalRuntimeStatus"> | null)
     !!status &&
     status.staffAuthority.status === "ready" &&
     status.saleAuthority?.status === "ready"
+  );
+}
+
+function runtimeHasActiveRegisterSession(
+  status: Doc<"posTerminalRuntimeStatus"> | null,
+) {
+  return (
+    status?.activeRegisterSession?.status === "open" ||
+    status?.activeRegisterSession?.status === "active"
   );
 }
 

--- a/packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts
+++ b/packages/athena-webapp/convex/pos/application/sync/registerSessionSyncReview.ts
@@ -3,6 +3,30 @@ import type { QueryCtx } from "../../../_generated/server";
 
 const SYNC_CONFLICT_LIMIT = 500;
 const MANAGER_REJECTED_SYNC_REVIEW_CODE = "manager_rejected";
+export const REGISTER_NOT_OPEN_SYNC_REVIEW_SUMMARY =
+  "Register was not open before this sale synced.";
+export const STAFF_ACCESS_SYNC_REVIEW_SUMMARY =
+  "Staff access changed before this POS history synced.";
+export const SERVICE_CUSTOMER_ATTRIBUTION_SYNC_REVIEW_SUMMARY =
+  "Service line is missing customer attribution.";
+export const CLOSED_REGISTER_SYNCED_CLOSEOUT_SUMMARY =
+  "Register session is not open for synced POS closeout.";
+export const REGISTER_CLOSEOUT_VARIANCE_SYNC_REVIEW_SUMMARY =
+  "Register closeout variance requires manager review before synced closeout can be applied.";
+
+export type RegisterSessionSyncReviewActionPolicy =
+  | "apply_or_reject"
+  | "override_or_reject"
+  | "reject_only";
+
+export type RegisterSessionSyncReviewKind =
+  | "duplicate_register_closeout"
+  | "register_closeout_variance"
+  | "register_not_open_sale"
+  | "server_rejected"
+  | "service_customer_attribution"
+  | "staff_access"
+  | "unknown";
 
 export type RegisterSessionSyncConflict = {
   _id: string;
@@ -28,6 +52,8 @@ export type RegisterSessionLocalSyncStatus = {
     id?: string;
     localEventId?: string | null;
     notes?: string | null;
+    reviewKind?: RegisterSessionSyncReviewKind;
+    actionPolicy?: RegisterSessionSyncReviewActionPolicy;
     sequence?: number | null;
     status?: string | null;
     summary?: string | null;
@@ -37,23 +63,105 @@ export type RegisterSessionLocalSyncStatus = {
 };
 
 function getSyncConflictReconciliationType(
-  conflict: Pick<
-    RegisterSessionSyncConflict,
-    "conflictType" | "localEventId" | "summary"
-  >,
+  review: RegisterSessionSyncReviewClassification,
 ) {
-  const localEventId = conflict.localEventId?.toLowerCase() ?? "";
-  const summary = conflict.summary?.toLowerCase() ?? "";
-
   if (
-    localEventId.includes("register-closed") ||
-    localEventId.includes("register-closeout") ||
-    summary.includes("register closeout")
+    review.reviewKind === "duplicate_register_closeout" ||
+    review.reviewKind === "register_closeout_variance"
   ) {
     return "register_closeout";
   }
 
-  return conflict.conflictType ?? null;
+  if (review.reviewKind === "server_rejected") {
+    return "server_rejected";
+  }
+
+  return review.conflictType ?? null;
+}
+
+type RegisterSessionSyncReviewClassification = {
+  actionPolicy: RegisterSessionSyncReviewActionPolicy;
+  conflictType?: string;
+  reviewKind: RegisterSessionSyncReviewKind;
+};
+
+export function classifyRegisterSessionSyncReview(
+  conflict: Pick<
+    RegisterSessionSyncConflict,
+    "conflictType" | "details" | "localEventId" | "status" | "summary"
+  >,
+): RegisterSessionSyncReviewClassification {
+  const localEventId = conflict.localEventId?.toLowerCase() ?? "";
+  const summary = conflict.summary?.trim() ?? "";
+  const normalizedSummary = summary.toLowerCase();
+  const details = conflict.details ?? {};
+  const hasVarianceDetails =
+    typeof details.countedCash === "number" ||
+    typeof details.expectedCash === "number" ||
+    typeof details.variance === "number";
+
+  if (
+    conflict.status === "rejected" ||
+    conflict.conflictType === "server_rejected"
+  ) {
+    return {
+      actionPolicy: "override_or_reject",
+      conflictType: "server_rejected",
+      reviewKind: "server_rejected",
+    };
+  }
+
+  if (summary === CLOSED_REGISTER_SYNCED_CLOSEOUT_SUMMARY) {
+    return {
+      actionPolicy: "reject_only",
+      conflictType: conflict.conflictType,
+      reviewKind: "duplicate_register_closeout",
+    };
+  }
+
+  if (
+    summary === REGISTER_CLOSEOUT_VARIANCE_SYNC_REVIEW_SUMMARY ||
+    localEventId.includes("register-closed") ||
+    localEventId.includes("register-closeout") ||
+    normalizedSummary.includes("register closeout") ||
+    hasVarianceDetails
+  ) {
+    return {
+      actionPolicy: "apply_or_reject",
+      conflictType: conflict.conflictType,
+      reviewKind: "register_closeout_variance",
+    };
+  }
+
+  if (summary === REGISTER_NOT_OPEN_SYNC_REVIEW_SUMMARY) {
+    return {
+      actionPolicy: "apply_or_reject",
+      conflictType: conflict.conflictType,
+      reviewKind: "register_not_open_sale",
+    };
+  }
+
+  if (summary === STAFF_ACCESS_SYNC_REVIEW_SUMMARY) {
+    return {
+      actionPolicy: "apply_or_reject",
+      conflictType: conflict.conflictType,
+      reviewKind: "staff_access",
+    };
+  }
+
+  if (summary === SERVICE_CUSTOMER_ATTRIBUTION_SYNC_REVIEW_SUMMARY) {
+    return {
+      actionPolicy: "reject_only",
+      conflictType: conflict.conflictType,
+      reviewKind: "service_customer_attribution",
+    };
+  }
+
+  return {
+    actionPolicy: "reject_only",
+    conflictType: conflict.conflictType,
+    reviewKind: "unknown",
+  };
 }
 
 function numberDetail(
@@ -83,19 +191,26 @@ export function buildRegisterSessionLocalSyncStatus(
 
   return {
     status: "needs_review",
-    reconciliationItems: conflicts.map((conflict) => ({
-      createdAt: conflict.createdAt,
-      countedCash: numberDetail(conflict.details, "countedCash"),
-      expectedCash: numberDetail(conflict.details, "expectedCash"),
-      id: conflict._id,
-      localEventId: conflict.localEventId,
-      notes: stringDetail(conflict.details, "notes") ?? conflict.sourceEventNotes,
-      sequence: conflict.sequence,
-      status: conflict.status,
-      summary: conflict.summary,
-      type: getSyncConflictReconciliationType(conflict),
-      variance: numberDetail(conflict.details, "variance"),
-    })),
+    reconciliationItems: conflicts.map((conflict) => {
+      const review = classifyRegisterSessionSyncReview(conflict);
+
+      return {
+        actionPolicy: review.actionPolicy,
+        createdAt: conflict.createdAt,
+        countedCash: numberDetail(conflict.details, "countedCash"),
+        expectedCash: numberDetail(conflict.details, "expectedCash"),
+        id: conflict._id,
+        localEventId: conflict.localEventId,
+        notes:
+          stringDetail(conflict.details, "notes") ?? conflict.sourceEventNotes,
+        reviewKind: review.reviewKind,
+        sequence: conflict.sequence,
+        status: conflict.status,
+        summary: conflict.summary,
+        type: getSyncConflictReconciliationType(review),
+        variance: numberDetail(conflict.details, "variance"),
+      };
+    }),
   };
 }
 

--- a/packages/athena-webapp/convex/pos/application/terminalRecovery/types.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRecovery/types.ts
@@ -14,6 +14,7 @@ export type TerminalRecoveryCommandType =
 
 export type TerminalRecoveryReadiness =
   | "healthy_idle"
+  | "drawer_open"
   | "able_to_transact_now"
   | "needs_cloud_repair"
   | "needs_terminal_action"

--- a/packages/athena-webapp/convex/pos/application/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/terminals.test.ts
@@ -17,6 +17,7 @@ import {
   getTerminalById,
   getTerminalByStoreIdAndRegisterNumber,
   getTerminalSyncEvidence,
+  hasActiveRegisterSessionForTerminal,
   listTerminalsForStore,
   patchTerminalRecord,
   registerTerminalRecord,
@@ -67,6 +68,7 @@ vi.mock("../infrastructure/repositories/terminalRepository", () => ({
   getTerminalByStoreIdAndRegisterNumber: vi.fn(),
   getLatestRuntimeStatusForTerminal: vi.fn(),
   getTerminalSyncEvidence: vi.fn(),
+  hasActiveRegisterSessionForTerminal: vi.fn(),
   listTerminalsForStore: vi.fn(),
   mapTerminalRecord: (terminal: typeof existingTerminal) => terminal,
   patchTerminalRecord: vi.fn(),
@@ -481,6 +483,30 @@ describe("submitTerminalRuntimeStatus", () => {
     );
   });
 
+  it("clears stale terminal diagnostics when runtime check-ins omit them", async () => {
+    vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
+    vi.mocked(upsertLatestRuntimeStatus).mockResolvedValue(
+      "runtime-status-1" as Id<"posTerminalRuntimeStatus">,
+    );
+
+    await submitTerminalRuntimeStatus(
+      { db: null as never } as never,
+      {
+        storeId: "store-1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+        status: buildRuntimeStatus(),
+      },
+    );
+
+    expect(vi.mocked(upsertLatestRuntimeStatus)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        drawerAuthority: undefined,
+        terminalIntegrity: undefined,
+      }),
+    );
+  });
+
   it("does not write for inactive or wrong-store terminals", async () => {
     vi.mocked(getTerminalById).mockResolvedValue({
       ...existingTerminal,
@@ -510,6 +536,7 @@ describe("terminal health summaries", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(resolveTerminalRegisterSessionActionTarget).mockResolvedValue(null);
+    vi.mocked(hasActiveRegisterSessionForTerminal).mockResolvedValue(false);
     vi.mocked(listTerminalRecoveryConflictsForRepair).mockResolvedValue([]);
     vi.mocked(getTerminalRecoverySourceEvent).mockResolvedValue(null);
     vi.mocked(createTerminalRecoveryCommandRepository).mockReturnValue({
@@ -521,7 +548,7 @@ describe("terminal health summaries", () => {
     vi.clearAllMocks();
   });
 
-  it("joins registration metadata and latest runtime status without sampling sync evidence in the roster", async () => {
+  it("joins registration metadata, latest runtime status, and sync evidence in the roster", async () => {
     vi.mocked(listTerminalsForStore).mockResolvedValue([existingTerminal]);
     vi.mocked(getLatestRuntimeStatusForTerminal).mockResolvedValue(
       buildPersistedRuntimeStatus(),
@@ -569,24 +596,27 @@ describe("terminal health summaries", () => {
         runtimeStatus: expect.objectContaining({
           source: "sync-runtime",
         }),
-        syncEvidence: {
-          latestEvent: null,
-          latestReviewEvent: null,
-          latestReviewEventsByStatus: {
-            conflicted: null,
-            held: null,
-            rejected: null,
-          },
-          sampledEventCount: 0,
-          acceptedCount: 0,
-          projectedCount: 0,
-          conflictedCount: 0,
-          heldCount: 0,
-          rejectedCount: 0,
-        },
+        syncEvidence: expect.objectContaining({
+          acceptedThroughSequence: 7,
+          conflictedCount: 1,
+          cursorUpdatedAt: 160,
+          latestEvent: expect.objectContaining({
+            localEventId: "local-event-1",
+            sequence: 7,
+            status: "projected",
+          }),
+          projectedCount: 2,
+          sampledEventCount: 3,
+        }),
       }),
     ]);
-    expect(vi.mocked(getTerminalSyncEvidence)).not.toHaveBeenCalled();
+    expect(vi.mocked(getTerminalSyncEvidence)).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        storeId: "store-1",
+        terminalId: "terminal-1",
+      },
+    );
   });
 
   it("carries support-safe app-session recovery status through terminal health", async () => {
@@ -598,6 +628,15 @@ describe("terminal health summaries", () => {
         },
       }),
     );
+    vi.mocked(getTerminalSyncEvidence).mockResolvedValue({
+      latestEvent: null,
+      sampledEventCount: 0,
+      acceptedCount: 0,
+      projectedCount: 0,
+      conflictedCount: 0,
+      heldCount: 0,
+      rejectedCount: 0,
+    });
 
     const result = await listTerminalHealthSummaries(
       { db: null as never } as never,
@@ -612,7 +651,7 @@ describe("terminal health summaries", () => {
     });
   });
 
-  it("loads sampled sync evidence only for terminal detail", async () => {
+  it("loads sampled sync evidence for terminal detail", async () => {
     vi.mocked(getTerminalById).mockResolvedValue(existingTerminal);
     vi.mocked(getLatestRuntimeStatusForTerminal).mockResolvedValue(
       buildPersistedRuntimeStatus(),
@@ -751,6 +790,16 @@ describe("terminal health summaries", () => {
         count: 14,
         source: "local_runtime",
         type: "local_review",
+      }),
+    ]);
+    expect(result?.recoveryPreview?.terminalActions).toEqual([
+      expect.objectContaining({
+        commandContext: expect.objectContaining({
+          expectedBlockerType: "local_review",
+        }),
+        commandType: "retry_sync",
+        expectedEvidence: { syncStatus: "idle" },
+        reason: "Local review items need a terminal sync retry.",
       }),
     ]);
   });
@@ -1311,6 +1360,7 @@ describe("terminal health summaries", () => {
     );
     expect(healthyIdle?.recoveryPreview?.readiness).toBe("healthy_idle");
 
+    vi.mocked(hasActiveRegisterSessionForTerminal).mockResolvedValue(true);
     vi.mocked(getLatestRuntimeStatusForTerminal).mockResolvedValue(
       buildPersistedRuntimeStatus({
         receivedAt: 230,

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.test.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/registerSessionRepository.test.ts
@@ -50,12 +50,14 @@ describe("register session repository", () => {
       status: "needs_review",
       reconciliationItems: [
         {
+          actionPolicy: "apply_or_reject",
           createdAt: 1710000000000,
           countedCash: 4_500,
           expectedCash: 5_000,
           id: "sync-conflict-1",
           localEventId: "event-register-closed-1",
           notes: "Short drawer",
+          reviewKind: "register_closeout_variance",
           sequence: 3,
           status: "needs_review",
           summary:
@@ -64,12 +66,14 @@ describe("register session repository", () => {
           variance: -500,
         },
         {
+          actionPolicy: "apply_or_reject",
           createdAt: 1710000000001,
           countedCash: 4_700,
           expectedCash: 5_000,
           id: "sync-conflict-2",
           localEventId: "event-register-closed-2",
           notes: "Recovered from source event",
+          reviewKind: "register_closeout_variance",
           sequence: 4,
           status: "needs_review",
           summary:

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { Doc, Id } from "../../../_generated/dataModel";
 import {
   getTerminalSyncEvidence,
+  hasActiveRegisterSessionForTerminal,
   resolveTerminalRegisterSessionActionTarget,
   upsertLatestRuntimeStatus,
 } from "./terminalRepository";
@@ -354,7 +355,62 @@ describe("terminalRepository sync evidence", () => {
       rejectedCount: 0,
     });
   });
+});
 
+describe("terminalRepository active register-session evidence", () => {
+  it("finds an active register session directly linked to the terminal", async () => {
+    const ctx = buildCtx({
+      registerSession: [
+        buildRegisterSession({
+          status: "open",
+        }),
+      ],
+    });
+
+    await expect(
+      hasActiveRegisterSessionForTerminal(ctx as never, {
+        storeId: "store-1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+      }),
+    ).resolves.toBe(true);
+  });
+
+  it("falls back to latest register-number evidence when the terminal latest session is closed", async () => {
+    const ctx = buildCtx({
+      registerSession: [
+        buildRegisterSession({
+          _creationTime: 30,
+          registerNumber: "7",
+          status: "closed",
+          terminalId: "terminal-1" as Id<"posTerminal">,
+        }),
+        buildRegisterSession({
+          _creationTime: 20,
+          registerNumber: "8",
+          status: "active",
+          terminalId: "terminal-1" as Id<"posTerminal">,
+        }),
+      ],
+    });
+
+    await expect(
+      hasActiveRegisterSessionForTerminal(ctx as never, {
+        registerNumber: "7",
+        storeId: "store-1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      hasActiveRegisterSessionForTerminal(ctx as never, {
+        registerNumber: "8",
+        storeId: "store-1" as Id<"store">,
+        terminalId: "terminal-1" as Id<"posTerminal">,
+      }),
+    ).resolves.toBe(true);
+  });
+});
+
+describe("terminalRepository register-session action targets", () => {
   it("resolves a local register session to its cloud register session mapping", async () => {
     const ctx = buildCtx({
       posLocalSyncMapping: [
@@ -535,6 +591,24 @@ function buildRuntimeStatus(
       status: "unknown",
     },
     snapshots: {},
+    ...overrides,
+  };
+}
+
+function buildRegisterSession(
+  overrides: Partial<Doc<"registerSession">> = {},
+): Doc<"registerSession"> {
+  return {
+    _id: "register-session-1" as Id<"registerSession">,
+    _creationTime: 1,
+    expectedCash: 100,
+    openedAt: 1,
+    openedByStaffProfileId: "staff-1" as Id<"staffProfile">,
+    openingFloat: 100,
+    registerNumber: "1",
+    status: "open",
+    storeId: "store-1" as Id<"store">,
+    terminalId: "terminal-1" as Id<"posTerminal">,
     ...overrides,
   };
 }

--- a/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
+++ b/packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.ts
@@ -2,6 +2,7 @@ import type { Doc, Id } from "../../../_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "../../../_generated/server";
 
 import type { PosLocalSyncEventStatus } from "../../../../shared/posLocalSyncContract";
+import { isPosUsableRegisterSessionStatus } from "../../../../shared/registerSessionStatus";
 import type { PosTerminalSummary } from "../../domain/types";
 
 const MANAGER_REJECTED_SYNC_REVIEW_CODE = "manager_rejected";
@@ -285,6 +286,47 @@ export async function getTerminalSyncEvidence(
     acceptedThroughSequence: latestCursor?.acceptedThroughSequence,
     cursorUpdatedAt: latestCursor?.updatedAt,
   };
+}
+
+export async function hasActiveRegisterSessionForTerminal(
+  ctx: QueryCtx | MutationCtx,
+  args: {
+    registerNumber?: string | null;
+    storeId: Id<"store">;
+    terminalId: Id<"posTerminal">;
+  },
+) {
+  const latestByTerminal = await ctx.db
+    .query("registerSession")
+    .withIndex("by_terminalId", (q) => q.eq("terminalId", args.terminalId))
+    .order("desc")
+    .first();
+
+  if (
+    latestByTerminal?.storeId === args.storeId &&
+    latestByTerminal.terminalId === args.terminalId &&
+    isPosUsableRegisterSessionStatus(latestByTerminal.status)
+  ) {
+    return true;
+  }
+
+  const registerNumber = args.registerNumber?.trim();
+  if (!registerNumber) {
+    return false;
+  }
+
+  const latestByRegisterNumber = await ctx.db
+    .query("registerSession")
+    .withIndex("by_storeId_registerNumber", (q) =>
+      q.eq("storeId", args.storeId).eq("registerNumber", registerNumber),
+    )
+    .order("desc")
+    .first();
+
+  return (
+    latestByRegisterNumber?.terminalId === args.terminalId &&
+    isPosUsableRegisterSessionStatus(latestByRegisterNumber.status)
+  );
 }
 
 function isActionableTerminalReviewSyncEvent(event: Doc<"posLocalSyncEvent">) {

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -46,8 +46,10 @@ import {
   posTerminalRecoveryVerificationStatusValidator,
 } from "../../schemas/pos/posTerminalRecovery";
 import {
-  posTerminalRuntimeBrowserInfoValidator,
+  posTerminalRuntimeActiveRegisterSessionValidator,
   posTerminalRuntimeAppSessionRecoveryValidator,
+  posTerminalRuntimeAppShellValidator,
+  posTerminalRuntimeBrowserInfoValidator,
   posTerminalRuntimeDrawerAuthorityValidator,
   posTerminalRuntimeLocalStoreValidator,
   posTerminalRuntimeSaleAuthorityValidator,
@@ -124,10 +126,14 @@ const runtimeStatusInputValidator = v.object({
   appSessionRecovery: v.optional(
     posTerminalRuntimeAppSessionRecoveryValidator,
   ),
+  appShell: v.optional(posTerminalRuntimeAppShellValidator),
   localStore: posTerminalRuntimeLocalStoreValidator,
   sync: posTerminalRuntimeSyncValidator,
   staffAuthority: posTerminalRuntimeStaffAuthorityValidator,
   saleAuthority: v.optional(posTerminalRuntimeSaleAuthorityValidator),
+  activeRegisterSession: v.optional(
+    posTerminalRuntimeActiveRegisterSessionValidator,
+  ),
   snapshots: posTerminalRuntimeSnapshotsValidator,
   terminalIntegrity: v.optional(posTerminalRuntimeTerminalIntegrityValidator),
   drawerAuthority: v.optional(posTerminalRuntimeDrawerAuthorityValidator),
@@ -238,6 +244,7 @@ const terminalSyncEvidenceReturnValidator = v.object({
 const terminalHealthActionTargetReturnValidator = v.union(
   v.object({
     type: v.literal("cash_control_register_session"),
+    automaticRepairEligible: v.optional(v.boolean()),
     registerSessionId: v.id("registerSession"),
   }),
   v.object({
@@ -308,6 +315,7 @@ const terminalHealthSummaryReturnValidator = v.object({
     v.object({
       readiness: v.union(
         v.literal("healthy_idle"),
+        v.literal("drawer_open"),
         v.literal("able_to_transact_now"),
         v.literal("needs_cloud_repair"),
         v.literal("needs_terminal_action"),
@@ -315,6 +323,7 @@ const terminalHealthSummaryReturnValidator = v.object({
       ),
       runtimeFresh: v.boolean(),
       evidence: v.object({
+        activeRegisterSession: v.boolean(),
         freshRuntimeRequiredForAbleToTransactNow: v.literal(true),
       }),
       cloudRepair: v.object({
@@ -325,6 +334,7 @@ const terminalHealthSummaryReturnValidator = v.object({
       commandStatus: v.union(
         v.object({
           commandId: v.optional(v.id("posTerminalRecoveryCommand")),
+          commandType: posTerminalRecoveryCommandTypeValidator,
           label: v.string(),
           latestAcknowledgement: v.optional(v.string()),
           status: posTerminalRecoveryCommandStatusValidator,
@@ -351,6 +361,16 @@ const terminalHealthSummaryReturnValidator = v.object({
           ),
           type: v.string(),
         }),
+      ),
+    }),
+    v.null(),
+  ),
+  registerSessionLink: v.union(
+    v.object({
+      registerSessionId: v.id("registerSession"),
+      status: v.union(
+        v.literal("open"),
+        v.literal("active"),
       ),
     }),
     v.null(),
@@ -422,6 +442,12 @@ function stripRuntimeStatusInput(
           status: status.appSessionRecovery.status,
         }
       : undefined,
+    appShell: status.appShell
+      ? {
+          observedAt: status.appShell.observedAt,
+          ready: status.appShell.ready,
+        }
+      : undefined,
     localStore: {
       available: status.localStore.available,
       schemaVersion: status.localStore.schemaVersion,
@@ -455,6 +481,18 @@ function stripRuntimeStatusInput(
           localRegisterSessionId: status.saleAuthority.localRegisterSessionId,
           staffProfileId: status.saleAuthority.staffProfileId,
           transactionMode: status.saleAuthority.transactionMode,
+        }
+      : undefined,
+    activeRegisterSession: status.activeRegisterSession
+      ? {
+          cloudRegisterSessionId:
+            status.activeRegisterSession.cloudRegisterSessionId,
+          localRegisterSessionId:
+            status.activeRegisterSession.localRegisterSessionId,
+          observedAt: status.activeRegisterSession.observedAt,
+          openedAt: status.activeRegisterSession.openedAt,
+          registerNumber: status.activeRegisterSession.registerNumber,
+          status: status.activeRegisterSession.status,
         }
       : undefined,
     terminalIntegrity: status.terminalIntegrity
@@ -541,8 +579,8 @@ export const listTerminals = query({
       storeId: args.storeId,
       userId: athenaUser._id,
     });
-	    const terminals = await listTerminalsQuery(ctx, args);
-	    return terminals.map(stripTerminalSyncSecret);
+    const terminals = await listTerminalsQuery(ctx, args);
+    return terminals.map(stripTerminalSyncSecret);
   },
 });
 
@@ -560,8 +598,8 @@ export const getTerminalByFingerprint = query({
       storeId: args.storeId,
       userId: athenaUser._id,
     });
-	    const terminal = await getTerminalByFingerprintQuery(ctx, args);
-	    return terminal ? stripTerminalSyncSecret(terminal) : null;
+    const terminal = await getTerminalByFingerprintQuery(ctx, args);
+    return terminal ? stripTerminalSyncSecret(terminal) : null;
   },
 });
 
@@ -847,8 +885,8 @@ export const updateTerminal = mutation({
       storeId: terminal.storeId,
       userId: athenaUser._id,
     });
-	    const updatedTerminal = await updateTerminalCommand(ctx, args);
-	    return stripTerminalSyncSecret(updatedTerminal);
+    const updatedTerminal = await updateTerminalCommand(ctx, args);
+    return stripTerminalSyncSecret(updatedTerminal);
   },
 });
 

--- a/packages/athena-webapp/convex/schemas/pos/posTerminalRuntimeStatus.ts
+++ b/packages/athena-webapp/convex/schemas/pos/posTerminalRuntimeStatus.ts
@@ -40,6 +40,11 @@ export const posTerminalRuntimeAppSessionRecoveryValidator = v.object({
   status: posTerminalRuntimeAppSessionRecoveryStatusValidator,
 });
 
+export const posTerminalRuntimeAppShellValidator = v.object({
+  observedAt: v.number(),
+  ready: v.boolean(),
+});
+
 export const posTerminalRuntimeBrowserInfoValidator = v.object({
   userAgent: v.optional(v.string()),
   platform: v.optional(v.string()),
@@ -107,6 +112,20 @@ export const posTerminalRuntimeSaleAuthorityValidator = v.object({
   ),
 });
 
+export const posTerminalRuntimeActiveRegisterSessionValidator = v.object({
+  cloudRegisterSessionId: v.optional(v.string()),
+  localRegisterSessionId: v.string(),
+  observedAt: v.number(),
+  openedAt: v.optional(v.number()),
+  registerNumber: v.optional(v.string()),
+  status: v.union(
+    v.literal("open"),
+    v.literal("active"),
+    v.literal("closing"),
+    v.literal("closed"),
+  ),
+});
+
 export const posTerminalRuntimeSnapshotsValidator = v.object({
   catalogAgeMs: v.optional(v.number()),
   serviceCatalogAgeMs: v.optional(v.number()),
@@ -161,10 +180,14 @@ export const posTerminalRuntimeStatusSchema = v.object({
   appSessionRecovery: v.optional(
     posTerminalRuntimeAppSessionRecoveryValidator,
   ),
+  appShell: v.optional(posTerminalRuntimeAppShellValidator),
   localStore: posTerminalRuntimeLocalStoreValidator,
   sync: posTerminalRuntimeSyncValidator,
   staffAuthority: posTerminalRuntimeStaffAuthorityValidator,
   saleAuthority: v.optional(posTerminalRuntimeSaleAuthorityValidator),
+  activeRegisterSession: v.optional(
+    posTerminalRuntimeActiveRegisterSessionValidator,
+  ),
   snapshots: posTerminalRuntimeSnapshotsValidator,
   terminalIntegrity: v.optional(posTerminalRuntimeTerminalIntegrityValidator),
   drawerAuthority: v.optional(posTerminalRuntimeDrawerAuthorityValidator),

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -337,6 +337,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/lib/theme.test.ts`](../../src/lib/theme.test.ts)
 - [`src/lib/traces/createWorkflowTraceId.test.ts`](../../src/lib/traces/createWorkflowTraceId.test.ts)
 - [`src/lib/utils.test.ts`](../../src/lib/utils.test.ts)
+- [`src/offline/posAppShellReadiness.test.ts`](../../src/offline/posAppShellReadiness.test.ts)
 - [`src/offline/posAppShellRoutes.test.ts`](../../src/offline/posAppShellRoutes.test.ts)
 - [`src/offline/posOfflineReadiness.test.ts`](../../src/offline/posOfflineReadiness.test.ts)
 - [`src/offline/registerPosAppShellServiceWorker.test.ts`](../../src/offline/registerPosAppShellServiceWorker.test.ts)

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.test.tsx
@@ -707,14 +707,105 @@ describe("RegisterSessionViewContent", () => {
     ).toBeInTheDocument();
   });
 
-  it("communicates synced closeouts that cannot be applied as reject-only", () => {
+  it("resolves only the displayed synced closeout review item", async () => {
+    const user = userEvent.setup();
+    const onAuthenticateStaff = vi.fn().mockResolvedValue(
+      ok({
+        activeRoles: ["manager"],
+        staffProfile: { fullName: "Ato Kofi" },
+        staffProfileId: "manager-1",
+      }),
+    );
+    const onResolveSyncReview = vi
+      .fn()
+      .mockResolvedValue(
+        ok({ action: "resolved", projectedCount: 0, resolvedCount: 1 }),
+      );
+
     render(
       <RegisterSessionViewContent
         currency="GHS"
         isLoading={false}
         onRecordDeposit={vi.fn()}
         {...closeoutHandlers}
-        onResolveSyncReview={vi.fn()}
+        onAuthenticateStaff={onAuthenticateStaff}
+        onResolveSyncReview={onResolveSyncReview}
+        registerSessionSnapshot={{
+          ...baseSnapshot,
+          registerSession: {
+            ...baseSnapshot.registerSession,
+            countedCash: undefined,
+            status: "active",
+            variance: undefined,
+            localSyncStatus: {
+              status: "needs_review",
+              reconciliationItems: [
+                {
+                  countedCash: 16100,
+                  expectedCash: 17600,
+                  id: "sync_conflict_closeout",
+                  localEventId: "event-register-closeout-1",
+                  sequence: 7,
+                  status: "needs_review",
+                  summary:
+                    "Register closeout variance requires manager review before synced closeout can be applied.",
+                  type: "permission",
+                  variance: -1500,
+                },
+                {
+                  id: "sync_conflict_sale",
+                  sequence: 8,
+                  status: "needs_review",
+                  summary: "Service line is missing customer attribution.",
+                  type: "permission",
+                },
+              ],
+            },
+          },
+        }}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Approve synced closeout" }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "Confirm staff for Approve synced closeout",
+      }),
+    );
+
+    expect(onResolveSyncReview).toHaveBeenCalledWith({
+      actorStaffProfileId: "manager-1",
+      decision: "approved",
+      registerSessionId: "session-1",
+      reviewConflictIds: ["sync_conflict_closeout"],
+    });
+  });
+
+  it("communicates synced closeouts that cannot be applied as reject-only", async () => {
+    const user = userEvent.setup();
+    const onAuthenticateStaff = vi.fn().mockResolvedValue(
+      ok({
+        activeRoles: ["manager"],
+        staffProfile: { fullName: "Ato Kofi" },
+        staffProfileId: "manager-1",
+      }),
+    );
+    const onResolveSyncReview = vi
+      .fn()
+      .mockResolvedValue(
+        ok({ action: "rejected", projectedCount: 0, resolvedCount: 1 }),
+      );
+
+    render(
+      <RegisterSessionViewContent
+        currency="GHS"
+        isLoading={false}
+        onRecordDeposit={vi.fn()}
+        {...closeoutHandlers}
+        onAuthenticateStaff={onAuthenticateStaff}
+        onResolveSyncReview={onResolveSyncReview}
         registerSessionSnapshot={{
           ...baseSnapshot,
           registerSession: {
@@ -763,6 +854,68 @@ describe("RegisterSessionViewContent", () => {
     expect(
       screen.getByRole("button", { name: "Reject synced closeout" }),
     ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Reject synced closeout" }),
+    );
+    await user.click(
+      screen.getByRole("button", {
+        name: "Confirm staff for Reject synced closeout",
+      }),
+    );
+
+    expect(onResolveSyncReview).toHaveBeenCalledWith({
+      actorStaffProfileId: "manager-1",
+      decision: "rejected",
+      registerSessionId: "session-1",
+      reviewConflictIds: ["sync_conflict_closed_closeout"],
+    });
+  });
+
+  it("does not keep rejected duplicate closeout evidence in the active review surface", () => {
+    render(
+      <RegisterSessionViewContent
+        currency="GHS"
+        isLoading={false}
+        onRecordDeposit={vi.fn()}
+        {...closeoutHandlers}
+        onResolveSyncReview={vi.fn()}
+        registerSessionSnapshot={{
+          ...baseSnapshot,
+          registerSession: {
+            ...baseSnapshot.registerSession,
+            status: "closed",
+            localSyncStatus: {
+              status: "needs_review",
+              reconciliationItems: [
+                {
+                  createdAt: new Date("2026-05-20T14:30:00.000Z").getTime(),
+                  id: "sync_conflict_closed_closeout",
+                  localEventId: "event-register-closed-1",
+                  reviewKind: "duplicate_register_closeout",
+                  sequence: 2,
+                  status: "rejected",
+                  summary:
+                    "Register session is not open for synced POS closeout.",
+                  type: "register_closeout",
+                },
+              ],
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(
+      screen.queryByText("Synced closeout cannot be applied"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Duplicate closeout")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Reject synced closeout" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Closeout review pending"),
+    ).not.toBeInTheDocument();
   });
 
   it("combines synced register review items with safe event evidence", () => {

--- a/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
+++ b/packages/athena-webapp/src/components/cash-controls/RegisterSessionView.tsx
@@ -221,6 +221,7 @@ type ResolveSyncReviewArgs = {
   actorStaffProfileId: string;
   decision: "approved" | "rejected";
   registerSessionId: string;
+  reviewConflictIds?: string[];
 };
 
 type ResolveSyncReviewResult = NormalizedCommandResult<{
@@ -315,6 +316,7 @@ type CloseoutStaffAuthIntent =
       kind: "sync_review";
       decision: "approved" | "rejected";
       registerSessionId: string;
+      reviewConflictIds?: string[];
     };
 
 type ReopenedCloseoutSubmitIntent = {
@@ -587,16 +589,30 @@ function formatReviewItemActivity(item: PosReconciliationItem) {
 }
 
 function isClosedRegisterSyncedCloseoutReviewItem(item: PosReconciliationItem) {
+  if (item.reviewKind === "duplicate_register_closeout") {
+    return true;
+  }
+
   const summary = item.summary?.trim().toLowerCase() ?? "";
 
   return summary.includes(CLOSED_REGISTER_SYNCED_CLOSEOUT_SUMMARY);
 }
 
+function isVisibleRegisterSyncReviewItem(item: PosReconciliationItem) {
+  return !(
+    item.status === "rejected" && isClosedRegisterSyncedCloseoutReviewItem(item)
+  );
+}
+
 function hasOnlyRejectedSyncReviewItems(syncStatus: PosSyncStatusPresentation) {
+  const visibleItems = syncStatus.reconciliationItems.filter(
+    isVisibleRegisterSyncReviewItem,
+  );
+
   return (
     syncStatus.status === "needs_review" &&
-    syncStatus.reconciliationItems.length > 0 &&
-    syncStatus.reconciliationItems.every((item) => item.status === "rejected")
+    visibleItems.length > 0 &&
+    visibleItems.every((item) => item.status === "rejected")
   );
 }
 
@@ -621,8 +637,10 @@ function getAutomaticStaffAccessSyncReviewSignature(
     unresolvedItems.length === 0 ||
     unresolvedItems.some(
       (item) =>
-        item.type !== "permission" ||
-        item.summary?.trim() !== STAFF_ACCESS_SYNC_REVIEW_SUMMARY,
+        item.reviewKind
+          ? item.reviewKind !== "staff_access"
+          : item.type !== "permission" ||
+            item.summary?.trim() !== STAFF_ACCESS_SYNC_REVIEW_SUMMARY,
     )
   ) {
     return null;
@@ -642,20 +660,23 @@ function isApprovableRegisterSyncReviewItem(item: PosReconciliationItem) {
     return true;
   }
 
-  if (isRegisterCloseoutReviewItem(item)) {
-    return true;
+  if (item.actionPolicy) {
+    return item.actionPolicy !== "reject_only";
   }
 
   return (
-    item.type === "permission" &&
-    (item.summary?.trim() === REGISTER_NOT_OPEN_SYNC_REVIEW_SUMMARY ||
-      item.summary?.trim() === STAFF_ACCESS_SYNC_REVIEW_SUMMARY)
+    (isRegisterCloseoutReviewItem(item) &&
+      !isClosedRegisterSyncedCloseoutReviewItem(item)) ||
+    (item.type === "permission" &&
+      (item.summary?.trim() === REGISTER_NOT_OPEN_SYNC_REVIEW_SUMMARY ||
+        item.summary?.trim() === STAFF_ACCESS_SYNC_REVIEW_SUMMARY))
   );
 }
 
 function hasServiceCustomerAttributionReview(items: PosReconciliationItem[]) {
   return items.some(
     (item) =>
+      item.reviewKind === "service_customer_attribution" ||
       item.summary?.trim() === SERVICE_CUSTOMER_ATTRIBUTION_SYNC_REVIEW_SUMMARY,
   );
 }
@@ -693,7 +714,13 @@ function RegisterSessionSyncNotice({
     return null;
   }
 
-  const reconciliationItems = syncStatus.reconciliationItems;
+  const reconciliationItems = syncStatus.reconciliationItems.filter(
+    isVisibleRegisterSyncReviewItem,
+  );
+  if (syncStatus.status === "needs_review" && reconciliationItems.length === 0) {
+    return null;
+  }
+
   const hasOnlyRejectedReviewItems =
     hasOnlyRejectedSyncReviewItems(syncStatus);
   const hasClosedRegisterSyncedCloseout = reconciliationItems.some(
@@ -1751,6 +1778,7 @@ export function RegisterSessionViewContent({
           actorStaffProfileId: result.staffProfileId,
           decision: intent.decision,
           registerSessionId: intent.registerSessionId,
+          reviewConflictIds: intent.reviewConflictIds,
         });
 
         if (commandResult.kind !== "ok") {
@@ -2031,11 +2059,14 @@ export function RegisterSessionViewContent({
       registerSession?.reconciliationItems ??
       [],
   });
+  const visibleSyncReviewItems = syncStatus.reconciliationItems.filter(
+    isVisibleRegisterSyncReviewItem,
+  );
   const isRegisterCloseoutSyncReview =
     syncStatus.status === "needs_review" &&
-    syncStatus.reconciliationItems.some(isRegisterCloseoutReviewItem);
+    visibleSyncReviewItems.some(isRegisterCloseoutReviewItem);
   const pendingCloseoutReviewItem = isRegisterCloseoutSyncReview
-    ? syncStatus.reconciliationItems.find(isRegisterCloseoutReviewItem)
+    ? visibleSyncReviewItems.find(isRegisterCloseoutReviewItem)
     : undefined;
   const displayedExpectedCash =
     typeof pendingCloseoutReviewItem?.expectedCash === "number"
@@ -2109,6 +2140,10 @@ export function RegisterSessionViewContent({
       kind: "sync_review",
       decision,
       registerSessionId: registerSession._id,
+      reviewConflictIds:
+        isRegisterCloseoutSyncReview && pendingCloseoutReviewItem?.id
+          ? [pendingCloseoutReviewItem.id]
+          : undefined,
     });
   }
   const sessionCode = registerSession
@@ -3757,6 +3792,7 @@ export function RegisterSessionView() {
         actorStaffProfileId: args.actorStaffProfileId as Id<"staffProfile">,
         decision: args.decision,
         registerSessionId: args.registerSessionId as Id<"registerSession">,
+        reviewConflictIds: args.reviewConflictIds,
         storeId: activeStore._id,
       }),
     );

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx
@@ -622,6 +622,11 @@ describe("DailyOpeningViewContent", () => {
         "Opening handoff is complete. The store day is ready to run.",
       ).length,
     ).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("button", {
+        name: "Change operating date, currently Friday, May 8, 2026",
+      }),
+    ).toBeInTheDocument();
     expect(screen.getByText("Opening handoff complete")).toBeInTheDocument();
     expect(screen.getByText("Started by")).toBeInTheDocument();
     expect(screen.getByText("Kofi Mensah")).toBeInTheDocument();
@@ -641,6 +646,7 @@ describe("DailyOpeningViewContent", () => {
         occurredAt: Date.UTC(2026, 4, 8, 8, 30),
       },
       startedOpening: {
+        actorType: "automation",
         startedAt: Date.UTC(2026, 4, 8, 8, 30),
       },
       status: "started",
@@ -648,6 +654,9 @@ describe("DailyOpeningViewContent", () => {
 
     expect(screen.getByText("Store day started")).toBeInTheDocument();
     expect(screen.getByText("Athena started Opening Handoff.")).toBeInTheDocument();
+    expect(screen.getByText("Started by")).toBeInTheDocument();
+    expect(screen.getByText("Athena")).toBeInTheDocument();
+    expect(screen.queryByText("Staff unavailable")).not.toBeInTheDocument();
     expect(screen.queryByText("Athena checked Opening Handoff. No change was made.")).not.toBeInTheDocument();
   });
 
@@ -742,6 +751,7 @@ describe("DailyOpeningView", () => {
   beforeEach(() => {
     window.scrollTo = vi.fn();
     vi.clearAllMocks();
+    mockedRouter.search = {};
     mockedHooks.useProtectedAdminPageState.mockReturnValue({
       activeStore: {
         _id: "store-1",
@@ -769,5 +779,19 @@ describe("DailyOpeningView", () => {
       },
     );
     expect(screen.getByText("Opening Handoff")).toBeInTheDocument();
+  });
+
+  it("queries Opening Handoff for the route operating date", () => {
+    mockedRouter.search = { operatingDate: "2026-05-08" };
+
+    render(<DailyOpeningView />);
+
+    expect(mockedHooks.useQuery).toHaveBeenCalledWith(
+      mockedApi.getDailyOpeningSnapshot,
+      expect.objectContaining({
+        operatingDate: "2026-05-08",
+        storeId: "store-1",
+      }),
+    );
   });
 });

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
@@ -10,6 +10,7 @@ import {
   ArrowUpRight,
   Ban,
   Bot,
+  Calendar as CalendarIcon,
   Check,
   CheckCircle2,
   ClipboardCheck,
@@ -42,9 +43,11 @@ import { NoPermissionView } from "../states/no-permission/NoPermissionView";
 import { ProtectedAdminSignInView } from "../states/signed-out/ProtectedAdminSignInView";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
+import { Calendar } from "../ui/calendar";
 import { Checkbox } from "../ui/checkbox";
 import { Label } from "../ui/label";
 import { LoadingButton } from "../ui/loading-button";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { OperationReviewWorkspace } from "./OperationReviewWorkspace";
 import { OperationReviewItemCard } from "./OperationReviewItemCard";
@@ -126,6 +129,7 @@ export type DailyOpeningSnapshot = {
   reviewItems: DailyOpeningItem[];
   startAt: number;
   startedOpening?: {
+    actorType?: "human" | "automation";
     notes?: string | null;
     reviewEvidence?: DailyOpeningItem[];
     startedAt?: number | null;
@@ -161,6 +165,7 @@ type DailyOpeningViewContentProps = {
   isStarting: boolean;
   onStartDay: (args: StartDayArgs) => Promise<NormalizedCommandResult<unknown>>;
   onAuthenticateForApproval?: CommandApprovalDialogProps["onAuthenticateForApproval"];
+  onOperatingDateChange?: (date: Date) => void;
   orgUrlSlug: string;
   snapshot?: DailyOpeningSnapshot;
   storeId?: Id<"store">;
@@ -251,6 +256,37 @@ function getLocalOperatingDateRange(date = new Date()) {
     operatingDate: getLocalOperatingDate(date),
     startAt: localStart.getTime(),
   };
+}
+
+function getLocalDateFromOperatingDate(operatingDate: string) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(operatingDate);
+
+  if (!match) return undefined;
+
+  const [, year, month, day] = match;
+  const parsed = new Date(Number(year), Number(month) - 1, Number(day));
+
+  if (
+    parsed.getFullYear() !== Number(year) ||
+    parsed.getMonth() !== Number(month) - 1 ||
+    parsed.getDate() !== Number(day)
+  ) {
+    return undefined;
+  }
+
+  return parsed;
+}
+
+function getLocalOperatingDateRangeFromSearch(operatingDate?: unknown) {
+  if (typeof operatingDate === "string") {
+    const localDate = getLocalDateFromOperatingDate(operatingDate);
+
+    if (localDate) {
+      return getLocalOperatingDateRange(localDate);
+    }
+  }
+
+  return getLocalOperatingDateRange();
 }
 
 function formatOperatingDate(operatingDate?: string | null) {
@@ -620,6 +656,20 @@ function getOpeningReviewEvidence(snapshot: DailyOpeningSnapshot) {
     snapshot.automationStatus?.reviewEvidence ??
     []
   );
+}
+
+function getOpeningStartedByLabel(
+  startedOpening: NonNullable<DailyOpeningSnapshot["startedOpening"]>,
+) {
+  if (startedOpening.startedByStaffName) {
+    return startedOpening.startedByStaffName;
+  }
+
+  if (startedOpening.actorType === "automation") {
+    return "Athena";
+  }
+
+  return "Staff unavailable";
 }
 
 function OpeningAutomationReviewPanel({
@@ -1314,8 +1364,7 @@ function OpeningRail({
               <div className="flex items-start justify-between gap-layout-md">
                 <dt className="text-muted-foreground">Started by</dt>
                 <dd className="text-right font-medium text-foreground">
-                  {snapshot.startedOpening.startedByStaffName ??
-                    "Staff unavailable"}
+                  {getOpeningStartedByLabel(snapshot.startedOpening)}
                 </dd>
               </div>
               <div className="flex items-start justify-between gap-layout-md">
@@ -1377,6 +1426,63 @@ function OpeningRail({
   );
 }
 
+function OperatingDatePicker({
+  disabled = false,
+  latestSelectableDate: latestSelectableDateProp,
+  operatingDate,
+  onChange,
+}: {
+  disabled?: boolean;
+  latestSelectableDate?: Date;
+  operatingDate: string;
+  onChange?: (date: Date) => void;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const selectedDate = getLocalDateFromOperatingDate(operatingDate);
+  const latestSelectableDate = useMemo(() => {
+    if (latestSelectableDateProp) return latestSelectableDateProp;
+
+    const today = new Date();
+
+    return new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  }, [latestSelectableDateProp]);
+
+  return (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          aria-label={`Change operating date, currently ${formatOperatingDateWithWeekday(
+            operatingDate,
+          )}`}
+          className="h-auto justify-start rounded-lg px-layout-md py-layout-sm text-sm font-normal text-muted-foreground shadow-surface"
+          disabled={disabled || !onChange}
+          variant="outline"
+        >
+          <CalendarIcon className="mr-2 h-4 w-4 shrink-0" />
+          Operating date{" "}
+          <span className="font-medium text-foreground">
+            {formatOperatingDateWithWeekday(operatingDate)}
+          </span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-auto p-0">
+        <Calendar
+          defaultMonth={selectedDate ?? undefined}
+          disabled={{ after: latestSelectableDate }}
+          mode="single"
+          onSelect={(date) => {
+            if (!date) return;
+
+            onChange?.(date);
+            setIsOpen(false);
+          }}
+          selected={selectedDate}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}
+
 export function DailyOpeningViewContent({
   currency,
   hasFullAdminAccess,
@@ -1384,6 +1490,7 @@ export function DailyOpeningViewContent({
   isLoadingAccess,
   isLoadingSnapshot,
   isStarting,
+  onOperatingDateChange,
   onStartDay,
   orgUrlSlug,
   snapshot,
@@ -1517,12 +1624,10 @@ export function DailyOpeningViewContent({
     <OperationReviewWorkspace
       actions={
         snapshot ? (
-          <div className="rounded-lg border border-border bg-surface-raised px-layout-md py-layout-sm text-sm text-muted-foreground shadow-surface">
-            Operating date{" "}
-            <span className="font-medium text-foreground">
-              {formatOperatingDateWithWeekday(snapshot.operatingDate)}
-            </span>
-          </div>
+          <OperatingDatePicker
+            operatingDate={snapshot.operatingDate}
+            onChange={onOperatingDateChange}
+          />
         ) : null
       }
       afterGrid={null}
@@ -1676,7 +1781,14 @@ function DailyOpeningConnectedView({
       }
     | undefined;
   const [isStarting, setIsStarting] = useState(false);
-  const operatingDateRange = useMemo(() => getLocalOperatingDateRange(), []);
+  const navigate = useNavigate();
+  const search = useSearch({ strict: false }) as {
+    operatingDate?: unknown;
+  };
+  const operatingDateRange = useMemo(
+    () => getLocalOperatingDateRangeFromSearch(search.operatingDate),
+    [search.operatingDate],
+  );
   const snapshot = useExpectedDailyOpeningQuery(
     getDailyOpeningSnapshot,
     canQueryProtectedData
@@ -1759,6 +1871,18 @@ function DailyOpeningConnectedView({
     }
   };
 
+  const handleOperatingDateChange = (date: Date) => {
+    const nextRange = getLocalOperatingDateRange(date);
+
+    void navigate({
+      search: ((current: Record<string, unknown>) => ({
+        ...current,
+        operatingDate: nextRange.operatingDate,
+        tab: undefined,
+      })) as never,
+    });
+  };
+
   return (
     <DailyOpeningViewContent
       currency={activeStore?.currency || "USD"}
@@ -1768,6 +1892,7 @@ function DailyOpeningConnectedView({
       isLoadingSnapshot={snapshot === undefined}
       isStarting={isStarting}
       onAuthenticateForApproval={handleAuthenticateForApproval}
+      onOperatingDateChange={handleOperatingDateChange}
       onStartDay={handleStartDay}
       orgUrlSlug={params?.orgUrlSlug ?? ""}
       snapshot={snapshot}

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -1,5 +1,13 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
-import type { AnchorHTMLAttributes, ReactNode } from "react";
+import {
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import React, {
+  type AnchorHTMLAttributes,
+  type ReactNode,
+} from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -21,18 +29,15 @@ const mockedApi = vi.hoisted(() => ({
 }));
 
 vi.mock("@tanstack/react-router", () => ({
-  Link: ({
-    children,
-    params,
-    search,
-    to,
-    ...props
-  }: AnchorHTMLAttributes<HTMLAnchorElement> & {
-    children: ReactNode;
-    params?: Record<string, string>;
-    search?: Record<string, string>;
-    to?: string;
-  }) => {
+  Link: React.forwardRef<
+    HTMLAnchorElement,
+    AnchorHTMLAttributes<HTMLAnchorElement> & {
+      children: ReactNode;
+      params?: Record<string, string>;
+      search?: Record<string, string>;
+      to?: string;
+    }
+  >(({ children, params, search, to, ...props }, ref) => {
     const path = to
       ? Object.entries(params ?? {}).reduce(
           (currentPath, [key, value]) =>
@@ -43,11 +48,11 @@ vi.mock("@tanstack/react-router", () => ({
     const searchParams = search ? `?${new URLSearchParams(search)}` : "";
 
     return (
-      <a href={`${path}${searchParams}`} {...props}>
+      <a ref={ref} href={`${path}${searchParams}`} {...props}>
         {children}
       </a>
     );
-  },
+  }),
   useParams: () => ({
     orgUrlSlug: "wigclub",
     storeUrlSlug: "osu",
@@ -163,6 +168,10 @@ const operatingSnapshot: DailyOperationsSnapshot = {
     expenseTotal: 19800,
     expenseTransactionCount: 1,
     netCashVariance: 0,
+    paymentTotals: [
+      { amount: 349100, method: "cash", transactionCount: 2 },
+      { amount: 1184000, method: "mobile_money", transactionCount: 2 },
+    ],
     registerVarianceCount: 0,
     salesTotal: 1533100,
     transactionCount: 3,
@@ -587,10 +596,15 @@ function renderContent(
 }
 
 describe("DailyOperationsViewContent", () => {
+  let scrollIntoViewMock: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(2026, 4, 10, 12));
     window.scrollTo = vi.fn();
+    scrollIntoViewMock = vi.fn();
+    Element.prototype.scrollIntoView = scrollIntoViewMock;
+    HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
     window.history.pushState({}, "", "/wigclub/store/osu/operations");
     mockedHooks.navigate.mockReset();
     mockedHooks.useSearch.mockReturnValue({});
@@ -624,14 +638,29 @@ describe("DailyOperationsViewContent", () => {
     );
     expect(screen.getByText("GH₵3,491")).toBeInTheDocument();
     expect(screen.getByText("2 cash transactions")).toBeInTheDocument();
+    expect(screen.getByText("Mobile Money")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Open Mobile Money transactions" }),
+    ).toHaveAttribute(
+      "href",
+      "/wigclub/store/osu/pos/transactions?o=%252Fwigclub%252Fstore%252Fosu%252Foperations&operatingDate=2026-05-08&paymentMethod=mobile_money",
+    );
+    expect(screen.getByText("GH₵11,840")).toBeInTheDocument();
+    expect(screen.getByText("2 payments")).toBeInTheDocument();
     expect(screen.getByText("Carried-over cash")).toBeInTheDocument();
     expect(screen.getAllByText("GH₵0")).not.toHaveLength(0);
     expect(screen.getByText("No registers from prior days")).toBeInTheDocument();
     expect(screen.getByText("Expenses")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Open expense reports" }),
+    ).toHaveAttribute(
+      "href",
+      "/wigclub/store/osu/pos/expense-reports?o=%252Fwigclub%252Fstore%252Fosu%252Foperations&operatingDate=2026-05-08",
+    );
     expect(screen.getByText("GH₵198")).toBeInTheDocument();
     expect(screen.getByText("1 expense transaction")).toBeInTheDocument();
-    expect(screen.getByText("Variance")).toBeInTheDocument();
-    expect(screen.getByText("No register variances")).toBeInTheDocument();
+    expect(screen.queryByText("Variance")).not.toBeInTheDocument();
+    expect(screen.queryByText("No register variances")).not.toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: "Week at a glance" }),
     ).toBeInTheDocument();
@@ -665,6 +694,11 @@ describe("DailyOperationsViewContent", () => {
     expect(
       screen.getByRole("link", { name: "View May 8, 2026 operations" }),
     ).toHaveAttribute("aria-current", "date");
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({
+      behavior: "auto",
+      block: "nearest",
+      inline: "center",
+    });
     expect(
       screen.getByRole("button", {
         name: "Change operating date, currently Friday, May 8, 2026",
@@ -732,6 +766,18 @@ describe("DailyOperationsViewContent", () => {
     ).toHaveAttribute(
       "href",
       "/wigclub/store/osu/pos/transactions?o=%252Fwigclub%252Fstore%252Fosu%252Foperations&paymentMethod=cash",
+    );
+    expect(
+      screen.getByRole("link", { name: "Open Mobile Money transactions" }),
+    ).toHaveAttribute(
+      "href",
+      "/wigclub/store/osu/pos/transactions?o=%252Fwigclub%252Fstore%252Fosu%252Foperations&paymentMethod=mobile_money",
+    );
+    expect(
+      screen.getByRole("link", { name: "Open expense reports" }),
+    ).toHaveAttribute(
+      "href",
+      "/wigclub/store/osu/pos/expense-reports?o=%252Fwigclub%252Fstore%252Fosu%252Foperations",
     );
     expect(
       screen.getByRole("link", { name: "Start EOD Review" }),

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   Link,
   useNavigate,
@@ -166,6 +166,11 @@ export type DailyOperationsSnapshot = {
     expenseTotal: number;
     expenseTransactionCount: number;
     netCashVariance: number;
+    paymentTotals?: Array<{
+      amount: number;
+      method: string;
+      transactionCount?: number;
+    }>;
     registerVarianceCount: number;
     salesTotal: number;
     transactionCount: number;
@@ -423,6 +428,13 @@ function buildOperationsTransactionSearch({
   };
 }
 
+function buildOperationsExpenseSearch(operatingDate: string) {
+  return {
+    o: getOrigin(),
+    ...(operatingDate !== getLocalOperatingDate() ? { operatingDate } : {}),
+  };
+}
+
 function getDailyOperationsMetricLabels(operatingDate: string) {
   const isCurrentOperatingDate = operatingDate === getLocalOperatingDate();
 
@@ -594,6 +606,19 @@ function formatTodayCashTransactionCount(value: number) {
   return `${value} cash transactions`;
 }
 
+function formatPaymentCount(value?: number | null) {
+  if (value === undefined || value === null) return "Payment total";
+  if (value === 0) return "No payments";
+  if (value === 1) return "1 payment";
+  return `${value} payments`;
+}
+
+function formatPaymentMethodLabel(method: string) {
+  return method
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
 function formatCarriedOverRegisterCount(value: number) {
   if (value === 0) return "No registers from prior days";
   if (value === 1) return "1 register from a prior day";
@@ -604,6 +629,28 @@ function formatRegisterVarianceCount(value: number) {
   if (value === 0) return "No register variances";
   if (value === 1) return "1 register variance";
   return `${value} register variances`;
+}
+
+function getOtherPaymentTotals(summary: DailyOperationsSnapshot["closeSummary"]) {
+  return (summary.paymentTotals ?? [])
+    .filter((paymentTotal) => paymentTotal.method.toLowerCase() !== "cash")
+    .sort((left, right) => right.amount - left.amount);
+}
+
+function shouldShowExpenseMetric(summary: DailyOperationsSnapshot["closeSummary"]) {
+  if (summary.salesTotal <= 0) {
+    return true;
+  }
+
+  return summary.expenseTransactionCount > 0 || summary.expenseTotal !== 0;
+}
+
+function shouldShowVarianceMetric(summary: DailyOperationsSnapshot["closeSummary"]) {
+  if (summary.salesTotal <= 0) {
+    return true;
+  }
+
+  return summary.registerVarianceCount > 0 || summary.netCashVariance !== 0;
 }
 
 function formatMoney(currency: string, amount: number) {
@@ -1177,6 +1224,14 @@ function WeekMetricsStrip({
   orgUrlSlug: string;
   storeUrlSlug: string;
 }) {
+  const scrollSelectedDayIntoView = useCallback((element: HTMLElement | null) => {
+    element?.scrollIntoView({
+      behavior: "auto",
+      block: "nearest",
+      inline: "center",
+    });
+  }, [metrics]);
+
   if (metrics.length === 0) return null;
 
   const currentOperatingDate = getLocalOperatingDate();
@@ -1338,7 +1393,9 @@ function WeekMetricsStrip({
                   aria-disabled="true"
                   aria-label={`${formatOperatingDate(metric.operatingDate)} operations unavailable`}
                   className={cardClassName}
+                  data-week-metric-selected={metric.isSelected ? "true" : undefined}
                   key={metric.operatingDate}
+                  ref={metric.isSelected ? scrollSelectedDayIntoView : undefined}
                 >
                   {content}
                 </div>
@@ -1350,8 +1407,10 @@ function WeekMetricsStrip({
                 aria-current={metric.isSelected ? "date" : undefined}
                 aria-label={`View ${formatOperatingDate(metric.operatingDate)} operations`}
                 className={cardClassName}
+                data-week-metric-selected={metric.isSelected ? "true" : undefined}
                 key={metric.operatingDate}
                 params={buildParams(orgUrlSlug, storeUrlSlug)}
+                ref={metric.isSelected ? scrollSelectedDayIntoView : undefined}
                 search={buildDailyOperationsSearch({
                   operatingDate: metric.operatingDate,
                   weekEndOperatingDate,
@@ -1402,6 +1461,9 @@ export function DailyOperationsViewContent({
   const metricLabels = snapshot
     ? getDailyOperationsMetricLabels(snapshot.operatingDate)
     : undefined;
+  const otherPaymentTotals = snapshot
+    ? getOtherPaymentTotals(snapshot.closeSummary)
+    : [];
   const showPrimaryAction = snapshot
     ? shouldShowPrimaryAction(snapshot)
     : false;
@@ -1543,6 +1605,42 @@ export function DailyOperationsViewContent({
                       </FinancialValue>
                     }
                   />
+                  {otherPaymentTotals.map((paymentTotal) => {
+                    const paymentMethodLabel = formatPaymentMethodLabel(
+                      paymentTotal.method,
+                    );
+
+                    return (
+                      <OperationsSummaryMetric
+                        helper={formatPaymentCount(
+                          paymentTotal.transactionCount,
+                        )}
+                        key={paymentTotal.method}
+                        label={paymentMethodLabel}
+                        link={{
+                          ariaLabel: `Open ${paymentMethodLabel} transactions`,
+                          orgUrlSlug,
+                          search: buildOperationsTransactionSearch({
+                            operatingDate: snapshot.operatingDate,
+                            paymentMethod: paymentTotal.method,
+                          }),
+                          storeUrlSlug,
+                          to: "/$orgUrlSlug/store/$storeUrlSlug/pos/transactions",
+                        }}
+                        value={
+                          <FinancialValue
+                            canView={hasFinancialDetailsAccess}
+                            label={paymentMethodLabel}
+                          >
+                            {formatMoney(
+                              snapshot.currency ?? currency,
+                              paymentTotal.amount,
+                            )}
+                          </FinancialValue>
+                        }
+                      />
+                    );
+                  })}
                   <OperationsSummaryMetric
                     helper={formatCarriedOverRegisterCount(
                       snapshot.closeSummary.carriedOverRegisterCount,
@@ -1560,41 +1658,54 @@ export function DailyOperationsViewContent({
                       </FinancialValue>
                     }
                   />
-                  <OperationsSummaryMetric
-                    helper={formatEntityCount(
-                      snapshot.closeSummary.expenseTransactionCount,
-                      "expense transaction",
-                    )}
-                    label="Expenses"
-                    value={
-                      <FinancialValue
-                        canView={hasFinancialDetailsAccess}
-                        label="Expenses"
-                      >
-                        {formatMoney(
-                          snapshot.currency ?? currency,
-                          snapshot.closeSummary.expenseTotal,
-                        )}
-                      </FinancialValue>
-                    }
-                  />
-                  <OperationsSummaryMetric
-                    helper={formatRegisterVarianceCount(
-                      snapshot.closeSummary.registerVarianceCount,
-                    )}
-                    label="Variance"
-                    value={
-                      <FinancialValue
-                        canView={hasFinancialDetailsAccess}
-                        label="Variance"
-                      >
-                        {formatMoney(
-                          snapshot.currency ?? currency,
-                          snapshot.closeSummary.netCashVariance,
-                        )}
-                      </FinancialValue>
-                    }
-                  />
+                  {shouldShowExpenseMetric(snapshot.closeSummary) ? (
+                    <OperationsSummaryMetric
+                      helper={formatEntityCount(
+                        snapshot.closeSummary.expenseTransactionCount,
+                        "expense transaction",
+                      )}
+                      label="Expenses"
+                      link={{
+                        ariaLabel: "Open expense reports",
+                        orgUrlSlug,
+                        search: buildOperationsExpenseSearch(
+                          snapshot.operatingDate,
+                        ),
+                        storeUrlSlug,
+                        to: "/$orgUrlSlug/store/$storeUrlSlug/pos/expense-reports",
+                      }}
+                      value={
+                        <FinancialValue
+                          canView={hasFinancialDetailsAccess}
+                          label="Expenses"
+                        >
+                          {formatMoney(
+                            snapshot.currency ?? currency,
+                            snapshot.closeSummary.expenseTotal,
+                          )}
+                        </FinancialValue>
+                      }
+                    />
+                  ) : null}
+                  {shouldShowVarianceMetric(snapshot.closeSummary) ? (
+                    <OperationsSummaryMetric
+                      helper={formatRegisterVarianceCount(
+                        snapshot.closeSummary.registerVarianceCount,
+                      )}
+                      label="Variance"
+                      value={
+                        <FinancialValue
+                          canView={hasFinancialDetailsAccess}
+                          label="Variance"
+                        >
+                          {formatMoney(
+                            snapshot.currency ?? currency,
+                            snapshot.closeSummary.netCashVariance,
+                          )}
+                        </FinancialValue>
+                      }
+                    />
+                  ) : null}
                 </div>
 
                 <WeekMetricsStrip

--- a/packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.test.tsx
@@ -1,10 +1,11 @@
 import { render, screen, within } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ExpenseReportsView } from "./ExpenseReportsView";
 
 const getActiveStoreMock = vi.fn();
 const useQueryMock = vi.fn();
+const useSearchMock = vi.fn();
 
 vi.mock("@tanstack/react-router", () => ({
   Link: ({
@@ -34,6 +35,7 @@ vi.mock("@tanstack/react-router", () => ({
       </a>
     );
   },
+  useSearch: () => useSearchMock(),
 }));
 
 vi.mock("convex/react", () => ({
@@ -103,13 +105,20 @@ vi.mock("@/components/ui/tabs", () => ({
 
 describe("ExpenseReportsView", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 4, 10, 12));
     vi.clearAllMocks();
+    useSearchMock.mockReturnValue({});
     getActiveStoreMock.mockReturnValue({
       activeStore: {
         _id: "store-1",
         currency: "GHS",
       },
     });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("renders expense reports in the workspace frame with back navigation", () => {
@@ -185,5 +194,38 @@ describe("ExpenseReportsView", () => {
     expect(within(card).getByText("Restock drawer supplies.")).toHaveClass(
       "text-sm",
     );
+  });
+
+  it("opens operating-date links on the selected day report list", () => {
+    useSearchMock.mockReturnValue({ operatingDate: "2026-05-08" });
+    useQueryMock.mockReturnValue([
+      {
+        _id: "expense-selected",
+        transactionNumber: "EXP-SELECTED",
+        totalValue: 19800,
+        staffProfileName: "Ada L.",
+        itemCount: 2,
+        completedAt: new Date(2026, 4, 8, 10).getTime(),
+        notes: null,
+      },
+      {
+        _id: "expense-today",
+        transactionNumber: "EXP-TODAY",
+        totalValue: 4200,
+        staffProfileName: "Ada L.",
+        itemCount: 1,
+        completedAt: new Date(2026, 4, 10, 10).getTime(),
+        notes: null,
+      },
+    ]);
+
+    render(<ExpenseReportsView />);
+
+    expect(screen.getByRole("button", { name: "Selected day" })).toHaveAttribute(
+      "data-remote-assist-control-id",
+      "pos-expense-reports-filter-operating-date",
+    );
+    expect(screen.getByText("EXP-SELECTED")).toBeInTheDocument();
+    expect(screen.queryByText("EXP-TODAY")).not.toBeInTheDocument();
   });
 });

--- a/packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx
+++ b/packages/athena-webapp/src/components/pos/expense-reports/ExpenseReportsView.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Link } from "@tanstack/react-router";
+import { Link, useSearch } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
 import { ArrowUpRight, Receipt } from "lucide-react";
 
@@ -26,6 +26,27 @@ const isToday = (timestamp: number) => {
   const today = new Date();
   return date.toDateString() === today.toDateString();
 };
+
+function getStartOfOperatingDate(operatingDate?: string) {
+  const match = operatingDate?.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return null;
+
+  const [, year, month, day] = match;
+  return new Date(
+    Number(year),
+    Number(month) - 1,
+    Number(day),
+  ).getTime();
+}
+
+function isOnOperatingDate(timestamp: number, operatingDateStartAt: number) {
+  const nextOperatingDateStartAt =
+    operatingDateStartAt + 24 * 60 * 60 * 1_000;
+
+  return (
+    timestamp >= operatingDateStartAt && timestamp < nextOperatingDateStartAt
+  );
+}
 
 function ExpenseReportMobileCard({ report }: { report: ExpenseReportRow }) {
   const itemLabel = `${report.itemCount} ${
@@ -98,7 +119,13 @@ function ExpenseReportMobileCard({ report }: { report: ExpenseReportRow }) {
 
 export function ExpenseReportsView() {
   const { activeStore } = useGetActiveStore();
-  const [filter, setFilter] = useState<"today" | "all">("today");
+  const { operatingDate } = useSearch({ strict: false }) as {
+    operatingDate?: string;
+  };
+  const operatingDateStartAt = getStartOfOperatingDate(operatingDate);
+  const [filter, setFilter] = useState<"today" | "operatingDate" | "all">(
+    operatingDateStartAt ? "operatingDate" : "today",
+  );
 
   const expenseTransactions = useQuery(
     api.inventory.expenseTransactions.getExpenseTransactions,
@@ -118,8 +145,14 @@ export function ExpenseReportsView() {
 
   const filteredData = useMemo(() => {
     if (filter === "all") return tableData;
+    if (filter === "operatingDate" && operatingDateStartAt !== null) {
+      return tableData.filter((t) =>
+        isOnOperatingDate(t.completedAt, operatingDateStartAt),
+      );
+    }
+
     return tableData.filter((t) => isToday(t.completedAt));
-  }, [tableData, filter]);
+  }, [tableData, filter, operatingDateStartAt]);
 
   if (!activeStore || !expenseTransactions || !formatter) return null;
 
@@ -139,9 +172,22 @@ export function ExpenseReportsView() {
           <section className="space-y-layout-md">
             <Tabs
               value={filter}
-              onValueChange={(v) => setFilter(v as "today" | "all")}
+              onValueChange={(v) =>
+                setFilter(v as "today" | "operatingDate" | "all")
+              }
             >
               <TabsList>
+                {operatingDateStartAt !== null ? (
+                  <TabsTrigger
+                    data-remote-assist-control="pos-expense-report-filter"
+                    data-remote-assist-control-id="pos-expense-reports-filter-operating-date"
+                    data-remote-assist-control-label="Selected day"
+                    data-remote-assist-control-role="button"
+                    value="operatingDate"
+                  >
+                    Selected day
+                  </TabsTrigger>
+                ) : null}
                 <TabsTrigger
                   data-remote-assist-control="pos-expense-report-filter"
                   data-remote-assist-control-id="pos-expense-reports-filter-today"
@@ -186,9 +232,11 @@ export function ExpenseReportsView() {
                   }
                   title={
                     <p className="text-muted-foreground">
-                      {filter === "today"
-                        ? "No expense reports today"
-                        : "No expense reports"}
+                      {filter === "all"
+                        ? "No expense reports"
+                        : filter === "operatingDate"
+                          ? "No expense reports for this day"
+                          : "No expense reports today"}
                     </p>
                   }
                 />

--- a/packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx
+++ b/packages/athena-webapp/src/components/pos/settings/POSSettingsView.tsx
@@ -37,6 +37,7 @@ import {
   type PosOfflineReadinessInput,
   type PosOfflineReadinessSummary,
 } from "@/offline/posOfflineReadiness";
+import { readPosAppShellReadiness } from "@/offline/posAppShellReadiness";
 import {
   createIndexedDbPosLocalStorageAdapter,
   createPosLocalStore,
@@ -68,7 +69,6 @@ type HealthLinkProps = {
 };
 
 const HealthLink = Link as unknown as ComponentType<HealthLinkProps>;
-const POS_APP_SHELL_CACHE_PREFIX = "athena-pos-app-shell-";
 const DEFAULT_STORE_DAY_AUTO_START_MINUTES = 8 * 60;
 const DEFAULT_STORE_DAY_TIMEZONE_OFFSET_MINUTES = 0;
 const STORE_DAY_AUTOMATION_HOURS = Array.from({ length: 12 }, (_, index) =>
@@ -892,45 +892,6 @@ function createDefaultLocalReadinessStore() {
   return createPosLocalStore({
     adapter: createIndexedDbPosLocalStorageAdapter(),
   });
-}
-
-async function readPosAppShellReadiness(input: {
-  orgUrlSlug?: string;
-  storeUrlSlug?: string;
-}): Promise<PosOfflineReadinessInput["appShell"]> {
-  if (typeof caches === "undefined") {
-    return { ready: false };
-  }
-
-  try {
-    const cacheNames = await caches.keys();
-    const shellCacheName = cacheNames.find((name) =>
-      name.startsWith(POS_APP_SHELL_CACHE_PREFIX),
-    );
-    if (!shellCacheName) {
-      return { ready: false };
-    }
-
-    const cache = await caches.open(shellCacheName);
-    const registerPath =
-      input.orgUrlSlug && input.storeUrlSlug
-        ? `/${input.orgUrlSlug}/store/${input.storeUrlSlug}/pos/register`
-        : null;
-    const cachedRegister =
-      registerPath && typeof window !== "undefined"
-        ? await cache.match(
-            new URL(registerPath, window.location.origin).toString(),
-            {
-              ignoreVary: true,
-            },
-          )
-        : null;
-    const cachedRoot = await cache.match("/", { ignoreVary: true });
-
-    return { ready: Boolean(cachedRegister || cachedRoot) };
-  } catch {
-    return { ready: false };
-  }
 }
 
 function signalFromSnapshot(

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
@@ -280,9 +280,9 @@ describe("POSTerminalDetailViewContent", () => {
     expect(screen.getAllByText("Catalog").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Service catalog").length).toBeGreaterThan(0);
     expect(screen.getByText("Register model")).toBeInTheDocument();
-    expect(
-      screen.getAllByText("Staff authority expired").length,
-    ).toBeGreaterThan(0);
+    expect(screen.getByText("Drawer authority")).toBeInTheDocument();
+    expect(screen.getByText("Ready")).toBeInTheDocument();
+    expect(screen.getByText("Expired")).toBeInTheDocument();
     expect(screen.getByText("2 minutes old")).toBeInTheDocument();
     expect(screen.getByText("3 minutes old")).toBeInTheDocument();
     expect(screen.getByText("4 minutes old")).toBeInTheDocument();
@@ -310,6 +310,39 @@ describe("POSTerminalDetailViewContent", () => {
     expect(screen.getByText("Local only")).toBeInTheDocument();
     expect(screen.getByText("IndexedDB blocked")).toBeInTheDocument();
     expect(screen.getByText("Upload failed")).toBeInTheDocument();
+  });
+
+  it("renders ready staff authority as a compact checked state", () => {
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          runtimeStatus: {
+            ...detail.runtimeStatus!,
+            staffAuthority: {
+              expiresAt: Date.now() + 60_000,
+              staffProfileId: "staff-1",
+              status: "ready",
+            },
+          },
+        }}
+        isLoading={false}
+      />,
+    );
+
+    const staffAuthorityLabel = screen.getByText("Staff authority");
+    expect(staffAuthorityLabel).toBeInTheDocument();
+    expect(screen.getAllByText("Ready").length).toBeGreaterThanOrEqual(2);
+    expect(
+      screen.queryByText("Staff authority ready"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders expired staff authority as a compact warning state", () => {
+    render(<POSTerminalDetailViewContent detail={detail} isLoading={false} />);
+
+    expect(screen.getByText("Staff authority")).toBeInTheDocument();
+    expect(screen.getByText("Expired")).toBeInTheDocument();
   });
 
   it("starts Remote Assist from an enrolled online terminal", async () => {
@@ -783,6 +816,133 @@ describe("POSTerminalDetailViewContent", () => {
     expect(mocks.toastSuccess).toHaveBeenCalledWith("Terminal command queued.");
   });
 
+  it("surfaces a next step when drawer repair verification fails and sync retry is available", () => {
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          attentionReasons: [
+            {
+              actionTarget: { type: "pos_register" },
+              count: 66,
+              nextPendingUploadSequence: 1,
+              source: "local_runtime",
+              summary: "66 local review items are still on this terminal.",
+              type: "local_review",
+            },
+          ],
+          recovery: {
+            commandStatus: {
+              commandType: "clear_stale_drawer_authority",
+              label: "Drawer authority repair",
+              latestAcknowledgement:
+                "Drawer repair expected a blocked drawer authority record, but this terminal no longer reported that same block.",
+              status: "precondition_failed",
+              verificationStatus: "verification_failed",
+            },
+            readiness: "needs_manual_review",
+            terminalActions: [
+              {
+                commandContext: {
+                  cloudRegisterSessionId: "cloud-session-1",
+                  expectedBlockerType: "cloud_closed",
+                  localRegisterSessionId: "local-session-1",
+                  reason: "Drawer authority requires terminal-local repair.",
+                },
+                commandType: "clear_stale_drawer_authority",
+                expectedEvidence: {
+                  drawerAuthorityStatus: "healthy",
+                  localRegisterSessionId: "local-session-1",
+                },
+                reason: "Drawer authority requires terminal-local repair.",
+              },
+              {
+                commandContext: {
+                  expectedBlockerType: "local_review",
+                  reason: "Local review items need a terminal sync retry.",
+                },
+                commandType: "retry_sync",
+                expectedEvidence: {
+                  syncStatus: "idle",
+                },
+                reason: "Local review items need a terminal sync retry.",
+              },
+            ],
+          },
+        }}
+        isLoading={false}
+        orgUrlSlug="wigclub"
+        storeUrlSlug="osu"
+      />,
+    );
+
+    expect(
+      screen.getByText("Drawer authority repair / Precondition Failed"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Verification Failed")).toBeInTheDocument();
+    expect(screen.getByText("1 safe action")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "retry terminal sync, then use the next check-in to decide whether drawer repair still needs to run.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Drawer repair expected a blocked drawer authority record, but this terminal no longer reported that same block.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Command did not complete. Retry terminal sync before sending drawer repair again.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /retry terminal sync/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not foreground old failed recovery commands when no support work remains", () => {
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          attentionReasons: [],
+          recovery: {
+            commandStatus: {
+              commandType: "clear_stale_drawer_authority",
+              label: "Drawer authority repair",
+              latestAcknowledgement:
+                "Drawer repair expected a blocked drawer authority record, but this terminal no longer reported that same block.",
+              status: "precondition_failed",
+              verificationStatus: "verification_failed",
+            },
+            readiness: "drawer_open",
+            terminalActions: [],
+          },
+        }}
+        isLoading={false}
+        orgUrlSlug="wigclub"
+        storeUrlSlug="osu"
+      />,
+    );
+
+    expect(screen.getByText("No support action needed")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Current terminal evidence has no repair or review blockers.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Drawer authority repair / Precondition Failed"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Verification Failed")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Recovery verification did not match the latest terminal check-in.",
+      ),
+    ).not.toBeInTheDocument();
+  });
+
   it("disables duplicate recovery command clicks while a command is pending", () => {
     const onIssueTerminalRecoveryCommand = vi.fn();
 
@@ -828,6 +988,76 @@ describe("POSTerminalDetailViewContent", () => {
     ).toBeInTheDocument();
     fireEvent.click(commandButton);
     expect(onIssueTerminalRecoveryCommand).not.toHaveBeenCalled();
+  });
+
+  it("omits verified drawer command attention once support work is clear", () => {
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          attentionReasons: [
+            {
+              actionTarget: { type: "pos_register" },
+              source: "terminal_runtime",
+              summary:
+                "Drawer authority needs repair. This checkout station must run the repair before selling.",
+              type: "drawer_authority_blocked",
+            },
+          ],
+          recovery: {
+            commandStatus: {
+              label: "Drawer authority repair",
+              status: "completed",
+              verificationStatus: "verified",
+            },
+            readiness: "needs_manual_review",
+            terminalActions: [
+              {
+                commandContext: {
+                  cloudRegisterSessionId: "cloud-session-1",
+                  expectedBlockerType: "cloud_closed",
+                  localRegisterSessionId: "local-session-1",
+                  reason: "Drawer authority requires terminal-local repair.",
+                },
+                commandType: "clear_stale_drawer_authority",
+                expectedEvidence: {
+                  drawerAuthorityStatus: "healthy",
+                  localRegisterSessionId: "local-session-1",
+                },
+                reason: "Drawer authority requires terminal-local repair.",
+              },
+            ],
+          },
+        }}
+        isLoading={false}
+        orgUrlSlug="wigclub"
+        storeUrlSlug="osu"
+      />,
+    );
+
+    expect(screen.getByText("No support action needed")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Drawer authority repair / Completed"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Verification")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Recovery was verified by the latest terminal check-in."),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Drawer repair command was completed and verified by terminal check-in. This row will clear when the terminal list receives the next check-in.",
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Drawer repair command verified; waiting for the next terminal check-in.",
+      ),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "This needs a fresh check-in or terminal-side repair before support can clear it remotely.",
+      ),
+    ).not.toBeInTheDocument();
   });
 
   it("shows normalized recovery action failures", async () => {
@@ -969,7 +1199,7 @@ describe("POSTerminalDetailViewContent", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("resolves mapped register reviews inline from terminal health", async () => {
+  it("routes mapped register reviews to cash controls by default", () => {
     const onResolveRegisterSessionReview = vi.fn().mockResolvedValue({
       data: { action: "resolved", resolvedCount: 1 },
       kind: "ok",
@@ -982,6 +1212,51 @@ describe("POSTerminalDetailViewContent", () => {
           attentionReasons: [
             {
               actionTarget: {
+                registerSessionId: "register-session-1",
+                type: "cash_control_register_session",
+              },
+              count: 14,
+              latestEventSequence: 1,
+              latestEventStatus: "conflicted",
+              source: "cloud_sync",
+              summary: "14 cloud sync conflicts need review.",
+              type: "cloud_conflict",
+            },
+          ],
+        }}
+        isLoading={false}
+        onResolveRegisterSessionReview={onResolveRegisterSessionReview}
+        orgUrlSlug="wigclub"
+        storeUrlSlug="osu"
+      />,
+    );
+
+    expect(
+      screen.getByRole("link", { name: /review register session/i }),
+    ).toHaveAttribute(
+      "href",
+      "/wigclub/store/osu/cash-controls/registers/register-session-1",
+    );
+    expect(
+      screen.queryByRole("button", { name: /resolve eligible review/i }),
+    ).not.toBeInTheDocument();
+    expect(onResolveRegisterSessionReview).not.toHaveBeenCalled();
+  });
+
+  it("resolves explicitly eligible register reviews inline from terminal health", async () => {
+    const onResolveRegisterSessionReview = vi.fn().mockResolvedValue({
+      data: { action: "resolved", resolvedCount: 1 },
+      kind: "ok",
+    });
+
+    render(
+      <POSTerminalDetailViewContent
+        detail={{
+          ...detail,
+          attentionReasons: [
+            {
+              actionTarget: {
+                automaticRepairEligible: true,
                 registerSessionId: "register-session-1",
                 type: "cash_control_register_session",
               },

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
@@ -263,6 +263,80 @@ function getStaffAuthorityTone(
   }
 }
 
+function getDrawerAuthorityTone(
+  runtimeStatus?: TerminalRuntimeStatus | null,
+) {
+  if (!runtimeStatus) {
+    return "neutral";
+  }
+
+  if (
+    !runtimeStatus.drawerAuthority ||
+    runtimeStatus.drawerAuthority.status === "healthy"
+  ) {
+    return "success";
+  }
+
+  if (runtimeStatus.drawerAuthority.status === "blocked") {
+    return "warning";
+  }
+
+  return "neutral";
+}
+
+function ReadyReadinessValue() {
+  return (
+    <span className="inline-flex items-center justify-end gap-1 text-success">
+      <CheckCircle2 className="h-3 w-3" aria-hidden="true" />
+      <span>Ready</span>
+    </span>
+  );
+}
+
+function ExpiredReadinessValue() {
+  return (
+    <span className="inline-flex items-center justify-end gap-1 text-warning-foreground">
+      <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+      <span>Expired</span>
+    </span>
+  );
+}
+
+function DrawerAuthorityReadinessValue({
+  runtimeStatus,
+}: {
+  runtimeStatus?: TerminalRuntimeStatus | null;
+}) {
+  if (!runtimeStatus) {
+    return "Not reported";
+  }
+
+  if (
+    !runtimeStatus.drawerAuthority ||
+    runtimeStatus.drawerAuthority.status === "healthy"
+  ) {
+    return <ReadyReadinessValue />;
+  }
+
+  return formatStatusLabel(runtimeStatus.drawerAuthority.status);
+}
+
+function StaffAuthorityReadinessValue({
+  status,
+}: {
+  status?: TerminalRuntimeStatus["staffAuthority"] | null;
+}) {
+  if (status?.status === "ready") {
+    return <ReadyReadinessValue />;
+  }
+
+  if (status?.status === "expired") {
+    return <ExpiredReadinessValue />;
+  }
+
+  return getStaffAuthorityLabel(status);
+}
+
 function RailSignalRow({
   label,
   tone = "neutral",
@@ -302,6 +376,7 @@ function SnapshotReadinessGroup({
   const staffAuthorityTone = getStaffAuthorityTone(
     runtimeStatus?.staffAuthority,
   );
+  const drawerAuthorityTone = getDrawerAuthorityTone(runtimeStatus);
 
   return (
     <div className="space-y-layout-xs rounded-md border border-border/80 bg-surface px-layout-md py-layout-sm">
@@ -331,9 +406,20 @@ function SnapshotReadinessGroup({
           value={formatAge(snapshots?.registerReadModelAgeMs)}
         />
         <RailSignalRow
+          label="Drawer authority"
+          tone={drawerAuthorityTone}
+          value={
+            <DrawerAuthorityReadinessValue runtimeStatus={runtimeStatus} />
+          }
+        />
+        <RailSignalRow
           label="Staff authority"
           tone={staffAuthorityTone}
-          value={getStaffAuthorityLabel(runtimeStatus?.staffAuthority)}
+          value={
+            <StaffAuthorityReadinessValue
+              status={runtimeStatus?.staffAuthority}
+            />
+          }
         />
       </div>
     </div>
@@ -699,7 +785,9 @@ function AttentionReasonsSection({
   orgUrlSlug?: string;
   storeUrlSlug?: string;
 }) {
-  const reasons = getTerminalAttentionReasons(detail);
+  const reasons = getTerminalAttentionReasons(detail).filter(
+    (reason) => !isVerifiedTerminalCommandAttention(reason, detail),
+  );
 
   if (reasons.length === 0) {
     return null;
@@ -719,7 +807,8 @@ function AttentionReasonsSection({
             <div className="flex flex-col gap-layout-sm md:flex-row md:items-start md:justify-between">
               <div className="min-w-0">
                 <p className="text-sm font-medium text-foreground">
-                  {getSupportSafeAttentionReasonSummary(reason)}
+                  {getTerminalCommandAttentionTitle(reason, detail) ??
+                    getSupportSafeAttentionReasonSummary(reason)}
                 </p>
                 <p className="mt-1 text-xs text-muted-foreground">
                   {reason.source === "cloud_sync"
@@ -733,6 +822,7 @@ function AttentionReasonsSection({
                 </p>
               </div>
               <AttentionReasonAction
+                detail={detail}
                 onResolveRegisterSessionReview={onResolveRegisterSessionReview}
                 orgUrlSlug={orgUrlSlug}
                 reason={reason}
@@ -747,11 +837,13 @@ function AttentionReasonsSection({
 }
 
 function AttentionReasonAction({
+  detail,
   onResolveRegisterSessionReview,
   orgUrlSlug,
   reason,
   storeUrlSlug,
 }: {
+  detail?: TerminalHealthDetail;
   onResolveRegisterSessionReview?: POSTerminalDetailViewContentProps["onResolveRegisterSessionReview"];
   orgUrlSlug?: string;
   reason: TerminalHealthAttentionReason;
@@ -769,7 +861,7 @@ function AttentionReasonAction({
     const registerSessionId = target.registerSessionId;
     const resolveRegisterSessionReview = onResolveRegisterSessionReview;
 
-    if (resolveRegisterSessionReview) {
+    if (target.automaticRepairEligible && resolveRegisterSessionReview) {
       const resolveReview = async () => {
         setIsResolving(true);
         setErrorMessage("");
@@ -847,8 +939,8 @@ function AttentionReasonAction({
   if (target.type === "pos_settings") {
     return (
       <p className="max-w-sm text-xs text-muted-foreground">
-        Terminal setup repair must run from this checkout station or through a
-        terminal repair command when available.
+        {getTerminalCommandAttentionCopy(reason, detail) ??
+          "Terminal setup repair must run from this checkout station or through a terminal repair command when available."}
       </p>
     );
   }
@@ -856,12 +948,124 @@ function AttentionReasonAction({
   if (target.type === "pos_register") {
     return (
       <p className="max-w-sm text-xs text-muted-foreground">
-        This needs a fresh check-in or terminal-side repair before support can
-        clear it remotely.
+        {getTerminalCommandAttentionCopy(reason, detail) ??
+          "This needs a fresh check-in or terminal-side repair before support can clear it remotely."}
       </p>
     );
   }
 
+  return null;
+}
+
+function getTerminalCommandAttentionCopy(
+  reason: TerminalHealthAttentionReason,
+  detail?: TerminalHealthDetail,
+) {
+  const expectedCommandType = getAttentionReasonCommandType(reason);
+  const recovery = detail?.recovery ?? detail?.recoveryPreview ?? null;
+  const commandStatus = recovery?.commandStatus;
+  if (
+    !expectedCommandType ||
+    !commandStatus ||
+    !recovery?.terminalActions?.some(
+      (action) => action.commandType === expectedCommandType,
+    )
+  ) {
+    return null;
+  }
+
+  const commandName =
+    expectedCommandType === "clear_stale_drawer_authority"
+      ? "Drawer repair command"
+      : "Terminal setup repair command";
+
+  if (commandStatus.verificationStatus === "verified") {
+    return `${commandName} was completed and verified by terminal check-in. This row will clear when the terminal list receives the next check-in.`;
+  }
+  if (
+    commandStatus.status === "completed" ||
+    commandStatus.verificationStatus === "runtime_verification_ready"
+  ) {
+    return `${commandName} completed locally. Waiting for a fresh terminal check-in to clear this attention item.`;
+  }
+  if (commandStatus.status === "claimed") {
+    return `${commandName} is running on this checkout station.`;
+  }
+  if (commandStatus.status === "pending") {
+    return `${commandName} is queued for this checkout station.`;
+  }
+
+  return null;
+}
+
+function isVerifiedTerminalCommandAttention(
+  reason: TerminalHealthAttentionReason,
+  detail?: TerminalHealthDetail,
+) {
+  const expectedCommandType = getAttentionReasonCommandType(reason);
+  const recovery = detail?.recovery ?? detail?.recoveryPreview ?? null;
+  const commandStatus = recovery?.commandStatus;
+
+  return Boolean(
+    expectedCommandType &&
+      commandStatus?.verificationStatus === "verified" &&
+      recovery?.terminalActions?.some(
+        (action) => action.commandType === expectedCommandType,
+      ),
+  );
+}
+
+function getTerminalCommandAttentionTitle(
+  reason: TerminalHealthAttentionReason,
+  detail?: TerminalHealthDetail,
+) {
+  const expectedCommandType = getAttentionReasonCommandType(reason);
+  const recovery = detail?.recovery ?? detail?.recoveryPreview ?? null;
+  const commandStatus = recovery?.commandStatus;
+  if (
+    !expectedCommandType ||
+    !commandStatus ||
+    !recovery?.terminalActions?.some(
+      (action) => action.commandType === expectedCommandType,
+    )
+  ) {
+    return null;
+  }
+
+  const commandName =
+    expectedCommandType === "clear_stale_drawer_authority"
+      ? "Drawer repair command"
+      : "Terminal setup repair command";
+
+  if (commandStatus.verificationStatus === "verified") {
+    return `${commandName} verified; waiting for the next terminal check-in.`;
+  }
+  if (
+    commandStatus.status === "completed" ||
+    commandStatus.verificationStatus === "runtime_verification_ready"
+  ) {
+    return `${commandName} completed locally.`;
+  }
+  if (commandStatus.status === "claimed") {
+    return `${commandName} running.`;
+  }
+  if (commandStatus.status === "pending") {
+    return `${commandName} queued.`;
+  }
+
+  return null;
+}
+
+function getAttentionReasonCommandType(reason: TerminalHealthAttentionReason) {
+  if (reason.type === "drawer_authority_blocked") {
+    return "clear_stale_drawer_authority";
+  }
+  if (
+    reason.type === "terminal_seed_missing" ||
+    reason.type === "terminal_authorization_failed"
+  ) {
+    return "repair_terminal_seed";
+  }
   return null;
 }
 
@@ -880,6 +1084,113 @@ function RecoveryMetric({
       <p className="mt-1 text-sm font-medium text-foreground">{value}</p>
     </div>
   );
+}
+
+function RecoveryNextStep({
+  commandStatus,
+  safeActions,
+}: {
+  commandStatus: ReturnType<typeof buildTerminalRecoveryPresentation>["commandStatus"];
+  safeActions: TerminalRecoveryAction[];
+}) {
+  const nextAction = safeActions[0];
+  if (!nextAction || !shouldShowRecoveryNextStep(commandStatus)) {
+    return null;
+  }
+
+  return (
+    <p className="mt-layout-sm rounded-md border border-warning/30 bg-warning/10 px-layout-md py-layout-sm text-sm text-muted-foreground">
+      <span className="font-medium text-foreground">Next step:</span>{" "}
+      {getRecoveryNextStepCopy(nextAction)}
+    </p>
+  );
+}
+
+function shouldShowRecoveryNextStep(
+  commandStatus: ReturnType<typeof buildTerminalRecoveryPresentation>["commandStatus"],
+) {
+  return (
+    commandStatus.status === "Failed" ||
+    commandStatus.status === "Precondition Failed" ||
+    commandStatus.verificationStatus === "Verification Failed"
+  );
+}
+
+function getRecoveryNextStepCopy(action: TerminalRecoveryAction) {
+  if (action.commandType === "retry_sync") {
+    return "retry terminal sync, then use the next check-in to decide whether drawer repair still needs to run.";
+  }
+  if (action.commandType === "clear_stale_drawer_authority") {
+    return "send drawer authority repair from this checkout station.";
+  }
+  if (action.commandType === "repair_terminal_seed") {
+    return "send terminal setup repair from this checkout station.";
+  }
+  if (action.kind === "cloud_repair") {
+    return "resolve the safe cloud repair item.";
+  }
+  return `run ${action.label}.`;
+}
+
+function RecoveryCommandFailureReason({
+  commandStatus,
+  safeActions,
+}: {
+  commandStatus: ReturnType<typeof buildTerminalRecoveryPresentation>["commandStatus"];
+  safeActions: TerminalRecoveryAction[];
+}) {
+  const reason = getRecoveryCommandFailureReason(commandStatus, safeActions);
+  if (!reason) return null;
+
+  return (
+    <p className="mt-layout-xs px-layout-md text-sm text-muted-foreground">
+      <span className="font-medium text-foreground">Why:</span> {reason}
+    </p>
+  );
+}
+
+function getRecoveryCommandFailureReason(
+  commandStatus: ReturnType<typeof buildTerminalRecoveryPresentation>["commandStatus"],
+  safeActions: TerminalRecoveryAction[],
+) {
+  if (!shouldShowRecoveryNextStep(commandStatus)) {
+    return null;
+  }
+  if (commandStatus.latestAcknowledgement) {
+    return commandStatus.latestAcknowledgement;
+  }
+  if (commandStatus.commandType === "clear_stale_drawer_authority") {
+    if (safeActions.some((action) => action.commandType === "retry_sync")) {
+      return "Drawer repair expected the stale drawer block to still be present, but terminal sync evidence changed first.";
+    }
+    return "Drawer repair expected the stale drawer block to still be present, but the latest terminal evidence did not match.";
+  }
+
+  return "The command evidence changed before recovery could complete.";
+}
+
+function hasCurrentSupportRecoveryWork(
+  recovery: ReturnType<typeof buildTerminalRecoveryPresentation>,
+) {
+  return (
+    recovery.safeActions.length > 0 ||
+    recovery.groups.cloudRepair.length > 0 ||
+    recovery.groups.terminalRequired.length > 0 ||
+    recovery.groups.manualReview.length > 0 ||
+    isCurrentRecoveryCommand(recovery.commandStatus)
+  );
+}
+
+function isCurrentRecoveryCommand(
+  commandStatus: ReturnType<
+    typeof buildTerminalRecoveryPresentation
+  >["commandStatus"],
+) {
+  if (commandStatus.verificationStatus === "Verified") {
+    return false;
+  }
+
+  return ["Pending", "Claimed", "Completed"].includes(commandStatus.status);
 }
 
 function RecoveryBlockerGroup({
@@ -1022,7 +1333,7 @@ function RecoveryBlockerAction({
         </Button>
         {action.status && action.status !== "available" ? (
           <p className="max-w-sm text-xs text-muted-foreground">
-            {getRecoveryActionStatusCopy(action.status)}
+            {getRecoveryActionStatusCopy(action)}
           </p>
         ) : null}
         {action.latestAcknowledgement ? (
@@ -1056,8 +1367,8 @@ function RecoveryBlockerAction({
   return null;
 }
 
-function getRecoveryActionStatusCopy(status: TerminalRecoveryAction["status"]) {
-  switch (status) {
+function getRecoveryActionStatusCopy(action: TerminalRecoveryAction) {
+  switch (action.status) {
     case "pending":
       return "Command is queued for this checkout station.";
     case "claimed":
@@ -1070,11 +1381,14 @@ function getRecoveryActionStatusCopy(status: TerminalRecoveryAction["status"]) {
     case "expired":
       return "Command expired. Refresh terminal health before sending another command.";
     case "failed":
-      return "Command did not complete. Refresh terminal health before retrying.";
+      if (action.commandType === "clear_stale_drawer_authority") {
+        return "Command did not complete. Retry terminal sync before sending drawer repair again.";
+      }
+      return "Command did not complete. Run the next safe action before retrying.";
     case "blocked":
       return "Recovery is blocked by current terminal evidence.";
     default:
-      return formatStatusLabel(status);
+      return formatStatusLabel(action.status);
   }
 }
 
@@ -1107,6 +1421,14 @@ function RecoveryPanel({
   storeUrlSlug?: string;
 }) {
   const recovery = buildTerminalRecoveryPresentation(detail);
+  const hasCurrentRecoveryWork = hasCurrentSupportRecoveryWork(recovery);
+  const supportReadiness = hasCurrentRecoveryWork
+    ? recovery.readiness
+    : {
+        description:
+          "Current terminal evidence has no repair or review blockers.",
+        label: "No support action needed",
+      };
 
   return (
     <DetailPanel
@@ -1120,65 +1442,77 @@ function RecoveryPanel({
               Readiness
             </p>
             <p className="mt-1 text-base font-medium text-foreground">
-              {recovery.readiness.label}
+              {supportReadiness.label}
             </p>
             <p className="mt-1 text-sm text-muted-foreground">
-              {recovery.readiness.description}
+              {supportReadiness.description}
             </p>
           </div>
         </div>
       </div>
 
-      <div className="mt-layout-md grid gap-layout-sm md:grid-cols-3">
-        <RecoveryMetric
-          label="Command status"
-          value={`${recovery.commandStatus.label} / ${recovery.commandStatus.status}`}
-        />
-        <RecoveryMetric
-          label="Verification"
-          value={recovery.commandStatus.verificationStatus}
-        />
-        <RecoveryMetric
-          label="Available actions"
-          value={`${recovery.safeActions.length} safe action${recovery.safeActions.length === 1 ? "" : "s"}`}
-        />
-      </div>
+      {hasCurrentRecoveryWork ? (
+        <>
+          <div className="mt-layout-md grid gap-layout-sm md:grid-cols-3">
+            <RecoveryMetric
+              label="Command status"
+              value={`${recovery.commandStatus.label} / ${recovery.commandStatus.status}`}
+            />
+            <RecoveryMetric
+              label="Verification"
+              value={recovery.commandStatus.verificationStatus}
+            />
+            <RecoveryMetric
+              label="Available actions"
+              value={`${recovery.safeActions.length} safe action${recovery.safeActions.length === 1 ? "" : "s"}`}
+            />
+          </div>
+          <RecoveryNextStep
+            commandStatus={recovery.commandStatus}
+            safeActions={recovery.safeActions}
+          />
+          <RecoveryCommandFailureReason
+            commandStatus={recovery.commandStatus}
+            safeActions={recovery.safeActions}
+          />
 
-      <div className="mt-layout-md space-y-layout-sm">
-        <RecoveryBlockerGroup
-          blockers={recovery.groups.cloudRepair}
-          emptyCopy="No cloud-safe repair blockers are reported."
-          onResolveTerminalCloudRepair={onResolveTerminalCloudRepair}
-          onResolveRegisterSessionReview={onResolveRegisterSessionReview}
-          orgUrlSlug={orgUrlSlug}
-          storeUrlSlug={storeUrlSlug}
-          terminalId={detail.terminal._id}
-          title="Cloud repair"
-        />
-        <RecoveryBlockerGroup
-          blockers={recovery.groups.terminalRequired}
-          emptyCopy="No terminal-required blockers are reported."
-          onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
-          onResolveRegisterSessionReview={onResolveRegisterSessionReview}
-          orgUrlSlug={orgUrlSlug}
-          storeUrlSlug={storeUrlSlug}
-          terminalId={detail.terminal._id}
-          title="Terminal required"
-        />
-        <RecoveryBlockerGroup
-          blockers={recovery.groups.manualReview}
-          emptyCopy="No manual-review blockers are reported."
-          onResolveRegisterSessionReview={onResolveRegisterSessionReview}
-          orgUrlSlug={orgUrlSlug}
-          storeUrlSlug={storeUrlSlug}
-          terminalId={detail.terminal._id}
-          title="Manual review"
-        />
-      </div>
+          <div className="mt-layout-md space-y-layout-sm">
+            <RecoveryBlockerGroup
+              blockers={recovery.groups.cloudRepair}
+              emptyCopy="No cloud-safe repair blockers are reported."
+              onResolveTerminalCloudRepair={onResolveTerminalCloudRepair}
+              onResolveRegisterSessionReview={onResolveRegisterSessionReview}
+              orgUrlSlug={orgUrlSlug}
+              storeUrlSlug={storeUrlSlug}
+              terminalId={detail.terminal._id}
+              title="Cloud repair"
+            />
+            <RecoveryBlockerGroup
+              blockers={recovery.groups.terminalRequired}
+              emptyCopy="No terminal-required blockers are reported."
+              onIssueTerminalRecoveryCommand={onIssueTerminalRecoveryCommand}
+              onResolveRegisterSessionReview={onResolveRegisterSessionReview}
+              orgUrlSlug={orgUrlSlug}
+              storeUrlSlug={storeUrlSlug}
+              terminalId={detail.terminal._id}
+              title="Terminal required"
+            />
+            <RecoveryBlockerGroup
+              blockers={recovery.groups.manualReview}
+              emptyCopy="No manual-review blockers are reported."
+              onResolveRegisterSessionReview={onResolveRegisterSessionReview}
+              orgUrlSlug={orgUrlSlug}
+              storeUrlSlug={storeUrlSlug}
+              terminalId={detail.terminal._id}
+              title="Manual review"
+            />
+          </div>
 
-      <p className="mt-layout-md text-sm text-muted-foreground">
-        {recovery.verification.summary}
-      </p>
+          <p className="mt-layout-md text-sm text-muted-foreground">
+            {recovery.verification.summary}
+          </p>
+        </>
+      ) : null}
     </DetailPanel>
   );
 }

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx
@@ -27,7 +27,12 @@ vi.mock("@tanstack/react-router", () => ({
     to,
   }: {
     children?: React.ReactNode;
-    params?: { orgUrlSlug: string; storeUrlSlug: string; terminalId?: string };
+    params?: {
+      orgUrlSlug: string;
+      sessionId?: string;
+      storeUrlSlug: string;
+      terminalId?: string;
+    };
     to?: string;
   }) => (
     <a
@@ -35,6 +40,7 @@ vi.mock("@tanstack/react-router", () => ({
         to
           ?.replace("$orgUrlSlug", params?.orgUrlSlug ?? "")
           .replace("$storeUrlSlug", params?.storeUrlSlug ?? "")
+          .replace("$sessionId", params?.sessionId ?? "")
           .replace("$terminalId", params?.terminalId ?? "") ?? "#"
       }
     >
@@ -95,10 +101,26 @@ vi.mock("@/components/states/signed-out/ProtectedAdminSignInView", () => ({
 }));
 
 const baseSummary: TerminalHealthSummary = {
+  registerSessionLink: {
+    registerSessionId: "register-session-1",
+    status: "open",
+  },
   runtimeStatus: {
     _id: "status-1",
     _creationTime: 1,
+    appShell: {
+      observedAt: Date.now(),
+      ready: true,
+    },
     browserInfo: { online: true, platform: "MacIntel" },
+    activeRegisterSession: {
+      cloudRegisterSessionId: "register-session-1",
+      localRegisterSessionId: "local-register-session-1",
+      observedAt: Date.now(),
+      openedAt: Date.now(),
+      registerNumber: "1",
+      status: "open",
+    },
     localStore: { available: true, terminalSeedReady: true },
     receivedAt: Date.now(),
     reportedAt: Date.now(),
@@ -253,19 +275,22 @@ describe("POSTerminalHealthViewContent", () => {
     expect(screen.getByText("Review kiosk")).toBeInTheDocument();
     expect(screen.getAllByText("Staff authority ready").length).toBeGreaterThan(0);
     expect(
-      screen.getAllByText("Register session evidence is shown in cash controls").length,
+      screen.getAllByText("Active in cash controls").length,
     ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByRole("link", { name: "Active in cash controls" })[0],
+    ).toHaveAttribute(
+      "href",
+      "/acme/store/osu/cash-controls/registers/register-session-1",
+    );
+    expect(screen.getAllByText("Offline checkout").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Products and stock").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Register details").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Offline diagnostics need attention").length).toBeGreaterThan(0);
     expect(
-      screen.getAllByText(
-        "Service catalog data is available locally. Last refreshed 3 minutes ago.",
-      ).length,
+      screen.getAllByText("Ready signals").length,
     ).toBeGreaterThan(0);
-    expect(
-      screen.getAllByText(
-        "App shell status has not reported to this page yet.",
-      ).length,
-    ).toBeGreaterThan(0);
+    expect(screen.getAllByText("App shell").length).toBeGreaterThan(0);
     expect(screen.getByRole("link", { name: /Front counter/i })).toHaveAttribute(
       "href",
       "/acme/store/osu/pos/terminals/terminal-1",
@@ -299,6 +324,24 @@ describe("POSTerminalHealthViewContent", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows unknown metric values while terminal health is loading", () => {
+    render(
+      <POSTerminalHealthViewContent
+        healthSummaries={[]}
+        isLoading
+        orgUrlSlug="acme"
+        storeUrlSlug="osu"
+      />,
+    );
+
+    expect(screen.getByText("Terminals")).toBeInTheDocument();
+    expect(screen.getByText("Pending sync")).toBeInTheDocument();
+    expect(screen.getByText("Needs review")).toBeInTheDocument();
+    expect(screen.getByText("Stale or missing")).toBeInTheDocument();
+    expect(screen.getAllByText("-")).toHaveLength(4);
+    expect(screen.queryByText("No POS terminals registered")).not.toBeInTheDocument();
+  });
+
   it("shows redacted app-session reconciliation posture without marking cashier continuation as review", () => {
     render(
       <POSTerminalHealthViewContent
@@ -329,7 +372,7 @@ describe("POSTerminalHealthViewContent", () => {
 
     expect(screen.getByText("Local continuation")).toBeInTheDocument();
     expect(screen.getAllByText("Needs review")).toHaveLength(1);
-    expect(screen.getByText("App-session posture")).toBeInTheDocument();
+    expect(screen.getByText("Register session")).toBeInTheDocument();
     expect(
       screen.getByText(
         "App session unverified; local sales stay on this terminal until cloud validation returns.",
@@ -347,9 +390,12 @@ describe("POSTerminalHealthViewContent", () => {
           {
             ...baseSummary,
             recovery: {
+              evidence: {
+                activeRegisterSession: true,
+                freshRuntimeRequiredForAbleToTransactNow: true,
+              },
               readiness: {
-                status: "healthy_idle",
-                summary: "Healthy idle. Open a drawer and sign in before selling.",
+                status: "drawer_open",
               },
             },
           },
@@ -375,9 +421,9 @@ describe("POSTerminalHealthViewContent", () => {
       />,
     );
 
-    expect(screen.getByText("Healthy idle")).toBeInTheDocument();
+    expect(screen.getByText("Drawer open")).toBeInTheDocument();
     expect(
-      screen.getByText("Healthy idle. Open a drawer and sign in before selling."),
+      screen.getByText("Drawer is open. Sign in before selling."),
     ).toBeInTheDocument();
     expect(screen.getByText("Able to transact now")).toBeInTheDocument();
     expect(
@@ -385,6 +431,59 @@ describe("POSTerminalHealthViewContent", () => {
         "Able to transact now. Drawer, cashier, and sale authority are active.",
       ),
     ).toBeInTheDocument();
+  });
+
+  it("does not show stale setup notes when recovery cleared the terminal blocker", () => {
+    render(
+      <POSTerminalHealthViewContent
+        healthSummaries={[
+          {
+            ...baseSummary,
+            attentionReasons: [
+              {
+                source: "terminal_runtime",
+                summary:
+                  "Terminal setup needs repair before this checkout station can record new sales.",
+                type: "terminal_seed_missing",
+              },
+            ],
+            health: "needs_attention",
+            recovery: {
+              commandStatus: {
+                commandType: "repair_terminal_seed",
+                label: "Terminal setup repair",
+                status: "completed",
+                verificationStatus: "verified",
+              },
+              readiness: "needs_terminal_action",
+              terminalActions: [
+                {
+                  commandContext: {
+                    expectedBlockerType: "terminal_seed",
+                  },
+                  commandType: "repair_terminal_seed",
+                  expectedEvidence: {
+                    terminalIntegrityStatus: "healthy",
+                  },
+                  reason: "Terminal setup data needs repair.",
+                },
+              ],
+            },
+          },
+        ]}
+        isLoading={false}
+        orgUrlSlug="acme"
+        storeUrlSlug="osu"
+      />,
+    );
+
+    expect(screen.getByText("Healthy")).toBeInTheDocument();
+    expect(screen.getByText("Healthy idle")).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        "Terminal setup needs repair before this checkout station can record new sales.",
+      ),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx
@@ -1,7 +1,17 @@
 import { Link, useParams } from "@tanstack/react-router";
 import { useQuery } from "convex/react";
 import type { FunctionReference } from "convex/server";
-import { Activity, AlertTriangle, MonitorCheck } from "lucide-react";
+import type { ReactNode } from "react";
+import {
+  Activity,
+  AlertTriangle,
+  ArrowUpRight,
+  CheckCircle2,
+  CircleAlert,
+  CircleHelp,
+  Clock3,
+  MonitorCheck,
+} from "lucide-react";
 
 import View from "@/components/View";
 import { FadeIn } from "@/components/common/FadeIn";
@@ -18,21 +28,26 @@ import { useAuth } from "@/hooks/useAuth";
 import { usePermissions } from "@/hooks/usePermissions";
 import { api } from "~/convex/_generated/api";
 import type { Id } from "~/convex/_generated/dataModel";
+import { cn } from "@/lib/utils";
 import {
   buildPosOfflineReadinessSummary,
+  type PosOfflineReadinessSignal,
   type PosOfflineReadinessSummary,
 } from "@/offline/posOfflineReadiness";
 import {
   buildTerminalRecoveryPresentation,
   classifyTerminalHealth,
+  formatAge,
   formatRegisterNumber,
   formatTerminalTimestamp,
   getReviewEvidenceCount,
-  getSnapshotAgeSummary,
   getStaffAuthorityLabel,
   getPrimaryTerminalAttentionReason,
 } from "./terminalHealthPresentation";
-import type { TerminalHealthSummary } from "./terminalHealthTypes";
+import type {
+  TerminalHealthSummary,
+  TerminalRuntimeStatus,
+} from "./terminalHealthTypes";
 import { getOrigin } from "~/src/lib/navigationUtils";
 
 const posTerminalApi = api.inventory.posTerminal as unknown as {
@@ -76,6 +91,16 @@ function OfflineReadinessDiagnostic({
 }: {
   readiness: PosOfflineReadinessSummary;
 }) {
+  const signalsNeedingAttention = readiness.signals.filter(
+    (signal) => signal.status === "needs_attention",
+  );
+  const unknownSignals = readiness.signals.filter(
+    (signal) => signal.status === "unknown",
+  );
+  const readySignals = readiness.signals.filter((signal) =>
+    ["local_continuation", "ready"].includes(signal.status),
+  );
+
   return (
     <div className="mt-layout-md border-t border-border pt-layout-md">
       <div className="flex flex-wrap items-start justify-between gap-layout-sm">
@@ -87,28 +112,238 @@ function OfflineReadinessDiagnostic({
             {readiness.description}
           </p>
         </div>
-        <span className="inline-flex rounded-full border border-border bg-background px-layout-sm py-layout-2xs text-sm text-muted-foreground">
+        <span className="inline-flex rounded-full border border-border px-layout-sm py-layout-2xs text-sm text-muted-foreground">
           {readiness.readyCount} of {readiness.signals.length} ready
         </span>
       </div>
 
-      <dl className="mt-layout-md grid gap-layout-sm md:grid-cols-2 xl:grid-cols-3">
-        {readiness.signals.map((signal) => (
-          <div
-            className="rounded-md border border-border bg-background px-layout-sm py-layout-xs"
-            key={signal.domain}
-          >
-            <dt className="text-xs font-medium uppercase text-muted-foreground">
-              {signal.label}
-            </dt>
-            <dd className="mt-layout-2xs text-sm text-foreground">
-              {signal.description}
-            </dd>
-          </div>
-        ))}
-      </dl>
+      {signalsNeedingAttention.length > 0 ? (
+        <ReadinessSignalList
+          className="mt-layout-md"
+          signals={signalsNeedingAttention}
+        />
+      ) : null}
+      {unknownSignals.length > 0 ? (
+        <ReadinessSignalList
+          className={
+            signalsNeedingAttention.length > 0
+              ? "mt-layout-sm"
+              : "mt-layout-md"
+          }
+          signals={unknownSignals}
+        />
+      ) : null}
+      {readySignals.length > 0 ? (
+        <ReadySignalSummary
+          className={
+            signalsNeedingAttention.length > 0 || unknownSignals.length > 0
+              ? "mt-layout-sm"
+              : "mt-layout-md"
+          }
+          signals={readySignals}
+        />
+      ) : null}
     </div>
   );
+}
+
+function ReadySignalSummary({
+  className,
+  signals,
+}: {
+  className?: string;
+  signals: PosOfflineReadinessSignal[];
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center gap-x-layout-sm gap-y-layout-2xs text-sm text-muted-foreground",
+        className,
+      )}
+    >
+      <span className="inline-flex items-center gap-layout-xs font-medium text-foreground">
+        <CheckCircle2 aria-hidden="true" className="h-3.5 w-3.5 text-success" />
+        Ready signals
+      </span>
+      <span>{signals.map((signal) => signal.label).join(", ")}</span>
+    </div>
+  );
+}
+
+function ReadinessSignalList({
+  className,
+  signals,
+}: {
+  className?: string;
+  signals: PosOfflineReadinessSignal[];
+}) {
+  return (
+    <dl className={cn("divide-y divide-border", className)}>
+      {signals.map((signal) => (
+        <div
+          className="grid gap-layout-xs py-layout-xs text-sm md:grid-cols-[11rem_minmax(0,1fr)]"
+          key={signal.domain}
+        >
+          <dt className="flex items-center gap-layout-xs font-medium text-foreground">
+            <ReadinessSignalIcon signal={signal} />
+            <span>{signal.label}</span>
+          </dt>
+          <dd className="text-muted-foreground md:text-right">
+            {signal.description}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function ReadinessSignalIcon({
+  signal,
+}: {
+  signal: PosOfflineReadinessSignal;
+}) {
+  if (signal.status === "ready" || signal.status === "local_continuation") {
+    return (
+      <CheckCircle2
+        aria-hidden="true"
+        className="h-3.5 w-3.5 text-success"
+      />
+    );
+  }
+
+  if (signal.status === "needs_attention") {
+    return (
+      <CircleAlert
+        aria-hidden="true"
+        className="h-3.5 w-3.5 text-warning"
+      />
+    );
+  }
+
+  return (
+    <CircleHelp
+      aria-hidden="true"
+      className="h-3.5 w-3.5 text-muted-foreground"
+    />
+  );
+}
+
+function TerminalFact({
+  label,
+  value,
+}: {
+  label: string;
+  value: ReactNode;
+}) {
+  return (
+    <div>
+      <dt className="text-xs font-medium uppercase text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="mt-1 text-sm text-foreground">{value}</dd>
+    </div>
+  );
+}
+
+function RegisterSessionFactValue({
+  orgUrlSlug,
+  registerSessionLink,
+  runtimeStatus,
+  storeUrlSlug,
+}: {
+  orgUrlSlug: string;
+  registerSessionLink?: TerminalHealthSummary["registerSessionLink"];
+  runtimeStatus?: TerminalRuntimeStatus | null;
+  storeUrlSlug: string;
+}) {
+  const isLocalContinuation =
+    runtimeStatus?.appSessionRecovery?.status === "waiting_for_network";
+  const label = isLocalContinuation
+    ? "Local sale continuation"
+    : registerSessionLink
+      ? "Active in cash controls"
+      : "No active session";
+  const registerSessionId = registerSessionLink?.registerSessionId;
+
+  if (!registerSessionId || isLocalContinuation) {
+    return <>{label}</>;
+  }
+
+  return (
+    <Link
+      className="inline-flex items-center gap-layout-xs font-medium text-foreground underline-offset-4 hover:underline"
+      params={{
+        orgUrlSlug,
+        sessionId: String(registerSessionId),
+        storeUrlSlug,
+      }}
+      search={{ o: getOrigin() }}
+      to="/$orgUrlSlug/store/$storeUrlSlug/cash-controls/registers/$sessionId"
+    >
+      {label}
+      <ArrowUpRight aria-hidden="true" className="h-3.5 w-3.5 shrink-0" />
+    </Link>
+  );
+}
+
+function LocalDataFreshness({
+  snapshots,
+}: {
+  snapshots?: TerminalRuntimeStatus["snapshots"] | null;
+}) {
+  const rows = getLocalDataFreshnessRows(snapshots);
+
+  return (
+    <div className="space-y-layout-2xs">
+      {rows.map((row) => (
+        <div
+          className="flex flex-wrap items-baseline gap-x-layout-xs"
+          key={row.label}
+        >
+          <span className="text-foreground">{row.label}</span>
+          <span className="text-muted-foreground">{row.value}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function getLocalDataFreshnessRows(
+  snapshots?: TerminalRuntimeStatus["snapshots"] | null,
+) {
+  if (!snapshots) {
+    return [{ label: "Offline checkout", value: "Not reported" }];
+  }
+
+  const sellingDataAges = [
+    snapshots.availabilityAgeMs,
+    snapshots.catalogAgeMs,
+    snapshots.serviceCatalogAgeMs,
+  ].filter(
+    (age): age is number => typeof age === "number" && Number.isFinite(age),
+  );
+  const rows: Array<{ label: string; value: string }> = [];
+
+  if (sellingDataAges.length > 0) {
+    rows.push({
+      label: "Products and stock",
+      value: formatAge(Math.max(...sellingDataAges)),
+    });
+  }
+
+  if (
+    typeof snapshots.registerReadModelAgeMs === "number" &&
+    Number.isFinite(snapshots.registerReadModelAgeMs)
+  ) {
+    rows.push({
+      label: "Register details",
+      value: formatAge(snapshots.registerReadModelAgeMs),
+    });
+  }
+
+  return rows.length > 0
+    ? rows
+    : [{ label: "Offline checkout", value: "Not reported" }];
 }
 
 function buildTerminalOfflineReadiness(
@@ -122,7 +357,9 @@ function buildTerminalOfflineReadiness(
     appSession: appSessionRecovery
       ? getAppSessionReadinessInput(appSessionRecovery)
       : null,
-    appShell: null,
+    appShell: runtimeStatus?.appShell
+      ? { ready: runtimeStatus.appShell.ready }
+      : null,
     terminalSeed: runtimeStatus
       ? { ready: runtimeStatus.localStore.terminalSeedReady }
       : null,
@@ -176,6 +413,7 @@ export function POSTerminalHealthViewContent({
   const staleCount = healthRows.filter((row) =>
     ["No check-in", "Stale"].includes(row.classification.label),
   ).length;
+  const loadingMetricValue = isLoading ? "-" : null;
 
   return (
     <View hideBorder hideHeaderBottomBorder scrollMode="page">
@@ -199,10 +437,22 @@ export function POSTerminalHealthViewContent({
           ) : (
             <>
               <section className="grid gap-layout-sm sm:grid-cols-2 xl:grid-cols-4">
-                <CountMetric label="Terminals" value={healthRows.length} />
-                <CountMetric label="Pending sync" value={pendingCount} />
-                <CountMetric label="Needs review" value={reviewCount} />
-                <CountMetric label="Stale or missing" value={staleCount} />
+                <CountMetric
+                  label="Terminals"
+                  value={loadingMetricValue ?? healthRows.length}
+                />
+                <CountMetric
+                  label="Pending sync"
+                  value={loadingMetricValue ?? pendingCount}
+                />
+                <CountMetric
+                  label="Needs review"
+                  value={loadingMetricValue ?? reviewCount}
+                />
+                <CountMetric
+                  label="Stale or missing"
+                  value={loadingMetricValue ?? staleCount}
+                />
               </section>
 
               {isLoading ? null : healthRows.length === 0 ? (
@@ -224,6 +474,20 @@ export function POSTerminalHealthViewContent({
                     const offlineReadiness =
                       buildTerminalOfflineReadiness(summary);
                     const recovery = buildTerminalRecoveryPresentation(summary);
+                    const syncReviewCount =
+                      (runtimeStatus?.sync.reviewEventCount ?? 0) +
+                      getReviewEvidenceCount(summary.syncEvidence);
+                    const syncSummary = runtimeStatus
+                      ? `${runtimeStatus.sync.pendingEventCount} pending / ${syncReviewCount} review`
+                      : "No runtime sync check-in";
+                    const cloudCursorSummary =
+                      summary.syncEvidence.acceptedThroughSequence == null
+                        ? "No accepted sequence"
+                        : `Accepted through ${summary.syncEvidence.acceptedThroughSequence}`;
+	                    const operationalNote =
+	                      classification.label === "Healthy"
+	                        ? null
+	                        : (primaryReason?.summary ?? classification.description);
 
                     return (
                       <article
@@ -251,12 +515,6 @@ export function POSTerminalHealthViewContent({
                                 )}
                               </span>
                               <span>
-                                Last check-in{" "}
-                                {formatTerminalTimestamp(
-                                  runtimeStatus?.receivedAt,
-                                )}
-                              </span>
-                              <span>
                                 {getStaffAuthorityLabel(
                                   runtimeStatus?.staffAuthority,
                                 )}
@@ -271,61 +529,66 @@ export function POSTerminalHealthViewContent({
                           </Badge>
                         </div>
 
-                        <div className="mt-layout-md grid gap-layout-sm md:grid-cols-2 xl:grid-cols-5">
+                        <div className="mt-layout-md grid gap-layout-md border-t border-border pt-layout-md lg:grid-cols-[minmax(0,1.2fr)_minmax(26rem,0.8fr)]">
                           <div>
                             <p className="text-xs font-medium uppercase text-muted-foreground">
-                              Sync
+                              Sales readiness
                             </p>
-                            <p className="mt-1 text-sm text-foreground">
-                              {runtimeStatus
-                                ? `${runtimeStatus.sync.pendingEventCount} pending / ${runtimeStatus.sync.reviewEventCount + getReviewEvidenceCount(summary.syncEvidence)} review`
-                                : "No runtime sync check-in"}
-                            </p>
-                            <p className="mt-1 text-xs text-muted-foreground">
-                              {primaryReason?.summary ?? classification.description}
-                            </p>
-                          </div>
-                          <div>
-                            <p className="text-xs font-medium uppercase text-muted-foreground">
-                              Snapshot age
-                            </p>
-                            <p className="mt-1 text-sm text-foreground">
-                              {getSnapshotAgeSummary(runtimeStatus?.snapshots)}
-                            </p>
-                          </div>
-                          <div>
-                            <p className="text-xs font-medium uppercase text-muted-foreground">
-                              App-session posture
-                            </p>
-                            <p className="mt-1 text-sm text-foreground">
-                              {runtimeStatus?.appSessionRecovery?.status ===
-                              "waiting_for_network"
-                                ? "Local sale continuation"
-                                : "Register session evidence is shown in cash controls"}
-                            </p>
-                          </div>
-                          <div>
-                            <p className="text-xs font-medium uppercase text-muted-foreground">
-                              Cloud cursor
-                            </p>
-                            <p className="mt-1 text-sm text-foreground">
-                              {summary.syncEvidence.acceptedThroughSequence ==
-                              null
-                                ? "No accepted sequence"
-                                : `Accepted through ${summary.syncEvidence.acceptedThroughSequence}`}
-                            </p>
-                          </div>
-                          <div>
-                            <p className="text-xs font-medium uppercase text-muted-foreground">
-                              Recovery readiness
-                            </p>
-                            <p className="mt-1 text-sm text-foreground">
+                            <p className="mt-1 text-base font-medium text-foreground">
                               {recovery.readiness.label}
                             </p>
-                            <p className="mt-1 text-xs text-muted-foreground">
+                            <p className="mt-layout-2xs text-sm text-muted-foreground">
                               {recovery.readiness.description}
                             </p>
+                            {operationalNote ? (
+                              <p className="mt-layout-sm text-sm text-foreground">
+                                {operationalNote}
+                              </p>
+                            ) : null}
                           </div>
+
+                          <dl className="grid gap-x-layout-lg gap-y-layout-sm sm:grid-cols-2">
+                            <TerminalFact
+                              label="Last check-in"
+                              value={
+                                <span className="inline-flex items-center gap-layout-xs">
+                                  <Clock3
+                                    aria-hidden="true"
+                                    className="h-3.5 w-3.5 text-muted-foreground"
+                                  />
+                                  {formatTerminalTimestamp(
+                                    runtimeStatus?.receivedAt,
+                                  )}
+                                </span>
+                              }
+                            />
+                            <TerminalFact label="Sync" value={syncSummary} />
+                            <TerminalFact
+                              label="Offline checkout"
+                              value={
+                                <LocalDataFreshness
+                                  snapshots={runtimeStatus?.snapshots}
+                                />
+                              }
+                            />
+                            <TerminalFact
+                              label="Register session"
+                              value={
+                                <RegisterSessionFactValue
+                                  orgUrlSlug={orgUrlSlug}
+                                  registerSessionLink={
+                                    summary.registerSessionLink
+                                  }
+                                  runtimeStatus={runtimeStatus}
+                                  storeUrlSlug={storeUrlSlug}
+                                />
+                              }
+                            />
+                            <TerminalFact
+                              label="Cloud cursor"
+                              value={cloudCursorSummary}
+                            />
+                          </dl>
                         </div>
 
                         <OfflineReadinessDiagnostic

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
@@ -34,6 +34,28 @@ describe("terminal health presentation", () => {
     expect(
       buildTerminalRecoveryPresentation({
         recovery: {
+          evidence: {
+            activeRegisterSession: true,
+            freshRuntimeRequiredForAbleToTransactNow: true,
+          },
+          readiness: {
+            status: "drawer_open",
+          },
+        },
+        runtimeStatus: null,
+        syncEvidence: {},
+        terminal: { status: "active" },
+      }).readiness,
+    ).toEqual(
+      expect.objectContaining({
+        description: "Drawer is open. Sign in before selling.",
+        label: "Drawer open",
+      }),
+    );
+
+    expect(
+      buildTerminalRecoveryPresentation({
+        recovery: {
           readiness: {
             status: "able_to_transact_now",
             summary: "Able to transact now. Drawer, cashier, and sale authority are active.",
@@ -131,6 +153,12 @@ describe("terminal health presentation", () => {
             source: "cloud_sync",
             type: "cloud_held",
           },
+          {
+            reason:
+              "Cloud conflict xs76r9cjk0qw5nnwcera3jd1tn88jhpj needs manual review before repair.",
+            source: "cloud_repair",
+            type: "unsafe_cloud_conflict",
+          },
         ],
         readiness: "needs_terminal_action",
         terminalActions: [
@@ -191,11 +219,58 @@ describe("terminal health presentation", () => {
     expect(presentation.groups.manualReview[0]?.summary).toBe(
       "Manual review required. Use the linked operations or cash-control review before support repairs this terminal.",
     );
+    expect(presentation.groups.manualReview[1]?.summary).toBe(
+      "A cloud sync conflict needs manual review before support can repair this terminal.",
+    );
     expect(presentation.safeActions.map((action) => action.kind)).toEqual([
       "cloud_repair",
       "terminal_command",
       "terminal_command",
     ]);
+  });
+
+  it("uses the Convex recoveryPreview field for terminal command actions", () => {
+    const presentation = buildTerminalRecoveryPresentation({
+      recoveryPreview: {
+        readiness: "needs_manual_review",
+        terminalActions: [
+          {
+            commandContext: {
+              cloudRegisterSessionId: "cloud-session-1",
+              expectedBlockerType: "cloud_closed",
+              localRegisterSessionId: "local-session-1",
+              reason: "Drawer authority requires terminal-local repair.",
+            },
+            commandType: "clear_stale_drawer_authority",
+            expectedEvidence: {
+              drawerAuthorityStatus: "healthy",
+              localRegisterSessionId: "local-session-1",
+            },
+            reason: "Drawer authority requires terminal-local repair.",
+          },
+        ],
+      },
+      runtimeStatus: null,
+      syncEvidence: {},
+      terminal: { status: "active" },
+    });
+
+    expect(presentation.readiness.label).toBe("Needs manual review");
+    expect(presentation.groups.terminalRequired[0]?.action).toEqual(
+      expect.objectContaining({
+        commandContext: expect.objectContaining({
+          cloudRegisterSessionId: "cloud-session-1",
+          localRegisterSessionId: "local-session-1",
+        }),
+        commandType: "clear_stale_drawer_authority",
+        expectedEvidence: {
+          drawerAuthorityStatus: "healthy",
+          localRegisterSessionId: "local-session-1",
+        },
+        kind: "terminal_command",
+      }),
+    );
+    expect(presentation.safeActions).toHaveLength(1);
   });
 
   it("suppresses duplicate recovery actions while command lifecycle is active", () => {
@@ -228,6 +303,49 @@ describe("terminal health presentation", () => {
     expect(presentation.groups.terminalRequired[0]?.action).toEqual(
       expect.objectContaining({
         status: "pending",
+      }),
+    );
+  });
+
+  it("presents local review backlog recovery as a terminal sync retry", () => {
+    const presentation = buildTerminalRecoveryPresentation({
+      recovery: {
+        commandStatus: {
+          commandType: "clear_stale_drawer_authority",
+          label: "Drawer authority repair",
+          status: "completed",
+          verificationStatus: "verified",
+        },
+        terminalActions: [
+          {
+            commandContext: {
+              expectedBlockerType: "local_review",
+              reason: "Local review items need a terminal sync retry.",
+            },
+            commandType: "retry_sync",
+            expectedEvidence: {
+              syncStatus: "idle",
+            },
+            reason: "Local review items need a terminal sync retry.",
+          },
+        ],
+      },
+      runtimeStatus: null,
+      syncEvidence: {},
+      terminal: { status: "active" },
+    });
+
+    expect(presentation.groups.terminalRequired[0]).toEqual(
+      expect.objectContaining({
+        detail: "Expected after check-in: Sync Idle.",
+        summary: "Local review items need a terminal sync retry.",
+        title: "Terminal sync retry",
+      }),
+    );
+    expect(presentation.safeActions[0]).toEqual(
+      expect.objectContaining({
+        commandType: "retry_sync",
+        label: "Retry terminal sync",
       }),
     );
   });
@@ -266,6 +384,97 @@ describe("terminal health presentation", () => {
         status: "expired",
       }),
     );
+  });
+
+  it("hides terminal command blockers after recovery is verified", () => {
+    const presentation = buildTerminalRecoveryPresentation({
+      recovery: {
+        commandStatus: {
+          commandType: "clear_stale_drawer_authority",
+          label: "Drawer authority repair",
+          status: "completed",
+          verificationStatus: "verified",
+        },
+        terminalActions: [
+          {
+            commandContext: {
+              cloudRegisterSessionId: "cloud-session-1",
+              expectedBlockerType: "cloud_closed",
+              localRegisterSessionId: "local-session-1",
+            },
+            commandType: "clear_stale_drawer_authority",
+            expectedEvidence: {
+              drawerAuthorityStatus: "healthy",
+              localRegisterSessionId: "local-session-1",
+            },
+            reason: "Drawer authority requires terminal-local repair.",
+          },
+        ],
+      },
+      runtimeStatus: null,
+      syncEvidence: {},
+      terminal: { status: "active" },
+    });
+
+    expect(presentation.groups.terminalRequired).toEqual([]);
+    expect(presentation.safeActions).toEqual([]);
+    expect(presentation.verification.summary).toBe(
+      "Recovery was verified by the latest terminal check-in.",
+    );
+  });
+
+  it("does not preserve stale terminal-action readiness when visible blockers are clear", () => {
+    const presentation = buildTerminalRecoveryPresentation({
+      recovery: {
+        readiness: "needs_terminal_action",
+        terminalActions: [],
+      },
+      runtimeStatus: {
+        receivedAt: Date.now(),
+        localStore: { available: true, terminalSeedReady: true },
+        staffAuthority: { status: "ready" },
+        sync: {
+          failedEventCount: 0,
+          pendingEventCount: 0,
+          reviewEventCount: 0,
+          status: "idle",
+          uploadableEventCount: 0,
+        },
+      },
+      syncEvidence: {},
+      terminal: { status: "active" },
+    });
+
+    expect(presentation.groups.terminalRequired).toEqual([]);
+    expect(presentation.readiness.label).toBe("Healthy idle");
+    expect(presentation.safeActions).toEqual([]);
+  });
+
+  it("keeps staff authority expiry out of support recovery blockers", () => {
+    const presentation = buildTerminalRecoveryPresentation({
+      recovery: {
+        readiness: "needs_terminal_action",
+        terminalActions: [],
+      },
+      runtimeStatus: {
+        receivedAt: Date.now(),
+        localStore: { available: true, terminalSeedReady: true },
+        staffAuthority: { status: "expired" },
+        sync: {
+          failedEventCount: 0,
+          pendingEventCount: 0,
+          reviewEventCount: 0,
+          status: "idle",
+          uploadableEventCount: 0,
+        },
+      },
+      syncEvidence: {},
+      terminal: { status: "active" },
+    });
+
+    expect(presentation.groups.terminalRequired).toEqual([]);
+    expect(presentation.readiness.label).toBe("Healthy idle");
+    expect(presentation.safeActions).toEqual([]);
   });
 
   it("normalizes duplicate register-open and authorization backend wording in derived recovery copy", () => {
@@ -315,10 +524,6 @@ describe("terminal health presentation", () => {
         expect.objectContaining({
           summary:
             "Terminal authorization needs refresh. This checkout station must reconnect before Athena can verify it.",
-        }),
-        expect.objectContaining({
-          summary:
-            "Staff authority expired. Sign in again at this checkout station before selling.",
         }),
       ]),
     );
@@ -508,6 +713,107 @@ describe("terminal health presentation", () => {
       expect.objectContaining({
         description: "Terminal setup data is not ready on this checkout station.",
         label: "Setup needed",
+      }),
+    );
+  });
+
+  it("does not keep setup-needed classification after recovery clears terminal blockers", () => {
+    expect(
+      classifyTerminalHealth({
+        attentionReasons: [
+          {
+            source: "terminal_runtime",
+            summary: "Terminal setup data is not ready on this checkout station.",
+            type: "terminal_seed_missing",
+          },
+        ],
+        health: "needs_attention",
+        recovery: {
+          commandStatus: {
+            commandType: "repair_terminal_seed",
+            label: "Terminal setup repair",
+            status: "completed",
+            verificationStatus: "verified",
+          },
+          readiness: "needs_terminal_action",
+          terminalActions: [
+            {
+              commandContext: {
+                expectedBlockerType: "terminal_seed",
+              },
+              commandType: "repair_terminal_seed",
+              expectedEvidence: {
+                terminalIntegrityStatus: "healthy",
+              },
+              reason: "Terminal setup data needs repair.",
+            },
+          ],
+        },
+        runtimeStatus: {
+          receivedAt: Date.now(),
+          localStore: { available: true, terminalSeedReady: true },
+          staffAuthority: { status: "ready" },
+          sync: {
+            failedEventCount: 0,
+            pendingEventCount: 0,
+            reviewEventCount: 0,
+            status: "idle",
+            uploadableEventCount: 0,
+          },
+        },
+        syncEvidence: { unresolvedConflictCount: 0 },
+        terminal: { status: "active" },
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        label: "Healthy",
+      }),
+    );
+  });
+
+  it("does not classify a terminal as healthy when support recovery has a repair blocker", () => {
+    expect(
+      classifyTerminalHealth({
+        health: "online",
+        recovery: {
+          commandStatus: {
+            commandType: "clear_stale_drawer_authority",
+            label: "Drawer authority repair",
+            status: "precondition_failed",
+            verificationStatus: "verification_failed",
+          },
+          readiness: "needs_terminal_action",
+          terminalActions: [
+            {
+              commandContext: {
+                expectedBlockerType: "terminal_seed",
+              },
+              commandType: "repair_terminal_seed",
+              expectedEvidence: {
+                terminalIntegrityStatus: "healthy",
+              },
+              reason: "Terminal setup data needs repair.",
+            },
+          ],
+        },
+        runtimeStatus: {
+          receivedAt: Date.now(),
+          localStore: { available: true, terminalSeedReady: true },
+          staffAuthority: { status: "ready" },
+          sync: {
+            failedEventCount: 0,
+            pendingEventCount: 0,
+            reviewEventCount: 0,
+            status: "idle",
+            uploadableEventCount: 0,
+          },
+        },
+        syncEvidence: { unresolvedConflictCount: 0 },
+        terminal: { status: "active" },
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        label: "Needs terminal action",
       }),
     );
   });

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
@@ -6,6 +6,7 @@ import type {
   TerminalHealthAttentionReason,
   TerminalRecoveryAction,
   TerminalRecoveryBlocker,
+  TerminalRecoveryCommandType,
   TerminalRecoveryPreview,
   TerminalRecoveryActionStatus,
   TerminalRecoveryReadinessStatus,
@@ -36,7 +37,9 @@ export type TerminalRecoveryReadinessPresentation = {
 
 export type TerminalRecoveryPresentation = {
   commandStatus: {
+    commandType?: TerminalRecoveryCommandType;
     label: string;
+    latestAcknowledgement?: string;
     status: string;
     verificationStatus: string;
   };
@@ -57,6 +60,7 @@ type TerminalHealthClassificationInput = {
   attentionReasons?: TerminalHealthAttentionReason[];
   health?: "needs_attention" | "offline" | "online" | "stale" | "unknown" | string;
   recovery?: TerminalRecoveryPreview | null;
+  recoveryPreview?: TerminalRecoveryPreview | null;
   runtimeStatus:
     | (Omit<Partial<TerminalRuntimeStatus>, "localStore" | "sync"> & {
         localStore?: Partial<TerminalRuntimeStatus["localStore"]>;
@@ -241,7 +245,14 @@ export function classifyTerminalHealth(
 
   const runtimeStatus = summary.runtimeStatus;
   const primaryReason = getPrimaryTerminalAttentionReason(summary);
-  if (summary.health === "needs_attention" && primaryReason) {
+  const suppressClearedSetupAttention =
+    isSetupAttentionReason(primaryReason) &&
+    recoveryPresentationClearsTerminalAttention(summary);
+  if (
+    summary.health === "needs_attention" &&
+    primaryReason &&
+    !suppressClearedSetupAttention
+  ) {
     switch (primaryReason.type) {
       case "local_review":
       case "cloud_conflict":
@@ -374,6 +385,23 @@ export function classifyTerminalHealth(
     };
   }
 
+  const recoveryPresentation = buildTerminalRecoveryPresentation(summary);
+  if (
+    recoveryPresentation.readiness.status === "needs_terminal_action" ||
+    recoveryPresentation.readiness.status === "needs_cloud_repair" ||
+    recoveryPresentation.readiness.status === "needs_manual_review"
+  ) {
+    return {
+      description:
+        recoveryPresentation.groups.terminalRequired[0]?.summary ??
+        recoveryPresentation.groups.cloudRepair[0]?.summary ??
+        recoveryPresentation.groups.manualReview[0]?.summary ??
+        recoveryPresentation.readiness.description,
+      label: recoveryPresentation.readiness.label,
+      toneClassName: recoveryPresentation.readiness.toneClassName,
+    };
+  }
+
   return {
     description: "The latest terminal check-in is clear.",
     label: "Healthy",
@@ -381,10 +409,37 @@ export function classifyTerminalHealth(
   };
 }
 
+function isSetupAttentionReason(reason?: TerminalHealthAttentionReason | null) {
+  return (
+    reason?.type === "terminal_seed_missing" ||
+    reason?.type === "terminal_authorization_failed"
+  );
+}
+
+function recoveryPresentationClearsTerminalAttention(
+  summary: TerminalHealthClassificationInput,
+) {
+  const recovery = getTerminalRecoveryPreview(summary);
+  if (!recovery) {
+    return false;
+  }
+
+  const presentation = buildTerminalRecoveryPresentation(summary);
+  return (
+    presentation.groups.terminalRequired.length === 0 &&
+    presentation.groups.cloudRepair.length === 0 &&
+    presentation.groups.manualReview.length === 0 &&
+    (presentation.readiness.status === "healthy_idle" ||
+      presentation.readiness.status === "drawer_open" ||
+      presentation.readiness.status === "able_to_transact_now")
+  );
+}
+
 export function buildTerminalRecoveryPresentation(
   summary: TerminalHealthClassificationInput,
 ): TerminalRecoveryPresentation {
-  const blockers = buildRecoveryBlockers(summary);
+  const recovery = getTerminalRecoveryPreview(summary);
+  const blockers = buildRecoveryBlockers(summary, recovery);
   const groups = {
     cloudRepair: blockers.filter((blocker) => blocker.category === "cloud_repair"),
     manualReview: blockers.filter((blocker) => blocker.category === "manual_review"),
@@ -401,11 +456,15 @@ export function buildTerminalRecoveryPresentation(
 
   return {
     commandStatus: {
-      label: normalizeSupportCopy(summary.recovery?.commandStatus?.label) ?? "No command issued",
-      status: formatStatusLabel(summary.recovery?.commandStatus?.status ?? "idle"),
+      commandType: recovery?.commandStatus?.commandType,
+      label: normalizeSupportCopy(recovery?.commandStatus?.label) ?? "No command issued",
+      latestAcknowledgement: normalizeSupportCopy(
+        recovery?.commandStatus?.latestAcknowledgement,
+      ),
+      status: formatStatusLabel(recovery?.commandStatus?.status ?? "idle"),
       verificationStatus: formatStatusLabel(
-        summary.recovery?.commandStatus?.verificationStatus ??
-          summary.recovery?.verification?.status ??
+        recovery?.commandStatus?.verificationStatus ??
+          recovery?.verification?.status ??
           "not_started",
       ),
     },
@@ -413,9 +472,14 @@ export function buildTerminalRecoveryPresentation(
     readiness,
     safeActions,
     verification: {
-      status: formatStatusLabel(summary.recovery?.verification?.status ?? "not_started"),
+      status: formatStatusLabel(
+        recovery?.verification?.status ??
+          recovery?.commandStatus?.verificationStatus ??
+          "not_started",
+      ),
       summary:
-        normalizeSupportCopy(summary.recovery?.verification?.summary) ??
+        normalizeSupportCopy(recovery?.verification?.summary) ??
+        getRecoveryVerificationSummary(recovery?.commandStatus?.verificationStatus) ??
         "Athena has not received recovery verification from a fresh terminal check-in.",
     },
   };
@@ -423,25 +487,66 @@ export function buildTerminalRecoveryPresentation(
 
 function buildRecoveryBlockers(
   summary: TerminalHealthClassificationInput,
+  recovery: TerminalRecoveryPreview | null | undefined = getTerminalRecoveryPreview(summary),
 ): RecoveryBlockerWithCategory[] {
-  if (summary.recovery?.blockers) {
-    return summary.recovery.blockers.map((blocker, index) =>
+  if (recovery?.blockers) {
+    return recovery.blockers.map((blocker, index) =>
       normalizeBackendRecoveryBlocker(blocker, index),
     );
   }
 
-  if (summary.recovery) {
-    return buildRecoveryBlockersFromPreview(summary.recovery);
+  if (recovery) {
+    return buildRecoveryBlockersFromPreview(recovery);
   }
 
   return deriveRecoveryBlockers(summary);
+}
+
+function getTerminalRecoveryPreview(summary: TerminalHealthClassificationInput) {
+  return summary.recovery ?? summary.recoveryPreview ?? null;
+}
+
+function getRecoveryVerificationSummary(status?: TerminalRecoveryActionStatus | null) {
+  if (status === "verified") {
+    return "Recovery was verified by the latest terminal check-in.";
+  }
+  if (status === "runtime_verification_ready" || status === "waiting_for_check_in") {
+    return "Command completed locally. Waiting for a fresh terminal check-in before verification.";
+  }
+  if (status === "waiting_for_acknowledgement") {
+    return "Command is waiting for this checkout station to acknowledge it.";
+  }
+  if (status === "verification_failed") {
+    return "Recovery verification did not match the latest terminal check-in.";
+  }
+  return undefined;
+}
+
+function getPreviewCommandActionStatus(
+  commandStatus?: TerminalRecoveryPreview["commandStatus"],
+  commandType?: TerminalRecoveryCommandType,
+) {
+  if (
+    commandStatus?.commandType &&
+    commandType &&
+    commandStatus.commandType !== commandType
+  ) {
+    return undefined;
+  }
+  if (commandStatus?.verificationStatus === "verified") {
+    return "verified";
+  }
+  if (commandStatus?.verificationStatus === "runtime_verification_ready") {
+    return "waiting_for_check_in";
+  }
+  return normalizeActionStatus(commandStatus?.status);
 }
 
 function buildRecoveryBlockersFromPreview(
   preview: TerminalRecoveryPreview,
 ): RecoveryBlockerWithCategory[] {
   const blockers: RecoveryBlockerWithCategory[] = [];
-  const commandStatus = normalizeActionStatus(preview.commandStatus?.status);
+  const commandStatus = getPreviewCommandActionStatus(preview.commandStatus);
 
   if ((preview.cloudRepair?.safeConflictIds.length ?? 0) > 0) {
     blockers.push({
@@ -464,6 +569,14 @@ function buildRecoveryBlockersFromPreview(
   }
 
   preview.terminalActions?.forEach((action, index) => {
+    const actionStatus = getPreviewCommandActionStatus(
+      preview.commandStatus,
+      action.commandType,
+    );
+    if (actionStatus === "verified") {
+      return;
+    }
+
     blockers.push({
       action: {
         commandContext: action.commandContext,
@@ -471,13 +584,16 @@ function buildRecoveryBlockersFromPreview(
         expectedEvidence: action.expectedEvidence,
         kind: "terminal_command",
         label: getTerminalCommandActionLabel(action.commandType),
-        status: commandStatus ?? "available",
+        status: actionStatus ?? "available",
       },
       category: "terminal_required",
       detail: getExpectedEvidenceSummary(action.expectedEvidence),
       id: `terminal-action-${action.commandType}-${index}`,
-      status: commandStatus ?? "available",
-      summary: normalizeSupportCopy(action.reason) ?? terminalRequiredSummary("drawer_authority_blocked"),
+      status: actionStatus ?? "available",
+      summary:
+        getTerminalCommandRecoverySummary(action.commandType, actionStatus) ??
+        normalizeSupportCopy(action.reason) ??
+        terminalRequiredSummary("drawer_authority_blocked"),
       title: getTerminalCommandTitle(action.commandType),
     });
   });
@@ -540,18 +656,22 @@ function buildRecoveryReadiness(
   summary: TerminalHealthClassificationInput,
   groups: TerminalRecoveryPresentation["groups"],
 ): TerminalRecoveryReadinessPresentation {
-  const readiness = summary.recovery?.readiness;
+  const recovery = getTerminalRecoveryPreview(summary);
+  const readiness = recovery?.readiness;
   const explicitStatus =
     typeof readiness === "string" ? readiness : readiness?.status;
-  const status =
-    explicitStatus ??
-    (groups.manualReview.length > 0
+  const derivedStatus =
+    groups.manualReview.length > 0
       ? "needs_manual_review"
       : groups.cloudRepair.length > 0
         ? "needs_cloud_repair"
         : groups.terminalRequired.length > 0
           ? "needs_terminal_action"
-          : "healthy_idle");
+          : "healthy_idle";
+  const status =
+    explicitStatus && explicitReadinessMatchesVisibleEvidence(explicitStatus, groups)
+      ? explicitStatus
+      : derivedStatus;
 
   const fallback = getRecoveryReadinessFallback(status);
 
@@ -563,6 +683,26 @@ function buildRecoveryReadiness(
     status,
     toneClassName: fallback.toneClassName,
   };
+}
+
+function explicitReadinessMatchesVisibleEvidence(
+  status: TerminalRecoveryReadinessStatus | undefined,
+  groups: TerminalRecoveryPresentation["groups"],
+) {
+  switch (status) {
+    case "needs_manual_review":
+      return true;
+    case "needs_cloud_repair":
+      return true;
+    case "needs_terminal_action":
+      return groups.terminalRequired.length > 0;
+    case "able_to_transact_now":
+    case "drawer_open":
+    case "healthy_idle":
+      return true;
+    default:
+      return false;
+  }
 }
 
 function getRecoveryReadinessFallback(status: TerminalRecoveryReadinessStatus) {
@@ -578,6 +718,12 @@ function getRecoveryReadinessFallback(status: TerminalRecoveryReadinessStatus) {
       return {
         description: "Healthy idle. Open a drawer and sign in before selling.",
         label: "Healthy idle",
+        toneClassName: "border-success/30 bg-success/10 text-success",
+      };
+    case "drawer_open":
+      return {
+        description: "Drawer is open. Sign in before selling.",
+        label: "Drawer open",
         toneClassName: "border-success/30 bg-success/10 text-success",
       };
     case "needs_cloud_repair":
@@ -666,7 +812,7 @@ function getTerminalCommandActionLabel(
     case "refresh_snapshots":
       return "Send snapshot refresh";
     case "retry_sync":
-      return "Send sync retry";
+      return "Retry terminal sync";
     case "report_diagnostics":
       return "Request diagnostics";
   }
@@ -685,10 +831,35 @@ function getTerminalCommandTitle(
     case "refresh_snapshots":
       return "Snapshot refresh";
     case "retry_sync":
-      return "Sync retry";
+      return "Terminal sync retry";
     case "report_diagnostics":
       return "Diagnostics request";
   }
+}
+
+function getTerminalCommandRecoverySummary(
+  commandType: NonNullable<TerminalRecoveryAction["commandType"]>,
+  status?: TerminalRecoveryActionStatus,
+) {
+  const commandName =
+    commandType === "clear_stale_drawer_authority"
+      ? "Drawer repair command"
+      : commandType === "retry_sync"
+        ? "Sync retry command"
+      : "Terminal repair command";
+  if (status === "verified") {
+    return `${commandName} was verified by the latest terminal check-in.`;
+  }
+  if (status === "waiting_for_check_in" || status === "completed") {
+    return `${commandName} completed locally. Waiting for a fresh terminal check-in before verification.`;
+  }
+  if (status === "claimed") {
+    return `${commandName} is running on this checkout station.`;
+  }
+  if (status === "pending") {
+    return `${commandName} is queued for this checkout station.`;
+  }
+  return undefined;
 }
 
 function getExpectedEvidenceSummary(
@@ -721,31 +892,9 @@ function getExpectedEvidenceSummary(
 function deriveRecoveryBlockers(
   summary: TerminalHealthClassificationInput,
 ): RecoveryBlockerWithCategory[] {
-  const blockers = (summary.attentionReasons ?? []).map((reason, index) =>
+  return (summary.attentionReasons ?? []).map((reason, index) =>
     deriveRecoveryBlockerFromReason(reason, index),
   );
-
-  if (summary.runtimeStatus?.staffAuthority?.status === "expired") {
-    blockers.push({
-      category: "terminal_required",
-      id: "staff-authority-expired",
-      status: "available",
-      summary:
-        "Staff authority expired. Sign in again at this checkout station before selling.",
-      title: "Staff authority expired",
-    });
-  } else if (summary.runtimeStatus?.staffAuthority?.status === "missing") {
-    blockers.push({
-      category: "terminal_required",
-      id: "staff-authority-missing",
-      status: "available",
-      summary:
-        "Staff authority missing. Sign in at this checkout station before selling.",
-      title: "Staff authority missing",
-    });
-  }
-
-  return blockers;
 }
 
 function deriveRecoveryBlockerFromReason(
@@ -843,11 +992,17 @@ function isSafeDuplicateDrawerOpen(summary: string) {
 }
 
 function isUnsafeManualReviewReason(summary: string) {
-  return MANUAL_REVIEW_EVENT_PATTERN.test(summary) || /authorization_failed|sync secret/i.test(summary);
+  return (
+    MANUAL_REVIEW_EVENT_PATTERN.test(summary) ||
+    /authorization_failed|sync secret/i.test(summary)
+  );
 }
 
 function normalizeSupportCopy(value?: string | null) {
   if (!value) return undefined;
+  if (/cloud conflict \S+ needs manual review before repair/i.test(value)) {
+    return "A cloud sync conflict needs manual review before support can repair this terminal.";
+  }
   if (isSafeDuplicateDrawerOpen(value)) {
     return "Duplicate drawer-open attempts can be resolved. No sales, payments, or inventory will be changed.";
   }

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts
@@ -35,6 +35,10 @@ export type TerminalRuntimeStatus = {
       | "stale_assertion"
       | string;
   };
+  appShell?: {
+    observedAt: number;
+    ready: boolean;
+  };
   appVersion?: string;
   browserInfo?: {
     language?: string;
@@ -67,6 +71,13 @@ export type TerminalRuntimeStatus = {
     expiresAt?: number;
     staffProfileId?: Id<"staffProfile"> | string;
     status: "expired" | "missing" | "ready" | "unknown" | string;
+  };
+  drawerAuthority?: {
+    cloudRegisterSessionId?: string;
+    localRegisterSessionId: string;
+    observedAt: number;
+    reason?: string;
+    status: "blocked" | "healthy" | string;
   };
   storeId?: Id<"store"> | string;
   sync: {
@@ -104,6 +115,14 @@ export type TerminalRuntimeStatus = {
     uploadableEventCount: number;
   };
   terminalId?: Id<"posTerminal"> | string;
+  activeRegisterSession?: {
+    cloudRegisterSessionId?: string;
+    localRegisterSessionId: string;
+    observedAt: number;
+    openedAt?: number;
+    registerNumber?: string;
+    status: "open" | "active" | "closing" | "closed" | string;
+  };
 };
 
 export type TerminalSyncEvent = {
@@ -158,7 +177,11 @@ export type TerminalSyncEvidence = {
 };
 
 export type TerminalHealthAttentionActionTarget =
-  | { registerSessionId: Id<"registerSession"> | string; type: "cash_control_register_session" }
+  | {
+      automaticRepairEligible?: boolean;
+      registerSessionId: Id<"registerSession"> | string;
+      type: "cash_control_register_session";
+    }
   | { type: "open_work" }
   | { type: "pos_register" }
   | { type: "pos_settings" };
@@ -188,6 +211,7 @@ export type TerminalHealthAttentionReason = {
 
 export type TerminalRecoveryReadinessStatus =
   | "able_to_transact_now"
+  | "drawer_open"
   | "healthy_idle"
   | "needs_cloud_repair"
   | "needs_manual_review"
@@ -290,12 +314,14 @@ export type TerminalRecoveryPreview = {
   };
   commandStatus?: {
     commandId?: string;
+    commandType?: TerminalRecoveryCommandType;
     label?: string;
     latestAcknowledgement?: string;
     status?: TerminalRecoveryActionStatus;
     verificationStatus?: TerminalRecoveryActionStatus;
   } | null;
   evidence?: {
+    activeRegisterSession?: boolean;
     freshRuntimeRequiredForAbleToTransactNow: true;
   };
   manualReview?: Array<{
@@ -326,7 +352,12 @@ export type TerminalRecoveryPreview = {
 export type TerminalHealthSummary = {
   attentionReasons?: TerminalHealthAttentionReason[];
   health?: "needs_attention" | "offline" | "online" | "stale" | "unknown" | string;
+  registerSessionLink?: {
+    registerSessionId: Id<"registerSession"> | string;
+    status: "active" | "open" | string;
+  } | null;
   recovery?: TerminalRecoveryPreview | null;
+  recoveryPreview?: TerminalRecoveryPreview | null;
   runtimeStatus: TerminalRuntimeStatus | null;
   syncEvidence: TerminalSyncEvidence;
   terminal: TerminalRecord;

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.test.ts
@@ -177,6 +177,7 @@ describe("terminalRecoveryCommands", () => {
 
     expect(result).toEqual({
       commandId: "command-1",
+      message: "Terminal evidence changed before this recovery command could run.",
       reason: "precondition_failed",
       status: "precondition_failed",
       type: "repair_terminal_seed",
@@ -453,6 +454,8 @@ describe("terminalRecoveryCommands", () => {
 
     expect(result).toEqual({
       commandId: "command-1",
+      message:
+        "Drawer repair expected a blocked drawer authority record, but this terminal no longer reported that same block.",
       reason: "unsafe_authority_state",
       status: "precondition_failed",
       type: "clear_stale_drawer_authority",

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.ts
@@ -556,12 +556,29 @@ function preconditionFailed(
   command: PosTerminalRecoveryCommand,
   reason: "precondition_failed" | "unsafe_authority_state" = "precondition_failed",
 ): PosTerminalRecoveryCommandResult {
+  const commandType = getCommandType(command) ?? "unknown_command";
+
   return {
     commandId: getCommandId(command),
+    message: getPreconditionFailureMessage(commandType, reason),
     reason,
     status: "precondition_failed",
-    type: getCommandType(command) ?? "unknown_command",
+    type: commandType,
   };
+}
+
+function getPreconditionFailureMessage(
+  commandType: string,
+  reason: "precondition_failed" | "unsafe_authority_state",
+) {
+  if (
+    commandType === "clear_stale_drawer_authority" &&
+    reason === "unsafe_authority_state"
+  ) {
+    return "Drawer repair expected a blocked drawer authority record, but this terminal no longer reported that same block.";
+  }
+
+  return "Terminal evidence changed before this recovery command could run.";
 }
 
 function getCommandId(command: PosTerminalRecoveryCommand) {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts
@@ -325,6 +325,20 @@ describe("terminalRuntimeStatus", () => {
     );
   });
 
+  it("reports app-shell readiness from the terminal runtime", () => {
+    const status = buildPosTerminalRuntimeStatus({
+      appShell: { ready: true },
+      clock: () => 2_000,
+      events: [],
+      source: "register",
+    });
+
+    expect(status.appShell).toEqual({
+      observedAt: 2_000,
+      ready: true,
+    });
+  });
+
   it("reports sale authority when the local terminal can transact now", () => {
     const status = buildPosTerminalRuntimeStatus({
       clock: () => 2_000,
@@ -350,6 +364,43 @@ describe("terminalRuntimeStatus", () => {
       transactionMode: "products_and_services",
     });
     expect(JSON.stringify(status.saleAuthority)).not.toContain("sync-secret");
+  });
+
+  it("reports support-safe active drawer evidence from the local register model", () => {
+    const status = buildPosTerminalRuntimeStatus({
+      activeRegisterSession: {
+        cloudRegisterSessionId: "cloud-register-1",
+        localRegisterSessionId: "local-register-1",
+        openedAt: 1_000,
+        registerNumber: "8",
+        status: "open",
+      },
+      clock: () => 2_000,
+      events: [],
+      source: "register",
+      staffAuthorityStatus: "ready",
+      terminalSeed: {
+        cloudTerminalId: "terminal-cloud-1",
+        displayName: "Front register",
+        provisionedAt: 1_000,
+        schemaVersion: 5,
+        storeId: "store-1",
+        syncSecretHash: "sync-secret-hash",
+        terminalId: "local-terminal-1",
+      },
+    });
+
+    expect(status.activeRegisterSession).toEqual({
+      cloudRegisterSessionId: "cloud-register-1",
+      localRegisterSessionId: "local-register-1",
+      observedAt: 2_000,
+      openedAt: 1_000,
+      registerNumber: "8",
+      status: "open",
+    });
+    expect(JSON.stringify(status.activeRegisterSession)).not.toContain(
+      "sync-secret",
+    );
   });
 
   it("reports uncertainty metadata as support-safe counts without exposing payload details", () => {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts
@@ -69,6 +69,8 @@ export type PosTerminalRuntimeStatusSource =
   ReportTerminalRuntimeStatusArgs["status"]["source"];
 export type PosTerminalRuntimeStatusPayload =
   ReportTerminalRuntimeStatusPayload & {
+    activeRegisterSession?: PosTerminalRuntimeActiveRegisterSessionDiagnostics;
+    appShell?: PosTerminalRuntimeAppShellDiagnostics;
     appSessionRecovery?: PosTerminalRuntimeAppSessionRecoveryDiagnostics;
   };
 export type PosTerminalRuntimeStatusSyncStatus =
@@ -99,7 +101,31 @@ export type PosTerminalRuntimeSnapshotReadiness = {
   serviceCatalogRefreshedAt?: number;
 };
 
+export type PosTerminalRuntimeActiveRegisterSessionInput = {
+  cloudRegisterSessionId?: string;
+  localRegisterSessionId: string;
+  openedAt?: number;
+  registerNumber?: string;
+  status: "open" | "active" | "closing" | "closed";
+};
+
+export type PosTerminalRuntimeActiveRegisterSessionDiagnostics =
+  PosTerminalRuntimeActiveRegisterSessionInput & {
+    observedAt: number;
+  };
+
+export type PosTerminalRuntimeAppShellInput = {
+  ready: boolean;
+};
+
+export type PosTerminalRuntimeAppShellDiagnostics =
+  PosTerminalRuntimeAppShellInput & {
+    observedAt: number;
+  };
+
 export type PosTerminalRuntimeStatusInput = {
+  activeRegisterSession?: PosTerminalRuntimeActiveRegisterSessionInput | null;
+  appShell?: PosTerminalRuntimeAppShellInput | null;
   appVersion?: string;
   appSessionRecovery?: PosTerminalRuntimeAppSessionRecoveryInput | null;
   browserInfo?: PosTerminalRuntimeBrowserInfo;
@@ -230,6 +256,36 @@ export function buildPosTerminalRuntimeStatus(
     ...(input.buildSha ? { buildSha: input.buildSha } : {}),
     ...(input.browserInfo ? { browserInfo: input.browserInfo } : {}),
     ...(appSessionRecovery ? { appSessionRecovery } : {}),
+    ...(input.appShell
+      ? {
+          appShell: {
+            observedAt: now,
+            ready: input.appShell.ready,
+          },
+        }
+      : {}),
+    ...(input.activeRegisterSession
+      ? {
+          activeRegisterSession: {
+            ...(input.activeRegisterSession.cloudRegisterSessionId
+              ? {
+                  cloudRegisterSessionId:
+                    input.activeRegisterSession.cloudRegisterSessionId,
+                }
+              : {}),
+            localRegisterSessionId:
+              input.activeRegisterSession.localRegisterSessionId,
+            observedAt: now,
+            ...(input.activeRegisterSession.openedAt
+              ? { openedAt: input.activeRegisterSession.openedAt }
+              : {}),
+            ...(input.activeRegisterSession.registerNumber
+              ? { registerNumber: input.activeRegisterSession.registerNumber }
+              : {}),
+            status: input.activeRegisterSession.status,
+          },
+        }
+      : {}),
     localStore: {
       available: !failureMessage,
       schemaVersion:

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   ingestLocalEvents: vi.fn(),
   listTerminalRecoveryCommands: vi.fn(),
   reportTerminalRuntimeStatus: vi.fn(),
+  refreshTerminalStaffAuthority: vi.fn(),
 }));
 
 vi.mock("convex/react", () => ({
@@ -19,6 +20,9 @@ vi.mock("convex/react", () => ({
     }
     if (mutation === "acknowledgeTerminalRecoveryCommand") {
       return mocks.acknowledgeTerminalRecoveryCommand;
+    }
+    if (mutation === "refreshTerminalStaffAuthority") {
+      return mocks.refreshTerminalStaffAuthority;
     }
     return mocks.ingestLocalEvents;
   },
@@ -42,6 +46,11 @@ vi.mock("~/convex/_generated/api", () => ({
         },
       },
     },
+    operations: {
+      staffCredentials: {
+        refreshTerminalStaffAuthority: "refreshTerminalStaffAuthority",
+      },
+    },
   },
 }));
 
@@ -59,6 +68,7 @@ import {
   writeReturnedLocalCloudMappings,
 } from "./usePosLocalSyncRuntime";
 import type {
+  PosDrawerAuthorityState,
   PosLocalEventRecord,
   PosTerminalIntegrityState,
 } from "./posLocalStore";
@@ -91,6 +101,10 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     mocks.acknowledgeTerminalRecoveryCommand.mockResolvedValue({
       kind: "ok",
       data: {},
+    });
+    mocks.refreshTerminalStaffAuthority.mockResolvedValue({
+      kind: "ok",
+      data: [],
     });
     Object.defineProperty(globalThis.navigator, "onLine", {
       configurable: true,
@@ -3905,6 +3919,193 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     expect(retry).toHaveBeenCalled();
   });
 
+  it("refreshes drawer authority before publishing the post-recovery check-in", async () => {
+    let drawerAuthority: PosDrawerAuthorityState | null = {
+      cloudRegisterSessionId: "register-cloud-1",
+      localRegisterSessionId: "register-local-1",
+      observedAt: 10,
+      reason: "cloud_closed",
+      status: "blocked",
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+    };
+    const command = buildRecoveryCommand({
+      commandContext: {
+        blockerReason: "cloud_closed",
+        cloudRegisterSessionId: "register-cloud-1",
+        localEventSettlement: "settled",
+        localRegisterSessionId: "register-local-1",
+      },
+      commandType: "clear_stale_drawer_authority",
+    });
+    const commandResult = { kind: "ok", data: [command] };
+    mocks.listTerminalRecoveryCommands.mockImplementation((args) =>
+      args === "skip" ? undefined : commandResult,
+    );
+    mocks.claimTerminalRecoveryCommand.mockResolvedValue({
+      kind: "ok",
+      data: command,
+    });
+    const store = {
+      ...buildRecoveryCommandStore(),
+      clearDrawerAuthorityState: vi.fn(async () => {
+        drawerAuthority = null;
+        return { ok: true, value: null };
+      }),
+      listEvents: vi.fn(async () => ({
+        ok: true,
+        value: [
+          buildLocalEvent({
+            localEventId: "event-open",
+            localRegisterSessionId: "register-local-1",
+            sequence: 1,
+            sync: { status: "synced" },
+            terminalId: "terminal-cloud-1",
+            type: "register.opened",
+          }),
+        ],
+      })),
+      listLocalCloudMappings: vi.fn(async () => ({
+        ok: true,
+        value: [
+          {
+            cloudId: "register-cloud-1",
+            cloudTable: "posSession",
+            createdAt: 1,
+            localId: "register-local-1",
+            localIdKind: "registerSession",
+            storeId: "store-1",
+            terminalId: "terminal-cloud-1",
+          },
+        ],
+      })),
+      readDrawerAuthorityState: vi.fn(async () => ({
+        ok: true,
+        value: drawerAuthority,
+      })),
+    };
+
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        mode: "status-only",
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.acknowledgeTerminalRecoveryCommand).toHaveBeenCalledWith({
+        commandId: "command-1",
+        message: undefined,
+        result: "completed",
+        storeId: "store-1",
+        syncSecretHash: "sync-secret-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+    await waitFor(() =>
+      expect(mocks.reportTerminalRuntimeStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: expect.not.objectContaining({
+            drawerAuthority: expect.objectContaining({ status: "blocked" }),
+          }),
+        }),
+      ),
+    );
+    expect(store.clearDrawerAuthorityState).toHaveBeenCalledWith({
+      localRegisterSessionId: "register-local-1",
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+    });
+  });
+
+  it("refreshes staff authority through the terminal recovery command path", async () => {
+    const command = buildRecoveryCommand({
+      commandType: "refresh_staff_authority",
+      expectedEvidence: {
+        staffAuthorityStatus: "ready",
+      },
+    });
+    const records = [
+      {
+        activeRoles: ["cashier"],
+        credentialId: "credential-1",
+        credentialVersion: 1,
+        displayName: "Ato K.",
+        expiresAt: Date.now() + 60_000,
+        issuedAt: Date.now(),
+        organizationId: "org-1",
+        refreshedAt: Date.now(),
+        staffProfileId: "staff-1",
+        status: "active",
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+        username: "ato",
+        verifier: {
+          algorithm: "PBKDF2-SHA256",
+          hash: "hash-1",
+          iterations: 120_000,
+          salt: "salt-1",
+          version: 1,
+        },
+      },
+    ];
+    mocks.listTerminalRecoveryCommands.mockImplementation((args) =>
+      args === "skip" ? undefined : { kind: "ok", data: [command] },
+    );
+    mocks.claimTerminalRecoveryCommand.mockResolvedValue({
+      kind: "ok",
+      data: command,
+    });
+    mocks.refreshTerminalStaffAuthority.mockResolvedValue({
+      kind: "ok",
+      data: records,
+    });
+    const store = {
+      ...buildRecoveryCommandStore(),
+      getStaffAuthorityReadiness: vi.fn(async () => ({
+        ok: true,
+        value: "ready",
+      })),
+      replaceStaffAuthoritySnapshot: vi.fn(async () => ({
+        ok: true,
+        value: records,
+      })),
+    };
+
+    renderHook(() =>
+      usePosLocalSyncRuntimeStatus({
+        mode: "status-only",
+        storeFactory: () => store as never,
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.refreshTerminalStaffAuthority).toHaveBeenCalledWith({
+        storeId: "store-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+    expect(store.replaceStaffAuthoritySnapshot).toHaveBeenCalledWith({
+      records,
+      storeId: "store-1",
+      terminalId: "terminal-cloud-1",
+    });
+    await waitFor(() =>
+      expect(mocks.acknowledgeTerminalRecoveryCommand).toHaveBeenCalledWith({
+        commandId: "command-1",
+        message: "Staff authority refreshed.",
+        result: "completed",
+        storeId: "store-1",
+        syncSecretHash: "sync-secret-1",
+        terminalId: "terminal-cloud-1",
+      }),
+    );
+  });
+
   it("acknowledges safe recovery precondition drift distinctly", async () => {
     const command = buildRecoveryCommand({
       commandContext: {
@@ -3946,7 +4147,8 @@ describe("usePosLocalSyncRuntimeStatus", () => {
     await waitFor(() =>
       expect(mocks.acknowledgeTerminalRecoveryCommand).toHaveBeenCalledWith({
         commandId: "command-1",
-        message: undefined,
+        message:
+          "Drawer repair expected a blocked drawer authority record, but this terminal no longer reported that same block.",
         result: "precondition_failed",
         storeId: "store-1",
         syncSecretHash: "sync-secret-1",

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -8,12 +8,15 @@ import {
   getInitialRuntimeBuildMetadata,
   readRuntimeBuildMetadata,
 } from "@/lib/runtimeBuildMetadata";
+import { readPosAppShellReadiness } from "@/offline/posAppShellReadiness";
+import { isLocalPinVerifierMetadata } from "@/lib/security/localPinVerifier";
 import {
   createIndexedDbPosLocalStorageAdapter,
   createPosLocalStore,
   type PosLocalCloudMapping,
   type PosDrawerAuthorityState,
   type PosLocalEventRecord,
+  type PosLocalStaffAuthorityRecord,
   type PosLocalStaffAuthorityReadiness,
   type PosLocalStoreResult,
   type PosTerminalIntegrityState,
@@ -35,6 +38,7 @@ import {
   readProjectedLocalRegisterModel,
   readScopedPosLocalEvents,
 } from "./localRegisterReader";
+import type { PosLocalCashDrawerReadModel } from "./registerReadModel";
 import {
   isPosLocalEventInTerminalScope,
   resolvePosLocalTerminalScope,
@@ -43,6 +47,8 @@ import {
   buildPosTerminalRuntimeCopyDiagnostics,
   buildPosTerminalRuntimeStatus,
   toReportablePosTerminalRuntimeStatus,
+  type PosTerminalRuntimeActiveRegisterSessionInput,
+  type PosTerminalRuntimeAppShellInput,
   type PosTerminalRuntimeAppSessionRecoveryInput,
   type PosTerminalRuntimeCopyDiagnostics,
   type PosTerminalRuntimeSnapshotReadiness,
@@ -156,9 +162,14 @@ export function usePosLocalSyncRuntimeStatus(input: {
   const acknowledgeTerminalRecoveryCommand = useMutation(
     api.pos.public.terminals.acknowledgeTerminalRecoveryCommand,
   );
+  const refreshTerminalStaffAuthority = useMutation(
+    api.operations.staffCredentials.refreshTerminalStaffAuthority,
+  );
   const [events, setEvents] = useState<PosLocalEventRecord[]>([]);
   const [runtimeReadiness, setRuntimeReadiness] =
     useState<PosTerminalRuntimeReadiness>({
+      activeRegisterSession: null,
+      appShell: null,
       drawerAuthority: null,
       snapshots: {},
       staffAuthorityStatus: "unknown",
@@ -283,6 +294,8 @@ export function usePosLocalSyncRuntimeStatus(input: {
         setEvents([]);
         setReadError(null);
         setRuntimeReadiness({
+          activeRegisterSession: null,
+          appShell: null,
           drawerAuthority: null,
           snapshots: {},
           staffAuthorityStatus: "unknown",
@@ -767,6 +780,8 @@ export function usePosLocalSyncRuntimeStatus(input: {
 
   const runtimeStatusInput = useMemo(
     () => ({
+      activeRegisterSession: runtimeReadiness.activeRegisterSession,
+      appShell: runtimeReadiness.appShell,
       appSessionRecovery: input.appSessionRecovery,
       appVersion: runtimeBuildMetadata.appVersion,
       buildSha: runtimeBuildMetadata.buildSha,
@@ -789,6 +804,8 @@ export function usePosLocalSyncRuntimeStatus(input: {
       input.staffAuthorityStatus,
       isOnline,
       readError,
+      runtimeReadiness.activeRegisterSession,
+      runtimeReadiness.appShell,
       runtimeBuildMetadata.appVersion,
       runtimeBuildMetadata.buildSha,
       runtimeReadiness.drawerAuthority,
@@ -1108,6 +1125,59 @@ export function usePosLocalSyncRuntimeStatus(input: {
       const localResult = await executeTerminalRecoveryCommand({
         command: claimResult.data,
         onRetrySync: requestRetry,
+        refreshStaffAuthority: async ({ storeId, terminalId }) => {
+          if (typeof store.replaceStaffAuthoritySnapshot !== "function") {
+            throw new Error("Local staff authority storage is unavailable.");
+          }
+
+          const result = await refreshTerminalStaffAuthority({
+            storeId: storeId as Id<"store">,
+            terminalId: terminalId as Id<"posTerminal">,
+          });
+          if (result.kind !== "ok") {
+            await store.replaceStaffAuthoritySnapshot({
+              records: [],
+              storeId,
+              terminalId,
+            });
+            throw new Error(
+              result.kind === "user_error"
+                ? result.error.message
+                : "Staff authority refresh failed.",
+            );
+          }
+
+          const records = result.data.flatMap((record) => {
+            if (record.status !== "active" && record.status !== "revoked") {
+              return [];
+            }
+            const verifier = record.verifier;
+            if (!isLocalPinVerifierMetadata(verifier)) {
+              return [];
+            }
+
+            const localRecord: PosLocalStaffAuthorityRecord = {
+              ...record,
+              status: record.status,
+              verifier,
+            };
+            return [localRecord];
+          });
+          const writeResult = await store.replaceStaffAuthoritySnapshot({
+            records,
+            storeId,
+            terminalId,
+          });
+          if (!writeResult.ok) {
+            throw new Error(writeResult.error.message);
+          }
+
+          return {
+            message: "Staff authority refreshed.",
+            refreshedAt: Date.now(),
+            status: "ready",
+          };
+        },
         store,
         storeId,
         terminalId: runtimeStatusTerminalId,
@@ -1144,6 +1214,18 @@ export function usePosLocalSyncRuntimeStatus(input: {
         }
       }
       if (isStale) return;
+
+      if (acknowledged.kind === "ok") {
+        const readiness = await refreshTerminalRuntimeReadiness({
+          store,
+          storeId,
+          terminalId: runtimeStatusTerminalId,
+          terminalSeed: runtimeReadiness.terminalSeed,
+        });
+        if (isStale) return;
+
+        setRuntimeReadiness(readiness);
+      }
 
       setDebug((current) => ({
         ...current,
@@ -1183,6 +1265,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
     onLocalEventsChanged,
     recoveryCommandRetryToken,
     recoveryCommands,
+    refreshTerminalStaffAuthority,
     requestRetry,
     runtimeReadiness.terminalSeed,
     runtimeStatusSyncSecretHash,
@@ -1236,6 +1319,8 @@ export function usePosLocalSyncRuntimeStatus(input: {
 }
 
 type PosTerminalRuntimeReadiness = {
+  activeRegisterSession: PosTerminalRuntimeActiveRegisterSessionInput | null;
+  appShell: PosTerminalRuntimeAppShellInput | null;
   drawerAuthority: PosDrawerAuthorityState | null;
   snapshots: PosTerminalRuntimeSnapshotReadiness;
   staffAuthorityStatus: PosLocalStaffAuthorityReadiness | "unknown";
@@ -1273,6 +1358,7 @@ async function refreshTerminalRuntimeReadiness(input: {
     availability,
     staffAuthority,
     terminalIntegrity,
+    appShell,
   ] = await Promise.all([
     store.readRegisterCatalogSnapshot
       ? store.readRegisterCatalogSnapshot({ storeId: input.storeId })
@@ -1295,6 +1381,7 @@ async function refreshTerminalRuntimeReadiness(input: {
           terminalId: input.terminalId,
         })
       : Promise.resolve({ ok: true as const, value: null }),
+    readPosAppShellReadiness(),
   ]);
   const localRegisterModel =
     input.terminalId && readDrawerAuthorityState
@@ -1331,6 +1418,13 @@ async function refreshTerminalRuntimeReadiness(input: {
   }
 
   return {
+    activeRegisterSession:
+      localRegisterModel.ok && localRegisterModel.value?.activeRegisterSession
+        ? toRuntimeActiveRegisterSession(
+            localRegisterModel.value.activeRegisterSession,
+          )
+        : null,
+    appShell,
     drawerAuthority: drawerAuthority.ok ? drawerAuthority.value : null,
     snapshots: {
       ...(catalog.ok && catalog.value
@@ -1346,6 +1440,20 @@ async function refreshTerminalRuntimeReadiness(input: {
     staffAuthorityStatus: staffAuthority.ok ? staffAuthority.value : "unknown",
     terminalIntegrity: terminalIntegrity.ok ? terminalIntegrity.value : null,
     terminalSeed: input.terminalSeed,
+  };
+}
+
+function toRuntimeActiveRegisterSession(
+  session: PosLocalCashDrawerReadModel,
+): PosTerminalRuntimeActiveRegisterSessionInput {
+  return {
+    ...(session.cloudRegisterSessionId
+      ? { cloudRegisterSessionId: session.cloudRegisterSessionId }
+      : {}),
+    localRegisterSessionId: session.localRegisterSessionId,
+    openedAt: session.openedAt,
+    ...(session.registerNumber ? { registerNumber: session.registerNumber } : {}),
+    status: session.status,
   };
 }
 

--- a/packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.test.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.test.ts
@@ -111,4 +111,21 @@ describe("formatPosReconciliationType", () => {
       }),
     ).toBe("Closeout variance review");
   });
+
+  it("detects closeout review items from review kind without parsing copy", () => {
+    expect(
+      isRegisterCloseoutReviewItem({
+        reviewKind: "register_closeout_variance",
+        summary: "Synced register closeout has a variance.",
+        type: "permission",
+      }),
+    ).toBe(true);
+    expect(
+      formatPosReconciliationType("permission", {
+        reviewKind: "duplicate_register_closeout",
+        summary: "This copy can change without changing the review category.",
+        type: "permission",
+      }),
+    ).toBe("Closeout variance review");
+  });
 });

--- a/packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts
+++ b/packages/athena-webapp/src/lib/pos/presentation/syncStatusPresentation.ts
@@ -8,12 +8,21 @@ export type PosSyncStatusKind =
 export type PosSyncStatusTone = "success" | "neutral" | "warning" | "danger";
 
 export type PosReconciliationItem = {
+  actionPolicy?: "apply_or_reject" | "override_or_reject" | "reject_only";
   createdAt?: number | null;
   expectedCash?: number | null;
   id?: string;
   localEventId?: string | null;
   countedCash?: number | null;
   notes?: string | null;
+  reviewKind?:
+    | "duplicate_register_closeout"
+    | "register_closeout_variance"
+    | "register_not_open_sale"
+    | "server_rejected"
+    | "service_customer_attribution"
+    | "staff_access"
+    | "unknown";
   sequence?: number | null;
   status?: string | null;
   summary?: string | null;
@@ -102,6 +111,13 @@ function normalizeStatus(status?: string | null): PosSyncStatusKind {
 }
 
 export function isRegisterCloseoutReviewItem(item: PosReconciliationItem) {
+  if (
+    item.reviewKind === "duplicate_register_closeout" ||
+    item.reviewKind === "register_closeout_variance"
+  ) {
+    return true;
+  }
+
   const localEventId = item.localEventId?.toLowerCase() ?? "";
   const summary = item.summary?.toLowerCase() ?? "";
 

--- a/packages/athena-webapp/src/offline/posAppShellReadiness.test.ts
+++ b/packages/athena-webapp/src/offline/posAppShellReadiness.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  readPosAppShellReadiness,
+  warmPosAppShellReadiness,
+} from "./posAppShellReadiness";
+
+describe("pos app-shell readiness", () => {
+  it("warms the POS app shell automatically when the cache is missing", async () => {
+    const handlers: Array<(event: MessageEvent) => void> = [];
+    let cacheReadCount = 0;
+    const cache = {
+      match: vi.fn(async () => {
+        cacheReadCount += 1;
+        return cacheReadCount > 1 ? ({} as Response) : null;
+      }),
+    };
+    const controller = {
+      postMessage: vi.fn((message: { id: string; type: string; url: string }) => {
+        expect(message.type).toBe("athena-pos-app-shell:warm");
+        expect(message.url).toBe(
+          "https://athena.test/wigclub/store/wigclub/pos/register",
+        );
+        handlers.forEach((handler) =>
+          handler({
+            data: {
+              id: message.id,
+              result: {
+                cacheName: "athena-pos-app-shell-v6",
+                cachedRequests: 2,
+              },
+              type: "athena-pos-app-shell:warm-complete",
+            },
+          } as MessageEvent),
+        );
+      }),
+    };
+    const win = {
+      caches: {
+        keys: vi
+          .fn()
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce(["athena-pos-app-shell-v6"]),
+        open: vi.fn(async () => cache),
+      },
+      clearTimeout: globalThis.clearTimeout.bind(globalThis),
+      location: {
+        hostname: "athena.test",
+        origin: "https://athena.test",
+        pathname: "/wigclub/store/wigclub/pos/terminals",
+        port: "",
+      },
+      navigator: {
+        serviceWorker: {
+          addEventListener: vi.fn(
+            (_type: string, handler: (event: MessageEvent) => void) => {
+              handlers.push(handler);
+            },
+          ),
+          controller,
+          removeEventListener: vi.fn(),
+        },
+      },
+      setTimeout: globalThis.setTimeout.bind(globalThis),
+    } as unknown as Window;
+
+    await expect(readPosAppShellReadiness({ win })).resolves.toEqual({
+      ready: true,
+    });
+    expect(controller.postMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("can read readiness without warming the app shell", async () => {
+    const controller = {
+      postMessage: vi.fn(),
+    };
+    const win = {
+      caches: {
+        keys: vi.fn(async () => []),
+      },
+      location: {
+        hostname: "athena.test",
+        origin: "https://athena.test",
+        pathname: "/wigclub/store/wigclub/pos/terminals",
+        port: "",
+      },
+      navigator: {
+        serviceWorker: {
+          controller,
+        },
+      },
+    } as unknown as Window;
+
+    await expect(
+      readPosAppShellReadiness({ warmIfMissing: false, win }),
+    ).resolves.toEqual({
+      ready: false,
+    });
+    expect(controller.postMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not fail when the page is not controlled by the app-shell service worker", async () => {
+    const win = {
+      location: {
+        hostname: "athena.test",
+        origin: "https://athena.test",
+        pathname: "/wigclub/store/wigclub/pos/terminals",
+        port: "",
+      },
+      navigator: {
+        serviceWorker: {},
+      },
+    } as unknown as Window;
+
+    await expect(warmPosAppShellReadiness({ win })).resolves.toBeNull();
+  });
+
+  it("does not mark local dev as needing app-shell recovery", async () => {
+    const controller = {
+      postMessage: vi.fn(),
+    };
+    const win = {
+      caches: {
+        keys: vi.fn(async () => []),
+      },
+      location: {
+        hostname: "localhost",
+        origin: "http://localhost:5173",
+        pathname: "/wigclub/store/wigclub/pos/terminals",
+        port: "5173",
+      },
+      navigator: {
+        serviceWorker: {
+          controller,
+        },
+      },
+    } as unknown as Window;
+
+    await expect(readPosAppShellReadiness({ win })).resolves.toEqual({
+      ready: true,
+    });
+    expect(controller.postMessage).not.toHaveBeenCalled();
+  });
+
+  it("warms through the active registration before the page has a controller", async () => {
+    const handlers: Array<(event: MessageEvent) => void> = [];
+    const activeWorker = {
+      postMessage: vi.fn((message: { id: string; type: string; url: string }) => {
+        handlers.forEach((handler) =>
+          handler({
+            data: {
+              id: message.id,
+              result: {
+                cacheName: "athena-pos-app-shell-v6",
+                cachedRequests: 2,
+              },
+              type: "athena-pos-app-shell:warm-complete",
+            },
+          } as MessageEvent),
+        );
+      }),
+    };
+    const win = {
+      clearTimeout: globalThis.clearTimeout.bind(globalThis),
+      location: {
+        hostname: "athena.test",
+        origin: "https://athena.test",
+        pathname: "/wigclub/store/wigclub/pos/terminals",
+        port: "",
+      },
+      navigator: {
+        serviceWorker: {
+          addEventListener: vi.fn(
+            (_type: string, handler: (event: MessageEvent) => void) => {
+              handlers.push(handler);
+            },
+          ),
+          controller: null,
+          ready: Promise.resolve({
+            active: activeWorker,
+          }),
+          removeEventListener: vi.fn(),
+        },
+      },
+      setTimeout: globalThis.setTimeout.bind(globalThis),
+    } as unknown as Window;
+
+    await expect(warmPosAppShellReadiness({ win })).resolves.toEqual({
+      cacheName: "athena-pos-app-shell-v6",
+      cachedRequests: 2,
+    });
+    expect(activeWorker.postMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/athena-webapp/src/offline/posAppShellReadiness.ts
+++ b/packages/athena-webapp/src/offline/posAppShellReadiness.ts
@@ -1,0 +1,211 @@
+import { POS_APP_SHELL_CACHE_PREFIX } from "./registerPosAppShellServiceWorker";
+
+export type PosAppShellReadiness = {
+  ready: boolean;
+};
+
+type PosAppShellWarmResult = {
+  cacheName: string;
+  cachedRequests: number;
+};
+
+export async function readPosAppShellReadiness(
+  input: {
+    orgUrlSlug?: string;
+    storeUrlSlug?: string;
+    warmIfMissing?: boolean;
+    win?: Window;
+  } = {},
+): Promise<PosAppShellReadiness> {
+  const targetWindow =
+    input.win ?? (typeof window === "undefined" ? undefined : window);
+  if (isLocalDevAppShellDisabled(targetWindow)) {
+    return { ready: true };
+  }
+
+  const warmIfMissing = input.warmIfMissing ?? true;
+  const readiness = await readCachedPosAppShellReadiness(input);
+
+  if (readiness.ready || !warmIfMissing) {
+    return readiness;
+  }
+
+  await warmPosAppShellReadiness(input);
+
+  return readCachedPosAppShellReadiness(input);
+}
+
+async function readCachedPosAppShellReadiness(
+  input: {
+    orgUrlSlug?: string;
+    storeUrlSlug?: string;
+    win?: Window;
+  } = {},
+): Promise<PosAppShellReadiness> {
+  const targetWindow =
+    input.win ?? (typeof window === "undefined" ? undefined : window);
+  const cacheStorage =
+    targetWindow?.caches ??
+    (typeof caches === "undefined" ? undefined : caches);
+
+  if (!cacheStorage) {
+    return { ready: false };
+  }
+
+  try {
+    const cacheNames = await cacheStorage.keys();
+    const shellCacheName = cacheNames.find((name) =>
+      name.startsWith(POS_APP_SHELL_CACHE_PREFIX),
+    );
+
+    if (!shellCacheName) {
+      return { ready: false };
+    }
+
+    const cache = await cacheStorage.open(shellCacheName);
+    const registerPath = resolveRegisterPath(input, targetWindow);
+    const cachedRegister =
+      registerPath && targetWindow
+        ? await cache.match(
+            new URL(registerPath, targetWindow.location.origin).toString(),
+            {
+              ignoreVary: true,
+            },
+          )
+        : null;
+    const cachedRoot = await cache.match("/", { ignoreVary: true });
+
+    return { ready: Boolean(cachedRegister || cachedRoot) };
+  } catch {
+    return { ready: false };
+  }
+}
+
+export async function warmPosAppShellReadiness(
+  input: {
+    orgUrlSlug?: string;
+    storeUrlSlug?: string;
+    timeoutMs?: number;
+    win?: Window;
+  } = {},
+): Promise<PosAppShellWarmResult | null> {
+  const targetWindow =
+    input.win ?? (typeof window === "undefined" ? undefined : window);
+  const serviceWorker = targetWindow?.navigator?.serviceWorker;
+  const registerPath = resolveRegisterPath(input, targetWindow);
+
+  if (!targetWindow || !serviceWorker || !registerPath) {
+    return null;
+  }
+
+  const win = targetWindow;
+  const sw = serviceWorker;
+  const messageTarget =
+    sw.controller ?? (await waitForActiveServiceWorker(sw, win));
+  if (!messageTarget) {
+    return null;
+  }
+
+  const id = `warm-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const url = new URL(registerPath, win.location.origin).toString();
+
+  try {
+    return await new Promise<PosAppShellWarmResult | null>((resolve) => {
+      const timeout = win.setTimeout(() => {
+        sw.removeEventListener("message", handleMessage);
+        resolve(null);
+      }, input.timeoutMs ?? 5_000);
+
+      function handleMessage(event: MessageEvent) {
+        const data = event.data;
+        if (!data || data.id !== id) return;
+
+        win.clearTimeout(timeout);
+        sw.removeEventListener("message", handleMessage);
+
+        if (data.type === "athena-pos-app-shell:warm-complete") {
+          resolve(toWarmResult(data.result));
+          return;
+        }
+
+        resolve(null);
+      }
+
+      sw.addEventListener("message", handleMessage);
+      messageTarget.postMessage({
+        type: "athena-pos-app-shell:warm",
+        id,
+        url,
+      });
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function waitForActiveServiceWorker(
+  serviceWorker: ServiceWorkerContainer,
+  win: Window,
+): Promise<ServiceWorker | null> {
+  if (!serviceWorker.ready) {
+    return null;
+  }
+
+  return new Promise<ServiceWorker | null>((resolve) => {
+    const timeout = win.setTimeout(() => resolve(null), 1_000);
+
+    serviceWorker.ready
+      .then((registration) => {
+        win.clearTimeout(timeout);
+        resolve(registration.active ?? null);
+      })
+      .catch(() => {
+        win.clearTimeout(timeout);
+        resolve(null);
+      });
+  });
+}
+
+function isLocalDevAppShellDisabled(win?: Window) {
+  const hostname = win?.location.hostname;
+  return (
+    (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]") &&
+    win?.location.port === "5173"
+  );
+}
+
+function toWarmResult(result: unknown): PosAppShellWarmResult | null {
+  if (!result || typeof result !== "object") return null;
+  const value = result as Partial<PosAppShellWarmResult>;
+
+  return typeof value.cacheName === "string" &&
+    typeof value.cachedRequests === "number"
+    ? {
+        cacheName: value.cacheName,
+        cachedRequests: value.cachedRequests,
+      }
+    : null;
+}
+
+function resolveRegisterPath(
+  input: {
+    orgUrlSlug?: string;
+    storeUrlSlug?: string;
+  },
+  win?: Window,
+) {
+  if (input.orgUrlSlug && input.storeUrlSlug) {
+    return `/${input.orgUrlSlug}/store/${input.storeUrlSlug}/pos/register`;
+  }
+
+  const segments = win?.location.pathname.split("/").filter(Boolean) ?? [];
+  const storeSegmentIndex = segments.indexOf("store");
+  const orgUrlSlug =
+    storeSegmentIndex > 0 ? segments[storeSegmentIndex - 1] : undefined;
+  const storeUrlSlug =
+    storeSegmentIndex >= 0 ? segments[storeSegmentIndex + 1] : undefined;
+
+  return orgUrlSlug && storeUrlSlug
+    ? `/${orgUrlSlug}/store/${storeUrlSlug}/pos/register`
+    : null;
+}

--- a/packages/athena-webapp/src/offline/registerPosAppShellServiceWorker.ts
+++ b/packages/athena-webapp/src/offline/registerPosAppShellServiceWorker.ts
@@ -1,5 +1,5 @@
 const POS_APP_SHELL_SERVICE_WORKER_URL = "/pos-app-shell-sw.js";
-const POS_APP_SHELL_CACHE_PREFIX = "athena-pos-app-shell-";
+export const POS_APP_SHELL_CACHE_PREFIX = "athena-pos-app-shell-";
 
 let registrationStarted = false;
 

--- a/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/opening.tsx
+++ b/packages/athena-webapp/src/routes/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/opening.tsx
@@ -1,11 +1,18 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { z } from "zod";
 
 import { DailyOpeningView } from "~/src/components/operations/DailyOpeningView";
+
+const dailyOpeningSearchSchema = z.object({
+  operatingDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  tab: z.enum(["blocked", "carry-forward", "ready", "review"]).optional(),
+});
 
 export const Route = createFileRoute(
   "/_authed/$orgUrlSlug/store/$storeUrlSlug/operations/opening",
 )({
   component: DailyOpeningRoute,
+  validateSearch: dailyOpeningSearchSchema,
 });
 
 function DailyOpeningRoute() {

--- a/scripts/deploy-qa-vps.test.ts
+++ b/scripts/deploy-qa-vps.test.ts
@@ -83,6 +83,8 @@ describe("VPS QA deploy contract", () => {
 
     expect(deployScript).toContain("athena-local");
     expect(deployScript).toContain("storefront-local");
+    expect(deployScript).toContain("convex-athena-local");
+    expect(deployScript).toContain("convex-storefront-local");
     expect(deployScript).toContain("full-prod-local");
     expect(deployScript).toContain("build_static_app_locally()");
     expect(deployScript).toContain("deploy_static_app_local()");
@@ -95,17 +97,29 @@ describe("VPS QA deploy contract", () => {
     expect(deployScript).toContain("deploy_storefront_local");
     expect(deployScript).toMatch(/athena\)\s+deploy_athena_local/);
     expect(deployScript).toMatch(
+      /convex-athena-local\)\s+deploy_convex_prod[\s\S]*deploy_athena_local[\s\S]*;;/,
+    );
+    expect(deployScript).toMatch(
+      /convex-storefront-local\)\s+deploy_convex_prod[\s\S]*deploy_storefront_local[\s\S]*;;/,
+    );
+    expect(deployScript).toMatch(
       /full-prod\)\s+require_remote_source[\s\S]*deploy_athena_local[\s\S]*deploy_storefront_local/,
     );
     expect(deployScript).toContain("athena-remote");
     expect(interactiveScript).toContain("athena-webapp local build");
     expect(interactiveScript).toContain("storefront local build");
+    expect(interactiveScript).toContain("convex + athena local build");
+    expect(interactiveScript).toContain("convex + storefront local build");
     expect(interactiveScript).toContain("full-deploy local builds");
     expect(interactiveScript).toContain("deploy_vps athena-local");
     expect(interactiveScript).toContain("deploy_vps storefront-local");
+    expect(interactiveScript).toContain("deploy_vps convex-athena-local");
+    expect(interactiveScript).toContain("deploy_vps convex-storefront-local");
     expect(interactiveScript).toContain("deploy_vps full-prod-local");
     expect(runbook).toContain("scripts/deploy-vps.sh athena-local");
     expect(runbook).toContain("scripts/deploy-vps.sh storefront-local");
+    expect(runbook).toContain("scripts/deploy-vps.sh convex-athena-local");
+    expect(runbook).toContain("scripts/deploy-vps.sh convex-storefront-local");
     expect(runbook).toContain("scripts/deploy-vps.sh full-prod-local");
   });
 

--- a/scripts/deploy-vps.sh
+++ b/scripts/deploy-vps.sh
@@ -40,6 +40,10 @@ Commands:
   qa-athena         Refresh the Athena admin QA dev server.
   qa-storefront     Refresh the storefront QA dev server.
   convex-prod       Deploy Convex from the local checkout.
+  convex-athena-local
+                    Deploy Convex plus a locally built Athena admin app.
+  convex-storefront-local
+                    Deploy Convex plus a locally built storefront.
   full-prod         Deploy Convex, locally built static apps, and Valkey proxy.
   full-prod-local   Alias for full-prod.
   all               Deploy full-prod with local builds and refresh QA.
@@ -836,6 +840,14 @@ case "$command" in
     ;;
   convex-prod)
     deploy_convex_prod
+    ;;
+  convex-athena-local)
+    deploy_convex_prod
+    deploy_athena_local
+    ;;
+  convex-storefront-local)
+    deploy_convex_prod
+    deploy_storefront_local
     ;;
   full-prod)
     require_remote_source "$REMOTE_REPO" "$REMOTE_SOURCE_DIR" "$DEPLOY_REF"


### PR DESCRIPTION
## Summary
- separates POS sales readiness, support recovery, and offline diagnostics so healthy terminals do not inherit stale repair-command outcomes
- reuses the same terminal recovery preview across roster and detail views, including active register-session and app-shell evidence
- classifies register-session review actions with durable review-kind policy and documents the boundary in docs/solutions

## Validation
- bun run pr:athena
- focused terminal, runtime, register review, operations, expense, sync presentation, and deploy-script suites passed during delivery

## Notes
- Browser validation intentionally left to the user per request.
- No production deploy is included in this PR.