### PR TITLE
[V26-744,V26-745,V26-746,V26-747,V26-748]: Decouple POS runtime boundaries

### DIFF
--- a/docs/plans/2026-06-15-001-refactor-pos-runtime-decoupling-plan.html
+++ b/docs/plans/2026-06-15-001-refactor-pos-runtime-decoupling-plan.html
@@ -1,0 +1,373 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>refactor: Decouple the POS Runtime</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #172026;
+      --muted: #5d6972;
+      --line: #d7dee3;
+      --panel: #f7f9fa;
+      --accent: #176c5f;
+      --accent-soft: #e5f3ef;
+      --warn: #8a5a00;
+      --warn-soft: #fff4da;
+      --risk: #9f2f2f;
+      --risk-soft: #fae8e7;
+      --code: #0f2f2b;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: var(--ink);
+      background: #ffffff;
+      line-height: 1.5;
+    }
+
+    main {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 32px 24px 56px;
+    }
+
+    header {
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 22px;
+      margin-bottom: 28px;
+    }
+
+    h1 {
+      margin: 0 0 10px;
+      font-size: clamp(30px, 5vw, 48px);
+      line-height: 1.05;
+      letter-spacing: 0;
+    }
+
+    h2 {
+      margin: 34px 0 12px;
+      font-size: 22px;
+      line-height: 1.2;
+      letter-spacing: 0;
+    }
+
+    h3 {
+      margin: 24px 0 10px;
+      font-size: 17px;
+      line-height: 1.3;
+      letter-spacing: 0;
+    }
+
+    p, li {
+      font-size: 15px;
+    }
+
+    p {
+      margin: 0 0 14px;
+    }
+
+    ul {
+      margin: 10px 0 18px;
+      padding-left: 22px;
+    }
+
+    li + li {
+      margin-top: 6px;
+    }
+
+    code {
+      color: var(--code);
+      background: #eef4f2;
+      border: 1px solid #d9e7e2;
+      border-radius: 4px;
+      padding: 1px 4px;
+      font-size: 0.93em;
+    }
+
+    .meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 14px;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      min-height: 28px;
+      padding: 4px 10px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      color: var(--muted);
+      font-size: 13px;
+      background: #fff;
+    }
+
+    .summary {
+      display: grid;
+      grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
+      gap: 18px;
+      margin: 20px 0 28px;
+    }
+
+    .panel {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--panel);
+      padding: 18px;
+    }
+
+    .panel h2:first-child,
+    .panel h3:first-child {
+      margin-top: 0;
+    }
+
+    .callout {
+      border-left: 4px solid var(--accent);
+      background: var(--accent-soft);
+      padding: 14px 16px;
+      margin: 18px 0;
+    }
+
+    .risk {
+      border-color: var(--risk);
+      background: var(--risk-soft);
+    }
+
+    .warn {
+      border-color: var(--warn);
+      background: var(--warn-soft);
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 14px;
+      margin-top: 14px;
+    }
+
+    .unit {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 14px;
+      background: #ffffff;
+    }
+
+    .unit h3 {
+      margin-top: 0;
+    }
+
+    .deps {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 16px;
+      background: #ffffff;
+      overflow-x: auto;
+    }
+
+    .deps svg {
+      min-width: 820px;
+      width: 100%;
+      height: auto;
+      display: block;
+    }
+
+    .node {
+      fill: #ffffff;
+      stroke: #839199;
+      stroke-width: 1.5;
+    }
+
+    .node.primary {
+      fill: var(--accent-soft);
+      stroke: var(--accent);
+    }
+
+    .edge {
+      stroke: #839199;
+      stroke-width: 1.7;
+      fill: none;
+      marker-end: url(#arrow);
+    }
+
+    .label {
+      font-size: 13px;
+      fill: var(--ink);
+      text-anchor: middle;
+      dominant-baseline: middle;
+    }
+
+    .small {
+      font-size: 13px;
+      color: var(--muted);
+    }
+
+    @media (max-width: 760px) {
+      main {
+        padding: 24px 16px 42px;
+      }
+
+      .summary,
+      .grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>refactor: Decouple the POS Runtime</h1>
+      <p>Focused plan for splitting the current POS browser runtime and Terminal Health recovery paths while preserving cashier continuity and existing runtime contracts.</p>
+      <div class="meta">
+        <span class="pill">type: refactor</span>
+        <span class="pill">status: active</span>
+        <span class="pill">date: 2026-06-15</span>
+        <span class="pill">worktree: codex/pos-runtime-decoupling</span>
+      </div>
+    </header>
+
+    <section class="summary">
+      <div class="panel">
+        <h2>What changes</h2>
+        <p>The public runtime facade stays stable, while readiness sensing, sync draining, drawer-authority reconciliation, runtime status publication, recovery command execution, staff authority refresh, runtime-status side effects, and Terminal Health presentation move into explicit modules.</p>
+        <p>The plan also splits detail-only Terminal Health work out of roster rows without splitting the truth operators see.</p>
+      </div>
+      <div class="panel">
+        <h2>What stays fixed</h2>
+        <ul>
+          <li>Local-first POS sales continue through check-in and support failures.</li>
+          <li>Runtime check-ins stay latest-wins serialized.</li>
+          <li>Recovery commands verify through fresh runtime evidence.</li>
+          <li>Remote Assist presence does not grant POS authority.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section>
+      <h2>Core Boundary</h2>
+      <div class="callout">
+        <p><strong>Sales readiness, support recovery, and diagnostic evidence remain separate.</strong> Terminal Health should treat <code>TerminalRecoveryPreview</code> as the primary recovery source of truth, while raw fallback paths exist only for older or partial responses.</p>
+      </div>
+    </section>
+
+    <section>
+      <h2>Dependency Shape</h2>
+      <div class="deps" role="img" aria-label="Implementation dependency graph">
+        <svg viewBox="0 0 920 420" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <marker id="arrow" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto" markerUnits="strokeWidth">
+              <path d="M0,0 L10,4 L0,8 Z" fill="#839199"></path>
+            </marker>
+          </defs>
+          <rect class="node primary" x="30" y="50" width="160" height="58" rx="8"></rect>
+          <text class="label" x="110" y="79">U1 Readiness</text>
+          <rect class="node" x="250" y="20" width="180" height="58" rx="8"></rect>
+          <text class="label" x="340" y="49">U2 Sync drain</text>
+          <rect class="node" x="250" y="112" width="180" height="58" rx="8"></rect>
+          <text class="label" x="340" y="141">U3 Publisher</text>
+          <rect class="node" x="490" y="92" width="190" height="58" rx="8"></rect>
+          <text class="label" x="585" y="121">U4 Commands + staff</text>
+          <rect class="node" x="490" y="188" width="190" height="58" rx="8"></rect>
+          <text class="label" x="585" y="217">U5 Server effects</text>
+          <rect class="node" x="730" y="188" width="160" height="58" rx="8"></rect>
+          <text class="label" x="810" y="217">U6 Health split</text>
+          <rect class="node" x="730" y="284" width="160" height="58" rx="8"></rect>
+          <text class="label" x="810" y="313">U7 Presentation</text>
+          <rect class="node primary" x="330" y="316" width="210" height="58" rx="8"></rect>
+          <text class="label" x="435" y="345">U8 Facade + validation</text>
+
+          <path class="edge" d="M190 74 C215 62 225 52 250 49"></path>
+          <path class="edge" d="M190 85 C220 110 225 135 250 141"></path>
+          <path class="edge" d="M430 141 C455 135 465 126 490 121"></path>
+          <path class="edge" d="M430 150 C470 178 465 207 490 217"></path>
+          <path class="edge" d="M680 217 L730 217"></path>
+          <path class="edge" d="M810 246 L810 284"></path>
+          <path class="edge" d="M110 108 C130 270 245 342 330 345"></path>
+          <path class="edge" d="M340 78 C330 178 350 273 390 316"></path>
+          <path class="edge" d="M340 170 C355 238 385 285 420 316"></path>
+          <path class="edge" d="M585 150 C565 222 520 278 470 316"></path>
+          <path class="edge" d="M730 313 C660 340 600 350 540 345"></path>
+        </svg>
+      </div>
+    </section>
+
+    <section>
+      <h2>Implementation Units</h2>
+      <div class="grid">
+        <article class="unit">
+          <h3>U1 Readiness sensing</h3>
+          <p>Extract local readiness observation from <code>usePosLocalSyncRuntime.ts</code> into <code>runtimeReadiness.ts</code>, without upload or publish side effects.</p>
+        </article>
+        <article class="unit">
+          <h3>U2 Sync drain coordinator</h3>
+          <p>Own upload scheduling, retry timing, status-only behavior, and append-triggered uploads behind a focused coordinator.</p>
+        </article>
+        <article class="unit">
+          <h3>U3 Runtime status publisher</h3>
+          <p>Preserve serialized latest-wins publication, payload signatures, and best-effort failure handling in a tested publisher module.</p>
+        </article>
+        <article class="unit">
+          <h3>U4 Commands + staff authority</h3>
+          <p>Extract recovery command orchestration and centralize redacted staff-authority refresh/write behavior by context.</p>
+        </article>
+        <article class="unit">
+          <h3>U5 Server side effects</h3>
+          <p>Name and test runtime-status side effects: command verification, Remote Assist presence, and session claims after accepted check-in.</p>
+        </article>
+        <article class="unit">
+          <h3>U6 Terminal Health split</h3>
+          <p>Make roster cheaper while sharing recovery/readiness classification rules with detail views.</p>
+        </article>
+        <article class="unit">
+          <h3>U7 Preview-first presentation</h3>
+          <p>Make <code>TerminalRecoveryPreview</code> primary in frontend presentation, with legacy fallback only when preview is absent.</p>
+        </article>
+        <article class="unit">
+          <h3>U8 Facade + validation</h3>
+          <p>Reassemble the facade, run focused tests, rebuild graph knowledge, and use <code>bun run pr:athena</code> as the final integration gate.</p>
+        </article>
+      </div>
+    </section>
+
+    <section>
+      <h2>Operator Contract</h2>
+      <div class="panel">
+        <p>Terminal Health list and detail must preserve the same terminal identity, runtime freshness, recovery readiness, current safe action category, latest command state, and local sync evidence classification.</p>
+        <p>Command acknowledgement remains an intermediate state: operators see that the terminal ran the helper, but the terminal is not called recovered until fresh runtime proof verifies the expected evidence.</p>
+        <p>Roster optimization is limited to avoiding detail-only command/action work in rows. List-visible recovery fields still include readiness, action category, duplicate-disable command state, verification state, and sync classification.</p>
+        <p>Post-status server side effects are isolated: accepted runtime status stays accepted, command verification still runs, and Remote Assist failures remain diagnostics.</p>
+      </div>
+    </section>
+
+    <section>
+      <h2>High-Risk Checks</h2>
+      <div class="callout risk">
+        <ul>
+          <li>Runtime check-in conflicts must not return.</li>
+          <li>Status-only pages must not start upload drains.</li>
+          <li>Command acknowledgement must not masquerade as verified health.</li>
+          <li>Roster optimization must not contradict detail recovery state.</li>
+          <li>Staff authority helper must classify refresh results before changing local clearing behavior.</li>
+          <li>Staff authority helper must not leak proof/PIN material or clear authority on generic failures.</li>
+          <li>Remote Assist runtime host drain ownership must stay explicit so extraction does not create duplicate or missing upload schedulers.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section>
+      <h2>Validation</h2>
+      <p>Focused coverage should center on runtime extraction tests, terminal command runtime tests, staff authority classifier/helper tests, drawer-authority reconciliation tests, Terminal Health server/presentation parity tests, Remote Assist side-effect tests, and existing facade/consumer tests.</p>
+      <div class="callout warn">
+        <p>After code changes, run <code>bun run graphify:rebuild</code>. Before merge or PR handoff, run <code>bun run pr:athena</code>.</p>
+      </div>
+      <p class="small">See the markdown plan for full file lists and scenario-level validation details.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/plans/2026-06-15-001-refactor-pos-runtime-decoupling-plan.md
+++ b/docs/plans/2026-06-15-001-refactor-pos-runtime-decoupling-plan.md
@@ -1,0 +1,587 @@
+---
+title: "refactor: Decouple the POS Runtime"
+type: refactor
+status: active
+date: 2026-06-15
+---
+
+# refactor: Decouple the POS Runtime
+
+## Summary
+
+Decouple the current POS browser runtime into focused, testable runtime modules while preserving the existing `usePosLocalSyncRuntimeStatus` contract for consumers. The work should keep cashier continuity, local-first sales, runtime status publication, terminal recovery commands, Terminal Health, and Remote Assist presence behavior intact, but reduce the amount of responsibility concentrated in `usePosLocalSyncRuntime.ts` and the terminal health query path.
+
+The end state is a smaller runtime facade backed by explicit units for readiness sensing, local sync draining, runtime status publication, terminal recovery command execution, staff authority refresh, runtime-status side effects, and Terminal Health presentation/listing behavior.
+
+---
+
+## Problem Frame
+
+Recent POS runtime work landed the right capabilities, but the runtime now has too many cross-cutting responsibilities in one browser hook and too much health/recovery assembly concentrated in shared query paths. That increases the risk of regressions when changing one responsibility: a sync-drain tweak can affect runtime check-ins, a recovery command tweak can affect cashier authority refresh, a Terminal Health list optimization can drift from detail behavior, and a presentation fallback can accidentally override the server's recovery preview.
+
+The audit found the same theme across code, prior sessions, and solution docs: Athena should keep sales readiness, support recovery, and diagnostic evidence separate. Runtime status is evidence, not command authority. Recovery command acknowledgement is execution evidence, not proof that a terminal is healthy. Staff and sale authority should stay distinct from local event-log state. Terminal Health should use `TerminalRecoveryPreview` as the recovery source of truth.
+
+This plan makes those boundaries explicit and moves the implementation toward smaller modules without changing the product behavior operators rely on.
+
+---
+
+## Requirements
+
+### Runtime Contract and Continuity
+
+- R1. Preserve the public browser runtime contract used by POS register and Remote Assist consumers while moving implementation details out of `usePosLocalSyncRuntime.ts`.
+- R2. Keep POS local-first continuity intact: runtime check-in failures, recovery command failures, Terminal Health diagnostics, and support presence must not block local sale creation or local upload unless an existing sale/drawer/staff authority gate already does.
+- R3. Preserve serialized latest-wins runtime status publication so overlapping `reportTerminalRuntimeStatus` calls do not reintroduce Convex document conflicts.
+- R4. Preserve status-only behavior: route entry can publish runtime presence/evidence, but must not start upload drains or retry loops until upload is enabled or a local append creates work.
+
+### Recovery and Authority Boundaries
+
+- R5. Preserve terminal recovery command lifecycle: the browser runtime claims and executes allow-listed local commands, acknowledges execution, and command verification remains tied to a fresh runtime status check-in rather than acknowledgement alone.
+- R6. Keep sales readiness, support recovery, and diagnostic evidence separate. `TerminalRecoveryPreview` should be the primary support-recovery source of truth, with raw-fact fallback only for legacy or absent preview data.
+- R8. Unify terminal staff-authority refresh/write behavior across the opening guard, cashier auth dialog, and recovery command runtime without leaking PIN/proof material or treating generic failures as authority revocation.
+
+### Support Surfaces and Diagnostics
+
+- R7. Reduce Terminal Health roster cost by removing detail-only command/action work from list rows while keeping list/detail recovery semantics and visible roster fields consistent.
+- R9. Keep Remote Assist modeled as browser-client presence and session orchestration. POS terminal runtime is the first adapter, but support presence must not grant POS sale, drawer, staff, or manager authority.
+- R10. Preserve existing diagnostic and support visibility signals, including runtime payload redaction, safe check-in failure handling, command status visibility, and local sync evidence.
+
+---
+
+## Scope Boundaries
+
+- This plan does not add arbitrary remote control, remote shell, free-form command execution, or a new Remote Assist transport.
+- This plan does not change cashier-facing sale authority rules, drawer authority rules, manager review ownership, payment handling, or inventory movement semantics.
+- This plan does not change staff authorization business rules, but it does tighten local staff-authority persistence semantics so generic refresh failures are not treated as revocation.
+- This plan does not clear review evidence as an optimization. Blockers that represent business facts remain review evidence.
+- This plan does not change production deployment posture or require a live terminal audit.
+- This plan does not modify unrelated root checkout changes. The implementation should stay inside the delivery worktree.
+
+### Deferred to Follow-Up Work
+
+- Fleet-level Terminal Health pagination or virtualization if the list/detail split shows more scaling work is needed.
+- Broader non-POS Remote Assist runtime adapters after the POS browser-client adapter is stable.
+- Runtime telemetry dashboards or alerting beyond existing status and support views.
+- A separate product runbook for support operators after implementation proves the final surface.
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts` currently owns local runtime sensing, sync drain scheduling, status-only triggers, runtime payload construction, serialized check-in publication, recovery command polling/claim/execution/acknowledgement, staff authority refresh, and several local integrity/authority repair helpers.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts` already contains runtime payload typing and runtime status helpers that should stay near publication concerns.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/syncScheduler.ts` and `packages/athena-webapp/src/lib/pos/infrastructure/local/syncContract.ts` already isolate lower-level sync mechanics that a drain coordinator can call instead of duplicating.
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.ts` already contains local command executors and should remain the command implementation boundary.
+- `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts` and `packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.tsx` consume the runtime hook and should not need to learn about the extracted modules.
+- `packages/athena-webapp/convex/pos/public/terminals.ts` reports terminal runtime status and currently performs several post-check-in side effects, including command verification and Remote Assist presence/session updates.
+- `packages/athena-webapp/convex/pos/application/queries/terminals.ts` builds terminal list and detail health summaries, including runtime evidence, sync evidence, active register links, command status, and recovery preview.
+- `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts` presents server health/recovery data but still has raw fallback classification paths that can outrank or duplicate preview semantics.
+- `packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx` and `packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx` both refresh/write terminal staff authority locally with related but not identical behavior.
+
+### Institutional Learnings
+
+- `docs/solutions/architecture/athena-pos-terminal-recovery-readiness-boundary-2026-06-14.md` establishes the most important boundary: sales readiness, support recovery, and diagnostic evidence are separate, and `TerminalRecoveryPreview` is the server source of truth for support recovery.
+- `docs/solutions/architecture/athena-pos-remote-terminal-health-recovery-2026-06-11.md` establishes that terminal recovery is orchestration, not server-side force-clear. The matching terminal performs local repair and fresh runtime check-in verifies completion.
+- `docs/solutions/architecture/athena-remote-assist-foundation-2026-06-11.md` and `docs/solutions/architecture/athena-remote-assist-runtime-surface-transport-2026-06-13.md` keep Remote Assist as browser-client presence/session orchestration rather than POS authority.
+- `docs/solutions/architecture/athena-pos-local-first-entry-readiness-2026-05-14.md` and `docs/solutions/architecture/athena-pos-local-first-sync-2026-05-13.md` keep POS entry and sync local-first so browser-local sales survive cloud and status-reporting failures.
+- `docs/solutions/logic-errors/athena-pos-stale-terminal-sale-block-2026-05-29.md` keeps sale authority separate from event-log state.
+- `docs/solutions/logic-errors/athena-pos-terminal-review-reason-reconciliation-2026-05-26.md` keeps Terminal Health grounded in both browser runtime and cloud sync evidence, without deriving detail solely from cloud conflict counts.
+- `docs/solutions/architecture/athena-terminal-scoped-cashier-presence-2026-06-04.md` treats cashier presence as continuity evidence, not drawer, sale, manager, or staff authority.
+
+### Prior Session Signals
+
+Recent session history reinforced three constraints that should shape implementation:
+
+- `usePosLocalSyncRuntime.ts` is the primary decoupling target because it became the integration point for readiness reads, sync draining, runtime check-ins, recovery command execution, staff/authority refresh, and Remote Assist presence.
+- Runtime check-ins previously produced Convex document conflicts when overlapping publishes raced. The preserved invariant is client-side serialization with a queued latest changed payload, not a server rewrite.
+- Terminal command verification should stay command queue -> terminal poll/claim -> browser-local execution -> acknowledgement -> fresh runtime proof. Runtime status is evidence; command acknowledgement is not terminal health.
+
+### External References
+
+External research was not needed. This plan depends on repo-local Convex patterns, Athena POS local store behavior, browser runtime effects, and existing solution docs.
+
+---
+
+## Key Technical Decisions
+
+- Keep `usePosLocalSyncRuntimeStatus` as the public facade first, then extract responsibilities behind it. This avoids widening the change to register, Remote Assist, and shell consumers while still shrinking the high-risk implementation file.
+- Extract behavior by responsibility, not by call stack. Readiness sensing, local sync draining, runtime status publication, recovery command runtime, staff-authority refresh, and presentation should each own one reason to change.
+- Preserve the latest-wins publisher as a named module with focused tests. That queue is a production-safety invariant, and moving it without tests would risk reintroducing runtime-status write conflicts.
+- Treat status-only runtime as a distinct mode in the drain coordinator. A terminal can publish presence/readiness while avoiding upload drains until the POS app explicitly enables them or local writes create upload work.
+- Keep command verification server-owned and evidence-based. Browser acknowledgement records execution result; server verification still waits for a runtime check-in whose evidence matches the expected command outcome.
+- Make the recovery preview primary in frontend presentation while keeping raw fallback compatibility. This preserves older or partial responses without allowing fallback heuristics to override explicit server readiness.
+- Split Terminal Health roster cost without forking recovery semantics. List and detail can differ in payload depth, but they should share readiness classification and preview construction rules so operators do not see contradictory states.
+- Extract server post-runtime-status side effects into named helpers without changing authority boundaries. Remote Assist presence/session updates and command verification should still happen only after a successful authorized runtime status report.
+- Centralize staff-authority refresh/write behavior with context-aware inputs. Cashier auth can handle proof-scoped material, while background and recovery paths must stay redacted and should not clear local authority on generic network or authorization failures.
+
+---
+
+## Planning Decisions and Open Questions
+
+### Planning Decisions
+
+- Should this be a new Remote Assist control feature? No. The plan is a runtime decoupling and optimization pass. Existing Remote Assist presence/session behavior is preserved but not expanded into control transport.
+- Should implementation start by rewriting all consumers to new modules? No. The safer path is a stable facade with internal extraction and characterization tests.
+- Should Terminal Health optimize list behavior by removing recovery preview semantics from roster rows? No. The list can reduce expensive detail payloads, but visible recovery semantics must stay consistent with detail.
+- Should check-in failure block local POS sale or local upload? No. Check-in failure remains diagnostic/support evidence unless an existing local authority gate independently blocks sale.
+- Should command acknowledgement mark the blocker resolved? No. Fresh runtime proof remains the verification boundary.
+
+### Deferred to Implementation
+
+- Exact module names can adapt to local conventions, but the intended boundaries are explicit in the implementation units.
+- The exact internal shape of a lightweight Terminal Health roster DTO can be refined once tests pin the fields the roster and detail views need. The optimization scope is limited to avoiding detail-only command/action work in roster rows; new public queries/validators should be added only if existing tests or measured query cost prove the internal builder split is insufficient. Pagination, virtualization, and fleet-level query redesign stay deferred.
+- Staff-authority refresh clearing depends on the current response taxonomy from the authority query. Defining the response taxonomy or helper-level classifier is a prerequisite for U4: explicit `authoritative_empty`/`revoked` states clear local authority; caller/session/transport/precondition failures never clear and become diagnostics.
+
+---
+
+## High-Level Technical Design
+
+> This is directional guidance for review. It describes the intended boundaries and data flow, not implementation code.
+
+```mermaid
+flowchart LR
+  Facade["usePosLocalSyncRuntimeStatus facade"]
+  Ready["Runtime readiness sensing"]
+  Drain["Local sync drain coordinator"]
+  Publish["Runtime status publisher"]
+  Commands["Recovery command runtime"]
+  Staff["Staff authority refresh helper"]
+  Convex["Convex terminal runtime endpoints"]
+  SideEffects["Post-status side effects"]
+  Health["Terminal Health queries"]
+  Present["Terminal health presentation"]
+
+  Facade --> Ready
+  Facade --> Drain
+  Facade --> Publish
+  Facade --> Commands
+  Commands --> Staff
+  Publish --> Convex
+  Commands --> Convex
+  Convex --> SideEffects
+  SideEffects --> Health
+  Health --> Present
+```
+
+The browser facade remains the integration point for current consumers, but the responsibilities behind it become explicit modules with focused tests. Server runtime endpoints keep the current authority model and side effects, but move orchestration into named helpers. Terminal Health keeps shared recovery semantics across roster and detail while allowing list payloads to avoid unnecessary detail work.
+
+---
+
+## Terminal Health Operator Contract
+
+The refactor should keep Terminal Health useful for support operators without adding new product surface area.
+
+### List and Detail Field Contract
+
+| Field | List row | Detail view | Fallback behavior | Parity expectation |
+| --- | --- | --- | --- | --- |
+| Terminal identity and store scope | Visible | Visible | Do not render cross-store data | Same terminal/store identity |
+| Runtime freshness and online/offline signal | Visible summary | Full runtime evidence | Show stale/unknown if missing | Same freshness classification |
+| Recovery readiness | Visible label | Full preview | Use raw fallback only when preview absent | Same readiness value |
+| Current safe action | Visible action category and disabled reason | Full action controls | Hide/disable when preconditions missing | Same action category |
+| Command status | Visible duplicate-disable state and verification state | Full lifecycle detail | Show none/pending safely | Same latest command state |
+| Local sync evidence | Visible summary/count | Full evidence detail | Show unavailable safely | Same counts/classification |
+| Detail-only payloads | Not required | Visible where already supported | Do not invent row copy | Detail only |
+
+The lightweight roster recovery shape must keep these list-visible fields if a new shape is introduced: readiness, action category, duplicate-disable command state, verification state, and sync classification. Expected evidence, raw command context, raw action targets, and full command lifecycle detail are detail-only.
+
+### Recovery Action Matrix
+
+| Preview readiness | Operator meaning | Primary action state | Copy guidance |
+| --- | --- | --- | --- |
+| `healthy_idle` | Terminal is healthy but not currently transacting | No repair action | "Healthy" / no blocker copy |
+| `drawer_open` | Drawer is open and not a support repair by itself | No support repair action | "Drawer open" without repair language |
+| `able_to_transact_now` | Current evidence says POS can transact | No repair action | "Ready to transact" without overstating sync completion |
+| `needs_cloud_repair` | Cloud-side repair is available | Cloud repair action enabled only when preconditions match | "Cloud repair available" |
+| `needs_terminal_action` | Matching terminal must run local recovery | Terminal command action enabled or pending based on command lifecycle | "Terminal action needed" |
+| `needs_manual_review` | Business/review evidence needs human review | No automatic repair action | "Manual review needed" |
+| Missing preview | Legacy/partial response | Fallback display only | Normalized safe copy; do not outrank preview when present |
+
+### Command Lifecycle Presentation
+
+| Command state | Operator-visible state | Action behavior |
+| --- | --- | --- |
+| Not issued | Action available when preview preconditions match | Enable safe action |
+| Pending/queued | Waiting for terminal | Disable duplicate issue |
+| Claimed/running | Terminal is working | Disable duplicate issue |
+| Acknowledged | Waiting for fresh runtime proof | Do not call healthy yet |
+| Verified | Repair verified by runtime evidence | Show resolved/recovered state |
+| Failed or precondition failed | Action failed or no longer applies | Show safe failure and next eligible action |
+| Expired/stale | Terminal did not complete in time | Allow retry only when preview still requires it |
+
+### Support Flow Acceptance Check
+
+For a known terminal fixture before and after extraction, Terminal Health list and detail must show the same recovery readiness, current safe action category, latest command state, and local sync evidence classification. The support flow remains: list row triage, open detail, trigger or observe safe action, wait for fresh proof, then show verified, retry, or manual-review escalation.
+
+---
+
+## Implementation Units
+
+```mermaid
+flowchart TB
+  U1["U1 Readiness sensing"]
+  U2["U2 Sync drain coordinator"]
+  U3["U3 Runtime status publisher"]
+  U4["U4 Recovery command runtime and staff authority"]
+  U5["U5 Runtime-status server side effects"]
+  U6["U6 Terminal Health query split"]
+  U7["U7 Preview-first presentation"]
+  U8["U8 Facade integration and validation"]
+
+  U1 --> U2
+  U1 --> U3
+  U3 --> U4
+  U3 --> U5
+  U5 --> U6
+  U6 --> U7
+  U1 --> U8
+  U2 --> U8
+  U3 --> U8
+  U4 --> U8
+  U7 --> U8
+```
+
+- U1. **Extract runtime readiness sensing**
+
+**Goal:** Move local runtime/readiness observation out of `usePosLocalSyncRuntime.ts` into a small module that reads local store state, terminal scope, register readiness, seed/integrity state, drawer authority, and local sync summary without triggering uploads or check-ins by itself.
+
+**Requirements:** R1, R2, R6, R10.
+
+**Dependencies:** None.
+
+**Files:**
+- Create: `packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`
+- Update tests: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`
+
+**Approach:**
+- Extract pure or mostly pure readiness assembly first, using existing local reader helpers where possible.
+- Keep persistence side effects, upload scheduling, and runtime publishing out of this module.
+- Preserve the current distinction between sale readiness, support recovery readiness, and diagnostic data returned to the runtime publisher.
+- Make failures explicit as readiness evidence rather than throwing through the facade.
+
+**Test scenarios:**
+- Healthy local terminal with active register session produces ready sale/runtime evidence without support recovery blockers.
+- Stale drawer authority and terminal-integrity failure are reported as distinct evidence and do not get merged into generic unhealthy state.
+- Missing or invalid terminal seed produces terminal-integrity evidence without forcing upload scheduling.
+- Store-day or opening-readiness evidence is reported separately from local sync diagnostics.
+- Local read failures return safe diagnostic evidence and do not throw through runtime facade callers.
+
+**Verification:**
+- The runtime facade can refresh local readiness through the extracted module and existing `usePosLocalSyncRuntime.test.ts` behavior remains intact.
+
+---
+
+- U2. **Extract local sync drain coordination**
+
+**Goal:** Move upload drain scheduling, retry timing, status-only behavior, immediate-append uploads, sync summary refresh, and drawer-authority reconciliation out of the facade into focused local runtime helpers.
+
+**Requirements:** R1, R2, R4, R10.
+
+**Dependencies:** U1.
+
+**Files:**
+- Create: `packages/athena-webapp/src/lib/pos/infrastructure/local/localSyncDrainCoordinator.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/localSyncDrainCoordinator.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`
+- Update tests: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`
+
+**Approach:**
+- Wrap existing `syncScheduler.ts` and `syncContract.ts` behavior instead of replacing them.
+- Extract drawer-authority reconciliation as a small helper owned by this unit, or explicitly leave it in the facade with a test proving why it cannot be safely moved yet.
+- Preserve status-only semantics as an explicit coordinator mode.
+- Keep upload failure handling and retry state local to the coordinator, while exposing summary/status snapshots to the facade.
+- Preserve local-first behavior: upload/check-in failures are surfaced as diagnostics and do not delete or mutate completed local sales.
+
+**Test scenarios:**
+- Status-only route entry publishes runtime evidence but does not call the upload drain.
+- Upload-enabled runtime starts one drain and does not create duplicate schedulers across rerenders.
+- A local event append while status-only is active schedules the allowed immediate upload behavior that exists today.
+- Upload failure updates diagnostic summary and schedules retry without blocking local sale creation.
+- Stale drawer-authority reconciliation updates only the targeted authority state and does not delete local events or clear unrelated review evidence.
+- Register or terminal scope changes dispose the prior coordinator before starting a new one.
+
+**Verification:**
+- Existing sync scheduler tests still pass, and facade tests show status-only/no-upload behavior is unchanged.
+
+---
+
+- U3. **Extract runtime status publication**
+
+**Goal:** Move runtime payload signature, publication serialization, latest-changed queueing, best-effort failure handling, and terminal integrity authorization persistence into a publisher module.
+
+**Requirements:** R1, R2, R3, R10.
+
+**Dependencies:** U1.
+
+**Files:**
+- Create: `packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeStatusPublisher.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeStatusPublisher.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRuntimeStatus.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`
+- Update tests: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`
+
+**Approach:**
+- Lift the in-flight publish guard and queued signature behavior as-is before simplifying.
+- Keep runtime status failures best-effort and observable, not sale-blocking.
+- Keep terminal authorization failure persistence/clearing coupled to explicit runtime status responses rather than generic network failures.
+- Keep Remote Assist presence as a server-side effect of successful runtime status, not a client-side authority decision.
+
+**Test scenarios:**
+- Identical runtime payloads do not republish solely because debug-only state changes.
+- A changed payload arriving during an in-flight publish is queued and published after the current call completes.
+- Multiple changed payloads during one in-flight publish collapse to the latest changed payload.
+- Runtime check-in failure records diagnostic state without blocking local sync drain or local sale readiness.
+- Terminal authorization failure persists only for explicit authorization failure responses and clears on accepted runtime status.
+
+**Verification:**
+- The existing Convex conflict regression is covered by focused publisher tests and preserved facade tests.
+
+---
+
+- U4. **Extract recovery command runtime and staff authority refresh**
+
+**Goal:** Move recovery command polling/claim/execution/acknowledgement and post-command runtime refresh into its own hook/module, and centralize terminal staff-authority local refresh/write behavior for background, cashier-auth, and recovery-command contexts.
+
+**Requirements:** R1, R2, R5, R8, R9, R10.
+
+**Dependencies:** U1, U3.
+
+**Files:**
+- Create: `packages/athena-webapp/src/lib/pos/infrastructure/local/useTerminalRecoveryCommandRuntime.ts`
+- Create: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalStaffAuthorityRefresh.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/useTerminalRecoveryCommandRuntime.test.ts`
+- Test: `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalStaffAuthorityRefresh.test.ts`
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`
+- Modify: `packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx`
+- Modify: `packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx`
+- Update tests: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`, `packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.test.tsx`, `packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx`, `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.test.ts`
+
+**Approach:**
+- Keep `terminalRecoveryCommands.ts` as the local executor boundary; the new runtime module should orchestrate query, claim, execute, acknowledge, and request a fresh publisher observation.
+- Preserve command idempotency and one-command-at-a-time behavior.
+- Preserve acknowledgement redaction and size limits: never persist or display PINs, proof/verifier material, sync secrets, raw local event bodies, customer/payment payloads, or oversized executor diagnostics.
+- Create a staff-authority helper with explicit context inputs so cashier proof material remains cashier-auth scoped and recovery/background refresh stays redacted.
+- Define the refresh result classifier before changing clearing behavior. The helper should distinguish accepted records, explicit `authoritative_empty`/`revoked` states, caller/session authorization failures, precondition failures, and generic transport/runtime failures.
+- Tighten clearing behavior so caller/session/transport/precondition failures do not automatically erase local authority; only explicit authoritative empty/revoked states should clear.
+
+**Test scenarios:**
+- Runtime claims one eligible command, executes the allow-listed local command, acknowledges completion, and requests a fresh runtime status publication.
+- Failed or precondition-failed command execution acknowledges the safe status and does not mark the command verified locally.
+- Command acknowledgement redacts forbidden fields, caps diagnostic size, and never persists raw local payloads or proof material.
+- `refresh_staff_authority` command refreshes local authority through the shared helper without carrying PIN/proof material.
+- Cashier auth dialog still writes proof-scoped authority only in the cashier-auth path.
+- Opening guard background refresh uses the shared helper and does not clear local authority on generic network failure.
+- Authorization/precondition/transport failures are classified distinctly and covered by tests before callers switch to the shared helper.
+- Explicit `authoritative_empty`/`revoked` responses clear local authority; caller/session/transport/precondition failures preserve the local snapshot and surface diagnostics.
+- Recovery command runtime remains inert when terminal identity or sync secret is absent.
+
+**Verification:**
+- Recovery command behavior remains command queue -> terminal claim -> local execution -> acknowledgement -> fresh runtime proof.
+
+---
+
+- U5. **Extract runtime-status server side effects**
+
+**Goal:** Make `reportTerminalRuntimeStatus` easier to reason about by extracting command verification, Remote Assist presence/session updates, and runtime-session side effects into named helpers without changing authorization or ordering.
+
+**Requirements:** R5, R9, R10.
+
+**Dependencies:** U3.
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/public/terminals.ts`
+- Modify or create helper under: `packages/athena-webapp/convex/pos/application/terminalRuntime/`
+- Update tests: `packages/athena-webapp/convex/pos/public/terminals.test.ts`, `packages/athena-webapp/convex/pos/application/terminals.test.ts`, `packages/athena-webapp/convex/remoteAssist/application/posRuntimeAdapter.test.ts`, `packages/athena-webapp/convex/remoteAssist/application/sessionService.test.ts`
+
+**Approach:**
+- Extract named helpers after tests pin the current side-effect sequence.
+- Keep side effects gated by successful terminal runtime status authorization and accepted status persistence.
+- Keep failed runtime status reports from enrolling Remote Assist presence or claiming sessions.
+- Keep command verification tied to accepted runtime status evidence.
+- Pass Remote Assist only a minimized presence projection from accepted runtime status. Do not forward staff proof, PIN/verifier material, sync secrets, raw local events, customer/payment payloads, or raw browser fingerprints.
+- Isolate post-status side effects so accepted runtime status remains accepted if Remote Assist presence/session work fails. Command verification must still run when status evidence was accepted; Remote Assist failures are diagnostic and idempotent, not a reason to make the browser retry the status write.
+
+**Test scenarios:**
+- Successful runtime status report persists status, verifies eligible command evidence, upserts Remote Assist presence, and claims matching connecting sessions.
+- Failed authorization does not verify commands, enroll presence, or claim Remote Assist sessions.
+- Runtime check-in without matching expected command evidence leaves command unverified.
+- Remote Assist presence/session helpers receive only minimized runtime presence fields and exclude sensitive terminal diagnostics.
+- A Remote Assist upsert/session failure after accepted status does not fail the status response, does not skip command verification, and records only safe diagnostics.
+- Remote Assist presence remains browser-client evidence and does not grant POS authority.
+
+**Verification:**
+- Server endpoint behavior is unchanged, but side-effect boundaries are named and independently testable.
+
+---
+
+- U6. **Split Terminal Health roster/detail cost without splitting truth**
+
+**Goal:** Reduce the amount of work done for Terminal Health roster rows while preserving shared recovery/readiness semantics with detail views.
+
+**Requirements:** R6, R7, R10.
+
+**Dependencies:** U5.
+
+**Files:**
+- Modify: `packages/athena-webapp/convex/pos/application/queries/terminals.ts`
+- Modify if frontend type alignment is needed: `packages/athena-webapp/src/components/pos/terminals/terminalHealthTypes.ts`
+- Modify: `packages/athena-webapp/convex/pos/public/terminals.ts`
+- Update tests: `packages/athena-webapp/convex/pos/application/queries/terminals.test.ts`, `packages/athena-webapp/convex/pos/application/terminals.test.ts`, `packages/athena-webapp/convex/pos/public/terminals.test.ts`, `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRepository.test.ts`, `packages/athena-webapp/convex/pos/infrastructure/repositories/terminalRecoveryRepository.test.ts`
+
+**Approach:**
+- Identify fields `POSTerminalHealthView` actually renders and keep those stable.
+- Choose an explicit API shape before implementation: either a new lightweight list validator/query, an optional summary mode with a distinct validator, or an internal builder split that preserves the current public validator.
+- Prefer the internal builder split unless measured query cost or existing tests show a new public list DTO/query is needed.
+- Preserve existing Terminal Health authorization and store scoping for any new or changed roster/detail query. Terminal sync-secret-only callers must not gain access to support roster/detail data.
+- If a lightweight roster DTO is introduced, define it before extraction with these required fields: readiness, action category, duplicate-disable command state, verification state, and sync classification.
+- Introduce shared recovery/readiness builders that can produce a lightweight roster shape and a full detail shape from the same classification rules.
+- Avoid recomputing full command/action detail for every row if the roster only needs readiness/status counts and safe summary flags.
+- Add parity tests so a terminal with the same underlying facts classifies the same way in roster and detail.
+
+**Test scenarios:**
+- Roster and detail classify current readiness values consistently: `healthy_idle`, `drawer_open`, `able_to_transact_now`, `needs_cloud_repair`, `needs_terminal_action`, and `needs_manual_review`.
+- Roster includes all fields `POSTerminalHealthView` needs and omits detail-only command/action payload where safe.
+- Roster retains readiness, action category, duplicate-disable command state, verification state, and sync classification while omitting expected evidence, raw command context, raw action targets, and full command lifecycle detail.
+- Detail still includes command lifecycle, safe actions, expected evidence, and action target resolution.
+- Stale drawer authority with closed cloud session follows the recovered/non-blocking semantics established in solution docs.
+- Staff authority expired alone does not create support recovery work.
+- Non-members, wrong-store users, and terminal sync-secret-only callers cannot read roster/detail health summaries.
+
+**Verification:**
+- Terminal Health list avoids detail-only command/action work without producing states that contradict detail view recovery readiness.
+
+---
+
+- U7. **Make Terminal Health presentation preview-first**
+
+**Goal:** Ensure frontend presentation uses `TerminalRecoveryPreview` as the primary support-recovery source and keeps raw fallback paths only for absent or legacy preview responses.
+
+**Requirements:** R6, R7, R10.
+
+**Dependencies:** U6.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts`
+- Modify as needed: `packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.tsx`
+- Modify as needed: `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx`
+- Update tests: `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts`, `packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx`, `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx`
+
+**Approach:**
+- Route recovery display through the preview/presentation builder first.
+- Keep raw attention/status fallbacks behind an explicit missing-preview branch.
+- Add tests where raw attention reasons are scary but preview says no current support blocker; preview should win.
+- Add tests where preview is absent and legacy fallback still produces safe operator copy.
+
+**Test scenarios:**
+- Preview state `able_to_transact_now` is not downgraded by stale raw attention reasons.
+- Preview states `needs_cloud_repair`, `needs_terminal_action`, and `needs_manual_review` surface safe support recovery copy and actions.
+- `drawer_open` and `healthy_idle` do not render as support repair states.
+- Missing preview still falls back to safe, normalized legacy presentation.
+- List and detail views render consistent recovery state labels for the same preview.
+
+**Verification:**
+- Frontend recovery state aligns with server preview semantics and avoids stale fallback-driven blocker copy.
+
+---
+
+- U8. **Integrate the facade, validate, and update graph knowledge**
+
+**Goal:** Wire the extracted runtime modules back into the existing facade and verify the POS runtime, Terminal Health, and Remote Assist seams together.
+
+**Requirements:** R1, R2, R3, R4, R5, R6, R7, R8, R9, R10.
+
+**Dependencies:** U1, U2, U3, U4, U5, U6, U7.
+
+**Files:**
+- Modify: `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`
+- Update consumers only if necessary: `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`, `packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.tsx`
+- Update generated graph output after code changes: `graphify-out/`
+
+**Approach:**
+- Keep facade return shape and consumer expectations stable.
+- Remove duplicated helper logic from the old monolithic hook only after extracted modules have focused tests.
+- Run focused tests after each extraction unit when practical, then run wider POS/runtime gates once the facade is reassembled.
+- Rebuild graph knowledge after code changes per repo instructions.
+
+**Test scenarios:**
+- `useRegisterViewModel` still receives runtime status without learning about extracted modules.
+- `PosRemoteAssistRuntimeHost` still observes runtime/presence behavior without POS authority changes.
+- `PosRemoteAssistRuntimeHost` keeps its intended `drain-enabled` runtime mode unless implementation proves and tests a safer owner handoff. POS hub/register/Remote Assist mounts must have exactly one upload-drain owner per terminal scope.
+- Runtime publisher, drain coordinator, and recovery runtime do not create duplicate intervals or duplicate in-flight calls when the facade rerenders.
+- Local-first sale continuity is preserved when runtime check-in fails.
+- Full runtime command path still executes and verifies through fresh status evidence.
+
+**Verification:**
+- Focused runtime and Terminal Health tests pass, the graph is rebuilt, and `bun run pr:athena` remains the final integration gate before merge/PR.
+
+---
+
+## System-Wide Impact
+
+- **Browser POS runtime:** The public hook remains stable, but its internal effects become smaller and easier to test. The main risk is effect dependency drift causing duplicate schedulers, duplicate command claims, or extra runtime publishes; U2, U3, U4, and U8 tests target that directly.
+- **Local POS store:** Completed sales and local event evidence must remain durable. Extraction must not delete or rewrite local events as a way to resolve health states.
+- **Terminal Health:** Roster and detail can diverge in payload depth, but not in recovery classification. Parity tests protect operator trust.
+- **Remote Assist:** Runtime status can continue to enroll browser-client presence after successful check-in. The refactor must not turn support presence into POS authority.
+- **Convex runtime endpoints:** Helper extraction should make side effects easier to reason about without changing terminal authorization, persistence, or verification ordering.
+- **Staff authority:** Shared refresh/write behavior reduces duplication, but proof/PIN material must remain scoped to cashier-auth flows only.
+- **Graphify:** Code changes require `bun run graphify:rebuild` so graph knowledge remains current.
+
+---
+
+## Risks & Mitigations
+
+- **Risk: Runtime status publish conflicts return.** Mitigation: extract latest-wins serialization as its own unit with focused queue tests before simplifying caller code.
+- **Risk: Status-only pages accidentally start upload drains.** Mitigation: make status-only an explicit coordinator mode and preserve existing no-upload route-entry tests.
+- **Risk: Command acknowledgement is mistaken for health.** Mitigation: keep verification server-owned and require fresh runtime evidence in U4/U5 tests.
+- **Risk: Terminal Health list optimization changes operator truth.** Mitigation: share readiness builders and add roster/detail parity tests.
+- **Risk: Raw presentation fallback overrides fresh preview state.** Mitigation: make preview-first behavior explicit and test preview-wins cases.
+- **Risk: Staff authority helper clears too aggressively.** Mitigation: clear only on explicit authoritative revoked/not-found states; generic failures remain diagnostics.
+- **Risk: Remote Assist side effects drift into authority.** Mitigation: keep presence/session updates behind successful runtime check-in and test that presence does not grant POS authority.
+- **Risk: Extraction creates effect dependency churn.** Mitigation: preserve facade behavior with characterization tests and avoid consumer rewrites unless tests prove they are necessary.
+
+---
+
+## Validation Plan
+
+Run focused tests as units land, then run the wider Athena gate before handoff.
+
+Focused tests to prioritize:
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.test.ts`
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/localSyncDrainCoordinator.test.ts`
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeStatusPublisher.test.ts`
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/useTerminalRecoveryCommandRuntime.test.ts`
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalStaffAuthorityRefresh.test.ts`
+- `packages/athena-webapp/src/lib/pos/infrastructure/local/terminalRecoveryCommands.test.ts`
+- `packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.test.ts`
+- `packages/athena-webapp/src/components/remote-assist/PosRemoteAssistRuntimeHost.test.tsx`
+- `packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.test.tsx`
+- `packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx`
+- `packages/athena-webapp/convex/pos/public/terminals.test.ts`
+- `packages/athena-webapp/convex/pos/application/queries/terminals.test.ts`
+- `packages/athena-webapp/convex/pos/application/terminals.test.ts`
+- `packages/athena-webapp/convex/pos/application/terminalRecovery/terminalCommandService.test.ts`
+- `packages/athena-webapp/convex/remoteAssist/application/posRuntimeAdapter.test.ts`
+- `packages/athena-webapp/convex/remoteAssist/application/sessionService.test.ts`
+- `packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts`
+- `packages/athena-webapp/src/components/pos/terminals/POSTerminalHealthView.test.tsx`
+- `packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx`
+
+Final validation:
+- Run changed-file lint/type checks according to repo scripts.
+- Run `bun run graphify:rebuild` after code modifications.
+- Run `bun run pr:athena` before merge/PR handoff.
+
+---
+
+## Implementation Notes
+
+- Preserve the implementation worktree: `codex/pos-runtime-decoupling`.
+- Keep changes narrow to POS runtime, terminal health, Remote Assist runtime side effects, and directly related tests.
+- Prefer characterization tests before extraction so behavior changes are intentional and visible.
+- Avoid rewriting consumer UI unless the facade contract cannot carry the extracted state safely.
+- Keep operator copy calm and normalized if any Terminal Health copy changes are required.

--- a/docs/solutions/architecture/athena-pos-runtime-decoupling-boundaries-2026-06-15.md
+++ b/docs/solutions/architecture/athena-pos-runtime-decoupling-boundaries-2026-06-15.md
@@ -1,0 +1,213 @@
+---
+title: Athena POS Runtime Decoupling Boundaries
+date: 2026-06-15
+category: architecture
+module: athena-webapp
+problem_type: pos_runtime_decoupling
+component: pos
+symptoms:
+  - "POS runtime changes in one concern can accidentally affect local sync, recovery commands, runtime check-ins, staff authority, or Terminal Health"
+  - "Runtime check-in side effects can make accepted status look failed if Remote Assist work throws"
+  - "Generic staff-authority refresh failures can wipe local staff authority and block offline cashier continuity"
+  - "Terminal Health list and detail can drift when roster code re-derives recovery state from raw evidence"
+root_cause: pos_runtime_facade_owned_too_many_runtime_support_and_authority_responsibilities
+resolution_type: runtime_boundary_refactor
+severity: high
+tags:
+  - pos
+  - local-first
+  - runtime-status
+  - terminal-health
+  - remote-assist
+  - staff-authority
+---
+
+# Athena POS Runtime Decoupling Boundaries
+
+## Problem
+
+`usePosLocalSyncRuntimeStatus` became the integration point for too many
+separate responsibilities:
+
+- local readiness sensing,
+- drawer-authority reconciliation,
+- local sync drain scheduling,
+- runtime status signature and publish serialization,
+- terminal recovery command execution,
+- staff-authority refresh,
+- terminal integrity repair evidence, and
+- support-facing Terminal Health diagnostics.
+
+That coupling made production fixes risky. A small change to status-only route
+behavior could start upload drains. A command-refresh change could wipe cached
+staff authority. A Remote Assist presence failure could make an accepted runtime
+status look failed. A Terminal Health list optimization could accidentally
+contradict the detail view.
+
+## Decision
+
+Keep the POS runtime facade, but move responsibility-specific logic behind
+focused modules. The facade remains the consumer contract for register and
+Remote Assist hosts; helper modules own the actual boundaries.
+
+The important boundaries are:
+
+1. **Readiness sensing is not publishing or draining.** Reading terminal seed,
+   local register state, drawer authority, staff authority readiness, snapshots,
+   terminal integrity, and app-shell readiness should be a local observation.
+2. **Drawer-authority reconciliation is sync-owned.** Recoverable drawer blocks
+   can be written or cleared as part of sync/retry outcomes, but completed local
+   events and review evidence must not be deleted to force a healthy state.
+3. **Runtime status publishing is latest-wins serialized.** Overlapping
+   `reportTerminalRuntimeStatus` calls must not race Convex writes. Changed
+   payloads queue behind the in-flight publish and collapse to the latest
+   changed payload.
+4. **Staff-authority refresh failures preserve local continuity.** A successful
+   empty authoritative refresh can clear local authority. Caller/session,
+   authorization, precondition, transport, and runtime failures are diagnostics
+   and must not wipe cached offline sign-in authority.
+5. **Recovery acknowledgement is not verification.** A command acknowledgement
+   says the terminal ran a helper. Fresh runtime status says whether the
+   expected evidence changed.
+6. **Post-status side effects are isolated.** Accepted runtime status remains
+   accepted if Remote Assist presence/session work fails, and command
+   verification still runs from the accepted evidence.
+7. **Terminal Health is preview-first.** Roster and detail must use the same
+   `TerminalRecoveryPreview` semantics. Raw blockers are compatibility fallback,
+   not stronger truth than a structured preview.
+
+## Solution
+
+Split the runtime into named modules that each own one durable boundary, then
+keep the existing hook as a facade over those modules. The implementation does
+not introduce a new POS runtime API for callers; it makes the existing runtime
+behavior easier to test and safer to change.
+
+The solution has five parts:
+
+1. Extract local readiness and drawer reconciliation out of the hook so runtime
+   evidence and sync-owned authority repair are not hidden inside one effect.
+2. Extract status-only trigger/debug helpers and runtime status publisher
+   helpers so upload ownership and check-in serialization can be tested without
+   rewriting consumers.
+3. Centralize staff-authority refresh persistence so refused or failed refreshes
+   preserve cached local authority instead of wiping offline cashier continuity.
+4. Move accepted runtime-status side effects behind a server helper that isolates
+   Remote Assist failures while still running command verification from accepted
+   evidence.
+5. Make Terminal Health presentation prefer structured recovery preview data and
+   keep roster/detail recovery parity covered by tests.
+
+## Implementation Pattern
+
+Use focused POS local/runtime modules rather than adding more nested effects to
+the facade:
+
+- `runtimeReadiness.ts` for local runtime readiness observation.
+- `drawerAuthorityReconciliation.ts` for recoverable drawer authority write and
+  clear behavior.
+- `localSyncDrainCoordinator.ts` for status-only triggers, upload trigger
+  classification, and sync debug assembly.
+- `runtimeStatusPublisher.ts` for status signatures, not-ready classification,
+  publisher debug patching, and browser runtime metadata.
+- `terminalStaffAuthorityRefresh.ts` for refresh result classification and
+  local snapshot persistence.
+- `postRuntimeStatusSideEffects.ts` for accepted runtime-status server
+  side effects.
+
+Keep the public hook as the adapter. Components and higher-level presentation
+code should not need to know which helper owns a sub-responsibility.
+
+## Staff Authority Rules
+
+Do not clear local staff authority for generic refresh failure. That converts a
+cloud/server/support condition into a cashier blocker and breaks POS continuity.
+
+Use this taxonomy:
+
+- `ok` with records: replace the local snapshot.
+- `ok` with no records: authoritative empty state; clear the local snapshot.
+- `user_error`, authorization failure, precondition failure, thrown exception,
+  or transport/runtime failure: preserve the local snapshot and surface safe
+  diagnostics.
+
+Only cashier-auth flows may wrap proof material. Background refresh and terminal
+recovery command refresh must not invent or carry PIN/proof payloads.
+
+## Runtime Status Rules
+
+Runtime status is evidence. It is not a control channel and does not grant POS
+authority.
+
+When changing the publisher or server status endpoint:
+
+- preserve latest-wins client-side publish serialization,
+- keep status publish failures best-effort from the cashier's point of view,
+- persist terminal authorization failure only from explicit authorization
+  responses,
+- clear local terminal integrity only after accepted runtime status, and
+- isolate Remote Assist side-effect failures from command verification and the
+  accepted status response.
+
+Remote Assist receives a minimized presence projection only. Do not forward
+staff proof, PIN/verifier material, sync secrets, raw local events,
+customer/payment payloads, or raw browser fingerprints.
+
+## Terminal Health Rules
+
+Terminal Health is a support surface. It should help support decide what to do
+without overstating cashier blockers.
+
+Roster and detail must agree on:
+
+- terminal identity and store scope,
+- runtime freshness,
+- recovery readiness,
+- current safe action category,
+- duplicate-disable command state,
+- verification state,
+- latest command state, and
+- sync classification.
+
+Detail can include expected evidence, raw command context, raw action targets,
+and full lifecycle detail. Roster rows should keep only the fields needed for
+triage and duplicate-action safety.
+
+If `TerminalRecoveryPreview` is present, presentation uses it first. Raw
+attention reasons and legacy blockers are fallback only when no structured
+preview exists.
+
+## Validation
+
+Use focused characterization tests around the facade before extracting behavior,
+then add unit tests for the helper boundary that changed.
+
+Minimum useful sensors:
+
+- `usePosLocalSyncRuntime.test.ts` for facade continuity, status-only behavior,
+  publish serialization, recovery command execution, and sale-continuity
+  diagnostics.
+- `terminalStaffAuthorityRefresh.test.ts`, `CashierAuthDialog.test.tsx`, and
+  `POSRegisterOpeningGuard.test.tsx` for staff authority preservation.
+- `convex/pos/public/terminals.test.ts` for accepted-status side effects and
+  command verification.
+- `terminalHealthPresentation.test.ts` and terminal health query tests for
+  preview-first roster/detail parity.
+- `bun run graphify:rebuild` after POS runtime/source-boundary changes.
+- `bun run pr:athena` before merge.
+
+## Prevention
+
+- Do not add another responsibility directly to `usePosLocalSyncRuntime.ts`
+  without first asking whether it belongs in an existing helper module.
+- Do not collapse sales readiness, support recovery, diagnostic evidence,
+  staff authority, drawer authority, Remote Assist presence, and runtime status
+  into one generic "terminal healthy" value.
+- Do not treat a command acknowledgement as a terminal-health verdict.
+- Do not treat Remote Assist presence as POS sale/drawer/staff authority.
+- Do not optimize Terminal Health list rows by dropping the fields needed to
+  disable duplicate safe actions.
+
+## Related Issues
+
+- Linear: V26-744, V26-745, V26-746, V26-747, V26-748.

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - .
 
 ## Corpus Check
-- 1933 files · ~0 words
+- 1940 files · ~0 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6866 nodes · 7718 edges · 1860 communities detected
+- 6882 nodes · 7728 edges · 1867 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1870,6 +1870,13 @@
 - [[_COMMUNITY_Community 1857|Community 1857]]
 - [[_COMMUNITY_Community 1858|Community 1858]]
 - [[_COMMUNITY_Community 1859|Community 1859]]
+- [[_COMMUNITY_Community 1860|Community 1860]]
+- [[_COMMUNITY_Community 1861|Community 1861]]
+- [[_COMMUNITY_Community 1862|Community 1862]]
+- [[_COMMUNITY_Community 1863|Community 1863]]
+- [[_COMMUNITY_Community 1864|Community 1864]]
+- [[_COMMUNITY_Community 1865|Community 1865]]
+- [[_COMMUNITY_Community 1866|Community 1866]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `createJourneyEvent()` - 40 edges
@@ -1915,71 +1922,71 @@ Nodes (50): assertNever(), buildSaleProjectedMessage(), calculateSalePayments(),
 
 ### Community 4 - "Community 4"
 Cohesion: 0.06
-Nodes (25): assertPosLocalStoreOk(), clearAcceptedTerminalIntegrityState(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents() (+17 more)
-
-### Community 5 - "Community 5"
-Cohesion: 0.06
 Nodes (24): asRecord(), createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), normalizeCashierPresenceRecord(), normalizeDrawerAuthorityState(), normalizeLocalEventPayload(), normalizePendingCheckoutItemDefinedPayload(), normalizePendingCheckoutItemLocalMetadata() (+16 more)
 
-### Community 6 - "Community 6"
+### Community 5 - "Community 5"
 Cohesion: 0.1
 Nodes (46): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectHarnessSafetySignalFindings(), collectHarnessScriptTestUpdateFindings(), createOutput() (+38 more)
 
-### Community 7 - "Community 7"
+### Community 6 - "Community 6"
 Cohesion: 0.08
 Nodes (43): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents(), buildWeekMetricForDate(), buildWeekMetrics(), compareDailyOperationsTimelineEvents() (+35 more)
 
-### Community 8 - "Community 8"
+### Community 7 - "Community 7"
 Cohesion: 0.1
 Nodes (37): canonicalize(), canonicalJson(), createLocalSyncIngestionService(), ingestLocalEventsWithCtx(), isNonEmptyString(), isNonNegativeFiniteNumber(), isOptionalBoolean(), isOptionalNonEmptyString() (+29 more)
 
-### Community 9 - "Community 9"
+### Community 8 - "Community 8"
 Cohesion: 0.09
 Nodes (45): compactContext(), createAuthEntryViewedEvent(), createAuthRequestStartedEvent(), createAuthVerificationSucceededEvent(), createAuthVerificationViewedEvent(), createBagAddSucceededEvent(), createBagMoveToSavedEvent(), createBagRemoveSucceededEvent() (+37 more)
+
+### Community 9 - "Community 9"
+Cohesion: 0.09
+Nodes (34): buildRecoveryBlockers(), buildRecoveryBlockersFromPreview(), buildRecoveryReadiness(), buildTerminalRecoveryPresentation(), classifyTerminalHealth(), defaultBlockerSummary(), deriveRecoveryBlockerFromReason(), deriveRecoveryBlockers() (+26 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.07
 Nodes (20): formatStatus(), formatUnitCount(), getPurchaseOrderMode(), getRecommendationForPurchaseOrder(), getRecommendationStateNote(), getRecommendationUrlSku(), handleAdvancePurchaseOrderToOrdered(), handleClearRecommendationFilters() (+12 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.1
-Nodes (33): buildRecoveryBlockers(), buildRecoveryBlockersFromPreview(), buildRecoveryReadiness(), buildTerminalRecoveryPresentation(), classifyTerminalHealth(), defaultBlockerSummary(), deriveRecoveryBlockerFromReason(), deriveRecoveryBlockers() (+25 more)
-
-### Community 12 - "Community 12"
 Cohesion: 0.07
 Nodes (22): cn(), formatMetadataDisplayValue(), formatMetadataValue(), formatOperatingDate(), formatTimestamp(), getAcknowledgementKey(), getArrayMetadataStringValue(), getBucketConfigs() (+14 more)
 
-### Community 13 - "Community 13"
+### Community 12 - "Community 12"
 Cohesion: 0.08
 Nodes (22): cleanInventoryMetadataValue(), formatInventoryItemPriceLabel(), formatInventoryNumber(), formatReservationSourceSummary(), getCountScopeLabel(), getInventoryItemDisplayName(), getInventoryItemOperationalPrice(), getReservationLabels() (+14 more)
 
-### Community 14 - "Community 14"
+### Community 13 - "Community 13"
 Cohesion: 0.13
 Nodes (35): buildFinalTrustedQuantitiesByRowNumber(), buildProvisionalSkuPatch(), buildSkuInsert(), buildSkuPatch(), finalizeProvisionalImportRowsForAppliedImport(), findExistingSku(), findOrCreateCategory(), findOrCreateProduct() (+27 more)
 
-### Community 15 - "Community 15"
+### Community 14 - "Community 14"
 Cohesion: 0.12
 Nodes (30): applyApprovedTransactionVoid(), buildCompleteTransactionResult(), buildVoidApprovalRequirement(), calculateCanonicalTransactionTotals(), calculateTotalPaid(), completedTransactionLabel(), completeTransaction(), createTransactionFromSessionHandler() (+22 more)
 
-### Community 16 - "Community 16"
+### Community 15 - "Community 15"
 Cohesion: 0.12
 Nodes (32): approvalMetadataEntries(), approvalRequestTypeLabel(), buildDailyOpeningSnapshotWithCtx(), buildReadiness(), compactMetadataEntries(), formatPaymentMethodLabel(), getDailyOpeningForDate(), getMissingCarryForwardItems() (+24 more)
 
-### Community 17 - "Community 17"
+### Community 16 - "Community 16"
 Cohesion: 0.07
 Nodes (16): formatCompactTextList(), formatRegisterHeaderName(), formatRegisterName(), formatReviewItemTimestamp(), formatReviewQueueSummary(), formatReviewReportedSummary(), formatReviewTypeSummary(), formatTimestamp() (+8 more)
 
-### Community 18 - "Community 18"
+### Community 17 - "Community 17"
 Cohesion: 0.16
 Nodes (33): asRecord(), cartItemSourceKey(), createMappingIndex(), errorFor(), errorMessage(), getCompletedSale(), getExpectedCashDelta(), getOrCreateSale() (+25 more)
 
-### Community 19 - "Community 19"
+### Community 18 - "Community 18"
 Cohesion: 0.15
 Nodes (31): collectHarnessOnboardingErrors(), collectMarkdownLinkErrors(), collectMissingRequiredLinkErrors(), collectPackageGuideLinkErrors(), collectPackagesRouterLinkErrors(), collectReadmeLinkErrors(), collectReferencedPathErrors(), collectRuntimeScenarioDocSyncErrors() (+23 more)
 
-### Community 20 - "Community 20"
+### Community 19 - "Community 19"
 Cohesion: 0.12
 Nodes (28): asRegExp(), collectLatencyDiagnostics(), collectRuntimeSignalDiagnostics(), collectRuntimeSignalMatches(), consumeLines(), escapeRegExp(), formatAssertionDiagnostics(), formatError() (+20 more)
+
+### Community 20 - "Community 20"
+Cohesion: 0.09
+Nodes (15): assertPosLocalStoreOk(), clearAcceptedTerminalIntegrityState(), collectAcceptedEventIdsWithLocalPrecursors(), collectReviewLocalEventIds(), collectRuntimeRelevantEvents(), collectSyncedLocalEventIds(), derivePosLocalRuntimeSyncStatus(), hasPendingLocalCloseout() (+7 more)
 
 ### Community 21 - "Community 21"
 Cohesion: 0.15
@@ -2178,12 +2185,12 @@ Cohesion: 0.15
 Nodes (4): asBoolean(), asNumber(), asRecord(), getCashControlsConfig()
 
 ### Community 70 - "Community 70"
-Cohesion: 0.13
-Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
-
-### Community 71 - "Community 71"
 Cohesion: 0.23
 Nodes (14): acknowledgeTerminalRecoveryCommand(), claimTerminalRecoveryCommand(), containsSecretLikeField(), isActiveCommand(), isEquivalentCommand(), issueTerminalRecoveryCommand(), loadScopedCommand(), normalizeOptionalHealthyStatus() (+6 more)
+
+### Community 71 - "Community 71"
+Cohesion: 0.13
+Nodes (2): buildPersistedRuntimeStatus(), buildRuntimeStatus()
 
 ### Community 72 - "Community 72"
 Cohesion: 0.27
@@ -2430,360 +2437,360 @@ Cohesion: 0.2
 Nodes (0):
 
 ### Community 133 - "Community 133"
+Cohesion: 0.38
+Nodes (8): assertPosLocalStoreOk(), clearRecoverableDrawerAuthorityForSyncedEvents(), clearSettledRecoverableDrawerAuthorityBlock(), clearSupersededRecoverableDrawerAuthorityBlocks(), drawerAuthorityEventKey(), isDrawerAuthorityLifecycleEvent(), isRecoverableDrawerAuthorityReason(), persistDrawerAuthorityBlockForReviewEvents()
+
+### Community 134 - "Community 134"
 Cohesion: 0.22
 Nodes (2): buildCashierPresence(), getTestOperatingDate()
 
-### Community 134 - "Community 134"
+### Community 135 - "Community 135"
 Cohesion: 0.27
 Nodes (3): createRemoteAssistTransportClient(), getRemoteAssistTransportClientFactory(), LazyLiveKitRemoteAssistClient
 
-### Community 135 - "Community 135"
+### Community 136 - "Community 136"
 Cohesion: 0.2
 Nodes (0):
 
-### Community 136 - "Community 136"
+### Community 137 - "Community 137"
 Cohesion: 0.38
 Nodes (9): awardPointsForGuestOrders(), awardPointsForPastOrder(), getBaseUrl(), getEligiblePastOrders(), getOrderRewardPoints(), getPointHistory(), getRewardTiers(), getUserPoints() (+1 more)
 
-### Community 137 - "Community 137"
+### Community 138 - "Community 138"
 Cohesion: 0.4
 Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalizeGraphJsonContents(), resolveGraphifyPython(), runGraphifyRebuild(), sortJsonArray(), sortJsonValue()
 
-### Community 138 - "Community 138"
-Cohesion: 0.39
-Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
-
 ### Community 139 - "Community 139"
-Cohesion: 0.39
-Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
-
-### Community 140 - "Community 140"
-Cohesion: 0.22
-Nodes (0):
-
-### Community 141 - "Community 141"
 Cohesion: 0.39
 Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
+### Community 140 - "Community 140"
+Cohesion: 0.39
+Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
+
+### Community 141 - "Community 141"
+Cohesion: 0.39
+Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
+
 ### Community 142 - "Community 142"
+Cohesion: 0.22
+Nodes (0):
+
+### Community 143 - "Community 143"
 Cohesion: 0.5
 Nodes (7): getNonEmptyString(), getOperationalEventJourney(), getOperationalEventStatus(), getOperationalEventStep(), isFailureStatus(), isOperationalEventDoc(), normalizeEvent()
 
-### Community 143 - "Community 143"
+### Community 144 - "Community 144"
 Cohesion: 0.39
 Nodes (7): calculateRefundAmount(), getAmountRefunded(), getAvailableItems(), getItemsToRefund(), getNetAmount(), shouldShowReturnToStock(), validateRefund()
 
-### Community 144 - "Community 144"
+### Community 145 - "Community 145"
 Cohesion: 0.25
 Nodes (2): buildUsername(), normalizeNameSegment()
 
-### Community 145 - "Community 145"
+### Community 146 - "Community 146"
 Cohesion: 0.39
 Nodes (6): handleDeliveryRestrictionToggle(), handlePickupRestrictionToggle(), handleSaveDeliveryRestriction(), handleSavePickupRestriction(), saveDeliveryRestriction(), savePickupRestriction()
 
-### Community 146 - "Community 146"
+### Community 147 - "Community 147"
 Cohesion: 0.44
 Nodes (1): Logger
 
-### Community 147 - "Community 147"
+### Community 148 - "Community 148"
 Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
-### Community 148 - "Community 148"
+### Community 149 - "Community 149"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 149 - "Community 149"
+### Community 150 - "Community 150"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 150 - "Community 150"
+### Community 151 - "Community 151"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 151 - "Community 151"
+### Community 152 - "Community 152"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 155 - "Community 155"
+### Community 156 - "Community 156"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 160 - "Community 160"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 161 - "Community 161"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 162 - "Community 162"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 163 - "Community 163"
 Cohesion: 0.36
 Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
 
-### Community 163 - "Community 163"
+### Community 164 - "Community 164"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 164 - "Community 164"
+### Community 165 - "Community 165"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 165 - "Community 165"
+### Community 166 - "Community 166"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.25
 Nodes (1): ResizeObserverStub
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 168 - "Community 168"
-Cohesion: 0.29
-Nodes (2): handleKeyDown(), isDebugShortcut()
 
 ### Community 169 - "Community 169"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.29
+Nodes (2): handleKeyDown(), isDebugShortcut()
 
 ### Community 170 - "Community 170"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 171 - "Community 171"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
-
-### Community 172 - "Community 172"
 Cohesion: 0.25
 Nodes (0):
+
+### Community 172 - "Community 172"
+Cohesion: 0.39
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 173 - "Community 173"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 174 - "Community 174"
-Cohesion: 0.46
-Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
-
-### Community 175 - "Community 175"
-Cohesion: 0.46
-Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
-
-### Community 176 - "Community 176"
-Cohesion: 0.43
-Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
-
-### Community 177 - "Community 177"
 Cohesion: 0.25
 Nodes (0):
 
+### Community 175 - "Community 175"
+Cohesion: 0.46
+Nodes (6): isLocalDevAppShellDisabled(), readCachedPosAppShellReadiness(), readPosAppShellReadiness(), resolveRegisterPath(), waitForActiveServiceWorker(), warmPosAppShellReadiness()
+
+### Community 176 - "Community 176"
+Cohesion: 0.46
+Nodes (7): addItemToBag(), clearBag(), getActiveBag(), getBaseUrl(), removeItemFromBag(), updateBagItem(), updateBagOwner()
+
+### Community 177 - "Community 177"
+Cohesion: 0.43
+Nodes (6): buildQueryString(), getAllProducts(), getBaseUrl(), getBestSellers(), getFeatured(), getProduct()
+
 ### Community 178 - "Community 178"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 179 - "Community 179"
 Cohesion: 0.43
 Nodes (7): createStorefrontObservabilityContext(), createStorefrontObservabilityPayload(), getOrCreateStorefrontObservabilitySessionId(), isBrowserAutomationContext(), isSyntheticMonitorOrigin(), resolveStorefrontAnalyticsOrigin(), trackStorefrontEvent()
 
-### Community 179 - "Community 179"
+### Community 180 - "Community 180"
 Cohesion: 0.39
 Nodes (5): createPackage(), installFixtureToolchain(), linkWorkspacePackage(), writeFixtureManifests(), writeJson()
 
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.52
 Nodes (5): getWhatsAppReceiptConfig(), getWhatsAppWebhookAppSecret(), getWhatsAppWebhookVerifyToken(), optionalEnv(), requiredEnv()
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.33
 Nodes (2): expenseSessionError(), mapExpenseSessionValidationError()
 
-### Community 182 - "Community 182"
+### Community 183 - "Community 183"
 Cohesion: 0.57
 Nodes (6): buildHeaders(), createCollectionsAccessToken(), encodeBasicAuth(), getRequestToPayStatus(), requestToPay(), toError()
 
-### Community 183 - "Community 183"
+### Community 184 - "Community 184"
 Cohesion: 0.33
 Nodes (2): completedDailyCloseRow(), completedDailyCloseSnapshot()
 
-### Community 184 - "Community 184"
+### Community 185 - "Community 185"
 Cohesion: 0.52
 Nodes (6): buildCustomerProfileDraft(), buildFullName(), findMatchingCustomerProfile(), normalizeLookupValue(), normalizePhoneNumber(), splitFullName()
 
-### Community 185 - "Community 185"
+### Community 186 - "Community 186"
 Cohesion: 0.33
 Nodes (2): buildOperationalWorkItem(), createOperationalWorkItemWithCtx()
 
-### Community 186 - "Community 186"
+### Community 187 - "Community 187"
 Cohesion: 0.48
 Nodes (5): buildExpenseSessionTraceEvent(), buildExpenseSessionTraceRecord(), buildTraceSummary(), recordExpenseSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 187 - "Community 187"
-Cohesion: 0.29
-Nodes (0):
 
 ### Community 188 - "Community 188"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 189 - "Community 189"
-Cohesion: 0.48
-Nodes (6): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), isDuplicateRegisterOpenConflict(), skipped()
+Cohesion: 0.29
+Nodes (0):
 
 ### Community 190 - "Community 190"
 Cohesion: 0.48
-Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
+Nodes (6): buildTerminalCloudRepairPreconditionHash(), buildTerminalCloudRepairPreview(), classifyTerminalCloudRepairConflict(), containsBusinessFacts(), isDuplicateRegisterOpenConflict(), skipped()
 
 ### Community 191 - "Community 191"
+Cohesion: 0.48
+Nodes (5): getActiveSessionForRegisterState(), listHeldSessionsForRegisterState(), querySessionsByStatus(), selectRegisterStateLookupStrategy(), summarizeRegisterStateSessions()
+
+### Community 192 - "Community 192"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 192 - "Community 192"
+### Community 193 - "Community 193"
 Cohesion: 0.52
 Nodes (6): blocked(), buildRecoveryAttemptId(), getOrganizationMemberForAccount(), recordRecoveryEvent(), validatePosAppAccount(), validateTerminalAppSessionRecoveryWithCtx()
 
-### Community 193 - "Community 193"
+### Community 194 - "Community 194"
 Cohesion: 0.33
 Nodes (2): findReusableRemoteAssistSession(), startRemoteAssistSession()
 
-### Community 194 - "Community 194"
+### Community 195 - "Community 195"
 Cohesion: 0.43
 Nodes (5): buildPosServiceCatalogRow(), buildPosServiceCheckoutReadiness(), buildServiceCatalogItem(), normalizeServiceCatalogNameKey(), suggestedDepositAmount()
 
-### Community 195 - "Community 195"
+### Community 196 - "Community 196"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 196 - "Community 196"
+### Community 197 - "Community 197"
 Cohesion: 0.33
 Nodes (2): getCustomerOperationalTimelineEvents(), resolveCustomerProfileIdForTimeline()
 
-### Community 197 - "Community 197"
+### Community 198 - "Community 198"
 Cohesion: 0.38
 Nodes (3): clearBagItems(), createOrderFromCheckoutSession(), generateOrderNumber()
 
-### Community 198 - "Community 198"
+### Community 199 - "Community 199"
 Cohesion: 0.57
 Nodes (5): getDeliveryAddress(), getLocationDetails(), getPickupLocation(), handleOrderStatusUpdate(), processOrderUpdateEmail()
 
-### Community 199 - "Community 199"
+### Community 200 - "Community 200"
 Cohesion: 0.33
 Nodes (2): appendTransition(), applyOnlineOrderUpdate()
 
-### Community 200 - "Community 200"
+### Community 201 - "Community 201"
 Cohesion: 0.38
 Nodes (3): createWorkflowTraceWithCtx(), getWorkflowTraceByIdWithCtx(), getWorkflowTraceByLookupWithCtx()
 
-### Community 201 - "Community 201"
+### Community 202 - "Community 202"
 Cohesion: 0.38
 Nodes (4): calculateCycleCountQuantityDelta(), hasHighStockAdjustmentVariance(), requiresStockAdjustmentApproval(), resolveStockAdjustmentQuantityDelta()
 
-### Community 202 - "Community 202"
+### Community 203 - "Community 203"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 203 - "Community 203"
-Cohesion: 0.33
-Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 204 - "Community 204"
 Cohesion: 0.33
-Nodes (2): handleKeypadPress(), setAmountFromTouch()
+Nodes (2): handlePinChange(), normalizeOtpCode()
 
 ### Community 205 - "Community 205"
 Cohesion: 0.33
-Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+Nodes (2): handleKeypadPress(), setAmountFromTouch()
 
 ### Community 206 - "Community 206"
+Cohesion: 0.33
+Nodes (2): getLocalOperatingDate(), getLocalOperatingDateRange()
+
+### Community 207 - "Community 207"
 Cohesion: 0.29
 Nodes (1): ResizeObserverStub
 
-### Community 207 - "Community 207"
+### Community 208 - "Community 208"
 Cohesion: 0.48
 Nodes (4): applyCommandResult(), async(), handleSubmit(), parseDateTimeLocal()
 
-### Community 208 - "Community 208"
+### Community 209 - "Community 209"
 Cohesion: 0.33
 Nodes (2): handleReset(), handleSubmit()
 
-### Community 209 - "Community 209"
+### Community 210 - "Community 210"
 Cohesion: 0.52
 Nodes (6): deriveRegisterPhase(), hasActiveRegisterSession(), hasResumableRegisterSession(), isRegisterReadyToStart(), requiresCashier(), requiresTerminal()
 
-### Community 210 - "Community 210"
+### Community 211 - "Community 211"
 Cohesion: 0.29
 Nodes (0):
-
-### Community 211 - "Community 211"
-Cohesion: 0.33
-Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
 
 ### Community 212 - "Community 212"
-Cohesion: 0.29
-Nodes (0):
+Cohesion: 0.33
+Nodes (2): selectNextOrderedBatch(), selectOrderedBatches()
 
 ### Community 213 - "Community 213"
 Cohesion: 0.29
 Nodes (0):
 
 ### Community 214 - "Community 214"
+Cohesion: 0.29
+Nodes (0):
+
+### Community 215 - "Community 215"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
 
-### Community 215 - "Community 215"
+### Community 216 - "Community 216"
 Cohesion: 0.33
 Nodes (2): getProductName(), sortProduct()
 
-### Community 216 - "Community 216"
+### Community 217 - "Community 217"
 Cohesion: 0.43
 Nodes (4): createFixtureRepo(), gitEnv(), runGit(), write()
 
-### Community 217 - "Community 217"
+### Community 218 - "Community 218"
 Cohesion: 0.52
 Nodes (5): emitSignal(), handleCheckoutSessionFetch(), handleCheckoutSessionUpdate(), jsonResponse(), withCorsHeaders()
 
-### Community 218 - "Community 218"
+### Community 219 - "Community 219"
 Cohesion: 0.33
 Nodes (2): overwriteFreshGraphifyArtifacts(), write()
 
-### Community 219 - "Community 219"
+### Community 220 - "Community 220"
 Cohesion: 0.38
 Nodes (4): createFixtureRepo(), initializeGitHistory(), runGit(), write()
 
-### Community 220 - "Community 220"
-Cohesion: 0.33
-Nodes (1): ValkeyClient
-
 ### Community 221 - "Community 221"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ValkeyClient
 
 ### Community 222 - "Community 222"
 Cohesion: 0.33
@@ -2794,76 +2801,76 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 224 - "Community 224"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 225 - "Community 225"
 Cohesion: 0.4
 Nodes (2): baseSaleCompletedPayload(), buildSaleCompletedEvent()
 
-### Community 225 - "Community 225"
+### Community 226 - "Community 226"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 226 - "Community 226"
+### Community 227 - "Community 227"
 Cohesion: 0.73
 Nodes (5): buildOrderStatusMessage(), buildPickupDetails(), sendPaymentVerificationEmails(), sendPODOrderEmails(), shouldSendToAdmins()
 
-### Community 227 - "Community 227"
+### Community 228 - "Community 228"
 Cohesion: 0.6
 Nodes (5): createVendorCommandWithCtx(), createVendorWithCtx(), mapCreateVendorError(), normalizeVendorLookupKey(), trimOptional()
 
-### Community 228 - "Community 228"
+### Community 229 - "Community 229"
 Cohesion: 0.6
 Nodes (5): find_block_end(), list_convex_files(), main(), scan_file(), strip_code()
 
-### Community 229 - "Community 229"
+### Community 230 - "Community 230"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 230 - "Community 230"
+### Community 231 - "Community 231"
 Cohesion: 0.53
 Nodes (4): includesRegisterSessionStatus(), isCashControlVisibleRegisterSessionStatus(), isPosUsableRegisterSessionStatus(), isRegisterSessionConflictBlockingStatus()
 
-### Community 231 - "Community 231"
+### Community 232 - "Community 232"
 Cohesion: 0.33
 Nodes (1): DataTableToolbar()
 
-### Community 232 - "Community 232"
+### Community 233 - "Community 233"
 Cohesion: 0.53
 Nodes (2): SelectedProductsProvider(), useSelectedProducts()
 
-### Community 233 - "Community 233"
+### Community 234 - "Community 234"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 234 - "Community 234"
+### Community 235 - "Community 235"
 Cohesion: 0.47
 Nodes (3): historyRecord(), snapshot(), storedReportSnapshot()
 
-### Community 235 - "Community 235"
+### Community 236 - "Community 236"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 236 - "Community 236"
+### Community 237 - "Community 237"
 Cohesion: 0.4
 Nodes (2): getReviewOverlayElement(), getReviewOverlaySection()
 
-### Community 237 - "Community 237"
+### Community 238 - "Community 238"
 Cohesion: 0.33
 Nodes (1): ResizeObserverStub
 
-### Community 238 - "Community 238"
+### Community 239 - "Community 239"
 Cohesion: 0.4
 Nodes (2): buildApprovalRetryArgs(), getAsyncApprovalRequestId()
 
-### Community 239 - "Community 239"
+### Community 240 - "Community 240"
 Cohesion: 0.4
 Nodes (2): formatCartAttributeParts(), normalizeCartAttribute()
 
-### Community 240 - "Community 240"
+### Community 241 - "Community 241"
 Cohesion: 0.47
 Nodes (3): getSummaryAmount(), getSummaryLabel(), getSummaryPanel()
-
-### Community 241 - "Community 241"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 242 - "Community 242"
 Cohesion: 0.33
@@ -2871,27 +2878,27 @@ Nodes (0):
 
 ### Community 243 - "Community 243"
 Cohesion: 0.33
-Nodes (1): ResizeObserverStub
+Nodes (0):
 
 ### Community 244 - "Community 244"
 Cohesion: 0.33
-Nodes (0):
+Nodes (1): ResizeObserverStub
 
 ### Community 245 - "Community 245"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 246 - "Community 246"
 Cohesion: 0.4
 Nodes (2): parseServiceCatalogCreateForm(), parseServiceCatalogUpdateForm()
 
-### Community 246 - "Community 246"
+### Community 247 - "Community 247"
 Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
-### Community 247 - "Community 247"
+### Community 248 - "Community 248"
 Cohesion: 0.47
 Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
-
-### Community 248 - "Community 248"
-Cohesion: 0.33
-Nodes (0):
 
 ### Community 249 - "Community 249"
 Cohesion: 0.33
@@ -2910,12 +2917,12 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 253 - "Community 253"
-Cohesion: 0.53
-Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
-
-### Community 254 - "Community 254"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 254 - "Community 254"
+Cohesion: 0.53
+Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
 
 ### Community 255 - "Community 255"
 Cohesion: 0.33
@@ -2926,172 +2933,172 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 257 - "Community 257"
-Cohesion: 0.53
-Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 258 - "Community 258"
-Cohesion: 0.6
-Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 259 - "Community 259"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 260 - "Community 260"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.53
+Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
 ### Community 261 - "Community 261"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
+Cohesion: 0.6
+Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
 ### Community 262 - "Community 262"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 263 - "Community 263"
-Cohesion: 0.47
-Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 264 - "Community 264"
-Cohesion: 0.47
-Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 265 - "Community 265"
 Cohesion: 0.33
 Nodes (0):
 
 ### Community 266 - "Community 266"
-Cohesion: 0.4
-Nodes (2): handleConfirm(), handlePrimaryAction()
+Cohesion: 0.47
+Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
 ### Community 267 - "Community 267"
+Cohesion: 0.47
+Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
+
+### Community 268 - "Community 268"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 268 - "Community 268"
+### Community 269 - "Community 269"
+Cohesion: 0.4
+Nodes (2): handleConfirm(), handlePrimaryAction()
+
+### Community 270 - "Community 270"
+Cohesion: 0.33
+Nodes (0):
+
+### Community 271 - "Community 271"
 Cohesion: 0.53
 Nodes (5): getRemainingForFreeDelivery(), hasWaiverConfigured(), isAnyFeeWaived(), isFeeWaived(), meetsThreshold()
 
-### Community 269 - "Community 269"
+### Community 272 - "Community 272"
 Cohesion: 0.47
 Nodes (3): onSubmit(), reportAuthFailure(), resendVerificationCode()
 
-### Community 270 - "Community 270"
+### Community 273 - "Community 273"
 Cohesion: 0.53
 Nodes (4): coverageSummary(), write(), writePackageSummaries(), writeRealBaselineSummaries()
 
-### Community 271 - "Community 271"
+### Community 274 - "Community 274"
 Cohesion: 0.67
 Nodes (5): collectRepoCodeFiles(), collectStaleGraphifyArtifacts(), copyGraphifyCheckInputs(), fileExists(), runGraphifyCheck()
 
-### Community 272 - "Community 272"
+### Community 275 - "Community 275"
 Cohesion: 0.4
 Nodes (2): createFixtureRoot(), write()
 
-### Community 273 - "Community 273"
+### Community 276 - "Community 276"
 Cohesion: 0.53
 Nodes (4): collectDefaultPlanHtmlFiles(), collectPlanHtmlFindings(), hasRemoteReference(), runPlanHtmlValidation()
 
-### Community 274 - "Community 274"
+### Community 277 - "Community 277"
 Cohesion: 0.5
 Nodes (2): createAuthorizedRegisterDepositCtx(), createQueryCtx()
 
-### Community 275 - "Community 275"
+### Community 278 - "Community 278"
 Cohesion: 0.6
 Nodes (4): buildInStorePaymentAllocations(), normalizeInStorePayments(), resolveRegisterSessionForInStoreCollectionWithCtx(), selectRegisterSessionForAttribution()
 
-### Community 276 - "Community 276"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 277 - "Community 277"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 278 - "Community 278"
-Cohesion: 0.6
-Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
-
 ### Community 279 - "Community 279"
-Cohesion: 0.7
-Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 280 - "Community 280"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 281 - "Community 281"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): formatStoredAmount(), toDisplayAmount(), toPesewas()
 
 ### Community 282 - "Community 282"
+Cohesion: 0.7
+Nodes (4): compactRecord(), ensureCustomerProfileFromSourcesWithCtx(), findExistingProfile(), loadCustomerSources()
+
+### Community 283 - "Community 283"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 283 - "Community 283"
-Cohesion: 0.7
-Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
-
 ### Community 284 - "Community 284"
-Cohesion: 0.6
-Nodes (3): isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 285 - "Community 285"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 286 - "Community 286"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): buildDecision(), classifyCorrectionIntent(), isSupportedCorrectionIntent(), isUnsupportedHighRiskCorrectionIntent()
 
 ### Community 287 - "Community 287"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): isTrustedCatalogResult(), lookupByBarcode(), mapSkuToCatalogResult()
 
 ### Community 288 - "Community 288"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 289 - "Community 289"
-Cohesion: 0.6
-Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 290 - "Community 290"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 291 - "Community 291"
-Cohesion: 0.7
-Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
-
-### Community 292 - "Community 292"
 Cohesion: 0.4
 Nodes (0):
 
-### Community 293 - "Community 293"
+### Community 292 - "Community 292"
 Cohesion: 0.6
-Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
+Nodes (3): denied(), evaluateRemoteAssistPolicy(), isClientFresh()
+
+### Community 293 - "Community 293"
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 294 - "Community 294"
-Cohesion: 0.5
-Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
+Cohesion: 0.7
+Nodes (4): getPaystackHeaders(), initializeTransaction(), initiateRefund(), verifyTransaction()
 
 ### Community 295 - "Community 295"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 296 - "Community 296"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): buildOnlineOrderReturnExchangePlan(), getApprovalReason(), getKind()
 
 ### Community 297 - "Community 297"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getNonEmptyString(), normalizeStorefrontObservabilityEvent()
 
 ### Community 298 - "Community 298"
-Cohesion: 0.5
-Nodes (2): handleFileSelect(), validateFile()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 299 - "Community 299"
 Cohesion: 0.4
@@ -3102,8 +3109,8 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 301 - "Community 301"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): handleFileSelect(), validateFile()
 
 ### Community 302 - "Community 302"
 Cohesion: 0.4
@@ -3114,8 +3121,8 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 304 - "Community 304"
-Cohesion: 0.5
-Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 305 - "Community 305"
 Cohesion: 0.4
@@ -3126,8 +3133,8 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 307 - "Community 307"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.5
+Nodes (2): getBalanceDueLabel(), getBalanceDuePanel()
 
 ### Community 308 - "Community 308"
 Cohesion: 0.4
@@ -3146,100 +3153,100 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 312 - "Community 312"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 313 - "Community 313"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 314 - "Community 314"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 315 - "Community 315"
 Cohesion: 0.7
 Nodes (4): getRuntimeOrigin(), isLocalHost(), resolveStoreFrontUrl(), trimTrailingSlash()
 
-### Community 313 - "Community 313"
+### Community 316 - "Community 316"
 Cohesion: 0.8
 Nodes (4): canAccessFullAdminSurface(), canAccessStoreDaySurface(), canViewFinancialDetails(), getSurfaceAccess()
 
-### Community 314 - "Community 314"
+### Community 317 - "Community 317"
 Cohesion: 0.7
 Nodes (4): bufferToHex(), collectBrowserInfo(), generateBrowserFingerprint(), hashFingerprintSource()
 
-### Community 315 - "Community 315"
+### Community 318 - "Community 318"
 Cohesion: 0.4
 Nodes (1): MockImage
 
-### Community 316 - "Community 316"
+### Community 319 - "Community 319"
 Cohesion: 0.4
 Nodes (0):
-
-### Community 317 - "Community 317"
-Cohesion: 0.6
-Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
-
-### Community 318 - "Community 318"
-Cohesion: 0.6
-Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
-
-### Community 319 - "Community 319"
-Cohesion: 0.6
-Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 320 - "Community 320"
 Cohesion: 0.6
-Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
+Nodes (4): mapRegisterStateDto(), mapTerminalDto(), useConvexRegisterState(), useConvexTerminalByFingerprint()
 
 ### Community 321 - "Community 321"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (3): appendOpenDrawer(), blockDrawerAuthority(), createBlockedSaleGateway()
 
 ### Community 322 - "Community 322"
-Cohesion: 0.7
-Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
+Cohesion: 0.6
+Nodes (3): event(), serviceDraftEvent(), serviceDraftPrelude()
 
 ### Community 323 - "Community 323"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.6
+Nodes (4): buildPosSyncStatusPresentation(), formatPosReconciliationType(), isRegisterCloseoutReviewItem(), normalizeStatus()
 
 ### Community 324 - "Community 324"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 325 - "Community 325"
-Cohesion: 0.4
-Nodes (0):
+Cohesion: 0.7
+Nodes (4): getInitialRuntimeBuildMetadata(), normalizeDeployMetadata(), normalizeMetadataValue(), readRuntimeBuildMetadata()
 
 ### Community 326 - "Community 326"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 327 - "Community 327"
-Cohesion: 0.5
-Nodes (2): completePendingAuthSync(), sleep()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 328 - "Community 328"
-Cohesion: 0.5
-Nodes (3): createVersionChecker(), shouldAutoReloadForCurrentRoute(), shouldAutoReloadForPath()
+Cohesion: 0.4
+Nodes (0):
 
 ### Community 329 - "Community 329"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 330 - "Community 330"
+Cohesion: 0.5
+Nodes (2): completePendingAuthSync(), sleep()
+
+### Community 331 - "Community 331"
+Cohesion: 0.5
+Nodes (3): createVersionChecker(), shouldAutoReloadForCurrentRoute(), shouldAutoReloadForPath()
+
+### Community 332 - "Community 332"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 333 - "Community 333"
 Cohesion: 0.7
 Nodes (4): getAllCategories(), getAllCategoriesWithSubcategories(), getBaseUrl(), getCategory()
 
-### Community 331 - "Community 331"
+### Community 334 - "Community 334"
 Cohesion: 0.7
 Nodes (4): getBaseUrl(), getOrder(), getOrders(), updateOrdersOwner()
 
-### Community 332 - "Community 332"
-Cohesion: 0.7
-Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
-
-### Community 333 - "Community 333"
-Cohesion: 0.4
-Nodes (0):
-
-### Community 334 - "Community 334"
-Cohesion: 0.4
-Nodes (0):
-
 ### Community 335 - "Community 335"
 Cohesion: 0.7
-Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
+Nodes (4): getActiveUser(), getBaseUrl(), getGuest(), updateUser()
 
 ### Community 336 - "Community 336"
 Cohesion: 0.4
@@ -3250,56 +3257,56 @@ Cohesion: 0.4
 Nodes (0):
 
 ### Community 338 - "Community 338"
-Cohesion: 0.6
-Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+Cohesion: 0.7
+Nodes (4): createStorefrontFailureEvent(), emitStorefrontFailure(), inferStorefrontJourneyFromRoute(), normalizeStorefrontError()
 
 ### Community 339 - "Community 339"
 Cohesion: 0.4
 Nodes (0):
 
 ### Community 340 - "Community 340"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 341 - "Community 341"
+Cohesion: 0.6
+Nodes (4): collectHarnessRepoValidationSelection(), matchesHarnessRepoValidationPath(), normalizeRepoPath(), sortUniquePaths()
+
+### Community 342 - "Community 342"
+Cohesion: 0.4
+Nodes (0):
+
+### Community 343 - "Community 343"
 Cohesion: 0.7
 Nodes (4): createFixtureRepo(), fixtureEnv(), runGit(), runWorktreeManager()
 
-### Community 341 - "Community 341"
+### Community 344 - "Community 344"
 Cohesion: 0.83
 Nodes (3): automationActionKey(), defineAutomationAction(), registerAutomationActions()
 
-### Community 342 - "Community 342"
+### Community 345 - "Community 345"
 Cohesion: 0.83
 Nodes (3): evaluateAutomationActionWithCtx(), isValidOperatingDate(), validateAdapterDecision()
 
-### Community 343 - "Community 343"
+### Community 346 - "Community 346"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 344 - "Community 344"
+### Community 347 - "Community 347"
 Cohesion: 0.67
 Nodes (2): maskReceiptPhone(), normalizeReceiptPhone()
 
-### Community 345 - "Community 345"
+### Community 348 - "Community 348"
 Cohesion: 0.83
 Nodes (3): createReceiptShareToken(), hashReceiptShareToken(), toHex()
 
-### Community 346 - "Community 346"
+### Community 349 - "Community 349"
 Cohesion: 0.83
 Nodes (3): timingSafeEqual(), toHex(), verifyMetaWebhookSignature()
 
-### Community 347 - "Community 347"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 348 - "Community 348"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 349 - "Community 349"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 350 - "Community 350"
-Cohesion: 0.67
-Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 351 - "Community 351"
 Cohesion: 0.5
@@ -3310,48 +3317,48 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 353 - "Community 353"
+Cohesion: 0.67
+Nodes (2): createExpenseTransactionFromSessionHandler(), expenseTransactionError()
+
+### Community 354 - "Community 354"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 354 - "Community 354"
-Cohesion: 0.67
-Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
-
 ### Community 355 - "Community 355"
-Cohesion: 0.83
-Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 356 - "Community 356"
-Cohesion: 0.67
-Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 357 - "Community 357"
 Cohesion: 0.67
-Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
+Nodes (2): createProductsQueryCtx(), createSkuMutationCtx()
 
 ### Community 358 - "Community 358"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getCachedTokenRecord(), resolveAccessTokenForStore(), resolveConfigForStore()
 
 ### Community 359 - "Community 359"
 Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Nodes (2): maskMtnPartyId(), normalizeCollectionsTransaction()
 
 ### Community 360 - "Community 360"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): consumeApprovalProofWithCtx(), invalidApprovalProofResult()
 
 ### Community 361 - "Community 361"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 362 - "Community 362"
-Cohesion: 0.83
-Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 363 - "Community 363"
-Cohesion: 0.67
-Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 364 - "Community 364"
 Cohesion: 0.5
@@ -3359,119 +3366,119 @@ Nodes (0):
 
 ### Community 365 - "Community 365"
 Cohesion: 0.83
-Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
+Nodes (3): resolveServiceIntakeCustomerProfile(), splitFullName(), trimOptional()
 
 ### Community 366 - "Community 366"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): createRestoredProofValidationCtx(), createStaffCredentialsMutationCtx()
 
 ### Community 367 - "Community 367"
-Cohesion: 0.83
-Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 368 - "Community 368"
 Cohesion: 0.83
-Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+Nodes (3): mapOpenDrawerUserError(), normalizeRegisterNumber(), openDrawer()
 
 ### Community 369 - "Community 369"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 370 - "Community 370"
+Cohesion: 0.83
+Nodes (3): createDbGetMock(), createDbMock(), createDbQueryMock()
+
+### Community 371 - "Community 371"
+Cohesion: 0.83
+Nodes (3): buildRegisterState(), getActiveSessionConflictForRegisterState(), getRegisterState()
+
+### Community 372 - "Community 372"
 Cohesion: 0.83
 Nodes (3): createPosLocalStaffProofToken(), hashPosLocalStaffProofToken(), toHex()
 
-### Community 370 - "Community 370"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 371 - "Community 371"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 372 - "Community 372"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 373 - "Community 373"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 374 - "Community 374"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 375 - "Community 375"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 376 - "Community 376"
 Cohesion: 0.67
 Nodes (2): requirePosTransactionAccess(), requirePosTransactionStoreAccess()
 
-### Community 374 - "Community 374"
+### Community 377 - "Community 377"
 Cohesion: 0.67
 Nodes (2): buildRepository(), buildSession()
 
-### Community 375 - "Community 375"
+### Community 378 - "Community 378"
 Cohesion: 0.67
 Nodes (2): sanitizeRemoteAssistMetadata(), sanitizeRemoteAssistValue()
 
-### Community 376 - "Community 376"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 377 - "Community 377"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 378 - "Community 378"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 379 - "Community 379"
-Cohesion: 0.67
-Nodes (2): expectIndex(), getTableIndexes()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 380 - "Community 380"
-Cohesion: 0.83
-Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 381 - "Community 381"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 382 - "Community 382"
-Cohesion: 0.83
-Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
+Cohesion: 0.67
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 383 - "Community 383"
 Cohesion: 0.83
-Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
+Nodes (3): findExistingCustomerProfileId(), getStoreOrganizationId(), recordStoreFrontCustomerMilestone()
 
 ### Community 384 - "Community 384"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 385 - "Community 385"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): normalizePosTerminalTransactionCapability(), posTerminalCanTransactProducts(), posTerminalCanTransactServices()
 
 ### Community 386 - "Community 386"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): formatStaffDisplayName(), formatStaffDisplayNameOrFallback(), normalizeNamePart()
 
 ### Community 387 - "Community 387"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 388 - "Community 388"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 389 - "Community 389"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 390 - "Community 390"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 391 - "Community 391"
 Cohesion: 0.67
 Nodes (2): countGroupedAnalytics(), groupAnalytics()
 
-### Community 389 - "Community 389"
+### Community 392 - "Community 392"
 Cohesion: 0.67
 Nodes (2): handleSubmit(), navigationTargetForRedirect()
 
-### Community 390 - "Community 390"
+### Community 393 - "Community 393"
 Cohesion: 0.67
 Nodes (2): getPosRouteScope(), Login()
-
-### Community 391 - "Community 391"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 392 - "Community 392"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 393 - "Community 393"
-Cohesion: 0.5
-Nodes (0):
 
 ### Community 394 - "Community 394"
 Cohesion: 0.5
@@ -3486,28 +3493,28 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 397 - "Community 397"
-Cohesion: 0.67
-Nodes (2): handleSubmit(), resetReplacementFields()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 398 - "Community 398"
-Cohesion: 0.67
-Nodes (2): CashierAuthDialog(), getStaffDisplayName()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 399 - "Community 399"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 400 - "Community 400"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): handleSubmit(), resetReplacementFields()
 
 ### Community 401 - "Community 401"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): CashierAuthDialog(), getStaffDisplayName()
 
 ### Community 402 - "Community 402"
-Cohesion: 1.0
-Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 403 - "Community 403"
 Cohesion: 0.5
@@ -3518,12 +3525,12 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 405 - "Community 405"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 1.0
+Nodes (3): isLikelyQuickAddBarcode(), normalizeQuickAddInitialLookupCode(), normalizeQuickAddLookupCode()
 
 ### Community 406 - "Community 406"
-Cohesion: 0.67
-Nodes (2): applyCommandResult(), handleCreateCase()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 407 - "Community 407"
 Cohesion: 0.5
@@ -3535,19 +3542,19 @@ Nodes (0):
 
 ### Community 409 - "Community 409"
 Cohesion: 0.67
-Nodes (2): getRiskStyles(), RiskIndicators()
+Nodes (2): applyCommandResult(), handleCreateCase()
 
 ### Community 410 - "Community 410"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 411 - "Community 411"
-Cohesion: 0.67
-Nodes (2): useGetArchivedProducts(), useGetProducts()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 412 - "Community 412"
 Cohesion: 0.67
-Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+Nodes (2): getRiskStyles(), RiskIndicators()
 
 ### Community 413 - "Community 413"
 Cohesion: 0.5
@@ -3555,99 +3562,99 @@ Nodes (0):
 
 ### Community 414 - "Community 414"
 Cohesion: 0.67
-Nodes (2): extractTraceId(), runCommand()
+Nodes (2): useGetArchivedProducts(), useGetProducts()
 
 ### Community 415 - "Community 415"
+Cohesion: 0.67
+Nodes (2): getReceiptPageHeightMm(), setContinuousReceiptPageSize()
+
+### Community 416 - "Community 416"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 416 - "Community 416"
-Cohesion: 0.67
-Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
-
 ### Community 417 - "Community 417"
 Cohesion: 0.67
-Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
+Nodes (2): extractTraceId(), runCommand()
 
 ### Community 418 - "Community 418"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 419 - "Community 419"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.67
+Nodes (2): formatStoredAmount(), formatStoredCurrencyAmount()
 
 ### Community 420 - "Community 420"
 Cohesion: 0.67
-Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+Nodes (2): buildExpenseReceiptHtml(), parseReceiptLocation()
 
 ### Community 421 - "Community 421"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 422 - "Community 422"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 423 - "Community 423"
+Cohesion: 0.67
+Nodes (2): mapActiveSessionDto(), normalizeCartItems()
+
+### Community 424 - "Community 424"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 425 - "Community 425"
 Cohesion: 0.67
 Nodes (2): isSeedReadLoading(), resolveLocalPosEntryContext()
 
-### Community 423 - "Community 423"
+### Community 426 - "Community 426"
 Cohesion: 0.83
 Nodes (3): readLatestDrawerAuthorityState(), readProjectedLocalRegisterModel(), readScopedPosLocalEvents()
 
-### Community 424 - "Community 424"
+### Community 427 - "Community 427"
+Cohesion: 0.67
+Nodes (2): refreshTerminalRuntimeReadiness(), toRuntimeActiveRegisterSession()
+
+### Community 428 - "Community 428"
 Cohesion: 0.83
 Nodes (3): derivePosLocalSyncStatus(), getContiguousSyncedSequence(), getSyncState()
 
-### Community 425 - "Community 425"
-Cohesion: 0.83
-Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
-
-### Community 426 - "Community 426"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 427 - "Community 427"
-Cohesion: 0.67
-Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
-
-### Community 428 - "Community 428"
-Cohesion: 0.5
-Nodes (0):
-
 ### Community 429 - "Community 429"
 Cohesion: 0.83
-Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
+Nodes (3): isBrowserFingerprintResult(), readStoredTerminalFingerprint(), readStoredTerminalFingerprintHash()
 
 ### Community 430 - "Community 430"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 431 - "Community 431"
-Cohesion: 0.83
-Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
+Cohesion: 0.67
+Nodes (2): getCashierDisplayName(), useExpenseRegisterViewModel()
 
 ### Community 432 - "Community 432"
-Cohesion: 0.83
-Nodes (3): getAllStores(), getBaseUrl(), getStore()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 433 - "Community 433"
 Cohesion: 0.83
-Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
+Nodes (3): waitForPosAppShellServiceWorker(), waitForRenderedRegisterShell(), warmPosRegisterRoute()
 
 ### Community 434 - "Community 434"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 435 - "Community 435"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getBaseUrl(), getUserRedeemedOffers(), submitOffer()
 
 ### Community 436 - "Community 436"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllStores(), getBaseUrl(), getStore()
 
 ### Community 437 - "Community 437"
-Cohesion: 0.5
-Nodes (0):
+Cohesion: 0.83
+Nodes (3): getAllSubcategories(), getBaseUrl(), getSubategory()
 
 ### Community 438 - "Community 438"
 Cohesion: 0.5
@@ -3666,71 +3673,71 @@ Cohesion: 0.5
 Nodes (0):
 
 ### Community 442 - "Community 442"
-Cohesion: 0.67
-Nodes (2): useOptionalStoreContext(), useStoreContext()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 443 - "Community 443"
-Cohesion: 0.67
-Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 444 - "Community 444"
-Cohesion: 0.83
-Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 445 - "Community 445"
 Cohesion: 0.5
 Nodes (0):
 
 ### Community 446 - "Community 446"
+Cohesion: 0.67
+Nodes (2): useOptionalStoreContext(), useStoreContext()
+
+### Community 447 - "Community 447"
+Cohesion: 0.67
+Nodes (2): clearFilters(), onMobileFiltersCloseClick()
+
+### Community 448 - "Community 448"
+Cohesion: 0.83
+Nodes (3): cancelOrder(), getErrorMessage(), placeOrder()
+
+### Community 449 - "Community 449"
+Cohesion: 0.5
+Nodes (0):
+
+### Community 450 - "Community 450"
 Cohesion: 0.83
 Nodes (3): bootstrapCheckout(), createBootstrapToken(), createMarker()
 
-### Community 447 - "Community 447"
+### Community 451 - "Community 451"
 Cohesion: 0.83
 Nodes (3): createFixtureRoot(), write(), writeGraphifyWikiArtifacts()
 
-### Community 448 - "Community 448"
+### Community 452 - "Community 452"
 Cohesion: 0.5
 Nodes (0):
 
-### Community 449 - "Community 449"
+### Community 453 - "Community 453"
 Cohesion: 0.67
 Nodes (2): buildHarnessDocPaths(), buildHarnessDocPathsForArchetype()
 
-### Community 450 - "Community 450"
+### Community 454 - "Community 454"
 Cohesion: 0.67
 Nodes (2): shutdown(), stopValkeyRuntimeServer()
 
-### Community 451 - "Community 451"
+### Community 455 - "Community 455"
 Cohesion: 0.83
 Nodes (3): createFixtureRepo(), createInferentialArtifact(), write()
 
-### Community 452 - "Community 452"
+### Community 456 - "Community 456"
 Cohesion: 0.67
 Nodes (2): collectHarnessTestTargets(), runHarnessTest()
 
-### Community 453 - "Community 453"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 454 - "Community 454"
-Cohesion: 0.5
-Nodes (0):
-
-### Community 455 - "Community 455"
-Cohesion: 0.67
-Nodes (0):
-
-### Community 456 - "Community 456"
-Cohesion: 0.67
-Nodes (0):
-
 ### Community 457 - "Community 457"
-Cohesion: 1.0
-Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
+Cohesion: 0.5
+Nodes (0):
 
 ### Community 458 - "Community 458"
-Cohesion: 0.67
+Cohesion: 0.5
 Nodes (0):
 
 ### Community 459 - "Community 459"
@@ -3742,8 +3749,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 461 - "Community 461"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): providerErrorCategory(), sendWhatsAppReceiptTemplate()
 
 ### Community 462 - "Community 462"
 Cohesion: 0.67
@@ -3766,8 +3773,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 467 - "Community 467"
-Cohesion: 1.0
-Nodes (2): buildCtx(), createDb()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 468 - "Community 468"
 Cohesion: 0.67
@@ -3782,12 +3789,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 471 - "Community 471"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildCtx(), createDb()
 
 ### Community 472 - "Community 472"
-Cohesion: 1.0
-Nodes (2): hashPosTerminalSyncSecret(), toHex()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 473 - "Community 473"
 Cohesion: 0.67
@@ -3799,27 +3806,27 @@ Nodes (0):
 
 ### Community 475 - "Community 475"
 Cohesion: 0.67
-Nodes (1): PosServerError
+Nodes (0):
 
 ### Community 476 - "Community 476"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): hashPosTerminalSyncSecret(), toHex()
 
 ### Community 477 - "Community 477"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 478 - "Community 478"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): reportRemoteAssistPresenceDiagnosticOnly(), runAcceptedRuntimeStatusSideEffects()
 
 ### Community 479 - "Community 479"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 480 - "Community 480"
-Cohesion: 1.0
-Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
+Cohesion: 0.67
+Nodes (1): PosServerError
 
 ### Community 481 - "Community 481"
 Cohesion: 0.67
@@ -3838,16 +3845,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 485 - "Community 485"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getActiveRegisterSessionForRegisterState(), mapRegisterSessionToCashDrawerSummary()
 
 ### Community 486 - "Community 486"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 487 - "Community 487"
-Cohesion: 1.0
-Nodes (2): expectIndex(), getTableIndexes()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 488 - "Community 488"
 Cohesion: 0.67
@@ -3867,15 +3874,15 @@ Nodes (0):
 
 ### Community 492 - "Community 492"
 Cohesion: 1.0
-Nodes (2): listBagItems(), loadBagWithItems()
+Nodes (2): expectIndex(), getTableIndexes()
 
 ### Community 493 - "Community 493"
-Cohesion: 1.0
-Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 494 - "Community 494"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 495 - "Community 495"
 Cohesion: 0.67
@@ -3887,15 +3894,15 @@ Nodes (0):
 
 ### Community 497 - "Community 497"
 Cohesion: 1.0
-Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
+Nodes (2): listBagItems(), loadBagWithItems()
 
 ### Community 498 - "Community 498"
 Cohesion: 1.0
-Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
+Nodes (2): buildRegisterSessionTraceSeed(), formatRegisterSessionLabel()
 
 ### Community 499 - "Community 499"
-Cohesion: 0.67
-Nodes (1): View()
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceViewByIdWithCtx(), getWorkflowTraceViewByLookupWithCtx()
 
 ### Community 500 - "Community 500"
 Cohesion: 0.67
@@ -3906,16 +3913,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 502 - "Community 502"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): isPosOnlyTerminalLoginMode(), normalizePosTerminalLoginMode()
 
 ### Community 503 - "Community 503"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createWorkflowTraceId(), normalizeWorkflowTraceLookupValue()
 
 ### Community 504 - "Community 504"
-Cohesion: 1.0
-Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
+Cohesion: 0.67
+Nodes (1): View()
 
 ### Community 505 - "Community 505"
 Cohesion: 0.67
@@ -3930,12 +3937,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 508 - "Community 508"
-Cohesion: 1.0
-Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 509 - "Community 509"
-Cohesion: 0.67
-Nodes (1): FadeIn()
+Cohesion: 1.0
+Nodes (2): AnalyticsTopUsers(), processAnalyticsToUsers()
 
 ### Community 510 - "Community 510"
 Cohesion: 0.67
@@ -3950,12 +3957,12 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 513 - "Community 513"
-Cohesion: 0.67
-Nodes (1): VideoPlayer()
+Cohesion: 1.0
+Nodes (2): normalizeAuthSyncRedirect(), startAthenaAuthSyncHandoff()
 
 ### Community 514 - "Community 514"
-Cohesion: 1.0
-Nodes (2): handleRefundOrder(), toast()
+Cohesion: 0.67
+Nodes (1): FadeIn()
 
 ### Community 515 - "Community 515"
 Cohesion: 0.67
@@ -3971,11 +3978,11 @@ Nodes (0):
 
 ### Community 518 - "Community 518"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): VideoPlayer()
 
 ### Community 519 - "Community 519"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleRefundOrder(), toast()
 
 ### Community 520 - "Community 520"
 Cohesion: 0.67
@@ -4010,8 +4017,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 528 - "Community 528"
-Cohesion: 1.0
-Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 529 - "Community 529"
 Cohesion: 0.67
@@ -4030,100 +4037,100 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 533 - "Community 533"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getRemoteAssistRuntimeState(), PosRemoteAssistRuntimeHost()
 
 ### Community 534 - "Community 534"
 Cohesion: 0.67
-Nodes (1): SingleLineError()
+Nodes (0):
 
 ### Community 535 - "Community 535"
 Cohesion: 0.67
-Nodes (1): ErrorPage()
+Nodes (0):
 
 ### Community 536 - "Community 536"
 Cohesion: 0.67
-Nodes (1): AppSkeleton()
+Nodes (0):
 
 ### Community 537 - "Community 537"
 Cohesion: 0.67
-Nodes (1): DashboardSkeleton()
+Nodes (0):
 
 ### Community 538 - "Community 538"
 Cohesion: 0.67
-Nodes (1): TableSkeleton()
+Nodes (0):
 
 ### Community 539 - "Community 539"
 Cohesion: 0.67
-Nodes (1): TransactionsSkeleton()
+Nodes (1): SingleLineError()
 
 ### Community 540 - "Community 540"
 Cohesion: 0.67
-Nodes (1): NotFound()
+Nodes (1): ErrorPage()
 
 ### Community 541 - "Community 541"
-Cohesion: 1.0
-Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
+Cohesion: 0.67
+Nodes (1): AppSkeleton()
 
 ### Community 542 - "Community 542"
 Cohesion: 0.67
-Nodes (1): AppContextMenu()
+Nodes (1): DashboardSkeleton()
 
 ### Community 543 - "Community 543"
 Cohesion: 0.67
-Nodes (1): Badge()
+Nodes (1): TableSkeleton()
 
 ### Community 544 - "Community 544"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): TransactionsSkeleton()
 
 ### Community 545 - "Community 545"
 Cohesion: 0.67
-Nodes (1): LoadingButton()
+Nodes (1): NotFound()
 
 ### Community 546 - "Community 546"
-Cohesion: 0.67
-Nodes (1): onChange()
+Cohesion: 1.0
+Nodes (2): getWorkflowTraceRouteTarget(), WorkflowTraceRouteLink()
 
 ### Community 547 - "Community 547"
 Cohesion: 0.67
-Nodes (1): AlertModal()
+Nodes (1): AppContextMenu()
 
 ### Community 548 - "Community 548"
 Cohesion: 0.67
-Nodes (1): OverlayModal()
+Nodes (1): Badge()
 
 ### Community 549 - "Community 549"
 Cohesion: 0.67
-Nodes (1): Skeleton()
+Nodes (0):
 
 ### Community 550 - "Community 550"
 Cohesion: 0.67
-Nodes (1): Toaster()
+Nodes (1): LoadingButton()
 
 ### Community 551 - "Community 551"
 Cohesion: 0.67
-Nodes (1): Spinner()
+Nodes (1): onChange()
 
 ### Community 552 - "Community 552"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): AlertModal()
 
 ### Community 553 - "Community 553"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): OverlayModal()
 
 ### Community 554 - "Community 554"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Skeleton()
 
 ### Community 555 - "Community 555"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Toaster()
 
 ### Community 556 - "Community 556"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): Spinner()
 
 ### Community 557 - "Community 557"
 Cohesion: 0.67
@@ -4139,7 +4146,7 @@ Nodes (0):
 
 ### Community 560 - "Community 560"
 Cohesion: 0.67
-Nodes (1): useAuth()
+Nodes (0):
 
 ### Community 561 - "Community 561"
 Cohesion: 0.67
@@ -4154,20 +4161,20 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 564 - "Community 564"
-Cohesion: 1.0
-Nodes (2): getApprovalGuidance(), presentCommandToast()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 565 - "Community 565"
 Cohesion: 0.67
-Nodes (1): isInMaintenanceMode()
+Nodes (1): useAuth()
 
 ### Community 566 - "Community 566"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 567 - "Community 567"
-Cohesion: 1.0
-Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 568 - "Community 568"
 Cohesion: 0.67
@@ -4175,43 +4182,43 @@ Nodes (0):
 
 ### Community 569 - "Community 569"
 Cohesion: 1.0
-Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
+Nodes (2): getApprovalGuidance(), presentCommandToast()
 
 ### Community 570 - "Community 570"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): isInMaintenanceMode()
 
 ### Community 571 - "Community 571"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 572 - "Community 572"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createTerminalSyncSecretToken(), registerAndProvisionPosTerminal()
 
 ### Community 573 - "Community 573"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 574 - "Community 574"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): buildLocalEvent(), isUploadSequenceEventType()
 
 ### Community 575 - "Community 575"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 576 - "Community 576"
-Cohesion: 1.0
-Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 577 - "Community 577"
-Cohesion: 0.67
-Nodes (1): App()
+Cohesion: 1.0
+Nodes (2): classifyTerminalStaffAuthorityRefreshResult(), refreshAndStoreTerminalStaffAuthority()
 
 ### Community 578 - "Community 578"
-Cohesion: 1.0
-Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 579 - "Community 579"
 Cohesion: 0.67
@@ -4222,48 +4229,48 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 581 - "Community 581"
-Cohesion: 1.0
-Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
-
-### Community 582 - "Community 582"
-Cohesion: 1.0
-Nodes (2): mockGetSku(), validateInventoryForTransaction()
-
-### Community 583 - "Community 583"
-Cohesion: 0.67
-Nodes (1): hashPassword()
-
-### Community 584 - "Community 584"
 Cohesion: 0.67
 Nodes (0):
 
+### Community 582 - "Community 582"
+Cohesion: 1.0
+Nodes (2): isRecord(), parseRemoteAssistTransportMessage()
+
+### Community 583 - "Community 583"
+Cohesion: 0.67
+Nodes (1): App()
+
+### Community 584 - "Community 584"
+Cohesion: 1.0
+Nodes (2): collectSourceFiles(), findIllegalConvexImports()
+
 ### Community 585 - "Community 585"
 Cohesion: 0.67
-Nodes (1): manualChunks()
+Nodes (0):
 
 ### Community 586 - "Community 586"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 587 - "Community 587"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getAthenaDesignTokenStyle(), withAthenaTheme()
 
 ### Community 588 - "Community 588"
 Cohesion: 1.0
-Nodes (2): getAllColors(), getBaseUrl()
+Nodes (2): mockGetSku(), validateInventoryForTransaction()
 
 ### Community 589 - "Community 589"
 Cohesion: 0.67
-Nodes (0):
+Nodes (1): hashPassword()
 
 ### Community 590 - "Community 590"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getLastViewedProduct()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 591 - "Community 591"
-Cohesion: 1.0
-Nodes (2): getBaseUrl(), getUserOffersEligibility()
+Cohesion: 0.67
+Nodes (1): manualChunks()
 
 ### Community 592 - "Community 592"
 Cohesion: 0.67
@@ -4274,8 +4281,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 594 - "Community 594"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getAllColors(), getBaseUrl()
 
 ### Community 595 - "Community 595"
 Cohesion: 0.67
@@ -4283,11 +4290,11 @@ Nodes (0):
 
 ### Community 596 - "Community 596"
 Cohesion: 1.0
-Nodes (2): handleKeyDown(), handleRedeemPromoCode()
+Nodes (2): getBaseUrl(), getLastViewedProduct()
 
 ### Community 597 - "Community 597"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getBaseUrl(), getUserOffersEligibility()
 
 ### Community 598 - "Community 598"
 Cohesion: 0.67
@@ -4298,16 +4305,16 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 600 - "Community 600"
-Cohesion: 1.0
-Nodes (2): getPromoAlertCopy(), PromoAlert()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 601 - "Community 601"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 602 - "Community 602"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): handleKeyDown(), handleRedeemPromoCode()
 
 ### Community 603 - "Community 603"
 Cohesion: 0.67
@@ -4322,8 +4329,8 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 606 - "Community 606"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): getPromoAlertCopy(), PromoAlert()
 
 ### Community 607 - "Community 607"
 Cohesion: 0.67
@@ -4370,68 +4377,68 @@ Cohesion: 0.67
 Nodes (0):
 
 ### Community 618 - "Community 618"
-Cohesion: 1.0
-Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 619 - "Community 619"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 620 - "Community 620"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 621 - "Community 621"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 622 - "Community 622"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 623 - "Community 623"
-Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Cohesion: 0.67
+Nodes (0):
 
 ### Community 624 - "Community 624"
 Cohesion: 1.0
-Nodes (2): createFixtureRepo(), write()
+Nodes (2): collectWorkflowFiles(), runWorkflowCheck()
 
 ### Community 625 - "Community 625"
 Cohesion: 0.67
 Nodes (0):
 
 ### Community 626 - "Community 626"
-Cohesion: 0.67
-Nodes (0):
+Cohesion: 1.0
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 627 - "Community 627"
 Cohesion: 1.0
-Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 628 - "Community 628"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 629 - "Community 629"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 630 - "Community 630"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): createFixtureRepo(), write()
 
 ### Community 631 - "Community 631"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 632 - "Community 632"
-Cohesion: 1.0
+Cohesion: 0.67
 Nodes (0):
 
 ### Community 633 - "Community 633"
 Cohesion: 1.0
-Nodes (0):
+Nodes (2): collectRootScriptTestFiles(), runRootScriptsCoverage()
 
 ### Community 634 - "Community 634"
 Cohesion: 1.0
@@ -9337,1588 +9344,1604 @@ Nodes (0):
 Cohesion: 1.0
 Nodes (0):
 
+### Community 1860 - "Community 1860"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1861 - "Community 1861"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1862 - "Community 1862"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1863 - "Community 1863"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1864 - "Community 1864"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1865 - "Community 1865"
+Cohesion: 1.0
+Nodes (0):
+
+### Community 1866 - "Community 1866"
+Cohesion: 1.0
+Nodes (0):
+
 ## Knowledge Gaps
 - **1 isolated node(s):** `HelpRequested`
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 628`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
+- **Thin community `Community 634`** (2 nodes): `createDb()`, `automationFoundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 629`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
+- **Thin community `Community 635`** (2 nodes): `paymentAllocationAttribution.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 630`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
+- **Thin community `Community 636`** (2 nodes): `registerSessions.test.ts`, `getHandler()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 631`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
+- **Thin community `Community 637`** (2 nodes): `stream.ts`, `getCloudflareConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 632`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
+- **Thin community `Community 638`** (2 nodes): `createCommandShimBin()`, `convexAuditScript.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 633`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
+- **Thin community `Community 639`** (2 nodes): `policy.ts`, `assertSupportedCustomerMessagePolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 634`** (2 nodes): `repository.test.ts`, `queryResult()`
+- **Thin community `Community 640`** (2 nodes): `repository.test.ts`, `queryResult()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 635`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
+- **Thin community `Community 641`** (2 nodes): `webhookSecurity.test.ts`, `sign()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 636`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
+- **Thin community `Community 642`** (2 nodes): `VerificationCode.tsx`, `VerificationCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 637`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
+- **Thin community `Community 643`** (2 nodes): `subcategories.ts`, `removeStorefrontHiddenSubcategoryList()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 638`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
+- **Thin community `Community 644`** (2 nodes): `storefrontCors.test.ts`, `readRouteFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 639`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
+- **Thin community `Community 645`** (2 nodes): `whatsapp.ts`, `mapWebhookStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 640`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
+- **Thin community `Community 646`** (2 nodes): `handleCollectionNotification()`, `mtnMomo.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 641`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
+- **Thin community `Community 647`** (2 nodes): `routerComposition.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 642`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
+- **Thin community `Community 648`** (2 nodes): `mapAthenaAuthSyncError()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 643`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
+- **Thin community `Community 649`** (2 nodes): `getHandler()`, `bestSeller.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 644`** (2 nodes): `createMutationCtx()`, `catalogImport.test.ts`
+- **Thin community `Community 650`** (2 nodes): `createMutationCtx()`, `catalogImport.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 645`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
+- **Thin community `Community 651`** (2 nodes): `userErrorFromExpenseItemCommandFailure()`, `expenseSessionItems.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 646`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
+- **Thin community `Community 652`** (2 nodes): `posQueryCleanup.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 647`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
+- **Thin community `Community 653`** (2 nodes): `productUtil.ts`, `buildAllProductsCacheKey()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 648`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
+- **Thin community `Community 654`** (2 nodes): `promoCode.ts`, `calculateSelectedProductPromoDiscount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 649`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
+- **Thin community `Community 655`** (2 nodes): `stores.ts`, `toV2OnlyConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 650`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
+- **Thin community `Community 656`** (2 nodes): `commandResultValidator()`, `commandResultValidators.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 651`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
+- **Thin community `Community 657`** (2 nodes): `callLlmProvider()`, `callLlmProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 652`** (2 nodes): `callAnthropic()`, `anthropic.ts`
+- **Thin community `Community 658`** (2 nodes): `callAnthropic()`, `anthropic.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 653`** (2 nodes): `callOpenAi()`, `openai.ts`
+- **Thin community `Community 659`** (2 nodes): `callOpenAi()`, `openai.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 654`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
+- **Thin community `Community 660`** (2 nodes): `readProjectFile()`, `foundation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 655`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
+- **Thin community `Community 661`** (2 nodes): `consumeCommandApprovalProofWithCtx()`, `approvalActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 656`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
+- **Thin community `Community 662`** (2 nodes): `createOperationalEventCtx()`, `approvalAuditEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 657`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
+- **Thin community `Community 663`** (2 nodes): `createApprovalProofMutationCtx()`, `approvalProofs.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 658`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
+- **Thin community `Community 664`** (2 nodes): `buildApprovalRequest()`, `approvalRequestHelpers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 659`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
+- **Thin community `Community 665`** (2 nodes): `createApprovalRequestMutationCtx()`, `approvalRequests.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 660`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
+- **Thin community `Community 666`** (2 nodes): `buildOperationalEventMessage()`, `eventBuilders.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 661`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
+- **Thin community `Community 667`** (2 nodes): `createInventoryMovementCtx()`, `inventoryMovements.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 662`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
+- **Thin community `Community 668`** (2 nodes): `createCtx()`, `operationalEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 663`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
+- **Thin community `Community 669`** (2 nodes): `getHandler()`, `operationalWorkItems.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 664`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
+- **Thin community `Community 670`** (2 nodes): `skuActivity.test.ts`, `createIndexedDb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 665`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
+- **Thin community `Community 671`** (2 nodes): `formatValidTime()`, `EmailOTP.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 666`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
+- **Thin community `Community 672`** (2 nodes): `createPendingCheckoutCtx()`, `createOrReusePendingCheckoutItem.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 667`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
+- **Thin community `Community 673`** (2 nodes): `quickAddCatalogItem.test.ts`, `createQuickAddCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 668`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
+- **Thin community `Community 674`** (2 nodes): `createMutationCtx()`, `correctTransactionPaymentMethod.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 669`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
+- **Thin community `Community 675`** (2 nodes): `buildCorrectionOperationalEvent()`, `correctionEvents.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 670`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
+- **Thin community `Community 676`** (2 nodes): `mockCorrectionHistoryDb()`, `getTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 671`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
+- **Thin community `Community 677`** (2 nodes): `createRegisterCatalogCtx()`, `listRegisterCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 672`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
+- **Thin community `Community 678`** (2 nodes): `staffProofValidation.ts`, `validatePosLocalStaffProofWithCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 673`** (2 nodes): `resolveTerminalCloudRepair.ts`, `resolveTerminalCloudRepair()`
+- **Thin community `Community 679`** (2 nodes): `resolveTerminalCloudRepair.ts`, `resolveTerminalCloudRepair()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 674`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
+- **Thin community `Community 680`** (2 nodes): `transactionAdjustmentPlanner.test.ts`, `baseInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 675`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
+- **Thin community `Community 681`** (2 nodes): `getCashierForRegisterState()`, `cashierRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 676`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
+- **Thin community `Community 682`** (2 nodes): `createExpenseSessionCommandRepository()`, `expenseSessionCommandRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 677`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
+- **Thin community `Community 683`** (2 nodes): `readProjectFile()`, `localSyncRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 678`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
+- **Thin community `Community 684`** (2 nodes): `createConvexLocalSyncRepository()`, `localSyncRepository.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 679`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
+- **Thin community `Community 685`** (2 nodes): `sessionCommandRepository.test.ts`, `readProjectFile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 680`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
+- **Thin community `Community 686`** (2 nodes): `sessionRepository.test.ts`, `buildSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 681`** (2 nodes): `terminalRecoveryRepository.test.ts`, `buildCtx()`
+- **Thin community `Community 687`** (2 nodes): `terminalRecoveryRepository.test.ts`, `buildCtx()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 682`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
+- **Thin community `Community 688`** (2 nodes): `posRuntimeAdapter.ts`, `buildPosRemoteAssistClientPresence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 683`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 689`** (2 nodes): `buildContext()`, `LiveKitRemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 684`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
+- **Thin community `Community 690`** (2 nodes): `createRemoteAssistTransportProvider()`, `createRemoteAssistTransportProvider.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 685`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
+- **Thin community `Community 691`** (2 nodes): `public.ts`, `toRemoteAssistSessionReturn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 686`** (2 nodes): `transport.ts`, `issueCredential()`
+- **Thin community `Community 692`** (2 nodes): `transport.ts`, `issueCredential()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 687`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
+- **Thin community `Community 693`** (2 nodes): `getSource()`, `moduleWiring.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 688`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
+- **Thin community `Community 694`** (2 nodes): `createStockOpsAccessQueryCtx()`, `access.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 689`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
+- **Thin community `Community 695`** (2 nodes): `requireStoreFullAdminAccess()`, `access.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 690`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
+- **Thin community `Community 696`** (2 nodes): `createCycleCountDraftCtx()`, `cycleCountDrafts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 691`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
+- **Thin community `Community 697`** (2 nodes): `getStoreFrontActorById()`, `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 692`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
+- **Thin community `Community 698`** (2 nodes): `createReservationActivityCtx()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 693`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
+- **Thin community `Community 699`** (2 nodes): `createQueryCtx()`, `customerBehaviorTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 694`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
+- **Thin community `Community 700`** (2 nodes): `createAnalyticsEvent()`, `customerObservabilityTimeline.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 695`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
+- **Thin community `Community 701`** (2 nodes): `readProjectFile()`, `helperOrchestration.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 696`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
+- **Thin community `Community 702`** (2 nodes): `createMutationCtx()`, `customerEngagementEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 697`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
+- **Thin community `Community 703`** (2 nodes): `getSource()`, `onlineOrder.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 698`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
+- **Thin community `Community 704`** (2 nodes): `updateOnlineOrderItem()`, `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 699`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 705`** (2 nodes): `reviews.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 700`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
+- **Thin community `Community 706`** (2 nodes): `rewards.ts`, `formatPointsLabel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 701`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
+- **Thin community `Community 707`** (2 nodes): `savedBag.ts`, `listSavedBagItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 702`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
+- **Thin community `Community 708`** (2 nodes): `storefrontObservabilityReport.test.ts`, `createAnalyticsEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 703`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
+- **Thin community `Community 709`** (2 nodes): `syntheticMonitor.ts`, `isSyntheticMonitorOrigin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 704`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
+- **Thin community `Community 710`** (2 nodes): `timeQueryRefactors.test.ts`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 705`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
+- **Thin community `Community 711`** (2 nodes): `user.ts`, `getStoreFrontActorById()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 706`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
+- **Thin community `Community 712`** (2 nodes): `userOffers.ts`, `determineOfferEligibility()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 707`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
+- **Thin community `Community 713`** (2 nodes): `buildExpenseSessionTraceSeed()`, `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 708`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
+- **Thin community `Community 714`** (2 nodes): `posSession.ts`, `buildPosSessionTraceSeed()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 709`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
+- **Thin community `Community 715`** (2 nodes): `presentation.ts`, `buildWorkflowTraceViewModel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 710`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
+- **Thin community `Community 716`** (2 nodes): `schemaIndexes.test.ts`, `getTableIndexes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 711`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
+- **Thin community `Community 717`** (2 nodes): `serviceIntake.ts`, `validateServiceIntakeInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 712`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
+- **Thin community `Community 718`** (2 nodes): `removeConvexAuthCodeParamFromUrl()`, `convexAuthUrl.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 713`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
+- **Thin community `Community 719`** (2 nodes): `Navigation()`, `OrganizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 714`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
+- **Thin community `Community 720`** (2 nodes): `Navigation()`, `OrganizationsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 715`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
+- **Thin community `Community 721`** (2 nodes): `PermissionGate.tsx`, `PermissionGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 716`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
+- **Thin community `Community 722`** (2 nodes): `ProtectedRoute.tsx`, `ProtectedRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 717`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
+- **Thin community `Community 723`** (2 nodes): `SettingsView.tsx`, `SettingsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 718`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
+- **Thin community `Community 724`** (2 nodes): `StoreActions.tsx`, `StoreActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 719`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
+- **Thin community `Community 725`** (2 nodes): `StoreDropdown.tsx`, `StoreDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 720`** (2 nodes): `StoreView.tsx`, `Navigation()`
+- **Thin community `Community 726`** (2 nodes): `StoreView.tsx`, `Navigation()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 721`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
+- **Thin community `Community 727`** (2 nodes): `StoresDropdown.tsx`, `StoresDropdown()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 722`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
+- **Thin community `Community 728`** (2 nodes): `handlePrint()`, `BarcodeQRViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 723`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
+- **Thin community `Community 729`** (2 nodes): `ProcessingFees.tsx`, `ProcessingFeesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 724`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
+- **Thin community `Community 730`** (2 nodes): `ProductAvailabilityToggleGroup.tsx`, `ProductAvailabilityToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 725`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
+- **Thin community `Community 731`** (2 nodes): `ProductDetails.tsx`, `handleNameChange()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 726`** (2 nodes): `ProductImages.tsx`, `Header()`
+- **Thin community `Community 732`** (2 nodes): `ProductImages.tsx`, `Header()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 727`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
+- **Thin community `Community 733`** (2 nodes): `ProductPage.tsx`, `ProductPage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 728`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
+- **Thin community `Community 734`** (2 nodes): `setIsUpdatingSku()`, `CopyImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 729`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
+- **Thin community `Community 735`** (2 nodes): `product-variant-columns.tsx`, `setSourceVariant()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 730`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
+- **Thin community `Community 736`** (2 nodes): `capitalizeFirstLetter()`, `ActivityTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 731`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
+- **Thin community `Community 737`** (2 nodes): `AnalyticsCombinedUsers()`, `AnalyticsCombinedUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 732`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
+- **Thin community `Community 738`** (2 nodes): `AnalyticsItems()`, `AnalyticsItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 733`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
+- **Thin community `Community 739`** (2 nodes): `AnalyticsProducts()`, `AnalyticsProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 734`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
+- **Thin community `Community 740`** (2 nodes): `AnalyticsUsers()`, `AnalyticsUsers.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 735`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
+- **Thin community `Community 741`** (2 nodes): `getDateRangeMilliseconds()`, `EnhancedAnalyticsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 736`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
+- **Thin community `Community 742`** (2 nodes): `StoreInsights.tsx`, `getTrendIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 737`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
+- **Thin community `Community 743`** (2 nodes): `VisitorChart.tsx`, `formatHour()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 738`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
+- **Thin community `Community 744`** (2 nodes): `readSource()`, `analyticsWorkspaceEfficiency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 739`** (2 nodes): `LogItems()`, `LogItems.tsx`
+- **Thin community `Community 745`** (2 nodes): `LogItems()`, `LogItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (2 nodes): `Header()`, `LogView.tsx`
+- **Thin community `Community 746`** (2 nodes): `Header()`, `LogView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (2 nodes): `Navigation()`, `LogsView.tsx`
+- **Thin community `Community 747`** (2 nodes): `Navigation()`, `LogsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
+- **Thin community `Community 748`** (2 nodes): `useLoadLogItems.ts`, `useLoadLogItems()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
+- **Thin community `Community 749`** (2 nodes): `Passthrough()`, `app-sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
+- **Thin community `Community 750`** (2 nodes): `SidebarMenuCollapsible()`, `app-sidebar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (2 nodes): `Auth()`, `Auth.tsx`
+- **Thin community `Community 751`** (2 nodes): `Auth()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
+- **Thin community `Community 752`** (2 nodes): `resolveSignIn()`, `InputOTP.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
+- **Thin community `Community 753`** (2 nodes): `DataTableColumnHeader()`, `data-table-column-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
+- **Thin community `Community 754`** (2 nodes): `handleLoadProducts()`, `BulkOperationsFilters.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
+- **Thin community `Community 755`** (2 nodes): `makeRow()`, `BulkOperationsPreview.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
+- **Thin community `Community 756`** (2 nodes): `formatPrice()`, `BulkOperationsPreview.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
+- **Thin community `Community 757`** (2 nodes): `formatReviewReason()`, `formatReviewReason.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
+- **Thin community `Community 758`** (2 nodes): `registerSessionColumns.tsx`, `RegisterSessionLink()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
+- **Thin community `Community 759`** (2 nodes): `CheckoutSessionsTable()`, `CheckoutSessionsTable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
+- **Thin community `Community 760`** (2 nodes): `Navigation()`, `CheckoutSesssionsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
+- **Thin community `Community 761`** (2 nodes): `FinancialValue()`, `FinancialValue.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
+- **Thin community `Community 762`** (2 nodes): `ExpenseCompletion()`, `ExpenseCompletion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
+- **Thin community `Community 763`** (2 nodes): `ExpenseView()`, `ExpenseView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
+- **Thin community `Community 764`** (2 nodes): `handleAddBestSeller()`, `BestSellersDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
+- **Thin community `Community 765`** (2 nodes): `handleAddFeaturedItem()`, `FeaturedSectionDialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (2 nodes): `Navigation()`, `Home.tsx`
+- **Thin community `Community 766`** (2 nodes): `Navigation()`, `Home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
+- **Thin community `Community 767`** (2 nodes): `handleUpdateConfig()`, `LandingPageReelVersion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
+- **Thin community `Community 768`** (2 nodes): `ShopLookDialog.tsx`, `handleAddFeaturedItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
+- **Thin community `Community 769`** (2 nodes): `ShopLookImageUploader.tsx`, `ShopLookImageUploader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (2 nodes): `JoinTeam()`, `index.tsx`
+- **Thin community `Community 770`** (2 nodes): `JoinTeam()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
+- **Thin community `Community 771`** (2 nodes): `Reveal()`, `AthenaLandingPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
+- **Thin community `Community 772`** (2 nodes): `cn()`, `OperationReviewItemCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
+- **Thin community `Community 773`** (2 nodes): `buildParams()`, `OperationsSummaryMetric.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
+- **Thin community `Community 774`** (2 nodes): `CustomerDetailsView()`, `CustomerDetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
+- **Thin community `Community 775`** (2 nodes): `handleSendOrderEmail()`, `EmailStatusView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
+- **Thin community `Community 776`** (2 nodes): `OrderMetricsPanel()`, `OrderMetricsPanel.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
+- **Thin community `Community 777`** (2 nodes): `getTimeFilter()`, `OrdersView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
+- **Thin community `Community 778`** (2 nodes): `RefundsView.tsx`, `handleRefundOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
+- **Thin community `Community 779`** (2 nodes): `useGetActiveOnlineOrder.ts`, `useGetActiveOnlineOrder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 774`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
+- **Thin community `Community 780`** (2 nodes): `handleClearFilters()`, `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 775`** (2 nodes): `if()`, `orderColumns.tsx`
+- **Thin community `Community 781`** (2 nodes): `if()`, `orderColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 776`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
+- **Thin community `Community 782`** (2 nodes): `OrganizationSwitcher()`, `organization-switcher.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 777`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
+- **Thin community `Community 783`** (2 nodes): `buildServiceLine()`, `CartItems.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 778`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
+- **Thin community `Community 784`** (2 nodes): `DebugProducts()`, `DebugProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 779`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
+- **Thin community `Community 785`** (2 nodes): `NoResultsMessage()`, `NoResultsMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 780`** (2 nodes): `PinInput.tsx`, `PinInput()`
+- **Thin community `Community 786`** (2 nodes): `PinInput.tsx`, `PinInput()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 781`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
+- **Thin community `Community 787`** (2 nodes): `PrintInstructions.tsx`, `PrintInstructions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 782`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
+- **Thin community `Community 788`** (2 nodes): `SearchResultsSection.test.tsx`, `buildProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 783`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
+- **Thin community `Community 789`** (2 nodes): `SessionDemo.tsx`, `SessionDemo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 784`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
+- **Thin community `Community 790`** (2 nodes): `handlePrintReceipt()`, `ExpenseReportView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 785`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
+- **Thin community `Community 791`** (2 nodes): `toExpenseReportRows()`, `expenseReportRows.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 786`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
+- **Thin community `Community 792`** (2 nodes): `buildCheckout()`, `ExpenseCompletionPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 787`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
+- **Thin community `Community 793`** (2 nodes): `POSRegisterView.test.tsx`, `pressDebugPanelShortcut()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 788`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
+- **Thin community `Community 794`** (2 nodes): `RegisterCheckoutPanel.tsx`, `RegisterCheckoutPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 789`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
+- **Thin community `Community 795`** (2 nodes): `RegisterCustomerAttribution.test.tsx`, `makeCustomer()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 790`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
+- **Thin community `Community 796`** (2 nodes): `RegisterCustomerPanel.tsx`, `RegisterCustomerPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 791`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
+- **Thin community `Community 797`** (2 nodes): `RegisterDrawerGate.test.tsx`, `renderGate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 792`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
+- **Thin community `Community 798`** (2 nodes): `RegisterSessionPanel.tsx`, `RegisterSessionPanel()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 793`** (2 nodes): `POSSettingsView.test.tsx`, `waitForFingerprintEffect()`
+- **Thin community `Community 799`** (2 nodes): `POSSettingsView.test.tsx`, `waitForFingerprintEffect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 794`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
+- **Thin community `Community 800`** (2 nodes): `POSTerminalHealthView.tsx`, `CountMetric()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 795`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
+- **Thin community `Community 801`** (2 nodes): `transactionColumns.test.tsx`, `renderTransactionCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 796`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
+- **Thin community `Community 802`** (2 nodes): `transactionColumns.tsx`, `getPaymentMethodIcon()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 797`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
+- **Thin community `Community 803`** (2 nodes): `BarcodeView()`, `BarcodeView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 798`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
+- **Thin community `Community 804`** (2 nodes): `CategorizationView()`, `CategorizationView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 799`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
+- **Thin community `Community 805`** (2 nodes): `handleKeyDown()`, `ImagesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 800`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
+- **Thin community `Community 806`** (2 nodes): `ProductDetailView.tsx`, `handleUnarchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 801`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
+- **Thin community `Community 807`** (2 nodes): `ProductStatus.tsx`, `ProductStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 802`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
+- **Thin community `Community 808`** (2 nodes): `product-actions.tsx`, `useArchiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 803`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
+- **Thin community `Community 809`** (2 nodes): `CategoryListView()`, `CategoryListView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 804`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
+- **Thin community `Community 810`** (2 nodes): `ProductsListView.logic.ts`, `getCategoryProductQueryOptions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 805`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
+- **Thin community `Community 811`** (2 nodes): `ProductsView.tsx`, `ProductsView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 806`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
+- **Thin community `Community 812`** (2 nodes): `ProductTaxonomyCells.tsx`, `ProductCategoryCell()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 807`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
+- **Thin community `Community 813`** (2 nodes): `AddProductCommand()`, `add-product-command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 808`** (2 nodes): `Products.tsx`, `Products()`
+- **Thin community `Community 814`** (2 nodes): `Products.tsx`, `Products()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 809`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
+- **Thin community `Community 815`** (2 nodes): `PromoCodeForm.tsx`, `toggleDiscountType()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 810`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
+- **Thin community `Community 816`** (2 nodes): `PromoCodeHeader.tsx`, `handleDeletePromoCode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 811`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
+- **Thin community `Community 817`** (2 nodes): `PromoCodePreview.tsx`, `Discount()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 812`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
+- **Thin community `Community 818`** (2 nodes): `PromoCodesView.test.tsx`, `readSource()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 813`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
+- **Thin community `Community 819`** (2 nodes): `PromoCodesView.tsx`, `PromoCodesView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 814`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
+- **Thin community `Community 820`** (2 nodes): `SelectableCategories.tsx`, `toggle()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 815`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
+- **Thin community `Community 821`** (2 nodes): `DiscountTypeToggleGroup()`, `DiscountTypeToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 816`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
+- **Thin community `Community 822`** (2 nodes): `PromoCodeSpanToggleGroup.tsx`, `PromoCodeSpanToggleGroup()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 817`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
+- **Thin community `Community 823`** (2 nodes): `CapturedEmails()`, `CapturedEmails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 818`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
+- **Thin community `Community 824`** (2 nodes): `promo-code-modal.tsx`, `PromoCodeModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 819`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
+- **Thin community `Community 825`** (2 nodes): `RemoteAssistLiveViewer.tsx`, `async()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 820`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
+- **Thin community `Community 826`** (2 nodes): `RemoteAssistRuntimeShell.tsx`, `handleDisconnect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 821`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
+- **Thin community `Community 827`** (2 nodes): `ReviewActions.tsx`, `ReviewActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 822`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 828`** (2 nodes): `ServiceCasesView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 823`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 829`** (2 nodes): `ServiceCatalogView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 824`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 830`** (2 nodes): `ServiceIntakeView.auth.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 825`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
+- **Thin community `Community 831`** (2 nodes): `ServicesWorkspaceView.test.tsx`, `chooseSelectOption()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 826`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
+- **Thin community `Community 832`** (2 nodes): `staffPinPolicy.ts`, `normalizeStaffPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 827`** (2 nodes): `onClick()`, `empty-state.tsx`
+- **Thin community `Community 833`** (2 nodes): `onClick()`, `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 828`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
+- **Thin community `Community 834`** (2 nodes): `NoPermission()`, `NoPermission.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 829`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
+- **Thin community `Community 835`** (2 nodes): `NoPermissionView()`, `NoPermissionView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 830`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
+- **Thin community `Community 836`** (2 nodes): `NotFoundView()`, `NotFoundView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 831`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
+- **Thin community `Community 837`** (2 nodes): `ProtectedAdminSignInView.tsx`, `ProtectedAdminSignInView()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 832`** (2 nodes): `ContactView()`, `ContactView.tsx`
+- **Thin community `Community 838`** (2 nodes): `ContactView()`, `ContactView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 833`** (2 nodes): `Header()`, `Header.tsx`
+- **Thin community `Community 839`** (2 nodes): `Header()`, `Header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 834`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
+- **Thin community `Community 840`** (2 nodes): `MaintenanceView()`, `MaintenanceView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 835`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
+- **Thin community `Community 841`** (2 nodes): `TaxView.tsx`, `handleUpdateTaxSettings()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 836`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
+- **Thin community `Community 842`** (2 nodes): `useStoreConfigUpdate.ts`, `useStoreConfigUpdate()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 837`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
+- **Thin community `Community 843`** (2 nodes): `store-switcher.tsx`, `onStoreSelect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 838`** (2 nodes): `useChart()`, `chart.tsx`
+- **Thin community `Community 844`** (2 nodes): `useChart()`, `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 839`** (2 nodes): `handleCopy()`, `copy-button.tsx`
+- **Thin community `Community 845`** (2 nodes): `handleCopy()`, `copy-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 840`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
+- **Thin community `Community 846`** (2 nodes): `handleCopy()`, `copy-wrapper.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 841`** (2 nodes): `Label()`, `label.tsx`
+- **Thin community `Community 847`** (2 nodes): `Label()`, `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 842`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
+- **Thin community `Community 848`** (2 nodes): `CustomModal()`, `custom-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 843`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
+- **Thin community `Community 849`** (2 nodes): `onSubmit()`, `organization-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 844`** (2 nodes): `store-modal.tsx`, `onSubmit()`
+- **Thin community `Community 850`** (2 nodes): `store-modal.tsx`, `onSubmit()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 845`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
+- **Thin community `Community 851`** (2 nodes): `welcome-back-modal-example.tsx`, `WelcomeBackModalExample()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 846`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
+- **Thin community `Community 852`** (2 nodes): `welcome-back-modal.tsx`, `WelcomeBackModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 847`** (2 nodes): `select-native.tsx`, `cn()`
+- **Thin community `Community 853`** (2 nodes): `select-native.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 848`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
+- **Thin community `Community 854`** (2 nodes): `timeline-item.tsx`, `TimelineItem()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 849`** (2 nodes): `webp-image.tsx`, `WebpImage()`
+- **Thin community `Community 855`** (2 nodes): `webp-image.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 850`** (2 nodes): `BagItems()`, `BagItems.tsx`
+- **Thin community `Community 856`** (2 nodes): `BagItems()`, `BagItems.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 851`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
+- **Thin community `Community 857`** (2 nodes): `BagItemsView()`, `BagItemsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 852`** (2 nodes): `Bags()`, `Bags.tsx`
+- **Thin community `Community 858`** (2 nodes): `Bags()`, `Bags.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 853`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
+- **Thin community `Community 859`** (2 nodes): `String()`, `CustomerBehaviorTimeline.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 854`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
+- **Thin community `Community 860`** (2 nodes): `UserAnalyticsName.tsx`, `UserAnalyticsName()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 855`** (2 nodes): `UserBag.tsx`, `UserBag()`
+- **Thin community `Community 861`** (2 nodes): `UserBag.tsx`, `UserBag()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 856`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
+- **Thin community `Community 862`** (2 nodes): `UserOnlineOrders.tsx`, `UserOnlineOrders()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 857`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
+- **Thin community `Community 863`** (2 nodes): `UserStatus.tsx`, `UserStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 858`** (2 nodes): `UserView.tsx`, `UserActions()`
+- **Thin community `Community 864`** (2 nodes): `UserView.tsx`, `UserActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 859`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
+- **Thin community `Community 865`** (2 nodes): `CustomerJourneyStageCard()`, `CustomerJourneyStage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 860`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
+- **Thin community `Community 866`** (2 nodes): `UserBehaviorInsights.tsx`, `UserBehaviorInsights()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 861`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
+- **Thin community `Community 867`** (2 nodes): `wrapper()`, `ManagerElevationContext.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 862`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
+- **Thin community `Community 868`** (2 nodes): `use-image-upload.ts`, `useImageUpload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 863`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
+- **Thin community `Community 869`** (2 nodes): `use-mobile.tsx`, `useIsMobile()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 864`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
+- **Thin community `Community 870`** (2 nodes): `use-navigate-back.ts`, `useNavigateBack()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 865`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
+- **Thin community `Community 871`** (2 nodes): `use-navigation-keyboard-shortcuts.ts`, `useNavigationKeyboardShortcuts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 866`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
+- **Thin community `Community 872`** (2 nodes): `use-pagination-persistence.ts`, `usePaginationPersistence()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 867`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
+- **Thin community `Community 873`** (2 nodes): `use-table-keyboard-pagination.ts`, `useTableKeyboardPagination()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 868`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
+- **Thin community `Community 874`** (2 nodes): `useBulkOperations.test.ts`, `makeSku()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 869`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
+- **Thin community `Community 875`** (2 nodes): `useConvexAuthIdentity.ts`, `useConvexAuthIdentity()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 870`** (2 nodes): `useCopyText.ts`, `useCopyText()`
+- **Thin community `Community 876`** (2 nodes): `useCopyText.ts`, `useCopyText()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 871`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
+- **Thin community `Community 877`** (2 nodes): `useCreateComplimentaryProduct.ts`, `useCreateComplimentaryProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 872`** (2 nodes): `useDebounce.ts`, `useDebounce()`
+- **Thin community `Community 878`** (2 nodes): `useDebounce.ts`, `useDebounce()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 873`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
+- **Thin community `Community 879`** (2 nodes): `useGetActiveProduct.ts`, `useGetActiveProduct()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 874`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
+- **Thin community `Community 880`** (2 nodes): `useGetAuthedUser.ts`, `useGetAuthedUser()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 875`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
+- **Thin community `Community 881`** (2 nodes): `useGetCategories.ts`, `useGetCategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 876`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
+- **Thin community `Community 882`** (2 nodes): `useGetComplimentaryProducts.ts`, `useGetComplimentaryProducts()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 877`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
+- **Thin community `Community 883`** (2 nodes): `useGetCurrencyFormatter.ts`, `useGetCurrencyFormatter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 878`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
+- **Thin community `Community 884`** (2 nodes): `useGetSubcategories.ts`, `useGetSubcategories()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 879`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
+- **Thin community `Community 885`** (2 nodes): `useGetTerminal.ts`, `useGetTerminal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 880`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
+- **Thin community `Community 886`** (2 nodes): `useNewOrderNotification.ts`, `useNewOrderNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 881`** (2 nodes): `usePermissions.ts`, `usePermissions()`
+- **Thin community `Community 887`** (2 nodes): `usePermissions.ts`, `usePermissions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 882`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
+- **Thin community `Community 888`** (2 nodes): `useProductSearchResults.ts`, `useProductSearchResults()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 883`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
+- **Thin community `Community 889`** (2 nodes): `useProductWithNoImagesNotification.tsx`, `useProductWithNoImagesNotification()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 884`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
+- **Thin community `Community 890`** (2 nodes): `useProtectedAdminPageState.ts`, `useProtectedAdminPageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 885`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
+- **Thin community `Community 891`** (2 nodes): `useSkusReservedInCheckout.ts`, `useSkusReservedInCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 886`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
+- **Thin community `Community 892`** (2 nodes): `useSkusReservedInPosSession.ts`, `useSkusReservedInPosSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 887`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
+- **Thin community `Community 893`** (2 nodes): `useToggleComplimentaryProductActive.ts`, `useToggleComplimentaryProductActive()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 888`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
+- **Thin community `Community 894`** (2 nodes): `toOperatorMessage()`, `operatorMessages.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 889`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
+- **Thin community `Community 895`** (2 nodes): `presentUnexpectedErrorToast.ts`, `presentUnexpectedErrorToast()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 890`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
+- **Thin community `Community 896`** (2 nodes): `getOrigin()`, `navigationUtils.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 891`** (2 nodes): `addItem()`, `addItem.ts`
+- **Thin community `Community 897`** (2 nodes): `addItem()`, `addItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 892`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
+- **Thin community `Community 898`** (2 nodes): `bootstrapRegister()`, `bootstrapRegister.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 893`** (2 nodes): `holdSession()`, `holdSession.ts`
+- **Thin community `Community 899`** (2 nodes): `holdSession()`, `holdSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 894`** (2 nodes): `openDrawer()`, `openDrawer.ts`
+- **Thin community `Community 900`** (2 nodes): `openDrawer()`, `openDrawer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 895`** (2 nodes): `startSession.ts`, `startSession()`
+- **Thin community `Community 901`** (2 nodes): `startSession.ts`, `startSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 896`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
+- **Thin community `Community 902`** (2 nodes): `calculateCartTotals()`, `calculations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 897`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
+- **Thin community `Community 903`** (2 nodes): `registerAvailabilitySnapshot.test.ts`, `buildAvailabilityRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 898`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
+- **Thin community `Community 904`** (2 nodes): `registerAvailabilitySnapshot.ts`, `readRegisterAvailabilitySnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 899`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
+- **Thin community `Community 905`** (2 nodes): `registerServiceCatalogSnapshot.test.ts`, `buildServiceCatalogRow()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 900`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
+- **Thin community `Community 906`** (2 nodes): `registerServiceCatalogSnapshot.ts`, `readRegisterServiceCatalogSnapshotState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 901`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
+- **Thin community `Community 907`** (2 nodes): `saleBlockerPolicy.ts`, `deriveLocalSaleBlocker()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 902`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
+- **Thin community `Community 908`** (2 nodes): `syncScheduler.test.ts`, `baseEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 903`** (2 nodes): `syncStatus.test.ts`, `event()`
+- **Thin community `Community 909`** (2 nodes): `syncStatus.test.ts`, `event()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 904`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
+- **Thin community `Community 910`** (2 nodes): `terminalRuntimeStatus.test.ts`, `buildLocalEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 905`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
+- **Thin community `Community 911`** (2 nodes): `terminalStaffAuthorityRefresh.test.ts`, `buildAuthorityRecord()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 906`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
+- **Thin community `Community 912`** (2 nodes): `useRegisterCatalogIndex.ts`, `useRegisterCatalogIndex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 907`** (2 nodes): `runtime.test.ts`, `buildState()`
+- **Thin community `Community 913`** (2 nodes): `remoteAssistCobrowseRecorder.test.ts`, `setElementRect()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 908`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
+- **Thin community `Community 914`** (2 nodes): `runtime.test.ts`, `buildState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 909`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
+- **Thin community `Community 915`** (2 nodes): `runtime.ts`, `getRemoteAssistConnectedState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 910`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
+- **Thin community `Community 916`** (2 nodes): `useRemoteAssistSupportTransport.ts`, `useRemoteAssistSupportTransport()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 911`** (2 nodes): `pinHash.ts`, `hashPin()`
+- **Thin community `Community 917`** (2 nodes): `RemoteAssistLiveTransportClient.test.ts`, `encode()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 912`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
+- **Thin community `Community 918`** (2 nodes): `pinHash.ts`, `hashPin()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 913`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
+- **Thin community `Community 919`** (2 nodes): `theme.test.ts`, `installMatchMedia()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 914`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 920`** (2 nodes): `hasOrgNotFoundPayload()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 915`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
+- **Thin community `Community 921`** (2 nodes): `$sessionId.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 916`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
+- **Thin community `Community 922`** (2 nodes): `registers.index.tsx`, `hasOrgNotFoundPayload()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 917`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
+- **Thin community `Community 923`** (2 nodes): `StoreRootRedirect()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 918`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
+- **Thin community `Community 924`** (2 nodes): `ApprovalsRoute()`, `approvals.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 919`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
+- **Thin community `Community 925`** (2 nodes): `DailyCloseHistoryRoute()`, `daily-close-history.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 920`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
+- **Thin community `Community 926`** (2 nodes): `DailyCloseRoute()`, `daily-close.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 921`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
+- **Thin community `Community 927`** (2 nodes): `OpenWorkRoute()`, `open-work.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 922`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
+- **Thin community `Community 928`** (2 nodes): `DailyOpeningRoute()`, `opening.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 923`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
+- **Thin community `Community 929`** (2 nodes): `stock-adjustments.tsx`, `StockAdjustmentsRoute()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 924`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
+- **Thin community `Community 930`** (2 nodes): `ExpenseRouteComponent()`, `expense.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 925`** (2 nodes): `published.index.tsx`, `RouteComponent()`
+- **Thin community `Community 931`** (2 nodes): `terminals.route.test.tsx`, `routeBuilder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 926`** (2 nodes): `Index()`, `index.tsx`
+- **Thin community `Community 932`** (2 nodes): `published.index.tsx`, `RouteComponent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 927`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
+- **Thin community `Community 933`** (2 nodes): `Index()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 928`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
+- **Thin community `Community 934`** (2 nodes): `AthenaLoginReadyView()`, `_layout.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 929`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 935`** (2 nodes): `OrganizationSettingsAccordion()`, `OrganizationsSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 930`** (2 nodes): `view-patterns.tsx`, `cn()`
+- **Thin community `Community 936`** (2 nodes): `PatternsOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 931`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
+- **Thin community `Community 937`** (2 nodes): `view-patterns.tsx`, `cn()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 932`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
+- **Thin community `Community 938`** (2 nodes): `ControlsShowcase()`, `Controls.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 933`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
+- **Thin community `Community 939`** (2 nodes): `DialogShowcase()`, `Dialog.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 934`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 940`** (2 nodes): `FeedbackShowcase()`, `Feedback.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 935`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
+- **Thin community `Community 941`** (2 nodes): `PrimitivesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 936`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
+- **Thin community `Community 942`** (2 nodes): `Popover.stories.tsx`, `PopoverShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 937`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
+- **Thin community `Community 943`** (2 nodes): `Sheet.stories.tsx`, `SheetShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 938`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
+- **Thin community `Community 944`** (2 nodes): `Tooltip.stories.tsx`, `TooltipShowcase()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 939`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
+- **Thin community `Community 945`** (2 nodes): `TemplatesOverview()`, `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 940`** (2 nodes): `formatNumber()`, `formatNumber.ts`
+- **Thin community `Community 946`** (2 nodes): `usePrint.test.ts`, `setWindowOpenMock()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 941`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
+- **Thin community `Community 947`** (2 nodes): `formatNumber()`, `formatNumber.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 942`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
+- **Thin community `Community 948`** (2 nodes): `getBannerMessage()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 943`** (2 nodes): `updateGuest()`, `guest.ts`
+- **Thin community `Community 949`** (2 nodes): `jsonResponse()`, `checkoutSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 944`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
+- **Thin community `Community 950`** (2 nodes): `updateGuest()`, `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 945`** (2 nodes): `storefront.ts`, `getStore()`
+- **Thin community `Community 951`** (2 nodes): `posTransaction.test.ts`, `jsonResponse()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 946`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
+- **Thin community `Community 952`** (2 nodes): `storefront.ts`, `getStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 947`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
+- **Thin community `Community 953`** (2 nodes): `EntityPage()`, `EntityPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 948`** (2 nodes): `AuthComponent()`, `Auth.tsx`
+- **Thin community `Community 954`** (2 nodes): `ProductsPage.tsx`, `ProductCardLoadingSkeleton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 949`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
+- **Thin community `Community 955`** (2 nodes): `AuthComponent()`, `Auth.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 950`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
+- **Thin community `Community 956`** (2 nodes): `toBagSummaryItems()`, `BagSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 951`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
+- **Thin community `Community 957`** (2 nodes): `CheckoutForm()`, `CheckoutForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 952`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
+- **Thin community `Community 958`** (2 nodes): `CheckoutProvider()`, `CheckoutProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 953`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
+- **Thin community `Community 959`** (2 nodes): `EnteredBillingAddressDetails()`, `EnteredBillingAddressDetails.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 954`** (2 nodes): `PickupDetails()`, `index.tsx`
+- **Thin community `Community 960`** (2 nodes): `OrderSummary()`, `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 955`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
+- **Thin community `Community 961`** (2 nodes): `PickupDetails()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 956`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
+- **Thin community `Community 962`** (2 nodes): `PaymentMethodSection.tsx`, `PaymentMethodSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 957`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
+- **Thin community `Community 963`** (2 nodes): `PaymentSection.tsx`, `PaymentSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 958`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
+- **Thin community `Community 964`** (2 nodes): `calculateDeliveryFee()`, `deliveryFees.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 959`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
+- **Thin community `Community 965`** (2 nodes): `deriveCheckoutState()`, `deriveCheckoutState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 960`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
+- **Thin community `Community 966`** (2 nodes): `getIssueMap()`, `checkoutSchemas.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 961`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
+- **Thin community `Community 967`** (2 nodes): `webOrderSchema.test.ts`, `getIssueMap()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 962`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
+- **Thin community `Community 968`** (2 nodes): `onSubmit()`, `CustomerDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 963`** (2 nodes): `useCountdown()`, `hooks.ts`
+- **Thin community `Community 969`** (2 nodes): `onSubmit()`, `DeliveryDetailsForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 964`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
+- **Thin community `Community 970`** (2 nodes): `useCountdown()`, `hooks.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 965`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
+- **Thin community `Community 971`** (2 nodes): `TrustSignals.tsx`, `TrustSignals()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 966`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
+- **Thin community `Community 972`** (2 nodes): `ProductFilter.tsx`, `ProductFilter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 967`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
+- **Thin community `Community 973`** (2 nodes): `handleCheckboxChange()`, `Filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 968`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
+- **Thin community `Community 974`** (2 nodes): `BestSellersSection()`, `BestSellersSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 969`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
+- **Thin community `Community 975`** (2 nodes): `resolveHomepageContent()`, `homePageContent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 970`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
+- **Thin community `Community 976`** (2 nodes): `handleOnLinkClick()`, `BagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 971`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
+- **Thin community `Community 977`** (2 nodes): `MobileBagMenu()`, `MobileBagMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 972`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
+- **Thin community `Community 978`** (2 nodes): `SiteBanner.tsx`, `SiteBanner()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 973`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
+- **Thin community `Community 979`** (2 nodes): `NotificationPill()`, `NotificationPill.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 974`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
+- **Thin community `Community 980`** (2 nodes): `mapValueToLabelIndex()`, `DimensionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 975`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
+- **Thin community `Community 981`** (2 nodes): `DiscountBadge()`, `DiscountBadge.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 976`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
+- **Thin community `Community 982`** (2 nodes): `handleClickOnPreview()`, `GalleryViewer.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 977`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
+- **Thin community `Community 983`** (2 nodes): `OnsaleProduct()`, `OnSaleProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 978`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
+- **Thin community `Community 984`** (2 nodes): `ProductActions.tsx`, `ProductActions()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 979`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
+- **Thin community `Community 985`** (2 nodes): `ProductAttributes.tsx`, `ProductAttributes()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 980`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
+- **Thin community `Community 986`** (2 nodes): `ProductPage.test.tsx`, `makePageState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 981`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
+- **Thin community `Community 987`** (2 nodes): `ProductPage.tsx`, `showShippingPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 982`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
+- **Thin community `Community 988`** (2 nodes): `ProductReview.tsx`, `handleHelpful()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 983`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
+- **Thin community `Community 989`** (2 nodes): `ReviewSummary.tsx`, `ReviewSummary()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 984`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
+- **Thin community `Community 990`** (2 nodes): `OrderItem()`, `OrderItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 985`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
+- **Thin community `Community 991`** (2 nodes): `RatingSelector.tsx`, `RatingSelector()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 986`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
+- **Thin community `Community 992`** (2 nodes): `GuestRewardsPrompt()`, `GuestRewardsPrompt.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 987`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
+- **Thin community `Community 993`** (2 nodes): `OrderPointsDisplay()`, `OrderPointsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 988`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
+- **Thin community `Community 994`** (2 nodes): `PastOrdersRewards.tsx`, `handleClaimPoints()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 989`** (2 nodes): `BagItem()`, `BagItem.tsx`
+- **Thin community `Community 995`** (2 nodes): `RewardsPanel.tsx`, `handleRedeemReward()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 990`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
+- **Thin community `Community 996`** (2 nodes): `BagItem()`, `BagItem.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 991`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
+- **Thin community `Community 997`** (2 nodes): `CheckoutUnavailable()`, `CheckoutUnavailable.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 992`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
+- **Thin community `Community 998`** (2 nodes): `ErrorBoundary()`, `ErrorBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 993`** (2 nodes): `CountrySelect()`, `country-select.tsx`
+- **Thin community `Community 999`** (2 nodes): `ScrollDownButton.tsx`, `ScrollDownButton()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 994`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
+- **Thin community `Community 1000`** (2 nodes): `CountrySelect()`, `country-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 995`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
+- **Thin community `Community 1001`** (2 nodes): `GhanaRegionSelect()`, `ghana-region-select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 996`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
+- **Thin community `Community 1002`** (2 nodes): `GhostButton()`, `ghost-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 997`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
+- **Thin community `Community 1003`** (2 nodes): `handleClose()`, `LeaveAReviewModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 998`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
+- **Thin community `Community 1004`** (2 nodes): `UpsellModalSuccess.tsx`, `UpsellModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 999`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
+- **Thin community `Community 1005`** (2 nodes): `WelcomeBackModalSuccess.tsx`, `WelcomeBackModalSuccess()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1000`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
+- **Thin community `Community 1006`** (2 nodes): `getModalConfig()`, `leaveReviewModalConfig.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1001`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
+- **Thin community `Community 1007`** (2 nodes): `welcomeBackModalConfig.tsx`, `getModalConfig()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1002`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
+- **Thin community `Community 1008`** (2 nodes): `webp-jpg.tsx`, `WebpImage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1003`** (2 nodes): `useCheckout.ts`, `useCheckout()`
+- **Thin community `Community 1009`** (2 nodes): `useFormSubmission()`, `FormSubmissionProvider.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1004`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
+- **Thin community `Community 1010`** (2 nodes): `useCheckout.ts`, `useCheckout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1005`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
+- **Thin community `Community 1011`** (2 nodes): `useDiscountCodeAlert.tsx`, `useDiscountCodeAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1006`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
+- **Thin community `Community 1012`** (2 nodes): `useEnhancedTracking.ts`, `useEnhancedTracking()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1007`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
+- **Thin community `Community 1013`** (2 nodes): `useGetActiveCheckoutSession.tsx`, `useGetActiveCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1008`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
+- **Thin community `Community 1014`** (2 nodes): `useGetProduct.tsx`, `useGetProductQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1009`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
+- **Thin community `Community 1015`** (2 nodes): `useGetProductFilters.ts`, `useGetProductFilters()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1010`** (2 nodes): `useGetStore.ts`, `useGetStore()`
+- **Thin community `Community 1016`** (2 nodes): `useGetProductReviews.ts`, `useGetProductReviewsQuery()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1011`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
+- **Thin community `Community 1017`** (2 nodes): `useGetStore.ts`, `useGetStore()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1012`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
+- **Thin community `Community 1018`** (2 nodes): `useInventoryStatus.ts`, `useInventoryStatus()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1013`** (2 nodes): `useLogout.ts`, `useLogout()`
+- **Thin community `Community 1019`** (2 nodes): `useLeaveAReviewModal.tsx`, `useLeaveAReviewModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1014`** (2 nodes): `useModalState.tsx`, `useModalState()`
+- **Thin community `Community 1020`** (2 nodes): `useLogout.ts`, `useLogout()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1015`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
+- **Thin community `Community 1021`** (2 nodes): `useModalState.tsx`, `useModalState()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1016`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
+- **Thin community `Community 1022`** (2 nodes): `useProductPageLogic.ts`, `useProductPageLogic()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1017`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
+- **Thin community `Community 1023`** (2 nodes): `useProductReminder.tsx`, `useProductReminder()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1018`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
+- **Thin community `Community 1024`** (2 nodes): `usePromoAlert.tsx`, `usePromoAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1019`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
+- **Thin community `Community 1025`** (2 nodes): `useQueryEnabled.ts`, `useQueryEnabled()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1020`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
+- **Thin community `Community 1026`** (2 nodes): `useRewardsAlert.tsx`, `useRewardsAlert()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1021`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
+- **Thin community `Community 1027`** (2 nodes): `useScrollToTop.ts`, `useScrollToTop()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1022`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
+- **Thin community `Community 1028`** (2 nodes): `useTrackAction.ts`, `useTrackAction()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1023`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
+- **Thin community `Community 1029`** (2 nodes): `useTrackEvent.ts`, `useTrackEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1024`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
+- **Thin community `Community 1030`** (2 nodes): `useUpsellModal.tsx`, `useUpsellModal()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1025`** (2 nodes): `useBagQueries()`, `bag.ts`
+- **Thin community `Community 1031`** (2 nodes): `usePostAnalytics()`, `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1026`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
+- **Thin community `Community 1032`** (2 nodes): `useBagQueries()`, `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1027`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
+- **Thin community `Community 1033`** (2 nodes): `useBannerMessageQueries()`, `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1028`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
+- **Thin community `Community 1034`** (2 nodes): `useCheckoutSessionQueries()`, `checkout.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1029`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
+- **Thin community `Community 1035`** (2 nodes): `useInventoryQueries()`, `inventory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1030`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
+- **Thin community `Community 1036`** (2 nodes): `useOnlineOrderQueries()`, `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1031`** (2 nodes): `product.ts`, `useProductQueries()`
+- **Thin community `Community 1037`** (2 nodes): `posTransaction.ts`, `usePosTransactionQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1032`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
+- **Thin community `Community 1038`** (2 nodes): `product.ts`, `useProductQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1033`** (2 nodes): `reviews.ts`, `useReviewQueries()`
+- **Thin community `Community 1039`** (2 nodes): `promoCode.ts`, `usePromoCodesQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1034`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
+- **Thin community `Community 1040`** (2 nodes): `reviews.ts`, `useReviewQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1035`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
+- **Thin community `Community 1041`** (2 nodes): `rewards.ts`, `useRewardsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1036`** (2 nodes): `user.ts`, `useUserQueries()`
+- **Thin community `Community 1042`** (2 nodes): `upsells.ts`, `useUpsellsQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1037`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
+- **Thin community `Community 1043`** (2 nodes): `user.ts`, `useUserQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1038`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
+- **Thin community `Community 1044`** (2 nodes): `userOffers.ts`, `useUserOffersQueries()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1039`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
+- **Thin community `Community 1045`** (2 nodes): `storeConfig.test.ts`, `buildV2Config()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1040`** (2 nodes): `validateEmail()`, `email.ts`
+- **Thin community `Community 1046`** (2 nodes): `storefrontObservability.test.ts`, `createMemoryStorage()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1041`** (2 nodes): `router.tsx`, `createRouter()`
+- **Thin community `Community 1047`** (2 nodes): `validateEmail()`, `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1042`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
+- **Thin community `Community 1048`** (2 nodes): `router.tsx`, `createRouter()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1043`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
+- **Thin community `Community 1049`** (2 nodes): `loadHomePageData()`, `-homePageLoader.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1044`** (2 nodes): `ContactUs()`, `contact-us.tsx`
+- **Thin community `Community 1050`** (2 nodes): `LayoutComponent()`, `_ordersLayout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1045`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
+- **Thin community `Community 1051`** (2 nodes): `ContactUs()`, `contact-us.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1046`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
+- **Thin community `Community 1052`** (2 nodes): `OnlineOrderPolicy()`, `delivery-returns-exchanges.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1047`** (2 nodes): `tos.index.tsx`, `TosSection()`
+- **Thin community `Community 1053`** (2 nodes): `privacy.index.tsx`, `PrivacyPolicy()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1048`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
+- **Thin community `Community 1054`** (2 nodes): `tos.index.tsx`, `TosSection()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1049`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
+- **Thin community `Community 1055`** (2 nodes): `shop.product.$productSlug.tsx`, `Component()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1050`** (2 nodes): `HomeRoute()`, `index.tsx`
+- **Thin community `Community 1056`** (2 nodes): `LayoutComponent()`, `_layout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1051`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
+- **Thin community `Community 1057`** (2 nodes): `HomeRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1052`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
+- **Thin community `Community 1058`** (2 nodes): `CheckoutCanceledView()`, `canceled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1053`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
+- **Thin community `Community 1059`** (2 nodes): `CheckoutComplete()`, `complete.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1054`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
+- **Thin community `Community 1060`** (2 nodes): `pod-confirmation.tsx`, `completePODCheckoutSession()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1055`** (2 nodes): `test-connection.js`, `main()`
+- **Thin community `Community 1061`** (2 nodes): `ReceiptShareRoute()`, `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1056`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
+- **Thin community `Community 1062`** (2 nodes): `test-connection.js`, `main()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1057`** (2 nodes): `run()`, `architecture-boundary-check.ts`
+- **Thin community `Community 1063`** (2 nodes): `createSnippetLinter()`, `architecture-boundaries.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1058`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
+- **Thin community `Community 1064`** (2 nodes): `run()`, `architecture-boundary-check.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1059`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
+- **Thin community `Community 1065`** (2 nodes): `readRepoFile()`, `deploy-qa-vps.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1060`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
+- **Thin community `Community 1066`** (2 nodes): `runCommand()`, `github-pr-merge.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1061`** (2 nodes): `shutdown()`, `sample-app.ts`
+- **Thin community `Community 1067`** (2 nodes): `shutdown()`, `athena-runtime-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1062`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
+- **Thin community `Community 1068`** (2 nodes): `shutdown()`, `sample-app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1063`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
+- **Thin community `Community 1069`** (2 nodes): `buildReportLine()`, `harness-runtime-trends.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1064`** (1 nodes): `api.d.ts`
+- **Thin community `Community 1070`** (2 nodes): `validate-plan-html.test.ts`, `createTempRepo()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1065`** (1 nodes): `api.js`
+- **Thin community `Community 1071`** (1 nodes): `api.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1066`** (1 nodes): `dataModel.d.ts`
+- **Thin community `Community 1072`** (1 nodes): `api.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1067`** (1 nodes): `server.d.ts`
+- **Thin community `Community 1073`** (1 nodes): `dataModel.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1068`** (1 nodes): `server.js`
+- **Thin community `Community 1074`** (1 nodes): `server.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1069`** (1 nodes): `app.ts`
+- **Thin community `Community 1075`** (1 nodes): `server.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1070`** (1 nodes): `PosRecoveryCode.test.ts`
+- **Thin community `Community 1076`** (1 nodes): `app.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1071`** (1 nodes): `PosRecoveryCode.ts`
+- **Thin community `Community 1077`** (1 nodes): `PosRecoveryCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1072`** (1 nodes): `auth.config.js`
+- **Thin community `Community 1078`** (1 nodes): `PosRecoveryCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1073`** (1 nodes): `auth.test.ts`
+- **Thin community `Community 1079`** (1 nodes): `auth.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1074`** (1 nodes): `auth.ts`
+- **Thin community `Community 1080`** (1 nodes): `auth.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1075`** (1 nodes): `authConfig.test.ts`
+- **Thin community `Community 1081`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1076`** (1 nodes): `authConfig.ts`
+- **Thin community `Community 1082`** (1 nodes): `authConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1077`** (1 nodes): `r2.test.ts`
+- **Thin community `Community 1083`** (1 nodes): `authConfig.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1078`** (1 nodes): `countries.ts`
+- **Thin community `Community 1084`** (1 nodes): `r2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1079`** (1 nodes): `email.ts`
+- **Thin community `Community 1085`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1080`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1086`** (1 nodes): `email.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1081`** (1 nodes): `payment.ts`
+- **Thin community `Community 1087`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1082`** (1 nodes): `crons.test.ts`
+- **Thin community `Community 1088`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1083`** (1 nodes): `crons.ts`
+- **Thin community `Community 1089`** (1 nodes): `crons.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1084`** (1 nodes): `domain.test.ts`
+- **Thin community `Community 1090`** (1 nodes): `crons.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1085`** (1 nodes): `internal.ts`
+- **Thin community `Community 1091`** (1 nodes): `domain.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1086`** (1 nodes): `public.test.ts`
+- **Thin community `Community 1092`** (1 nodes): `internal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1087`** (1 nodes): `token.test.ts`
+- **Thin community `Community 1093`** (1 nodes): `public.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1088`** (1 nodes): `whatsappClient.test.ts`
+- **Thin community `Community 1094`** (1 nodes): `token.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1089`** (1 nodes): `whatsappConfig.test.ts`
+- **Thin community `Community 1095`** (1 nodes): `whatsappClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1090`** (1 nodes): `devPatchBadTransaction.ts`
+- **Thin community `Community 1096`** (1 nodes): `whatsappConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1091`** (1 nodes): `ExpenseReceiptEmail.tsx`
+- **Thin community `Community 1097`** (1 nodes): `devPatchBadTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1092`** (1 nodes): `FeedbackRequest.tsx`
+- **Thin community `Community 1098`** (1 nodes): `ExpenseReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1093`** (1 nodes): `NewOrderAdmin.tsx`
+- **Thin community `Community 1099`** (1 nodes): `FeedbackRequest.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1094`** (1 nodes): `OrderEmail.tsx`
+- **Thin community `Community 1100`** (1 nodes): `NewOrderAdmin.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1095`** (1 nodes): `PosReceiptEmail.test.tsx`
+- **Thin community `Community 1101`** (1 nodes): `OrderEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1096`** (1 nodes): `PosReceiptEmail.tsx`
+- **Thin community `Community 1102`** (1 nodes): `PosReceiptEmail.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1097`** (1 nodes): `env.ts`
+- **Thin community `Community 1103`** (1 nodes): `PosReceiptEmail.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1098`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1104`** (1 nodes): `env.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1099`** (1 nodes): `auth.ts`
+- **Thin community `Community 1105`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1100`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1106`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1101`** (1 nodes): `colors.ts`
+- **Thin community `Community 1107`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1102`** (1 nodes): `index.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1103`** (1 nodes): `organizations.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1104`** (1 nodes): `products.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1105`** (1 nodes): `storefrontHidden.test.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1106`** (1 nodes): `stores.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1107`** (1 nodes): `bag.ts`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1108`** (1 nodes): `guest.ts`
+- **Thin community `Community 1108`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1109`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1110`** (1 nodes): `me.ts`
+- **Thin community `Community 1110`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1111`** (1 nodes): `offers.ts`
+- **Thin community `Community 1111`** (1 nodes): `products.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1112`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1112`** (1 nodes): `storefrontHidden.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1113`** (1 nodes): `paystack.ts`
+- **Thin community `Community 1113`** (1 nodes): `stores.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1114`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1114`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1115`** (1 nodes): `reviews.ts`
+- **Thin community `Community 1115`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1116`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1116`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1117`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1117`** (1 nodes): `me.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1118`** (1 nodes): `security.test.ts`
+- **Thin community `Community 1118`** (1 nodes): `offers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1119`** (1 nodes): `storefront.ts`
+- **Thin community `Community 1119`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1120`** (1 nodes): `upsells.ts`
+- **Thin community `Community 1120`** (1 nodes): `paystack.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1121`** (1 nodes): `user.ts`
+- **Thin community `Community 1121`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1122`** (1 nodes): `userOffers.ts`
+- **Thin community `Community 1122`** (1 nodes): `reviews.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1123`** (1 nodes): `index.ts`
+- **Thin community `Community 1123`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1124`** (1 nodes): `health.test.ts`
+- **Thin community `Community 1124`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1125`** (1 nodes): `http.ts`
+- **Thin community `Community 1125`** (1 nodes): `security.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1126`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1126`** (1 nodes): `storefront.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1127`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1127`** (1 nodes): `upsells.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1128`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1128`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1129`** (1 nodes): `categories.ts`
+- **Thin community `Community 1129`** (1 nodes): `userOffers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1130`** (1 nodes): `colors.ts`
+- **Thin community `Community 1130`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1131`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1131`** (1 nodes): `health.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1132`** (1 nodes): `expenseTransactions.test.ts`
+- **Thin community `Community 1132`** (1 nodes): `http.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1133`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1133`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1134`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1134`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1135`** (1 nodes): `organizationMembers.ts`
+- **Thin community `Community 1135`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1136`** (1 nodes): `organizations.ts`
+- **Thin community `Community 1136`** (1 nodes): `categories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1137`** (1 nodes): `pos.ts`
+- **Thin community `Community 1137`** (1 nodes): `colors.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1138`** (1 nodes): `posCustomers.ts`
+- **Thin community `Community 1138`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1139`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1139`** (1 nodes): `expenseTransactions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1140`** (1 nodes): `productSku.ts`
+- **Thin community `Community 1140`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1141`** (1 nodes): `productUtil.test.ts`
+- **Thin community `Community 1141`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1142`** (1 nodes): `promoCode.test.ts`
+- **Thin community `Community 1142`** (1 nodes): `organizationMembers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1143`** (1 nodes): `stockValidation.ts`
+- **Thin community `Community 1143`** (1 nodes): `organizations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1144`** (1 nodes): `storeConfigV2.test.ts`
+- **Thin community `Community 1144`** (1 nodes): `pos.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1145`** (1 nodes): `subcategories.ts`
+- **Thin community `Community 1145`** (1 nodes): `posCustomers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1146`** (1 nodes): `commandResultValidators.test.ts`
+- **Thin community `Community 1146`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1147`** (1 nodes): `currency.test.ts`
+- **Thin community `Community 1147`** (1 nodes): `productSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1148`** (1 nodes): `storeInsights.ts`
+- **Thin community `Community 1148`** (1 nodes): `productUtil.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1149`** (1 nodes): `userInsights.ts`
+- **Thin community `Community 1149`** (1 nodes): `promoCode.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1150`** (1 nodes): `migrateAmountsToPesewas.ts`
+- **Thin community `Community 1150`** (1 nodes): `stockValidation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1151`** (1 nodes): `client.test.ts`
+- **Thin community `Community 1151`** (1 nodes): `storeConfigV2.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1152`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1152`** (1 nodes): `subcategories.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1153`** (1 nodes): `normalize.test.ts`
+- **Thin community `Community 1153`** (1 nodes): `commandResultValidators.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1154`** (1 nodes): `types.ts`
+- **Thin community `Community 1154`** (1 nodes): `currency.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1155`** (1 nodes): `customerProfiles.test.ts`
+- **Thin community `Community 1155`** (1 nodes): `storeInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1156`** (1 nodes): `paymentAllocations.test.ts`
+- **Thin community `Community 1156`** (1 nodes): `userInsights.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1157`** (1 nodes): `EmailOTP.test.ts`
+- **Thin community `Community 1157`** (1 nodes): `migrateAmountsToPesewas.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1158`** (1 nodes): `correctTransactionCustomer.test.ts`
+- **Thin community `Community 1158`** (1 nodes): `client.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1159`** (1 nodes): `correctionEvents.test.ts`
+- **Thin community `Community 1159`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1160`** (1 nodes): `correctionPolicy.test.ts`
+- **Thin community `Community 1160`** (1 nodes): `normalize.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1161`** (1 nodes): `dto.ts`
+- **Thin community `Community 1161`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1162`** (1 nodes): `getRegisterState.test.ts`
+- **Thin community `Community 1162`** (1 nodes): `customerProfiles.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1163`** (1 nodes): `posSessionTracing.test.ts`
+- **Thin community `Community 1163`** (1 nodes): `paymentAllocations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1164`** (1 nodes): `searchCatalog.test.ts`
+- **Thin community `Community 1164`** (1 nodes): `EmailOTP.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1165`** (1 nodes): `types.ts`
+- **Thin community `Community 1165`** (1 nodes): `correctTransactionCustomer.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1166`** (1 nodes): `types.ts`
+- **Thin community `Community 1166`** (1 nodes): `correctionEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1167`** (1 nodes): `types.ts`
+- **Thin community `Community 1167`** (1 nodes): `correctionPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1168`** (1 nodes): `registerSessionRepository.test.ts`
+- **Thin community `Community 1168`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1169`** (1 nodes): `customers.ts`
+- **Thin community `Community 1169`** (1 nodes): `getRegisterState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1170`** (1 nodes): `register.ts`
+- **Thin community `Community 1170`** (1 nodes): `posSessionTracing.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1171`** (1 nodes): `sync.ts`
+- **Thin community `Community 1171`** (1 nodes): `searchCatalog.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1172`** (1 nodes): `posRuntimeAdapter.test.ts`
+- **Thin community `Community 1172`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1173`** (1 nodes): `types.test.ts`
+- **Thin community `Community 1173`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1174`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
+- **Thin community `Community 1174`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1175`** (1 nodes): `schema.ts`
+- **Thin community `Community 1175`** (1 nodes): `registerSessionRepository.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1176`** (1 nodes): `automation.ts`
+- **Thin community `Community 1176`** (1 nodes): `customers.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1177`** (1 nodes): `customerMessageDelivery.ts`
+- **Thin community `Community 1177`** (1 nodes): `register.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1178`** (1 nodes): `index.ts`
+- **Thin community `Community 1178`** (1 nodes): `sync.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1179`** (1 nodes): `receiptShareToken.ts`
+- **Thin community `Community 1179`** (1 nodes): `posRuntimeAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1180`** (1 nodes): `appVerificationCode.ts`
+- **Thin community `Community 1180`** (1 nodes): `types.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1181`** (1 nodes): `athenaUser.ts`
+- **Thin community `Community 1181`** (1 nodes): `RemoteAssistTransportProvider.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1182`** (1 nodes): `bannerMessage.ts`
+- **Thin community `Community 1182`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1183`** (1 nodes): `bestSeller.ts`
+- **Thin community `Community 1183`** (1 nodes): `automation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1184`** (1 nodes): `category.ts`
+- **Thin community `Community 1184`** (1 nodes): `customerMessageDelivery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1185`** (1 nodes): `color.ts`
+- **Thin community `Community 1185`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1186`** (1 nodes): `complimentaryProduct.ts`
+- **Thin community `Community 1186`** (1 nodes): `receiptShareToken.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1187`** (1 nodes): `featuredItem.ts`
+- **Thin community `Community 1187`** (1 nodes): `appVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1188`** (1 nodes): `index.ts`
+- **Thin community `Community 1188`** (1 nodes): `athenaUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1189`** (1 nodes): `inventoryHold.ts`
+- **Thin community `Community 1189`** (1 nodes): `bannerMessage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1190`** (1 nodes): `inventoryImportProvisionalSku.ts`
+- **Thin community `Community 1190`** (1 nodes): `bestSeller.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1191`** (1 nodes): `inventoryImportReviewVersion.ts`
+- **Thin community `Community 1191`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1192`** (1 nodes): `inviteCode.ts`
+- **Thin community `Community 1192`** (1 nodes): `color.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1193`** (1 nodes): `organization.ts`
+- **Thin community `Community 1193`** (1 nodes): `complimentaryProduct.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1194`** (1 nodes): `organizationMember.ts`
+- **Thin community `Community 1194`** (1 nodes): `featuredItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1195`** (1 nodes): `product.ts`
+- **Thin community `Community 1195`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1196`** (1 nodes): `promoCode.ts`
+- **Thin community `Community 1196`** (1 nodes): `inventoryHold.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1197`** (1 nodes): `redeemedPromoCode.ts`
+- **Thin community `Community 1197`** (1 nodes): `inventoryImportProvisionalSku.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1198`** (1 nodes): `store.ts`
+- **Thin community `Community 1198`** (1 nodes): `inventoryImportReviewVersion.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1199`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1199`** (1 nodes): `inviteCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1200`** (1 nodes): `index.ts`
+- **Thin community `Community 1200`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1201`** (1 nodes): `workflowTrace.ts`
+- **Thin community `Community 1201`** (1 nodes): `organizationMember.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1202`** (1 nodes): `workflowTraceEvent.ts`
+- **Thin community `Community 1202`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1203`** (1 nodes): `workflowTraceLookup.ts`
+- **Thin community `Community 1203`** (1 nodes): `promoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1204`** (1 nodes): `approvalRequest.ts`
+- **Thin community `Community 1204`** (1 nodes): `redeemedPromoCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1205`** (1 nodes): `customerProfile.ts`
+- **Thin community `Community 1205`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1206`** (1 nodes): `dailyClose.ts`
+- **Thin community `Community 1206`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1207`** (1 nodes): `dailyOpening.ts`
+- **Thin community `Community 1207`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1208`** (1 nodes): `index.ts`
+- **Thin community `Community 1208`** (1 nodes): `workflowTrace.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1209`** (1 nodes): `inventoryMovement.ts`
+- **Thin community `Community 1209`** (1 nodes): `workflowTraceEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1210`** (1 nodes): `managerElevation.ts`
+- **Thin community `Community 1210`** (1 nodes): `workflowTraceLookup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1211`** (1 nodes): `operationalEvent.ts`
+- **Thin community `Community 1211`** (1 nodes): `approvalRequest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1212`** (1 nodes): `operationalWorkItem.ts`
+- **Thin community `Community 1212`** (1 nodes): `customerProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1213`** (1 nodes): `paymentAllocation.ts`
+- **Thin community `Community 1213`** (1 nodes): `dailyClose.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1214`** (1 nodes): `registerSession.ts`
+- **Thin community `Community 1214`** (1 nodes): `dailyOpening.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1215`** (1 nodes): `skuActivityEvent.ts`
+- **Thin community `Community 1215`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1216`** (1 nodes): `staffCredential.ts`
+- **Thin community `Community 1216`** (1 nodes): `inventoryMovement.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1217`** (1 nodes): `staffProfile.ts`
+- **Thin community `Community 1217`** (1 nodes): `managerElevation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1218`** (1 nodes): `staffRoleAssignment.ts`
+- **Thin community `Community 1218`** (1 nodes): `operationalEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1219`** (1 nodes): `mtnCollections.ts`
+- **Thin community `Community 1219`** (1 nodes): `operationalWorkItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1220`** (1 nodes): `customer.ts`
+- **Thin community `Community 1220`** (1 nodes): `paymentAllocation.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1221`** (1 nodes): `expenseSession.ts`
+- **Thin community `Community 1221`** (1 nodes): `registerSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1222`** (1 nodes): `expenseSessionItem.ts`
+- **Thin community `Community 1222`** (1 nodes): `skuActivityEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1223`** (1 nodes): `expenseTransaction.ts`
+- **Thin community `Community 1223`** (1 nodes): `staffCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1224`** (1 nodes): `expenseTransactionItem.ts`
+- **Thin community `Community 1224`** (1 nodes): `staffProfile.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1225`** (1 nodes): `index.ts`
+- **Thin community `Community 1225`** (1 nodes): `staffRoleAssignment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1226`** (1 nodes): `posLocalStaffProof.ts`
+- **Thin community `Community 1226`** (1 nodes): `mtnCollections.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1227`** (1 nodes): `posLocalSyncConflict.ts`
+- **Thin community `Community 1227`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1228`** (1 nodes): `posLocalSyncCursor.ts`
+- **Thin community `Community 1228`** (1 nodes): `expenseSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1229`** (1 nodes): `posLocalSyncEvent.ts`
+- **Thin community `Community 1229`** (1 nodes): `expenseSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1230`** (1 nodes): `posLocalSyncMapping.ts`
+- **Thin community `Community 1230`** (1 nodes): `expenseTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1231`** (1 nodes): `posPendingCheckoutItem.ts`
+- **Thin community `Community 1231`** (1 nodes): `expenseTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1232`** (1 nodes): `posRecoveryCredential.ts`
+- **Thin community `Community 1232`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1233`** (1 nodes): `posSession.ts`
+- **Thin community `Community 1233`** (1 nodes): `posLocalStaffProof.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1234`** (1 nodes): `posSessionItem.ts`
+- **Thin community `Community 1234`** (1 nodes): `posLocalSyncConflict.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1235`** (1 nodes): `posTerminal.test.ts`
+- **Thin community `Community 1235`** (1 nodes): `posLocalSyncCursor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1236`** (1 nodes): `posTerminal.ts`
+- **Thin community `Community 1236`** (1 nodes): `posLocalSyncEvent.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1237`** (1 nodes): `posTerminalRecovery.ts`
+- **Thin community `Community 1237`** (1 nodes): `posLocalSyncMapping.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1238`** (1 nodes): `posTerminalRuntimeStatus.ts`
+- **Thin community `Community 1238`** (1 nodes): `posPendingCheckoutItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1239`** (1 nodes): `posTransaction.ts`
+- **Thin community `Community 1239`** (1 nodes): `posRecoveryCredential.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1240`** (1 nodes): `posTransactionAdjustment.ts`
+- **Thin community `Community 1240`** (1 nodes): `posSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1241`** (1 nodes): `posTransactionAdjustmentLine.ts`
+- **Thin community `Community 1241`** (1 nodes): `posSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1242`** (1 nodes): `posTransactionItem.ts`
+- **Thin community `Community 1242`** (1 nodes): `posTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1243`** (1 nodes): `posTransactionServiceLine.test.ts`
+- **Thin community `Community 1243`** (1 nodes): `posTerminal.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1244`** (1 nodes): `posTransactionServiceLine.ts`
+- **Thin community `Community 1244`** (1 nodes): `posTerminalRecovery.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1245`** (1 nodes): `index.ts`
+- **Thin community `Community 1245`** (1 nodes): `posTerminalRuntimeStatus.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1246`** (1 nodes): `remoteAssistClient.ts`
+- **Thin community `Community 1246`** (1 nodes): `posTransaction.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1247`** (1 nodes): `remoteAssistSession.ts`
+- **Thin community `Community 1247`** (1 nodes): `posTransactionAdjustment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1248`** (1 nodes): `index.ts`
+- **Thin community `Community 1248`** (1 nodes): `posTransactionAdjustmentLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1249`** (1 nodes): `serviceAppointment.ts`
+- **Thin community `Community 1249`** (1 nodes): `posTransactionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1250`** (1 nodes): `serviceCase.ts`
+- **Thin community `Community 1250`** (1 nodes): `posTransactionServiceLine.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1251`** (1 nodes): `serviceCaseLineItem.ts`
+- **Thin community `Community 1251`** (1 nodes): `posTransactionServiceLine.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1252`** (1 nodes): `serviceCatalog.ts`
+- **Thin community `Community 1252`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1253`** (1 nodes): `serviceInventoryUsage.ts`
+- **Thin community `Community 1253`** (1 nodes): `remoteAssistClient.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1254`** (1 nodes): `cycleCountDraft.ts`
+- **Thin community `Community 1254`** (1 nodes): `remoteAssistSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1255`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1256`** (1 nodes): `purchaseOrder.ts`
+- **Thin community `Community 1256`** (1 nodes): `serviceAppointment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1257`** (1 nodes): `purchaseOrderLineItem.ts`
+- **Thin community `Community 1257`** (1 nodes): `serviceCase.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1258`** (1 nodes): `receivingBatch.ts`
+- **Thin community `Community 1258`** (1 nodes): `serviceCaseLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1259`** (1 nodes): `stockAdjustmentBatch.ts`
+- **Thin community `Community 1259`** (1 nodes): `serviceCatalog.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1260`** (1 nodes): `vendor.ts`
+- **Thin community `Community 1260`** (1 nodes): `serviceInventoryUsage.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1261`** (1 nodes): `analytics.ts`
+- **Thin community `Community 1261`** (1 nodes): `cycleCountDraft.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1262`** (1 nodes): `bag.ts`
+- **Thin community `Community 1262`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1263`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1263`** (1 nodes): `purchaseOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1264`** (1 nodes): `checkoutSession.ts`
+- **Thin community `Community 1264`** (1 nodes): `purchaseOrderLineItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1265`** (1 nodes): `checkoutSessionItem.ts`
+- **Thin community `Community 1265`** (1 nodes): `receivingBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1266`** (1 nodes): `guest.ts`
+- **Thin community `Community 1266`** (1 nodes): `stockAdjustmentBatch.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1267`** (1 nodes): `index.ts`
+- **Thin community `Community 1267`** (1 nodes): `vendor.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1268`** (1 nodes): `offer.ts`
+- **Thin community `Community 1268`** (1 nodes): `analytics.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1269`** (1 nodes): `onlineOrder.ts`
+- **Thin community `Community 1269`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1270`** (1 nodes): `onlineOrderItem.ts`
+- **Thin community `Community 1270`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1271`** (1 nodes): `review.ts`
+- **Thin community `Community 1271`** (1 nodes): `checkoutSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1272`** (1 nodes): `rewards.ts`
+- **Thin community `Community 1272`** (1 nodes): `checkoutSessionItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1273`** (1 nodes): `savedBag.ts`
+- **Thin community `Community 1273`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1274`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1274`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1275`** (1 nodes): `storeFrontSession.ts`
+- **Thin community `Community 1275`** (1 nodes): `offer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1276`** (1 nodes): `storeFrontUser.ts`
+- **Thin community `Community 1276`** (1 nodes): `onlineOrder.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1277`** (1 nodes): `storeFrontVerificationCode.ts`
+- **Thin community `Community 1277`** (1 nodes): `onlineOrderItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1278`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1278`** (1 nodes): `review.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1279`** (1 nodes): `catalogAppointments.test.ts`
+- **Thin community `Community 1279`** (1 nodes): `rewards.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1280`** (1 nodes): `orderEmailService.test.ts`
+- **Thin community `Community 1280`** (1 nodes): `savedBag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1281`** (1 nodes): `bag.ts`
+- **Thin community `Community 1281`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1282`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1282`** (1 nodes): `storeFrontSession.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1283`** (1 nodes): `customer.ts`
+- **Thin community `Community 1283`** (1 nodes): `storeFrontUser.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1284`** (1 nodes): `guest.ts`
+- **Thin community `Community 1284`** (1 nodes): `storeFrontVerificationCode.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1285`** (1 nodes): `offers.test.ts`
+- **Thin community `Community 1285`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1286`** (1 nodes): `onlineOrderUtilFns.ts`
+- **Thin community `Community 1286`** (1 nodes): `catalogAppointments.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1287`** (1 nodes): `orderOperations.test.ts`
+- **Thin community `Community 1287`** (1 nodes): `orderEmailService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1288`** (1 nodes): `payment.test.ts`
+- **Thin community `Community 1288`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1289`** (1 nodes): `payment.ts`
+- **Thin community `Community 1289`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1290`** (1 nodes): `paystackActions.ts`
+- **Thin community `Community 1290`** (1 nodes): `customer.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1291`** (1 nodes): `savedBagItem.ts`
+- **Thin community `Community 1291`** (1 nodes): `guest.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1292`** (1 nodes): `supportTicket.ts`
+- **Thin community `Community 1292`** (1 nodes): `offers.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1293`** (1 nodes): `users.ts`
+- **Thin community `Community 1293`** (1 nodes): `onlineOrderUtilFns.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1294`** (1 nodes): `payment.ts`
+- **Thin community `Community 1294`** (1 nodes): `orderOperations.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1295`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1295`** (1 nodes): `payment.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1296`** (1 nodes): `posSession.test.ts`
+- **Thin community `Community 1296`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1297`** (1 nodes): `registerSession.test.ts`
+- **Thin community `Community 1297`** (1 nodes): `paystackActions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1298`** (1 nodes): `presentation.test.ts`
+- **Thin community `Community 1298`** (1 nodes): `savedBagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1299`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1299`** (1 nodes): `supportTicket.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1300`** (1 nodes): `index.ts`
+- **Thin community `Community 1300`** (1 nodes): `users.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1301`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1301`** (1 nodes): `payment.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1302`** (1 nodes): `playwright.prod.config.ts`
+- **Thin community `Community 1302`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1303`** (1 nodes): `postcss.config.js`
+- **Thin community `Community 1303`** (1 nodes): `posSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1304`** (1 nodes): `approvalPolicy.ts`
+- **Thin community `Community 1304`** (1 nodes): `registerSession.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1305`** (1 nodes): `auth.ts`
+- **Thin community `Community 1305`** (1 nodes): `presentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1306`** (1 nodes): `commandResult.test.ts`
+- **Thin community `Community 1306`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1307`** (1 nodes): `currencyFormatter.test.ts`
+- **Thin community `Community 1307`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1308`** (1 nodes): `posLocalSyncContract.ts`
+- **Thin community `Community 1308`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1309`** (1 nodes): `registerSessionStatus.test.ts`
+- **Thin community `Community 1309`** (1 nodes): `playwright.prod.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1310`** (1 nodes): `staffDisplayName.test.ts`
+- **Thin community `Community 1310`** (1 nodes): `postcss.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1311`** (1 nodes): `convexAuthUrl.test.ts`
+- **Thin community `Community 1311`** (1 nodes): `approvalPolicy.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1312`** (1 nodes): `GenericComboBox.tsx`
+- **Thin community `Community 1312`** (1 nodes): `auth.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1313`** (1 nodes): `StoreAccordion.tsx`
+- **Thin community `Community 1313`** (1 nodes): `commandResult.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1314`** (1 nodes): `StoresAccordion.tsx`
+- **Thin community `Community 1314`** (1 nodes): `currencyFormatter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1315`** (1 nodes): `ThemeToggle.tsx`
+- **Thin community `Community 1315`** (1 nodes): `posLocalSyncContract.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1316`** (1 nodes): `View.test.tsx`
+- **Thin community `Community 1316`** (1 nodes): `registerSessionStatus.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1317`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
+- **Thin community `Community 1317`** (1 nodes): `staffDisplayName.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1318`** (1 nodes): `ProductAttributes.tsx`
+- **Thin community `Community 1318`** (1 nodes): `convexAuthUrl.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1319`** (1 nodes): `ProductAttributesView.tsx`
+- **Thin community `Community 1319`** (1 nodes): `GenericComboBox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1320`** (1 nodes): `ProductStock.test.ts`
+- **Thin community `Community 1320`** (1 nodes): `StoreAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1321`** (1 nodes): `ProductView.test.tsx`
+- **Thin community `Community 1321`** (1 nodes): `StoresAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1322`** (1 nodes): `constants.ts`
+- **Thin community `Community 1322`** (1 nodes): `ThemeToggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1323`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1323`** (1 nodes): `View.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1324`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1324`** (1 nodes): `DefaultAttributesToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1325`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1325`** (1 nodes): `ProductAttributes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1326`** (1 nodes): `types.ts`
+- **Thin community `Community 1326`** (1 nodes): `ProductAttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1327`** (1 nodes): `ConversionFunnelChart.tsx`
+- **Thin community `Community 1327`** (1 nodes): `ProductStock.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1328`** (1 nodes): `RevenueChart.tsx`
+- **Thin community `Community 1328`** (1 nodes): `ProductView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1329`** (1 nodes): `analytics-columns.tsx`
+- **Thin community `Community 1329`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1330`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1331`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1332`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1332`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1333`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1333`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1334`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1334`** (1 nodes): `ConversionFunnelChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1335`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1335`** (1 nodes): `RevenueChart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1336`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1336`** (1 nodes): `analytics-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1337`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1337`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1338`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1338`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1339`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1339`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1340`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1340`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1341`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1341`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1342`** (1 nodes): `chart.tsx`
+- **Thin community `Community 1342`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1343`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1343`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1344`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1344`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1345`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1346`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1347`** (1 nodes): `constants.ts`
+- **Thin community `Community 1347`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1348`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1348`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1349`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1349`** (1 nodes): `chart.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1350`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1350`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1351`** (1 nodes): `data.ts`
+- **Thin community `Community 1351`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1352`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1352`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1353`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1353`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1354`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1354`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1355`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1355`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1356`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1356`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1357`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1357`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1358`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1358`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1359`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1359`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1360`** (1 nodes): `assetsColumns.tsx`
+- **Thin community `Community 1360`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1361`** (1 nodes): `constants.ts`
+- **Thin community `Community 1361`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1362`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1362`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1363`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1363`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1364`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1364`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1365`** (1 nodes): `data.ts`
+- **Thin community `Community 1365`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1366`** (1 nodes): `DefaultCatchBoundary.test.tsx`
+- **Thin community `Community 1366`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1367`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1367`** (1 nodes): `assetsColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1368`** (1 nodes): `LoginForm.test.tsx`
+- **Thin community `Community 1368`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1369`** (1 nodes): `LoginForm.tsx`
+- **Thin community `Community 1369`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1370`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
+- **Thin community `Community 1370`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1371`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1371`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1372`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1372`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1373`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1373`** (1 nodes): `DefaultCatchBoundary.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1374`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1374`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1375`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1375`** (1 nodes): `LoginForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1376`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1376`** (1 nodes): `LoginForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1377`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1377`** (1 nodes): `PosRecoveryCodeForm.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1378`** (1 nodes): `constants.ts`
+- **Thin community `Community 1378`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1379`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1379`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1380`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1380`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1381`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1381`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1382`** (1 nodes): `BulkOperationsPage.tsx`
+- **Thin community `Community 1382`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1383`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
+- **Thin community `Community 1383`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1384`** (1 nodes): `CashControlsDashboard.test.tsx`
+- **Thin community `Community 1384`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1385`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
+- **Thin community `Community 1385`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1386`** (1 nodes): `RegisterSessionView.auth.test.tsx`
+- **Thin community `Community 1386`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1387`** (1 nodes): `RegisterSessionView.test.tsx`
+- **Thin community `Community 1387`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1388`** (1 nodes): `RegisterSessionsView.test.tsx`
+- **Thin community `Community 1388`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1389`** (1 nodes): `formatReviewReason.test.ts`
+- **Thin community `Community 1389`** (1 nodes): `BulkOperationsPage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1390`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1390`** (1 nodes): `CashControlsDashboard.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1391`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1391`** (1 nodes): `CashControlsDashboard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1392`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1392`** (1 nodes): `CashControlsWorkspaceHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1393`** (1 nodes): `ListPagination.tsx`
+- **Thin community `Community 1393`** (1 nodes): `RegisterSessionView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1394`** (1 nodes): `PageHeader.test.tsx`
+- **Thin community `Community 1394`** (1 nodes): `RegisterSessionView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1395`** (1 nodes): `PageLevelHeader.test.tsx`
+- **Thin community `Community 1395`** (1 nodes): `RegisterSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1396`** (1 nodes): `PageLevelHeader.tsx`
+- **Thin community `Community 1396`** (1 nodes): `formatReviewReason.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1397`** (1 nodes): `MetricCard.tsx`
+- **Thin community `Community 1397`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1398`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1398`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1399`** (1 nodes): `CommandApprovalDialog.test.tsx`
+- **Thin community `Community 1399`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1400`** (1 nodes): `OperationReviewWorkspace.tsx`
+- **Thin community `Community 1400`** (1 nodes): `ListPagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1401`** (1 nodes): `OperationsQueueView.auth.test.tsx`
+- **Thin community `Community 1401`** (1 nodes): `PageHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1402`** (1 nodes): `SkuActivityTimeline.test.tsx`
+- **Thin community `Community 1402`** (1 nodes): `PageLevelHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1403`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
+- **Thin community `Community 1403`** (1 nodes): `PageLevelHeader.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1404`** (1 nodes): `useApprovedCommand.test.tsx`
+- **Thin community `Community 1404`** (1 nodes): `MetricCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1405`** (1 nodes): `OrderStatus.test.tsx`
+- **Thin community `Community 1405`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1406`** (1 nodes): `OrderStatus.tsx`
+- **Thin community `Community 1406`** (1 nodes): `CommandApprovalDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1407`** (1 nodes): `OrderSummary.tsx`
+- **Thin community `Community 1407`** (1 nodes): `OperationReviewWorkspace.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1408`** (1 nodes): `Orders.tsx`
+- **Thin community `Community 1408`** (1 nodes): `OperationsQueueView.auth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1409`** (1 nodes): `RefundsView.test.tsx`
+- **Thin community `Community 1409`** (1 nodes): `SkuActivityTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1410`** (1 nodes): `ReturnExchangeView.test.tsx`
+- **Thin community `Community 1410`** (1 nodes): `skuActivityTimelineAdapter.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1411`** (1 nodes): `constants.ts`
+- **Thin community `Community 1411`** (1 nodes): `useApprovedCommand.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1412`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1412`** (1 nodes): `OrderStatus.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1413`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1413`** (1 nodes): `OrderStatus.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1414`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1414`** (1 nodes): `OrderSummary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1415`** (1 nodes): `data.ts`
+- **Thin community `Community 1415`** (1 nodes): `Orders.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1416`** (1 nodes): `refundUtils.test.ts`
+- **Thin community `Community 1416`** (1 nodes): `RefundsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1417`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1417`** (1 nodes): `ReturnExchangeView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1418`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -10926,13 +10949,13 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1420`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1421`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1421`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1422`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1422`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1423`** (1 nodes): `data.ts`
+- **Thin community `Community 1423`** (1 nodes): `refundUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1424`** (1 nodes): `inviteColumns.tsx`
+- **Thin community `Community 1424`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1425`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
@@ -10946,863 +10969,877 @@ Nodes (0):
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1430`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1431`** (1 nodes): `membersColumns.tsx`
+- **Thin community `Community 1431`** (1 nodes): `inviteColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1432`** (1 nodes): `organization-switcher.test.tsx`
+- **Thin community `Community 1432`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1433`** (1 nodes): `CashierView.tsx`
+- **Thin community `Community 1433`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1434`** (1 nodes): `POSRegisterView.tsx`
+- **Thin community `Community 1434`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1435`** (1 nodes): `PaymentView.test.tsx`
+- **Thin community `Community 1435`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1436`** (1 nodes): `PointOfSaleView.test.tsx`
+- **Thin community `Community 1436`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1437`** (1 nodes): `PointOfSaleView.tsx`
+- **Thin community `Community 1437`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1438`** (1 nodes): `ProductLookup.tsx`
+- **Thin community `Community 1438`** (1 nodes): `membersColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1439`** (1 nodes): `RegisterActions.tsx`
+- **Thin community `Community 1439`** (1 nodes): `organization-switcher.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1440`** (1 nodes): `SessionManager.test.tsx`
+- **Thin community `Community 1440`** (1 nodes): `CashierView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1441`** (1 nodes): `SessionManager.tsx`
+- **Thin community `Community 1441`** (1 nodes): `POSRegisterView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1442`** (1 nodes): `TotalsDisplay.test.tsx`
+- **Thin community `Community 1442`** (1 nodes): `PaymentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1443`** (1 nodes): `TotalsDisplay.tsx`
+- **Thin community `Community 1443`** (1 nodes): `PointOfSaleView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1444`** (1 nodes): `ExpenseReportView.test.tsx`
+- **Thin community `Community 1444`** (1 nodes): `PointOfSaleView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1445`** (1 nodes): `ExpenseReportsView.test.ts`
+- **Thin community `Community 1445`** (1 nodes): `ProductLookup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1446`** (1 nodes): `ExpenseReportsView.test.tsx`
+- **Thin community `Community 1446`** (1 nodes): `RegisterActions.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1447`** (1 nodes): `expenseReportColumns.tsx`
+- **Thin community `Community 1447`** (1 nodes): `SessionManager.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1448`** (1 nodes): `PosReceiptShareControl.test.tsx`
+- **Thin community `Community 1448`** (1 nodes): `SessionManager.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1449`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
+- **Thin community `Community 1449`** (1 nodes): `TotalsDisplay.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1450`** (1 nodes): `RegisterActionBar.test.tsx`
+- **Thin community `Community 1450`** (1 nodes): `TotalsDisplay.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1451`** (1 nodes): `RegisterActionBar.tsx`
+- **Thin community `Community 1451`** (1 nodes): `ExpenseReportView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1452`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
+- **Thin community `Community 1452`** (1 nodes): `ExpenseReportsView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1453`** (1 nodes): `HeldSessionsList.test.tsx`
+- **Thin community `Community 1453`** (1 nodes): `ExpenseReportsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1454`** (1 nodes): `POSSessionsView.test.tsx`
+- **Thin community `Community 1454`** (1 nodes): `expenseReportColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1455`** (1 nodes): `posSessionColumns.tsx`
+- **Thin community `Community 1455`** (1 nodes): `PosReceiptShareControl.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1456`** (1 nodes): `POSTerminalDetailView.test.tsx`
+- **Thin community `Community 1456`** (1 nodes): `POSRegisterOpeningGuard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1457`** (1 nodes): `POSTerminalHealthView.test.tsx`
+- **Thin community `Community 1457`** (1 nodes): `RegisterActionBar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1458`** (1 nodes): `terminalHealthPresentation.test.ts`
+- **Thin community `Community 1458`** (1 nodes): `RegisterActionBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1459`** (1 nodes): `terminalHealthTypes.ts`
+- **Thin community `Community 1459`** (1 nodes): `RegisterCheckoutPanel.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1460`** (1 nodes): `TransactionsView.test.tsx`
+- **Thin community `Community 1460`** (1 nodes): `HeldSessionsList.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1461`** (1 nodes): `types.ts`
+- **Thin community `Community 1461`** (1 nodes): `POSSessionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1462`** (1 nodes): `ReceivingView.test.tsx`
+- **Thin community `Community 1462`** (1 nodes): `posSessionColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1463`** (1 nodes): `AnalyticsInsights.tsx`
+- **Thin community `Community 1463`** (1 nodes): `POSTerminalDetailView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1464`** (1 nodes): `AttributesView.tsx`
+- **Thin community `Community 1464`** (1 nodes): `POSTerminalHealthView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1465`** (1 nodes): `DetailsView.tsx`
+- **Thin community `Community 1465`** (1 nodes): `terminalHealthPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1466`** (1 nodes): `ProductOperationalTimeline.test.tsx`
+- **Thin community `Community 1466`** (1 nodes): `terminalHealthTypes.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1467`** (1 nodes): `ArchivedProducts.tsx`
+- **Thin community `Community 1467`** (1 nodes): `TransactionsView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1468`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
+- **Thin community `Community 1468`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1469`** (1 nodes): `ProductsListView.test.ts`
+- **Thin community `Community 1469`** (1 nodes): `ReceivingView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1470`** (1 nodes): `StoreProducts.tsx`
+- **Thin community `Community 1470`** (1 nodes): `AnalyticsInsights.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1471`** (1 nodes): `UnresolvedProducts.test.tsx`
+- **Thin community `Community 1471`** (1 nodes): `AttributesView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1472`** (1 nodes): `UnresolvedProducts.tsx`
+- **Thin community `Community 1472`** (1 nodes): `DetailsView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1473`** (1 nodes): `ComplimentaryProducts.tsx`
+- **Thin community `Community 1473`** (1 nodes): `ProductOperationalTimeline.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1474`** (1 nodes): `complimentaryProductsColumn.tsx`
+- **Thin community `Community 1474`** (1 nodes): `ArchivedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1475`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1475`** (1 nodes): `ProductSubcategoryToggleGroup.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1476`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1476`** (1 nodes): `ProductsListView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1477`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1477`** (1 nodes): `StoreProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1478`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1478`** (1 nodes): `UnresolvedProducts.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1479`** (1 nodes): `data.ts`
+- **Thin community `Community 1479`** (1 nodes): `UnresolvedProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1480`** (1 nodes): `productColumns.tsx`
+- **Thin community `Community 1480`** (1 nodes): `ComplimentaryProducts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1481`** (1 nodes): `PromoCodeHeader.test.tsx`
+- **Thin community `Community 1481`** (1 nodes): `complimentaryProductsColumn.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1482`** (1 nodes): `PromoCodes.tsx`
+- **Thin community `Community 1482`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1483`** (1 nodes): `PromoCodeAnalytics.tsx`
+- **Thin community `Community 1483`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1484`** (1 nodes): `captured-emails-columns.tsx`
+- **Thin community `Community 1484`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1485`** (1 nodes): `promoCodeMoney.test.ts`
+- **Thin community `Community 1485`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1486`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1486`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1487`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1487`** (1 nodes): `productColumns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1488`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1488`** (1 nodes): `PromoCodeHeader.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1489`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1489`** (1 nodes): `PromoCodes.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1490`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1490`** (1 nodes): `PromoCodeAnalytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1491`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1491`** (1 nodes): `captured-emails-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1492`** (1 nodes): `constants.ts`
+- **Thin community `Community 1492`** (1 nodes): `promoCodeMoney.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1493`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1493`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1494`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1494`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1495`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1495`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1496`** (1 nodes): `data.ts`
+- **Thin community `Community 1496`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1497`** (1 nodes): `types.ts`
+- **Thin community `Community 1497`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1498`** (1 nodes): `welcome-offer-card.tsx`
+- **Thin community `Community 1498`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1499`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
+- **Thin community `Community 1499`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1500`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
+- **Thin community `Community 1500`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1501`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
+- **Thin community `Community 1501`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1502`** (1 nodes): `RemoteAssistSupportConsole.tsx`
+- **Thin community `Community 1502`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1503`** (1 nodes): `index.ts`
+- **Thin community `Community 1503`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1504`** (1 nodes): `RatingStars.tsx`
+- **Thin community `Community 1504`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1505`** (1 nodes): `ReviewCard.tsx`
+- **Thin community `Community 1505`** (1 nodes): `welcome-offer-card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1506`** (1 nodes): `ReviewMetadata.tsx`
+- **Thin community `Community 1506`** (1 nodes): `PosRemoteAssistRuntimeHost.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1507`** (1 nodes): `ServiceIntakeForm.tsx`
+- **Thin community `Community 1507`** (1 nodes): `RemoteAssistLiveViewer.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1508`** (1 nodes): `index.tsx`
+- **Thin community `Community 1508`** (1 nodes): `RemoteAssistRuntimeShell.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1509`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
+- **Thin community `Community 1509`** (1 nodes): `RemoteAssistSupportConsole.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1510`** (1 nodes): `StaffPinInput.tsx`
+- **Thin community `Community 1510`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1511`** (1 nodes): `SkuSearchFilterBar.tsx`
+- **Thin community `Community 1511`** (1 nodes): `RatingStars.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1512`** (1 nodes): `FeesView.test.ts`
+- **Thin community `Community 1512`** (1 nodes): `ReviewCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1513`** (1 nodes): `FulfillmentView.test.tsx`
+- **Thin community `Community 1513`** (1 nodes): `ReviewMetadata.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1514`** (1 nodes): `MaintenanceView.test.tsx`
+- **Thin community `Community 1514`** (1 nodes): `ServiceIntakeForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1515`** (1 nodes): `MtnMomoView.test.tsx`
+- **Thin community `Community 1515`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1516`** (1 nodes): `useStoreConfigUpdate.test.tsx`
+- **Thin community `Community 1516`** (1 nodes): `StaffAuthenticationDialog.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1517`** (1 nodes): `index.tsx`
+- **Thin community `Community 1517`** (1 nodes): `StaffPinInput.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1518`** (1 nodes): `WorkflowTraceView.test.tsx`
+- **Thin community `Community 1518`** (1 nodes): `SkuSearchFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1519`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1519`** (1 nodes): `FeesView.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1520`** (1 nodes): `button.test.tsx`
+- **Thin community `Community 1520`** (1 nodes): `FulfillmentView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1521`** (1 nodes): `button.tsx`
+- **Thin community `Community 1521`** (1 nodes): `MaintenanceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1522`** (1 nodes): `calendar.test.tsx`
+- **Thin community `Community 1522`** (1 nodes): `MtnMomoView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1523`** (1 nodes): `card.tsx`
+- **Thin community `Community 1523`** (1 nodes): `useStoreConfigUpdate.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1524`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1524`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1525`** (1 nodes): `collapsible.tsx`
+- **Thin community `Community 1525`** (1 nodes): `WorkflowTraceView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1526`** (1 nodes): `command.tsx`
+- **Thin community `Community 1526`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1527`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1527`** (1 nodes): `button.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1528`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1528`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1529`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1529`** (1 nodes): `calendar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1530`** (1 nodes): `form.tsx`
+- **Thin community `Community 1530`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1531`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1531`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1532`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1532`** (1 nodes): `collapsible.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1533`** (1 nodes): `input.tsx`
+- **Thin community `Community 1533`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1534`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1534`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1535`** (1 nodes): `panel-header.tsx`
+- **Thin community `Community 1535`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1536`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1536`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1537`** (1 nodes): `primitives.test.tsx`
+- **Thin community `Community 1537`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1538`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1538`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1539`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1539`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1540`** (1 nodes): `select.tsx`
+- **Thin community `Community 1540`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1541`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1541`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1542`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1542`** (1 nodes): `panel-header.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1543`** (1 nodes): `sidebar.test.tsx`
+- **Thin community `Community 1543`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1544`** (1 nodes): `switch.tsx`
+- **Thin community `Community 1544`** (1 nodes): `primitives.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1545`** (1 nodes): `table.tsx`
+- **Thin community `Community 1545`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1546`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1546`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1547`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1547`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1548`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1548`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1549`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1549`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1550`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1550`** (1 nodes): `sidebar.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1551`** (1 nodes): `upload-button.tsx`
+- **Thin community `Community 1551`** (1 nodes): `switch.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1552`** (1 nodes): `BagView.tsx`
+- **Thin community `Community 1552`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1553`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1553`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1554`** (1 nodes): `constants.ts`
+- **Thin community `Community 1554`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1555`** (1 nodes): `data-table-faceted-filter.tsx`
+- **Thin community `Community 1555`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1556`** (1 nodes): `data-table-pagination.tsx`
+- **Thin community `Community 1556`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1557`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1557`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1558`** (1 nodes): `data.ts`
+- **Thin community `Community 1558`** (1 nodes): `upload-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1559`** (1 nodes): `bag-columns.tsx`
+- **Thin community `Community 1559`** (1 nodes): `BagView.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1560`** (1 nodes): `bags-table.tsx`
+- **Thin community `Community 1560`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1561`** (1 nodes): `columns.tsx`
+- **Thin community `Community 1561`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1562`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1563`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1564`** (1 nodes): `data-table-toolbar.tsx`
+- **Thin community `Community 1564`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1565`** (1 nodes): `data-table.tsx`
+- **Thin community `Community 1565`** (1 nodes): `data.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1566`** (1 nodes): `LinkedAccounts.tsx`
+- **Thin community `Community 1566`** (1 nodes): `bag-columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1567`** (1 nodes): `TimelineEventCard.test.tsx`
+- **Thin community `Community 1567`** (1 nodes): `bags-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1568`** (1 nodes): `UserCheckoutSession.tsx`
+- **Thin community `Community 1568`** (1 nodes): `columns.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1569`** (1 nodes): `UserInsightsSection.tsx`
+- **Thin community `Community 1569`** (1 nodes): `data-table-faceted-filter.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1570`** (1 nodes): `index.ts`
+- **Thin community `Community 1570`** (1 nodes): `data-table-pagination.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1571`** (1 nodes): `config.test.ts`
+- **Thin community `Community 1571`** (1 nodes): `data-table-toolbar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1572`** (1 nodes): `ThemeContext.tsx`
+- **Thin community `Community 1572`** (1 nodes): `data-table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1573`** (1 nodes): `design-system-build-config.test.ts`
+- **Thin community `Community 1573`** (1 nodes): `LinkedAccounts.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1574`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1574`** (1 nodes): `TimelineEventCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1575`** (1 nodes): `useAuth.test.tsx`
+- **Thin community `Community 1575`** (1 nodes): `UserCheckoutSession.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1576`** (1 nodes): `useExpenseSessions.test.ts`
+- **Thin community `Community 1576`** (1 nodes): `UserInsightsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1577`** (1 nodes): `useGetActiveStore.test.ts`
+- **Thin community `Community 1577`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1578`** (1 nodes): `useGetTerminal.test.ts`
+- **Thin community `Community 1578`** (1 nodes): `config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1579`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1579`** (1 nodes): `ThemeContext.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1580`** (1 nodes): `useProtectedAdminPageState.test.tsx`
+- **Thin community `Community 1580`** (1 nodes): `design-system-build-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1581`** (1 nodes): `capabilities.test.ts`
+- **Thin community `Community 1581`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1582`** (1 nodes): `aws.ts`
+- **Thin community `Community 1582`** (1 nodes): `useAuth.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1583`** (1 nodes): `constants.ts`
+- **Thin community `Community 1583`** (1 nodes): `useExpenseSessions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1584`** (1 nodes): `countries.ts`
+- **Thin community `Community 1584`** (1 nodes): `useGetActiveStore.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1585`** (1 nodes): `operatorMessages.test.ts`
+- **Thin community `Community 1585`** (1 nodes): `useGetTerminal.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1586`** (1 nodes): `presentCommandToast.test.ts`
+- **Thin community `Community 1586`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1587`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
+- **Thin community `Community 1587`** (1 nodes): `useProtectedAdminPageState.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1588`** (1 nodes): `runCommand.test.ts`
+- **Thin community `Community 1588`** (1 nodes): `capabilities.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1589`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1589`** (1 nodes): `aws.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1590`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1590`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1591`** (1 nodes): `inventoryImportParser.test.ts`
+- **Thin community `Community 1591`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1592`** (1 nodes): `dto.ts`
+- **Thin community `Community 1592`** (1 nodes): `operatorMessages.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1593`** (1 nodes): `ports.ts`
+- **Thin community `Community 1593`** (1 nodes): `presentCommandToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1594`** (1 nodes): `constants.ts`
+- **Thin community `Community 1594`** (1 nodes): `presentUnexpectedErrorToast.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1595`** (1 nodes): `displayAmounts.test.ts`
+- **Thin community `Community 1595`** (1 nodes): `runCommand.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1596`** (1 nodes): `cart.test.ts`
+- **Thin community `Community 1596`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1597`** (1 nodes): `index.ts`
+- **Thin community `Community 1597`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1598`** (1 nodes): `session.test.ts`
+- **Thin community `Community 1598`** (1 nodes): `inventoryImportParser.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1599`** (1 nodes): `types.ts`
+- **Thin community `Community 1599`** (1 nodes): `dto.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1600`** (1 nodes): `expenseReceipt.test.ts`
+- **Thin community `Community 1600`** (1 nodes): `ports.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1601`** (1 nodes): `registerGateway.test.ts`
+- **Thin community `Community 1601`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1602`** (1 nodes): `sessionGateway.test.ts`
+- **Thin community `Community 1602`** (1 nodes): `displayAmounts.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1603`** (1 nodes): `localPosEntryContext.test.ts`
+- **Thin community `Community 1603`** (1 nodes): `cart.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1604`** (1 nodes): `localPosReadiness.test.ts`
+- **Thin community `Community 1604`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1605`** (1 nodes): `saleBlockerPolicy.test.ts`
+- **Thin community `Community 1605`** (1 nodes): `session.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1606`** (1 nodes): `loggerGateway.ts`
+- **Thin community `Community 1606`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1607`** (1 nodes): `catalogSearch.test.ts`
+- **Thin community `Community 1607`** (1 nodes): `expenseReceipt.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1608`** (1 nodes): `catalogSearchPresentation.test.ts`
+- **Thin community `Community 1608`** (1 nodes): `registerGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1609`** (1 nodes): `registerUiState.ts`
+- **Thin community `Community 1609`** (1 nodes): `sessionGateway.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1610`** (1 nodes): `syncStatusPresentation.test.ts`
+- **Thin community `Community 1610`** (1 nodes): `localPosEntryContext.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1611`** (1 nodes): `productUtils.test.ts`
+- **Thin community `Community 1611`** (1 nodes): `localPosReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1612`** (1 nodes): `contract.test.ts`
+- **Thin community `Community 1612`** (1 nodes): `saleBlockerPolicy.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1613`** (1 nodes): `guardrails.test.ts`
+- **Thin community `Community 1613`** (1 nodes): `loggerGateway.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1614`** (1 nodes): `index.ts`
+- **Thin community `Community 1614`** (1 nodes): `catalogSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1615`** (1 nodes): `runtimeBuildMetadata.test.ts`
+- **Thin community `Community 1615`** (1 nodes): `catalogSearchPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1616`** (1 nodes): `category.ts`
+- **Thin community `Community 1616`** (1 nodes): `registerUiState.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1617`** (1 nodes): `product.ts`
+- **Thin community `Community 1617`** (1 nodes): `syncStatusPresentation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1618`** (1 nodes): `store.ts`
+- **Thin community `Community 1618`** (1 nodes): `productUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1619`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1619`** (1 nodes): `contract.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1620`** (1 nodes): `user.ts`
+- **Thin community `Community 1620`** (1 nodes): `guardrails.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1621`** (1 nodes): `localPinVerifier.test.ts`
+- **Thin community `Community 1621`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1622`** (1 nodes): `skuSearch.test.ts`
+- **Thin community `Community 1622`** (1 nodes): `runtimeBuildMetadata.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1623`** (1 nodes): `storeConfig.test.ts`
+- **Thin community `Community 1623`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1624`** (1 nodes): `createWorkflowTraceId.test.ts`
+- **Thin community `Community 1624`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1625`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1625`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1626`** (1 nodes): `posAppShellReadiness.test.ts`
+- **Thin community `Community 1626`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1627`** (1 nodes): `posAppShellRoutes.test.ts`
+- **Thin community `Community 1627`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1628`** (1 nodes): `posOfflineReadiness.test.ts`
+- **Thin community `Community 1628`** (1 nodes): `localPinVerifier.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1629`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
+- **Thin community `Community 1629`** (1 nodes): `skuSearch.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1630`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1630`** (1 nodes): `storeConfig.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1631`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1631`** (1 nodes): `createWorkflowTraceId.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1632`** (1 nodes): `index.tsx`
+- **Thin community `Community 1632`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1633`** (1 nodes): `index.tsx`
+- **Thin community `Community 1633`** (1 nodes): `posAppShellReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1634`** (1 nodes): `index.tsx`
+- **Thin community `Community 1634`** (1 nodes): `posAppShellRoutes.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1635`** (1 nodes): `$storeUrlSlug.tsx`
+- **Thin community `Community 1635`** (1 nodes): `posOfflineReadiness.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1636`** (1 nodes): `analytics.tsx`
+- **Thin community `Community 1636`** (1 nodes): `registerPosAppShellServiceWorker.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1637`** (1 nodes): `assets.index.tsx`
+- **Thin community `Community 1637`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1638`** (1 nodes): `bags.$bagId.tsx`
+- **Thin community `Community 1638`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1639`** (1 nodes): `bags.index.tsx`
+- **Thin community `Community 1639`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1640`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1641`** (1 nodes): `checkout-sessions.index.tsx`
+- **Thin community `Community 1641`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1642`** (1 nodes): `configuration.index.tsx`
+- **Thin community `Community 1642`** (1 nodes): `$storeUrlSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1643`** (1 nodes): `dashboard.index.tsx`
+- **Thin community `Community 1643`** (1 nodes): `analytics.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1644`** (1 nodes): `home.tsx`
+- **Thin community `Community 1644`** (1 nodes): `assets.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1645`** (1 nodes): `logs.$logId.tsx`
+- **Thin community `Community 1645`** (1 nodes): `bags.$bagId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1646`** (1 nodes): `logs.index.tsx`
+- **Thin community `Community 1646`** (1 nodes): `bags.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1647`** (1 nodes): `members.index.tsx`
+- **Thin community `Community 1647`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1648`** (1 nodes): `index.tsx`
+- **Thin community `Community 1648`** (1 nodes): `checkout-sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1649`** (1 nodes): `review.tsx`
+- **Thin community `Community 1649`** (1 nodes): `configuration.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1650`** (1 nodes): `inventory-import.tsx`
+- **Thin community `Community 1650`** (1 nodes): `dashboard.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1651`** (1 nodes): `sku-activity.test.tsx`
+- **Thin community `Community 1651`** (1 nodes): `home.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1652`** (1 nodes): `index.tsx`
+- **Thin community `Community 1652`** (1 nodes): `logs.$logId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1653`** (1 nodes): `all.index.tsx`
+- **Thin community `Community 1653`** (1 nodes): `logs.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1654`** (1 nodes): `cancelled.index.tsx`
+- **Thin community `Community 1654`** (1 nodes): `members.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1655`** (1 nodes): `completed.index.tsx`
+- **Thin community `Community 1655`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1656`** (1 nodes): `index.tsx`
+- **Thin community `Community 1656`** (1 nodes): `review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1657`** (1 nodes): `open.index.tsx`
+- **Thin community `Community 1657`** (1 nodes): `inventory-import.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1658`** (1 nodes): `out-for-delivery.index.tsx`
+- **Thin community `Community 1658`** (1 nodes): `sku-activity.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1659`** (1 nodes): `ready.index.tsx`
+- **Thin community `Community 1659`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1660`** (1 nodes): `refunded.index.tsx`
+- **Thin community `Community 1660`** (1 nodes): `all.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1661`** (1 nodes): `$reportId.tsx`
+- **Thin community `Community 1661`** (1 nodes): `cancelled.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1662`** (1 nodes): `expense-reports.index.tsx`
+- **Thin community `Community 1662`** (1 nodes): `completed.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1663`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1664`** (1 nodes): `register.index.tsx`
+- **Thin community `Community 1664`** (1 nodes): `open.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1665`** (1 nodes): `sessions.index.tsx`
+- **Thin community `Community 1665`** (1 nodes): `out-for-delivery.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1666`** (1 nodes): `settings.index.tsx`
+- **Thin community `Community 1666`** (1 nodes): `ready.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1667`** (1 nodes): `$terminalId.tsx`
+- **Thin community `Community 1667`** (1 nodes): `refunded.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1668`** (1 nodes): `terminals.index.tsx`
+- **Thin community `Community 1668`** (1 nodes): `$reportId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1669`** (1 nodes): `$transactionId.tsx`
+- **Thin community `Community 1669`** (1 nodes): `expense-reports.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1670`** (1 nodes): `transactions.index.tsx`
+- **Thin community `Community 1670`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1671`** (1 nodes): `procurement.index.test.ts`
+- **Thin community `Community 1671`** (1 nodes): `register.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1672`** (1 nodes): `edit.tsx`
+- **Thin community `Community 1672`** (1 nodes): `sessions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1673`** (1 nodes): `index.tsx`
+- **Thin community `Community 1673`** (1 nodes): `settings.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1674`** (1 nodes): `archived.tsx`
+- **Thin community `Community 1674`** (1 nodes): `$terminalId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1675`** (1 nodes): `index.tsx`
+- **Thin community `Community 1675`** (1 nodes): `terminals.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1676`** (1 nodes): `new.tsx`
+- **Thin community `Community 1676`** (1 nodes): `$transactionId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1677`** (1 nodes): `index.tsx`
+- **Thin community `Community 1677`** (1 nodes): `transactions.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1678`** (1 nodes): `new.tsx`
+- **Thin community `Community 1678`** (1 nodes): `procurement.index.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1679`** (1 nodes): `unresolved.tsx`
+- **Thin community `Community 1679`** (1 nodes): `edit.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1680`** (1 nodes): `$promoCodeSlug.tsx`
+- **Thin community `Community 1680`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1681`** (1 nodes): `index.tsx`
+- **Thin community `Community 1681`** (1 nodes): `archived.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1682`** (1 nodes): `new.tsx`
+- **Thin community `Community 1682`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1683`** (1 nodes): `index.tsx`
+- **Thin community `Community 1683`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1684`** (1 nodes): `new.index.tsx`
+- **Thin community `Community 1684`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1685`** (1 nodes): `active-cases.index.tsx`
+- **Thin community `Community 1685`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1686`** (1 nodes): `appointments.index.tsx`
+- **Thin community `Community 1686`** (1 nodes): `unresolved.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1687`** (1 nodes): `catalog-management.index.tsx`
+- **Thin community `Community 1687`** (1 nodes): `$promoCodeSlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 1688`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1689`** (1 nodes): `intake.index.tsx`
+- **Thin community `Community 1689`** (1 nodes): `new.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1690`** (1 nodes): `$traceId.test.tsx`
+- **Thin community `Community 1690`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1691`** (1 nodes): `users.$userId.tsx`
+- **Thin community `Community 1691`** (1 nodes): `new.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1692`** (1 nodes): `index.tsx`
+- **Thin community `Community 1692`** (1 nodes): `active-cases.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1693`** (1 nodes): `_authed.test.tsx`
+- **Thin community `Community 1693`** (1 nodes): `appointments.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1694`** (1 nodes): `index.test.tsx`
+- **Thin community `Community 1694`** (1 nodes): `catalog-management.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1695`** (1 nodes): `join-team.index.tsx`
+- **Thin community `Community 1695`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1696`** (1 nodes): `landing.tsx`
+- **Thin community `Community 1696`** (1 nodes): `intake.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1697`** (1 nodes): `_layout.index.test.tsx`
+- **Thin community `Community 1697`** (1 nodes): `$traceId.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1698`** (1 nodes): `_layout.test.tsx`
+- **Thin community `Community 1698`** (1 nodes): `users.$userId.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1699`** (1 nodes): `StoresSettingsAccordion.tsx`
+- **Thin community `Community 1699`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1700`** (1 nodes): `expenseStore.ts`
+- **Thin community `Community 1700`** (1 nodes): `_authed.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1701`** (1 nodes): `Overview.stories.tsx`
+- **Thin community `Community 1701`** (1 nodes): `index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1702`** (1 nodes): `foundations-content.test.tsx`
+- **Thin community `Community 1702`** (1 nodes): `join-team.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1703`** (1 nodes): `Introduction.stories.tsx`
+- **Thin community `Community 1703`** (1 nodes): `landing.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1704`** (1 nodes): `introduction-content.test.tsx`
+- **Thin community `Community 1704`** (1 nodes): `_layout.index.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1705`** (1 nodes): `introduction-content.tsx`
+- **Thin community `Community 1705`** (1 nodes): `_layout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1706`** (1 nodes): `AdminShell.stories.tsx`
+- **Thin community `Community 1706`** (1 nodes): `StoresSettingsAccordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1707`** (1 nodes): `View.stories.tsx`
+- **Thin community `Community 1707`** (1 nodes): `expenseStore.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1708`** (1 nodes): `admin-shell-patterns.test.tsx`
+- **Thin community `Community 1708`** (1 nodes): `Overview.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1709`** (1 nodes): `view-patterns.test.tsx`
+- **Thin community `Community 1709`** (1 nodes): `foundations-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1710`** (1 nodes): `Surfaces.stories.tsx`
+- **Thin community `Community 1710`** (1 nodes): `Introduction.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1711`** (1 nodes): `DashboardWorkspace.stories.tsx`
+- **Thin community `Community 1711`** (1 nodes): `introduction-content.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1712`** (1 nodes): `DataWorkspace.stories.tsx`
+- **Thin community `Community 1712`** (1 nodes): `introduction-content.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1713`** (1 nodes): `SettingsWorkspace.stories.tsx`
+- **Thin community `Community 1713`** (1 nodes): `AdminShell.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1714`** (1 nodes): `reference-fixtures.test.tsx`
+- **Thin community `Community 1714`** (1 nodes): `View.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1715`** (1 nodes): `storybook-config.test.ts`
+- **Thin community `Community 1715`** (1 nodes): `admin-shell-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1716`** (1 nodes): `storybook-theme-decorator.test.ts`
+- **Thin community `Community 1716`** (1 nodes): `view-patterns.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1717`** (1 nodes): `setup.ts`
+- **Thin community `Community 1717`** (1 nodes): `Surfaces.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1718`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1718`** (1 nodes): `DashboardWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1719`** (1 nodes): `types.ts`
+- **Thin community `Community 1719`** (1 nodes): `DataWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1720`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1720`** (1 nodes): `SettingsWorkspace.stories.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1721`** (1 nodes): `eslint.config.js`
+- **Thin community `Community 1721`** (1 nodes): `reference-fixtures.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1722`** (1 nodes): `global.d.ts`
+- **Thin community `Community 1722`** (1 nodes): `storybook-config.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1723`** (1 nodes): `playwright.config.ts`
+- **Thin community `Community 1723`** (1 nodes): `storybook-theme-decorator.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1724`** (1 nodes): `analytics.test.ts`
+- **Thin community `Community 1724`** (1 nodes): `setup.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1725`** (1 nodes): `types.ts`
+- **Thin community `Community 1725`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1726`** (1 nodes): `HeartIconFilled.tsx`
+- **Thin community `Community 1726`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1727`** (1 nodes): `DefaultCatchBoundary.tsx`
+- **Thin community `Community 1727`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1728`** (1 nodes): `HomePage.test.tsx`
+- **Thin community `Community 1728`** (1 nodes): `eslint.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1729`** (1 nodes): `ProductCard.test.tsx`
+- **Thin community `Community 1729`** (1 nodes): `global.d.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1730`** (1 nodes): `ProductCard.tsx`
+- **Thin community `Community 1730`** (1 nodes): `playwright.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1731`** (1 nodes): `Upsell.tsx`
+- **Thin community `Community 1731`** (1 nodes): `analytics.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1732`** (1 nodes): `Checkout.test.tsx`
+- **Thin community `Community 1732`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1733`** (1 nodes): `Checkout.tsx`
+- **Thin community `Community 1733`** (1 nodes): `HeartIconFilled.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1734`** (1 nodes): `CustomerInfoSection.tsx`
+- **Thin community `Community 1734`** (1 nodes): `DefaultCatchBoundary.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1735`** (1 nodes): `schema.ts`
+- **Thin community `Community 1735`** (1 nodes): `HomePage.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1736`** (1 nodes): `DeliveryDetailsSection.tsx`
+- **Thin community `Community 1736`** (1 nodes): `ProductCard.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1737`** (1 nodes): `checkoutStorage.test.ts`
+- **Thin community `Community 1737`** (1 nodes): `ProductCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1738`** (1 nodes): `deliveryFees.test.ts`
+- **Thin community `Community 1738`** (1 nodes): `Upsell.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1739`** (1 nodes): `deriveCheckoutState.test.ts`
+- **Thin community `Community 1739`** (1 nodes): `Checkout.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1740`** (1 nodes): `billingDetailsSchema.ts`
+- **Thin community `Community 1740`** (1 nodes): `Checkout.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1741`** (1 nodes): `checkoutFormSchema.ts`
+- **Thin community `Community 1741`** (1 nodes): `CustomerInfoSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1742`** (1 nodes): `customerDetailsSchema.ts`
+- **Thin community `Community 1742`** (1 nodes): `schema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1743`** (1 nodes): `deliveryDetailsSchema.ts`
+- **Thin community `Community 1743`** (1 nodes): `DeliveryDetailsSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1744`** (1 nodes): `webOrderSchema.ts`
+- **Thin community `Community 1744`** (1 nodes): `checkoutStorage.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1745`** (1 nodes): `types.ts`
+- **Thin community `Community 1745`** (1 nodes): `deliveryFees.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1746`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1746`** (1 nodes): `deriveCheckoutState.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1747`** (1 nodes): `ProductFilterBar.tsx`
+- **Thin community `Community 1747`** (1 nodes): `billingDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1748`** (1 nodes): `BestSellersSection.test.tsx`
+- **Thin community `Community 1748`** (1 nodes): `checkoutFormSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1749`** (1 nodes): `HomeHero.tsx`
+- **Thin community `Community 1749`** (1 nodes): `customerDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1750`** (1 nodes): `HomeHeroSection.tsx`
+- **Thin community `Community 1750`** (1 nodes): `deliveryDetailsSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1751`** (1 nodes): `homePageContent.test.ts`
+- **Thin community `Community 1751`** (1 nodes): `webOrderSchema.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1752`** (1 nodes): `MobileMenu.tsx`
+- **Thin community `Community 1752`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1753`** (1 nodes): `constants.ts`
+- **Thin community `Community 1753`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1754`** (1 nodes): `navBarConstants.ts`
+- **Thin community `Community 1754`** (1 nodes): `ProductFilterBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1755`** (1 nodes): `About.tsx`
+- **Thin community `Community 1755`** (1 nodes): `BestSellersSection.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1756`** (1 nodes): `AboutProduct.tsx`
+- **Thin community `Community 1756`** (1 nodes): `HomeHero.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1757`** (1 nodes): `ProductActions.test.tsx`
+- **Thin community `Community 1757`** (1 nodes): `HomeHeroSection.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1758`** (1 nodes): `ProductInfo.tsx`
+- **Thin community `Community 1758`** (1 nodes): `homePageContent.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1759`** (1 nodes): `ProductReviews.tsx`
+- **Thin community `Community 1759`** (1 nodes): `MobileMenu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1760`** (1 nodes): `ProductsNavigationBar.tsx`
+- **Thin community `Community 1760`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1761`** (1 nodes): `ErrorMessage.tsx`
+- **Thin community `Community 1761`** (1 nodes): `navBarConstants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1762`** (1 nodes): `ExistingReviewMessage.tsx`
+- **Thin community `Community 1762`** (1 nodes): `About.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1763`** (1 nodes): `OrderItem.test.tsx`
+- **Thin community `Community 1763`** (1 nodes): `AboutProduct.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1764`** (1 nodes): `ReviewForm.tsx`
+- **Thin community `Community 1764`** (1 nodes): `ProductActions.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1765`** (1 nodes): `SuccessMessage.tsx`
+- **Thin community `Community 1765`** (1 nodes): `ProductInfo.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1766`** (1 nodes): `types.ts`
+- **Thin community `Community 1766`** (1 nodes): `ProductReviews.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1767`** (1 nodes): `SavedBag.tsx`
+- **Thin community `Community 1767`** (1 nodes): `ProductsNavigationBar.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1768`** (1 nodes): `SavedIcon.tsx`
+- **Thin community `Community 1768`** (1 nodes): `ErrorMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1769`** (1 nodes): `CartIcon.tsx`
+- **Thin community `Community 1769`** (1 nodes): `ExistingReviewMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1770`** (1 nodes): `ShoppingBag.test.tsx`
+- **Thin community `Community 1770`** (1 nodes): `OrderItem.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1771`** (1 nodes): `empty-state.tsx`
+- **Thin community `Community 1771`** (1 nodes): `ReviewForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1772`** (1 nodes): `Maintenance.test.tsx`
+- **Thin community `Community 1772`** (1 nodes): `SuccessMessage.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1773`** (1 nodes): `Maintenance.tsx`
+- **Thin community `Community 1773`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1774`** (1 nodes): `AnimatedCard.tsx`
+- **Thin community `Community 1774`** (1 nodes): `SavedBag.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1775`** (1 nodes): `accordion.tsx`
+- **Thin community `Community 1775`** (1 nodes): `SavedIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1776`** (1 nodes): `alert.tsx`
+- **Thin community `Community 1776`** (1 nodes): `CartIcon.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1777`** (1 nodes): `breadcrumb.tsx`
+- **Thin community `Community 1777`** (1 nodes): `ShoppingBag.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1778`** (1 nodes): `button.tsx`
+- **Thin community `Community 1778`** (1 nodes): `empty-state.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1779`** (1 nodes): `card.tsx`
+- **Thin community `Community 1779`** (1 nodes): `Maintenance.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1780`** (1 nodes): `checkbox.tsx`
+- **Thin community `Community 1780`** (1 nodes): `Maintenance.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1781`** (1 nodes): `command.tsx`
+- **Thin community `Community 1781`** (1 nodes): `AnimatedCard.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1782`** (1 nodes): `context-menu.tsx`
+- **Thin community `Community 1782`** (1 nodes): `accordion.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1783`** (1 nodes): `dialog.tsx`
+- **Thin community `Community 1783`** (1 nodes): `alert.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1784`** (1 nodes): `dropdown-menu.tsx`
+- **Thin community `Community 1784`** (1 nodes): `breadcrumb.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1785`** (1 nodes): `form.tsx`
+- **Thin community `Community 1785`** (1 nodes): `button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1786`** (1 nodes): `icons.tsx`
+- **Thin community `Community 1786`** (1 nodes): `card.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1787`** (1 nodes): `image-with-fallback.tsx`
+- **Thin community `Community 1787`** (1 nodes): `checkbox.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1788`** (1 nodes): `input-otp.tsx`
+- **Thin community `Community 1788`** (1 nodes): `command.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1789`** (1 nodes): `input-with-end-button.tsx`
+- **Thin community `Community 1789`** (1 nodes): `context-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1790`** (1 nodes): `input.tsx`
+- **Thin community `Community 1790`** (1 nodes): `dialog.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1791`** (1 nodes): `label.tsx`
+- **Thin community `Community 1791`** (1 nodes): `dropdown-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1792`** (1 nodes): `LeaveAReviewModalForm.tsx`
+- **Thin community `Community 1792`** (1 nodes): `form.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1793`** (1 nodes): `action-modal.tsx`
+- **Thin community `Community 1793`** (1 nodes): `icons.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1794`** (1 nodes): `welcomeBackModalAnimations.ts`
+- **Thin community `Community 1794`** (1 nodes): `image-with-fallback.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1795`** (1 nodes): `index.ts`
+- **Thin community `Community 1795`** (1 nodes): `input-otp.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1796`** (1 nodes): `types.ts`
+- **Thin community `Community 1796`** (1 nodes): `input-with-end-button.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1797`** (1 nodes): `navigation-menu.tsx`
+- **Thin community `Community 1797`** (1 nodes): `input.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1798`** (1 nodes): `popover.tsx`
+- **Thin community `Community 1798`** (1 nodes): `label.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1799`** (1 nodes): `radio-group.tsx`
+- **Thin community `Community 1799`** (1 nodes): `LeaveAReviewModalForm.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1800`** (1 nodes): `scroll-area.tsx`
+- **Thin community `Community 1800`** (1 nodes): `action-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1801`** (1 nodes): `select.tsx`
+- **Thin community `Community 1801`** (1 nodes): `welcomeBackModalAnimations.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1802`** (1 nodes): `separator.tsx`
+- **Thin community `Community 1802`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1803`** (1 nodes): `sheet.tsx`
+- **Thin community `Community 1803`** (1 nodes): `types.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1804`** (1 nodes): `table.tsx`
+- **Thin community `Community 1804`** (1 nodes): `navigation-menu.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1805`** (1 nodes): `tabs.tsx`
+- **Thin community `Community 1805`** (1 nodes): `popover.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1806`** (1 nodes): `textarea.tsx`
+- **Thin community `Community 1806`** (1 nodes): `radio-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1807`** (1 nodes): `toggle-group.tsx`
+- **Thin community `Community 1807`** (1 nodes): `scroll-area.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1808`** (1 nodes): `toggle.tsx`
+- **Thin community `Community 1808`** (1 nodes): `select.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1809`** (1 nodes): `tooltip.tsx`
+- **Thin community `Community 1809`** (1 nodes): `separator.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1810`** (1 nodes): `config.ts`
+- **Thin community `Community 1810`** (1 nodes): `sheet.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1811`** (1 nodes): `use-store-modal.tsx`
+- **Thin community `Community 1811`** (1 nodes): `table.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1812`** (1 nodes): `useOrganizationModal.tsx`
+- **Thin community `Community 1812`** (1 nodes): `tabs.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1813`** (1 nodes): `useQueryEnabled.test.ts`
+- **Thin community `Community 1813`** (1 nodes): `textarea.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1814`** (1 nodes): `useStorefrontObservability.ts`
+- **Thin community `Community 1814`** (1 nodes): `toggle-group.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1815`** (1 nodes): `constants.ts`
+- **Thin community `Community 1815`** (1 nodes): `toggle.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1816`** (1 nodes): `countries.ts`
+- **Thin community `Community 1816`** (1 nodes): `tooltip.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1817`** (1 nodes): `feeUtils.test.ts`
+- **Thin community `Community 1817`** (1 nodes): `config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1818`** (1 nodes): `ghana.ts`
+- **Thin community `Community 1818`** (1 nodes): `use-store-modal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1819`** (1 nodes): `ghanaRegions.ts`
+- **Thin community `Community 1819`** (1 nodes): `useOrganizationModal.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1820`** (1 nodes): `maintenanceUtils.test.ts`
+- **Thin community `Community 1820`** (1 nodes): `useQueryEnabled.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1821`** (1 nodes): `index.ts`
+- **Thin community `Community 1821`** (1 nodes): `useStorefrontObservability.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1822`** (1 nodes): `store.ts`
+- **Thin community `Community 1822`** (1 nodes): `constants.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1823`** (1 nodes): `bag.ts`
+- **Thin community `Community 1823`** (1 nodes): `countries.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1824`** (1 nodes): `bagItem.ts`
+- **Thin community `Community 1824`** (1 nodes): `feeUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1825`** (1 nodes): `category.ts`
+- **Thin community `Community 1825`** (1 nodes): `ghana.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1826`** (1 nodes): `organization.ts`
+- **Thin community `Community 1826`** (1 nodes): `ghanaRegions.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1827`** (1 nodes): `product.ts`
+- **Thin community `Community 1827`** (1 nodes): `maintenanceUtils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1828`** (1 nodes): `store.ts`
+- **Thin community `Community 1828`** (1 nodes): `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1829`** (1 nodes): `subcategory.ts`
+- **Thin community `Community 1829`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1830`** (1 nodes): `user.ts`
+- **Thin community `Community 1830`** (1 nodes): `bag.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1831`** (1 nodes): `states.ts`
+- **Thin community `Community 1831`** (1 nodes): `bagItem.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1832`** (1 nodes): `storefrontFailureObservability.test.ts`
+- **Thin community `Community 1832`** (1 nodes): `category.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1833`** (1 nodes): `storefrontJourneyEvents.test.ts`
+- **Thin community `Community 1833`** (1 nodes): `organization.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1834`** (1 nodes): `utils.test.ts`
+- **Thin community `Community 1834`** (1 nodes): `product.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1835`** (1 nodes): `routeTree.gen.ts`
+- **Thin community `Community 1835`** (1 nodes): `store.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1836`** (1 nodes): `-homePageLoader.test.ts`
+- **Thin community `Community 1836`** (1 nodes): `subcategory.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1837`** (1 nodes): `__root.tsx`
+- **Thin community `Community 1837`** (1 nodes): `user.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1838`** (1 nodes): `$orderItemId.review.tsx`
+- **Thin community `Community 1838`** (1 nodes): `states.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1839`** (1 nodes): `index.tsx`
+- **Thin community `Community 1839`** (1 nodes): `storefrontFailureObservability.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1840`** (1 nodes): `$subcategorySlug.tsx`
+- **Thin community `Community 1840`** (1 nodes): `storefrontJourneyEvents.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1841`** (1 nodes): `index.tsx`
+- **Thin community `Community 1841`** (1 nodes): `utils.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1842`** (1 nodes): `rewards.index.tsx`
+- **Thin community `Community 1842`** (1 nodes): `routeTree.gen.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1843`** (1 nodes): `shop.saved.index.tsx`
+- **Thin community `Community 1843`** (1 nodes): `-homePageLoader.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1844`** (1 nodes): `bag.index.tsx`
+- **Thin community `Community 1844`** (1 nodes): `__root.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1845`** (1 nodes): `complete.tsx`
+- **Thin community `Community 1845`** (1 nodes): `$orderItemId.review.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1846`** (1 nodes): `incomplete.tsx`
+- **Thin community `Community 1846`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1847`** (1 nodes): `index.tsx`
+- **Thin community `Community 1847`** (1 nodes): `$subcategorySlug.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1848`** (1 nodes): `pending.tsx`
+- **Thin community `Community 1848`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1849`** (1 nodes): `tailwind.config.js`
+- **Thin community `Community 1849`** (1 nodes): `rewards.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1850`** (1 nodes): `storefront-boot.e2e.ts`
+- **Thin community `Community 1850`** (1 nodes): `shop.saved.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1851`** (1 nodes): `vitest.config.ts`
+- **Thin community `Community 1851`** (1 nodes): `bag.index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1852`** (1 nodes): `vitest.setup.ts`
+- **Thin community `Community 1852`** (1 nodes): `complete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1853`** (1 nodes): `index.js`
+- **Thin community `Community 1853`** (1 nodes): `incomplete.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1854`** (1 nodes): `harness-app-registry.test.ts`
+- **Thin community `Community 1854`** (1 nodes): `index.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1855`** (1 nodes): `athena-runtime-app.test.ts`
+- **Thin community `Community 1855`** (1 nodes): `pending.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1856`** (1 nodes): `storefront-runtime-api.test.ts`
+- **Thin community `Community 1856`** (1 nodes): `tailwind.config.js`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1857`** (1 nodes): `valkey-runtime-app.test.ts`
+- **Thin community `Community 1857`** (1 nodes): `storefront-boot.e2e.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1858`** (1 nodes): `harness-behavior-scenarios.test.ts`
+- **Thin community `Community 1858`** (1 nodes): `vitest.config.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 1859`** (1 nodes): `harness-repo-validation.test.ts`
+- **Thin community `Community 1859`** (1 nodes): `vitest.setup.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1860`** (1 nodes): `index.js`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1861`** (1 nodes): `harness-app-registry.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1862`** (1 nodes): `athena-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1863`** (1 nodes): `storefront-runtime-api.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1864`** (1 nodes): `valkey-runtime-app.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1865`** (1 nodes): `harness-behavior-scenarios.test.ts`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 1866`** (1 nodes): `harness-repo-validation.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
@@ -11821,4 +11858,4 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 4` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 5` be split into smaller, more focused modules?**
-  _Cohesion score 0.06 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.1 - nodes in this community are weakly interconnected._

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -7,20 +7,20 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - [packages/AGENTS.md](../../packages/AGENTS.md) - package router plus the operational guides for each harnessed package
 
 ## Repo Summary
-- Code files discovered: 1933
-- Graph nodes: 6866
-- Graph edges: 7718
-- Communities: 1860
+- Code files discovered: 1940
+- Graph nodes: 6882
+- Graph edges: 7728
+- Communities: 1867
 
 ## Graph Hotspots
 - `DailyCloseView.tsx` (87 edges, Community 0) - [`packages/athena-webapp/src/components/operations/DailyCloseView.tsx`](../../packages/athena-webapp/src/components/operations/DailyCloseView.tsx)
 - `useRegisterViewModel.ts` (72 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `dailyClose.ts` (65 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `projectLocalEvents.ts` (52 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
-- `usePosLocalSyncRuntime.ts` (49 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
-- `harness-inferential-review.ts` (47 edges, Community 6) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
-- `dailyOperations.ts` (46 edges, Community 7) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
-- `ingestLocalEvents.ts` (46 edges, Community 8) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
+- `harness-inferential-review.ts` (47 edges, Community 5) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
+- `dailyOperations.ts` (46 edges, Community 6) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
+- `ingestLocalEvents.ts` (46 edges, Community 7) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
+- `posLocalStore.ts` (46 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
 
 ## Registered Packages
 - [Athena Webapp](packages/athena-webapp.md)

--- a/graphify-out/wiki/packages/athena-webapp.md
+++ b/graphify-out/wiki/packages/athena-webapp.md
@@ -21,7 +21,7 @@ Landing page for packages/athena-webapp. Use this page to orient around graph ho
 - `useRegisterViewModel.ts` (72 edges, Community 1) - [`packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts`](../../../packages/athena-webapp/src/lib/pos/presentation/register/useRegisterViewModel.ts)
 - `dailyClose.ts` (65 edges, Community 2) - [`packages/athena-webapp/convex/operations/dailyClose.ts`](../../../packages/athena-webapp/convex/operations/dailyClose.ts)
 - `projectLocalEvents.ts` (52 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
-- `usePosLocalSyncRuntime.ts` (49 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts`](../../../packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts)
+- `dailyOperations.ts` (46 edges, Community 6) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../../packages/athena-webapp/convex/operations/dailyOperations.ts)
 
 ## Navigation
 - [wiki index](../index.md) - back to the wiki index

--- a/graphify-out/wiki/packages/storefront-webapp.md
+++ b/graphify-out/wiki/packages/storefront-webapp.md
@@ -17,8 +17,8 @@ Landing page for packages/storefront-webapp. Use this page to orient around grap
 - [validation-map.json](../../../packages/storefront-webapp/docs/agent/validation-map.json)
 
 ## Graph Hotspots
-- `storefrontJourneyEvents.ts` (45 edges, Community 9) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
-- `createJourneyEvent()` (40 edges, Community 9) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `storefrontJourneyEvents.ts` (45 edges, Community 8) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
+- `createJourneyEvent()` (40 edges, Community 8) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 - `getStoreConfigV2()` (17 edges, Community 46) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)
 - `checkoutSession.ts` (14 edges, Community 76) - [`packages/storefront-webapp/src/api/checkoutSession.ts`](../../../packages/storefront-webapp/src/api/checkoutSession.ts)
 - `storeConfig.ts` (14 edges, Community 46) - [`packages/storefront-webapp/src/lib/storeConfig.ts`](../../../packages/storefront-webapp/src/lib/storeConfig.ts)

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (14 edges, Community 87) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 151) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 152) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 87) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `createRedisCluster()` (3 edges, Community 87) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `deleteKeysIndividually()` (3 edges, Community 87) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/convex/_generated/api.d.ts
+++ b/packages/athena-webapp/convex/_generated/api.d.ts
@@ -187,6 +187,7 @@ import type * as pos_application_terminalRecovery_cloudRepairPolicy from "../pos
 import type * as pos_application_terminalRecovery_resolveTerminalCloudRepair from "../pos/application/terminalRecovery/resolveTerminalCloudRepair.js";
 import type * as pos_application_terminalRecovery_terminalCommandService from "../pos/application/terminalRecovery/terminalCommandService.js";
 import type * as pos_application_terminalRecovery_types from "../pos/application/terminalRecovery/types.js";
+import type * as pos_application_terminalRuntime_postRuntimeStatusSideEffects from "../pos/application/terminalRuntime/postRuntimeStatusSideEffects.js";
 import type * as pos_domain_errors from "../pos/domain/errors.js";
 import type * as pos_domain_sessionRules from "../pos/domain/sessionRules.js";
 import type * as pos_domain_types from "../pos/domain/types.js";
@@ -562,6 +563,7 @@ declare const fullApi: ApiFromModules<{
   "pos/application/terminalRecovery/resolveTerminalCloudRepair": typeof pos_application_terminalRecovery_resolveTerminalCloudRepair;
   "pos/application/terminalRecovery/terminalCommandService": typeof pos_application_terminalRecovery_terminalCommandService;
   "pos/application/terminalRecovery/types": typeof pos_application_terminalRecovery_types;
+  "pos/application/terminalRuntime/postRuntimeStatusSideEffects": typeof pos_application_terminalRuntime_postRuntimeStatusSideEffects;
   "pos/domain/errors": typeof pos_domain_errors;
   "pos/domain/sessionRules": typeof pos_domain_sessionRules;
   "pos/domain/types": typeof pos_domain_types;

--- a/packages/athena-webapp/convex/pos/application/queries/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/application/queries/terminals.test.ts
@@ -253,6 +253,85 @@ describe("terminal health queries", () => {
     );
   });
 
+  it("keeps terminal health roster and detail recovery preview in parity", async () => {
+    const ctx = buildQueryCtx({
+      posTerminal: [buildTerminal()],
+      posTerminalRecoveryCommand: [
+        {
+          _id: "command-retry-sync" as Id<"posTerminalRecoveryCommand">,
+          _creationTime: now - 5_000,
+          commandContext: {
+            expectedBlockerType: "sync_runtime",
+            reason: "Local sync needs a terminal retry.",
+          },
+          commandType: "retry_sync",
+          expectedEvidence: {
+            syncStatus: "idle",
+          },
+          expiresAt: now + 10_000,
+          issuedAt: now - 5_000,
+          issuedByUserId: "user-1" as Id<"athenaUser">,
+          status: "pending",
+          storeId,
+          terminalId,
+          verificationStatus: "waiting_for_acknowledgement",
+        } satisfies Doc<"posTerminalRecoveryCommand">,
+      ],
+      posTerminalRuntimeStatus: [
+        buildRuntimeStatus({
+          sync: {
+            failedEventCount: 1,
+            lastFailureMessage: "Network unavailable.",
+            localOnlyEventCount: 0,
+            nextPendingUploadSequence: 45,
+            oldestPendingEventAt: now - 30_000,
+            pendingEventCount: 1,
+            reviewEventCount: 0,
+            status: "failed",
+            uploadableEventCount: 1,
+          },
+        }),
+      ],
+    });
+
+    const [rosterSummary] = await listTerminalHealthSummaries(ctx, {
+      now,
+      storeId,
+    });
+    const detailSummary = await getTerminalHealthSummary(ctx, {
+      now,
+      storeId,
+      terminalId,
+    });
+
+    expect(rosterSummary?.attentionReasons).toEqual([
+      expect.objectContaining({
+        nextPendingUploadSequence: 45,
+        source: "local_runtime",
+        type: "sync_failed",
+      }),
+    ]);
+    expect(rosterSummary?.recoveryPreview).toEqual(detailSummary?.recoveryPreview);
+    expect(rosterSummary?.recoveryPreview).toEqual(
+      expect.objectContaining({
+        commandStatus: expect.objectContaining({
+          commandType: "retry_sync",
+          status: "pending",
+          verificationStatus: "waiting_for_acknowledgement",
+        }),
+        readiness: "needs_terminal_action",
+        terminalActions: [
+          expect.objectContaining({
+            commandType: "retry_sync",
+            expectedEvidence: {
+              syncStatus: "idle",
+            },
+          }),
+        ],
+      }),
+    );
+  });
+
   it("includes active register-session evidence in recovery preview", async () => {
     const ctx = buildQueryCtx({
       posTerminal: [buildTerminal()],

--- a/packages/athena-webapp/convex/pos/application/terminalRuntime/postRuntimeStatusSideEffects.ts
+++ b/packages/athena-webapp/convex/pos/application/terminalRuntime/postRuntimeStatusSideEffects.ts
@@ -1,0 +1,80 @@
+import type { MutationCtx } from "../../../_generated/server";
+import type { Doc, Id } from "../../../_generated/dataModel";
+import type { TerminalRuntimeStatusInput } from "../commands/terminals";
+import { buildPosRemoteAssistClientPresence } from "../../../remoteAssist/application/posRuntimeAdapter";
+import { claimRemoteAssistSession } from "../../../remoteAssist/application/sessionService";
+import { createRemoteAssistRepository } from "../../../remoteAssist/infrastructure/remoteAssistRepository";
+import { verifyTerminalRecoveryCommandsFromRuntime } from "../terminalRecovery/terminalCommandService";
+import { createTerminalRecoveryCommandRepository } from "../../infrastructure/repositories/terminalRecoveryRepository";
+
+type AcceptedRuntimeStatusSideEffectsArgs = {
+  ctx: MutationCtx;
+  receivedAt: number;
+  runtimeStatus: TerminalRuntimeStatusInput;
+  storeId: Id<"store">;
+  terminal: Doc<"posTerminal">;
+  terminalId: Id<"posTerminal">;
+};
+
+export async function runAcceptedRuntimeStatusSideEffects(
+  args: AcceptedRuntimeStatusSideEffectsArgs,
+) {
+  await reportRemoteAssistPresenceDiagnosticOnly(args);
+  await verifyTerminalRecoveryCommandsFromRuntime(
+    createTerminalRecoveryCommandRepository(args.ctx),
+    {
+      runtimeStatus: {
+        _id: "runtime-status-current" as never,
+        _creationTime: args.receivedAt,
+        storeId: args.storeId,
+        terminalId: args.terminalId,
+        receivedAt: args.receivedAt,
+        ...args.runtimeStatus,
+      },
+      storeId: args.storeId,
+      terminalId: args.terminalId,
+      verifiedAt: args.receivedAt,
+    },
+  );
+}
+
+async function reportRemoteAssistPresenceDiagnosticOnly(
+  args: AcceptedRuntimeStatusSideEffectsArgs,
+) {
+  try {
+    const store = await args.ctx.db.get("store", args.storeId);
+    if (!store) {
+      return;
+    }
+
+    const remoteAssistRepository = createRemoteAssistRepository(args.ctx);
+    const remoteAssistClient = await remoteAssistRepository.upsertClient(
+      buildPosRemoteAssistClientPresence({
+        receivedAt: args.receivedAt,
+        runtimeStatus: {
+          browserInfo: args.runtimeStatus.browserInfo,
+        },
+        store,
+        terminal: args.terminal,
+      }),
+    );
+    const currentRemoteAssistSession =
+      await remoteAssistRepository.getCurrentSessionForClient({
+        clientId: remoteAssistClient._id,
+        now: args.receivedAt,
+      });
+    if (currentRemoteAssistSession?.status === "connecting") {
+      await claimRemoteAssistSession(remoteAssistRepository, {
+        clientId: remoteAssistClient._id,
+        now: args.receivedAt,
+        sessionId: currentRemoteAssistSession._id,
+      });
+    }
+  } catch (error) {
+    console.warn("[pos-runtime] remote-assist-side-effect-failed", {
+      errorName: error instanceof Error ? error.name : typeof error,
+      storeId: args.storeId,
+      terminalId: args.terminalId,
+    });
+  }
+}

--- a/packages/athena-webapp/convex/pos/public/terminals.test.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.test.ts
@@ -646,6 +646,58 @@ describe("POS terminal public mutations", () => {
     );
   });
 
+  it("keeps accepted runtime status accepted when Remote Assist presence fails", async () => {
+    const diagnosticSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    mocks.remoteAssistUpsertClient.mockRejectedValue(
+      new Error("Remote Assist repository unavailable"),
+    );
+    const ctx = buildCtx({
+      terminal: {
+        _id: "terminal-1",
+        storeId: "store-1",
+        status: "active",
+        registeredByUserId: "athena-user-2",
+        syncSecretHash: SYNC_SECRET_HASH,
+        displayName: "Front register",
+      },
+    });
+
+    try {
+      const result = await getHandler(submitTerminalRuntimeStatus)(
+        ctx as never,
+        {
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          syncSecretHash: "sync-secret-1",
+          status: buildRuntimeStatus(),
+        },
+      );
+
+      expect(result).toEqual({
+        kind: "ok",
+        data: {
+          terminalId: "terminal-1",
+          reportedAt: 100,
+          receivedAt: 200,
+        },
+      });
+      expect(
+        mocks.verifyTerminalRecoveryCommandsFromRuntime,
+      ).toHaveBeenCalled();
+      expect(diagnosticSpy).toHaveBeenCalledWith(
+        "[pos-runtime] remote-assist-side-effect-failed",
+        expect.objectContaining({
+          storeId: "store-1",
+          terminalId: "terminal-1",
+        }),
+      );
+    } finally {
+      diagnosticSpy.mockRestore();
+    }
+  });
+
   it("hydrates a runtime Remote Assist session with terminal proof", async () => {
     mocks.remoteAssistGetCurrentSessionForClient.mockResolvedValue(
       buildRemoteAssistSession({ status: "active" }),

--- a/packages/athena-webapp/convex/pos/public/terminals.ts
+++ b/packages/athena-webapp/convex/pos/public/terminals.ts
@@ -29,12 +29,10 @@ import {
   claimTerminalRecoveryCommand as claimTerminalRecoveryCommandService,
   issueTerminalRecoveryCommand as issueTerminalRecoveryCommandService,
   listClaimableTerminalRecoveryCommands,
-  verifyTerminalRecoveryCommandsFromRuntime,
 } from "../application/terminalRecovery/terminalCommandService";
+import { runAcceptedRuntimeStatusSideEffects } from "../application/terminalRuntime/postRuntimeStatusSideEffects";
 import { createTerminalRecoveryCommandRepository } from "../infrastructure/repositories/terminalRecoveryRepository";
-import { buildPosRemoteAssistClientPresence } from "../../remoteAssist/application/posRuntimeAdapter";
 import {
-  claimRemoteAssistSession,
   disconnectRemoteAssistRuntimeSession,
 } from "../../remoteAssist/application/sessionService";
 import { createRemoteAssistRepository } from "../../remoteAssist/infrastructure/remoteAssistRepository";
@@ -688,46 +686,14 @@ export const submitTerminalRuntimeStatus = mutation({
       status: safeStatus,
     });
     if (result.kind === "ok") {
-      const store = await ctx.db.get("store", args.storeId);
-      if (store) {
-        const remoteAssistRepository = createRemoteAssistRepository(ctx);
-        const remoteAssistClient = await remoteAssistRepository.upsertClient(
-          buildPosRemoteAssistClientPresence({
-            receivedAt: result.data.receivedAt,
-            runtimeStatus: safeStatus,
-            store,
-            terminal,
-          }),
-        );
-        const currentRemoteAssistSession =
-          await remoteAssistRepository.getCurrentSessionForClient({
-            clientId: remoteAssistClient._id,
-            now: result.data.receivedAt,
-          });
-        if (currentRemoteAssistSession?.status === "connecting") {
-          await claimRemoteAssistSession(remoteAssistRepository, {
-            clientId: remoteAssistClient._id,
-            now: result.data.receivedAt,
-            sessionId: currentRemoteAssistSession._id,
-          });
-        }
-      }
-      await verifyTerminalRecoveryCommandsFromRuntime(
-        createTerminalRecoveryCommandRepository(ctx),
-        {
-          runtimeStatus: {
-            _id: "runtime-status-current" as never,
-            _creationTime: result.data.receivedAt,
-            storeId: args.storeId,
-            terminalId: args.terminalId,
-            receivedAt: result.data.receivedAt,
-            ...safeStatus,
-          },
-          storeId: args.storeId,
-          terminalId: args.terminalId,
-          verifiedAt: result.data.receivedAt,
-        },
-      );
+      await runAcceptedRuntimeStatusSideEffects({
+        ctx,
+        receivedAt: result.data.receivedAt,
+        runtimeStatus: safeStatus,
+        storeId: args.storeId,
+        terminal,
+        terminalId: args.terminalId,
+      });
     }
     return result;
   },

--- a/packages/athena-webapp/docs/agent/key-folder-index.md
+++ b/packages/athena-webapp/docs/agent/key-folder-index.md
@@ -13,7 +13,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`src/components/procurement`](../../src/components/procurement) — Procurement planning and receiving views for replenishment pressure and purchase-order execution. Currently 4 file(s); key children: ProcurementView.test.tsx, ProcurementView.tsx, ReceivingView.test.tsx, ReceivingView.tsx.
 - [`src/hooks`](../../src/hooks) — React hooks that fan out auth, shell, and feature state. Currently 43 file(s); key children: use-image-upload.ts, use-mobile.tsx, use-navigate-back.ts, use-navigation-keyboard-shortcuts.ts, use-pagination-persistence.ts.
 - [`src/contexts`](../../src/contexts) — Context providers for app-wide state and wiring. Currently 8 file(s); key children: AppShellFullscreenContext.tsx, ManagerElevationContext.test.tsx, ManagerElevationContext.tsx, OnlineOrderContext.tsx, PermissionsContext.tsx.
-- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 152 file(s); key children: access, aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts.
+- [`src/lib`](../../src/lib) — Shared frontend helpers, schemas, and package utilities. Currently 158 file(s); key children: access, aws.ts, behaviorUtils.ts, browserFingerprint.ts, constants.ts.
 - [`shared`](../../shared) — Browser-safe helpers shared with Convex-backed workflows. Currently 16 file(s); key children: approvalPolicy.ts, auth.ts, commandResult.test.ts, commandResult.ts, currencyFormatter.test.ts.
 - [`src/utils`](../../src/utils) — Cross-cutting browser helpers and lower-level utilities. Currently 4 file(s); key children: formatNumber.ts, index.ts, versionChecker.test.ts, versionChecker.ts.
 
@@ -22,7 +22,7 @@ This key-folder index highlights the main directories agents are likely to need 
 - [`convex/stockOps`](../../convex/stockOps) — Stock-adjustment, procurement, replenishment, receiving, and vendor flows layered over inventory state. Currently 14 file(s); key children: access.test.ts, access.ts, adjustments.test.ts, adjustments.ts, cycleCountDrafts.test.ts.
 - [`convex/serviceOps`](../../convex/serviceOps) — Service catalog, appointment, and service-case workflows layered on operational work items. Currently 6 file(s); key children: appointments.ts, catalog.ts, catalogAppointments.test.ts, moduleWiring.test.ts, serviceCases.test.ts.
 - [`convex/workflowTraces`](../../convex/workflowTraces) — Shared workflow trace creation, lookup, presentation, and adapter helpers. Currently 11 file(s); key children: adapters, core.ts, presentation.test.ts, presentation.ts, public.ts.
-- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 527 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
+- [`convex`](../../convex) — Convex functions, HTTP composition, schemas, and backend tests. Currently 528 file(s); key children: README.md, _generated, app.ts, auth, auth.config.js.
 - [`src/tests`](../../src/tests) — Focused browser-facing regression tests. Currently 9 file(s); key children: README.md, SUMMARY.md, pos, prod.
 - [`src/test`](../../src/test) — Package test harness helpers and setup. Currently 1 file(s); key children: setup.ts.
 

--- a/packages/athena-webapp/docs/agent/test-index.md
+++ b/packages/athena-webapp/docs/agent/test-index.md
@@ -316,6 +316,7 @@ This index enumerates the current automated test files and ties them back to the
 - [`src/lib/pos/infrastructure/local/syncStatus.test.ts`](../../src/lib/pos/infrastructure/local/syncStatus.test.ts)
 - [`src/lib/pos/infrastructure/local/terminalRecoveryCommands.test.ts`](../../src/lib/pos/infrastructure/local/terminalRecoveryCommands.test.ts)
 - [`src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts`](../../src/lib/pos/infrastructure/local/terminalRuntimeStatus.test.ts)
+- [`src/lib/pos/infrastructure/local/terminalStaffAuthorityRefresh.test.ts`](../../src/lib/pos/infrastructure/local/terminalStaffAuthorityRefresh.test.ts)
 - [`src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts`](../../src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.test.ts)
 - [`src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.test.ts`](../../src/lib/pos/infrastructure/terminal/usePosTerminalAppSessionRecovery.test.ts)
 - [`src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts`](../../src/lib/pos/presentation/expense/useExpenseRegisterViewModel.test.ts)

--- a/packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx
+++ b/packages/athena-webapp/src/components/pos/CashierAuthDialog.test.tsx
@@ -295,7 +295,7 @@ describe("CashierAuthDialog", () => {
     expect(onAuthenticated).not.toHaveBeenCalled();
   });
 
-  it("clears local staff authority when an online refresh is refused", async () => {
+  it("preserves local staff authority when an online refresh is refused", async () => {
     const replaceStaffAuthoritySnapshot = vi.fn(async () => ({
       ok: true,
       value: [],
@@ -318,12 +318,12 @@ describe("CashierAuthDialog", () => {
     renderDialog({ refreshAuthorityMutation });
 
     await waitFor(() =>
-      expect(replaceStaffAuthoritySnapshot).toHaveBeenCalledWith({
-        records: [],
+      expect(refreshAuthorityMutation).toHaveBeenCalledWith({
         storeId,
         terminalId,
       }),
     );
+    expect(replaceStaffAuthoritySnapshot).not.toHaveBeenCalled();
   });
 
   it("uses expense session copy when signing into expense mode", () => {

--- a/packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx
+++ b/packages/athena-webapp/src/components/pos/CashierAuthDialog.tsx
@@ -13,6 +13,7 @@ import {
   createPosLocalStore,
   type PosLocalStaffAuthorityRecord,
 } from "@/lib/pos/infrastructure/local/posLocalStore";
+import { refreshAndStoreTerminalStaffAuthority } from "@/lib/pos/infrastructure/local/terminalStaffAuthorityRefresh";
 import {
   unwrapLocalStaffProofToken,
   verifyLocalPin,
@@ -143,88 +144,65 @@ export function CashierAuthDialog({
       return null;
     }
 
-    let result: CommandResult<PosLocalStaffAuthorityRecord[]>;
-    try {
-      result = await (
-        refreshTerminalStaffAuthority as (args: {
-          storeId: Id<"store">;
-          terminalId: Id<"posTerminal">;
-        }) => Promise<CommandResult<PosLocalStaffAuthorityRecord[]>>
-      )({ storeId, terminalId });
-    } catch (error) {
-      logger.warn("[POS] Staff authority refresh failed", {
-        message: error instanceof Error ? error.message : String(error),
-        storeId,
-        terminalId,
-      });
-      return null;
-    }
-
-    if (result.kind !== "ok") {
-      logger.warn("[POS] Staff authority refresh skipped", {
-        kind: result.kind,
-        storeId,
-        terminalId,
-      });
-      const clearResult = await localStore.replaceStaffAuthoritySnapshot({
-        records: [],
-        storeId,
-        terminalId,
-      });
-      if (!clearResult.ok) {
-        logger.warn("[POS] Staff authority snapshot could not be cleared", {
-          code: clearResult.error.code,
-          storeId,
-          terminalId,
-        });
-      }
-      return null;
-    }
-
-    const records = await Promise.all(
-      result.data.map(async (record) => {
-        if (
-          !unlock?.posLocalStaffProof ||
-          record.staffProfileId !== unlock.staffProfileId
-        ) {
-          return record;
-        }
-
-        const wrappedProof = await wrapLocalStaffProofToken(
-          record.verifier,
-          unlock.pin,
-          unlock.posLocalStaffProof,
-        );
-        if (!wrappedProof) {
-          logger.warn("[POS] Staff authority proof could not be wrapped", {
-            staffProfileId: record.staffProfileId,
-            storeId,
-            terminalId,
-          });
-          return record;
-        }
-
-        return {
-          ...record,
-          wrappedPosLocalStaffProof: wrappedProof,
-        };
-      }),
-    );
-
-    const writeResult = await localStore.replaceStaffAuthoritySnapshot({
-      records,
+    const refreshOutcome = await refreshAndStoreTerminalStaffAuthority({
+      localStore,
+      refreshTerminalStaffAuthority: refreshTerminalStaffAuthority as Parameters<
+        typeof refreshAndStoreTerminalStaffAuthority
+      >[0]["refreshTerminalStaffAuthority"],
       storeId,
       terminalId,
+      mapRecords: async (records) =>
+        Promise.all(
+          records.map(async (record) => {
+            if (
+              !unlock?.posLocalStaffProof ||
+              record.staffProfileId !== unlock.staffProfileId
+            ) {
+              return record;
+            }
+
+            const wrappedProof = await wrapLocalStaffProofToken(
+              record.verifier,
+              unlock.pin,
+              unlock.posLocalStaffProof,
+            );
+            if (!wrappedProof) {
+              logger.warn("[POS] Staff authority proof could not be wrapped", {
+                staffProfileId: record.staffProfileId,
+                storeId,
+                terminalId,
+              });
+              return record;
+            }
+
+            return {
+              ...record,
+              wrappedPosLocalStaffProof: wrappedProof,
+            };
+          }),
+        ),
     });
-    if (!writeResult.ok) {
-      logger.warn("[POS] Staff authority refresh could not be stored", {
-        code: writeResult.error.code,
+
+    if (refreshOutcome.status === "preserved") {
+      logger.warn("[POS] Staff authority refresh skipped", {
+        code: refreshOutcome.code,
+        message: refreshOutcome.message,
         storeId,
         terminalId,
       });
       return null;
     }
 
+    if (refreshOutcome.status === "write_failed") {
+      logger.warn("[POS] Staff authority refresh could not be stored", {
+        message: refreshOutcome.message,
+        storeId,
+        terminalId,
+      });
+      return null;
+    }
+
+    const records = refreshOutcome.records;
     return (
       records.find(
         (record) =>

--- a/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx
+++ b/packages/athena-webapp/src/components/pos/register/POSRegisterOpeningGuard.tsx
@@ -31,8 +31,8 @@ import {
 import {
   createIndexedDbPosLocalStorageAdapter,
   createPosLocalStore,
-  type PosLocalStaffAuthorityRecord,
 } from "@/lib/pos/infrastructure/local/posLocalStore";
+import { refreshAndStoreTerminalStaffAuthority } from "@/lib/pos/infrastructure/local/terminalStaffAuthorityRefresh";
 import { logger } from "@/lib/logger";
 
 type DailyOpeningSnapshot = {
@@ -147,52 +147,28 @@ export function POSRegisterOpeningGuard({
     }
 
     void (async () => {
-      let result: CommandResult<PosLocalStaffAuthorityRecord[]>;
-      try {
-        result = await (
-          refreshTerminalStaffAuthority as (args: {
-            storeId: Id<"store">;
-            terminalId: Id<"posTerminal">;
-          }) => Promise<CommandResult<PosLocalStaffAuthorityRecord[]>>
-        )({ storeId, terminalId });
-      } catch (error) {
-        logger.warn("[POS] Staff authority background refresh failed", {
-          message: error instanceof Error ? error.message : String(error),
-          storeId,
-          terminalId,
-        });
-        return;
-      }
-
-      if (result.kind !== "ok") {
-        logger.warn("[POS] Staff authority background refresh skipped", {
-          kind: result.kind,
-          storeId,
-          terminalId,
-        });
-        const clearResult = await localStore.replaceStaffAuthoritySnapshot({
-          records: [],
-          storeId,
-          terminalId,
-        });
-        if (!clearResult.ok) {
-          logger.warn("[POS] Staff authority snapshot could not be cleared", {
-            code: clearResult.error.code,
-            storeId,
-            terminalId,
-          });
-        }
-        return;
-      }
-
-      const writeResult = await localStore.replaceStaffAuthoritySnapshot({
-        records: result.data,
+      const result = await refreshAndStoreTerminalStaffAuthority({
+        localStore,
+        refreshTerminalStaffAuthority: refreshTerminalStaffAuthority as Parameters<
+          typeof refreshAndStoreTerminalStaffAuthority
+        >[0]["refreshTerminalStaffAuthority"],
         storeId,
         terminalId,
       });
-      if (!writeResult.ok) {
+
+      if (result.status === "preserved") {
+        logger.warn("[POS] Staff authority background refresh skipped", {
+          code: result.code,
+          message: result.message,
+          storeId,
+          terminalId,
+        });
+        return;
+      }
+
+      if (result.status === "write_failed") {
         logger.warn("[POS] Staff authority background refresh could not be stored", {
-          code: writeResult.error.code,
+          message: result.message,
           storeId,
           terminalId,
         });

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.test.ts
@@ -273,6 +273,145 @@ describe("terminal health presentation", () => {
     expect(presentation.safeActions).toHaveLength(1);
   });
 
+  it("lets structured preview data win over legacy blockers in the same preview", () => {
+    const presentation = buildTerminalRecoveryPresentation({
+      recoveryPreview: {
+        blockers: [
+          {
+            category: "manual_review",
+            id: "raw-fallback-review",
+            summary: "Raw fallback review should not override the preview.",
+            title: "Raw fallback review",
+          },
+        ],
+        commandStatus: {
+          commandType: "retry_sync",
+          label: "Sync retry",
+          status: "pending",
+          verificationStatus: "waiting_for_acknowledgement",
+        },
+        readiness: "needs_terminal_action",
+        terminalActions: [
+          {
+            commandContext: {
+              expectedBlockerType: "local_review",
+              reason: "Local review items need a terminal sync retry.",
+            },
+            commandType: "retry_sync",
+            expectedEvidence: {
+              syncStatus: "idle",
+            },
+            reason: "Local review items need a terminal sync retry.",
+          },
+        ],
+      },
+      runtimeStatus: null,
+      syncEvidence: {},
+      terminal: { status: "active" },
+    });
+
+    expect(presentation.readiness.label).toBe("Needs terminal action");
+    expect(presentation.groups.manualReview).toEqual([]);
+    expect(presentation.groups.terminalRequired).toEqual([
+      expect.objectContaining({
+        action: expect.objectContaining({
+          commandType: "retry_sync",
+          status: "pending",
+        }),
+        summary: "Sync retry command is queued for this checkout station.",
+        title: "Terminal sync retry",
+      }),
+    ]);
+    expect(presentation.safeActions).toEqual([]);
+    expect(presentation.commandStatus).toEqual(
+      expect.objectContaining({
+        label: "Sync retry",
+        status: "Pending",
+        verificationStatus: "Waiting For Acknowledgement",
+      }),
+    );
+  });
+
+  it("keeps legacy blockers when preview only adds command lifecycle metadata", () => {
+    const presentation = buildTerminalRecoveryPresentation({
+      recoveryPreview: {
+        blockers: [
+          {
+            category: "manual_review",
+            id: "raw-fallback-review",
+            summary: "Payment allocation requires manager review.",
+            title: "Manual review required",
+          },
+        ],
+        commandStatus: {
+          commandType: "retry_sync",
+          label: "Sync retry",
+          status: "pending",
+          verificationStatus: "waiting_for_acknowledgement",
+        },
+        evidence: {
+          activeRegisterSession: true,
+          freshRuntimeRequiredForAbleToTransactNow: true,
+        },
+        readiness: "needs_manual_review",
+      },
+      runtimeStatus: null,
+      syncEvidence: {},
+      terminal: { status: "active" },
+    });
+
+    expect(presentation.readiness.label).toBe("Needs manual review");
+    expect(presentation.groups.manualReview).toEqual([
+      expect.objectContaining({
+        id: "raw-fallback-review",
+        summary: "Payment allocation requires manager review.",
+        title: "Manual review required",
+      }),
+    ]);
+    expect(presentation.commandStatus).toEqual(
+      expect.objectContaining({
+        label: "Sync retry",
+        status: "Pending",
+        verificationStatus: "Waiting For Acknowledgement",
+      }),
+    );
+  });
+
+  it("keeps legacy blockers when structured blocker fields are empty", () => {
+    const presentation = buildTerminalRecoveryPresentation({
+      recoveryPreview: {
+        blockers: [
+          {
+            category: "manual_review",
+            id: "raw-empty-structured-review",
+            summary: "A manager needs to review this terminal.",
+            title: "Manual review required",
+          },
+        ],
+        cloudRepair: {
+          preconditionHash: "terminal-cloud-repair:empty",
+          safeConflictIds: [],
+          skippedConflictIds: [],
+        },
+        manualReview: [],
+        readiness: "needs_manual_review",
+        terminalActions: [],
+      },
+      runtimeStatus: null,
+      syncEvidence: {},
+      terminal: { status: "active" },
+    });
+
+    expect(presentation.groups.manualReview).toEqual([
+      expect.objectContaining({
+        id: "raw-empty-structured-review",
+        summary: "A manager needs to review this terminal.",
+      }),
+    ]);
+    expect(presentation.groups.cloudRepair).toEqual([]);
+    expect(presentation.groups.terminalRequired).toEqual([]);
+  });
+
   it("suppresses duplicate recovery actions while command lifecycle is active", () => {
     const presentation = buildTerminalRecoveryPresentation({
       recovery: {

--- a/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
+++ b/packages/athena-webapp/src/components/pos/terminals/terminalHealthPresentation.ts
@@ -489,7 +489,7 @@ function buildRecoveryBlockers(
   summary: TerminalHealthClassificationInput,
   recovery: TerminalRecoveryPreview | null | undefined = getTerminalRecoveryPreview(summary),
 ): RecoveryBlockerWithCategory[] {
-  if (recovery?.blockers) {
+  if (recovery?.blockers && !hasStructuredRecoveryPreview(recovery)) {
     return recovery.blockers.map((blocker, index) =>
       normalizeBackendRecoveryBlocker(blocker, index),
     );
@@ -503,7 +503,15 @@ function buildRecoveryBlockers(
 }
 
 function getTerminalRecoveryPreview(summary: TerminalHealthClassificationInput) {
-  return summary.recovery ?? summary.recoveryPreview ?? null;
+  return summary.recoveryPreview ?? summary.recovery ?? null;
+}
+
+function hasStructuredRecoveryPreview(recovery: TerminalRecoveryPreview) {
+  return Boolean(
+    (recovery.cloudRepair?.safeConflictIds.length ?? 0) > 0 ||
+      (recovery.terminalActions?.length ?? 0) > 0 ||
+      (recovery.manualReview?.length ?? 0) > 0,
+  );
 }
 
 function getRecoveryVerificationSummary(status?: TerminalRecoveryActionStatus | null) {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/drawerAuthorityReconciliation.ts
@@ -1,0 +1,376 @@
+import {
+  createPosLocalStore,
+  type PosDrawerAuthorityState,
+  type PosLocalEventRecord,
+  type PosLocalStoreResult,
+} from "./posLocalStore";
+
+type PosLocalRuntimeStore = ReturnType<typeof createPosLocalStore>;
+
+export async function persistDrawerAuthorityBlockForReviewEvents(input: {
+  events: PosLocalEventRecord[];
+  reason: NonNullable<PosDrawerAuthorityState["reason"]>;
+  reviewEventIds: string[];
+  store: PosLocalRuntimeStore;
+}) {
+  const writeDrawerAuthorityState = (
+    input.store as {
+      writeDrawerAuthorityState?: PosLocalRuntimeStore["writeDrawerAuthorityState"];
+    }
+  ).writeDrawerAuthorityState;
+  if (input.reviewEventIds.length === 0 || !writeDrawerAuthorityState) {
+    return;
+  }
+
+  const reviewEventIds = new Set(input.reviewEventIds);
+  const event = input.events.find(
+    (candidate) =>
+      reviewEventIds.has(candidate.localEventId) &&
+      isDrawerAuthorityLifecycleEvent(candidate) &&
+      candidate.localRegisterSessionId,
+  );
+  if (!event?.localRegisterSessionId) return;
+
+  const mappings = await input.store.listLocalCloudMappings?.();
+  if (mappings && !mappings.ok) return;
+  const cloudRegisterSessionId = mappings?.value.find(
+    (mapping) =>
+      mapping.entity === "registerSession" &&
+      mapping.localId === event.localRegisterSessionId,
+  )?.cloudId;
+
+  const result = await writeDrawerAuthorityState({
+    ...(cloudRegisterSessionId ? { cloudRegisterSessionId } : {}),
+    localRegisterSessionId: event.localRegisterSessionId,
+    message: "Cloud sync needs review before this local drawer can continue.",
+    observedAt: Date.now(),
+    reason: input.reason,
+    registerNumber: event.registerNumber,
+    status: "blocked",
+    storeId: event.storeId,
+    terminalId: event.terminalId,
+  });
+  assertPosLocalStoreOk(result);
+}
+
+export async function clearRecoverableDrawerAuthorityForSyncedEvents(input: {
+  events: PosLocalEventRecord[];
+  reviewEventIds: string[];
+  store: PosLocalRuntimeStore;
+  syncedEventIds: string[];
+}) {
+  const clearDrawerAuthorityState = (
+    input.store as {
+      clearDrawerAuthorityState?: PosLocalRuntimeStore["clearDrawerAuthorityState"];
+    }
+  ).clearDrawerAuthorityState;
+  const readDrawerAuthorityState = (
+    input.store as {
+      readDrawerAuthorityState?: PosLocalRuntimeStore["readDrawerAuthorityState"];
+    }
+  ).readDrawerAuthorityState;
+  if (
+    !clearDrawerAuthorityState ||
+    !readDrawerAuthorityState ||
+    input.syncedEventIds.length === 0
+  ) {
+    return;
+  }
+
+  const syncedEventIds = new Set(input.syncedEventIds);
+  const reviewEventIds = new Set(input.reviewEventIds);
+  const remainingReviewDrawers = new Set(
+    input.events
+      .filter(
+        (event) =>
+          ((event.sync.status === "needs_review" && event.sync.uploaded) ||
+            reviewEventIds.has(event.localEventId)) &&
+          !syncedEventIds.has(event.localEventId) &&
+          event.localRegisterSessionId &&
+          isDrawerAuthorityLifecycleEvent(event),
+      )
+      .map((event) =>
+        drawerAuthorityEventKey({
+          localRegisterSessionId: event.localRegisterSessionId!,
+          storeId: event.storeId,
+          terminalId: event.terminalId,
+        }),
+      ),
+  );
+  const cleared = new Set<string>();
+  for (const event of input.events) {
+    if (
+      !syncedEventIds.has(event.localEventId) ||
+      !event.localRegisterSessionId ||
+      !isDrawerAuthorityLifecycleEvent(event)
+    ) {
+      continue;
+    }
+
+    const key = drawerAuthorityEventKey({
+      localRegisterSessionId: event.localRegisterSessionId,
+      storeId: event.storeId,
+      terminalId: event.terminalId,
+    });
+    if (remainingReviewDrawers.has(key)) continue;
+    if (cleared.has(key)) continue;
+    cleared.add(key);
+
+    const drawerAuthority = await readDrawerAuthorityState({
+      localRegisterSessionId: event.localRegisterSessionId,
+      storeId: event.storeId,
+      terminalId: event.terminalId,
+    });
+    assertPosLocalStoreOk(drawerAuthority);
+    if (!isRecoverableDrawerAuthorityReason(drawerAuthority.value?.reason)) {
+      continue;
+    }
+
+    const result: PosLocalStoreResult<null> = await clearDrawerAuthorityState({
+      localRegisterSessionId: event.localRegisterSessionId,
+      storeId: event.storeId,
+      terminalId: event.terminalId,
+    });
+    assertPosLocalStoreOk(result);
+  }
+}
+
+export async function clearSupersededRecoverableDrawerAuthorityBlocks(input: {
+  acceptedEvents: Array<{
+    localEventId: string;
+    status: string;
+  }>;
+  events: PosLocalEventRecord[];
+  returnedMappings: Array<{
+    cloudId: string;
+    localId: string;
+    localIdKind: string;
+  }>;
+  store: PosLocalRuntimeStore;
+}) {
+  const clearDrawerAuthorityState = (
+    input.store as {
+      clearDrawerAuthorityState?: PosLocalRuntimeStore["clearDrawerAuthorityState"];
+    }
+  ).clearDrawerAuthorityState;
+  const readDrawerAuthorityState = (
+    input.store as {
+      readDrawerAuthorityState?: PosLocalRuntimeStore["readDrawerAuthorityState"];
+    }
+  ).readDrawerAuthorityState;
+  const listLocalCloudMappings = (
+    input.store as {
+      listLocalCloudMappings?: PosLocalRuntimeStore["listLocalCloudMappings"];
+    }
+  ).listLocalCloudMappings;
+  if (
+    !clearDrawerAuthorityState ||
+    !readDrawerAuthorityState ||
+    !listLocalCloudMappings
+  ) {
+    return;
+  }
+
+  const acceptedProjectedEventIds = new Set(
+    input.acceptedEvents
+      .filter((event) => event.status === "projected")
+      .map((event) => event.localEventId),
+  );
+  const replacementDrawerOpenings = input.returnedMappings
+    .filter((mapping) => mapping.localIdKind === "registerSession")
+    .map((mapping) => {
+      const event = input.events.find(
+        (candidate) =>
+          candidate.type === "register.opened" &&
+          candidate.localRegisterSessionId === mapping.localId &&
+          acceptedProjectedEventIds.has(candidate.localEventId),
+      );
+      return event
+        ? {
+            cloudRegisterSessionId: mapping.cloudId,
+            event,
+          }
+        : null;
+    })
+    .filter(
+      (entry): entry is {
+        cloudRegisterSessionId: string;
+        event: PosLocalEventRecord;
+      } => Boolean(entry),
+    );
+  if (replacementDrawerOpenings.length === 0) {
+    return;
+  }
+
+  const mappings = await listLocalCloudMappings();
+  assertPosLocalStoreOk(mappings);
+
+  for (const replacement of replacementDrawerOpenings) {
+    const supersededRegisterSessionIds = mappings.value
+      .filter(
+        (mapping) =>
+          mapping.entity === "registerSession" &&
+          mapping.cloudId === replacement.cloudRegisterSessionId &&
+          mapping.localId !== replacement.event.localRegisterSessionId,
+      )
+      .map((mapping) => mapping.localId);
+    const uniqueSupersededRegisterSessionIds = [
+      ...new Set(supersededRegisterSessionIds),
+    ];
+
+    for (const localRegisterSessionId of uniqueSupersededRegisterSessionIds) {
+      const terminalIds = [
+        ...new Set(
+          input.events
+            .filter(
+              (event) =>
+                event.storeId === replacement.event.storeId &&
+                event.localRegisterSessionId === localRegisterSessionId,
+            )
+            .map((event) => event.terminalId),
+        ),
+      ];
+      for (const terminalId of terminalIds) {
+        const drawerAuthority: PosLocalStoreResult<PosDrawerAuthorityState | null> =
+          await readDrawerAuthorityState({
+            localRegisterSessionId,
+            storeId: replacement.event.storeId,
+            terminalId,
+          });
+        assertPosLocalStoreOk(drawerAuthority);
+        if (
+          drawerAuthority.value?.status !== "blocked" ||
+          !isRecoverableDrawerAuthorityReason(drawerAuthority.value.reason) ||
+          drawerAuthority.value.observedAt > replacement.event.createdAt ||
+          (drawerAuthority.value.cloudRegisterSessionId &&
+            drawerAuthority.value.cloudRegisterSessionId !==
+              replacement.cloudRegisterSessionId)
+        ) {
+          continue;
+        }
+
+        const result: PosLocalStoreResult<null> = await clearDrawerAuthorityState({
+          localRegisterSessionId,
+          storeId: replacement.event.storeId,
+          terminalId,
+        });
+        assertPosLocalStoreOk(result);
+      }
+    }
+  }
+}
+
+export async function clearSettledRecoverableDrawerAuthorityBlock(input: {
+  drawerAuthority: PosDrawerAuthorityState;
+  events: PosLocalEventRecord[];
+  store: PosLocalRuntimeStore;
+}): Promise<PosLocalStoreResult<boolean>> {
+  const clearDrawerAuthorityState = (
+    input.store as {
+      clearDrawerAuthorityState?: PosLocalRuntimeStore["clearDrawerAuthorityState"];
+    }
+  ).clearDrawerAuthorityState;
+  if (
+    !clearDrawerAuthorityState ||
+    input.drawerAuthority.status !== "blocked" ||
+    !isRecoverableDrawerAuthorityReason(input.drawerAuthority.reason)
+  ) {
+    return { ok: true, value: false };
+  }
+
+  const drawerLifecycleEvents = input.events.filter(
+    (event) =>
+      event.localRegisterSessionId ===
+        input.drawerAuthority.localRegisterSessionId &&
+      event.storeId === input.drawerAuthority.storeId &&
+      event.terminalId === input.drawerAuthority.terminalId &&
+      isDrawerAuthorityLifecycleEvent(event),
+  );
+  if (drawerLifecycleEvents.length === 0) {
+    return { ok: true, value: false };
+  }
+
+  const hasUnsettledLifecycleEvent = drawerLifecycleEvents.some(
+    (event) => event.sync.status !== "synced",
+  );
+  if (hasUnsettledLifecycleEvent) {
+    return { ok: true, value: false };
+  }
+
+  const hasRemainingLifecycleReview = drawerLifecycleEvents.some(
+    (event) => event.sync.status === "needs_review" && event.sync.uploaded,
+  );
+  if (hasRemainingLifecycleReview) {
+    return { ok: true, value: false };
+  }
+
+  const result = await clearDrawerAuthorityState({
+    localRegisterSessionId: input.drawerAuthority.localRegisterSessionId,
+    storeId: input.drawerAuthority.storeId,
+    terminalId: input.drawerAuthority.terminalId,
+  });
+  if (!result.ok) return result;
+
+  return { ok: true, value: true };
+}
+
+export async function readLatestRuntimeDrawerAuthorityState(input: {
+  localRegisterSessionId: string;
+  readDrawerAuthorityState: NonNullable<
+    PosLocalRuntimeStore["readDrawerAuthorityState"]
+  >;
+  storeId: string;
+  terminalIds: Set<string>;
+}): Promise<PosLocalStoreResult<PosDrawerAuthorityState | null>> {
+  if (input.terminalIds.size === 0) {
+    return { ok: true, value: null };
+  }
+
+  const states: PosDrawerAuthorityState[] = [];
+  for (const terminalId of input.terminalIds) {
+    const result = await input.readDrawerAuthorityState({
+      localRegisterSessionId: input.localRegisterSessionId,
+      storeId: input.storeId,
+      terminalId,
+    });
+    if (!result.ok) return result;
+    if (result.value) states.push(result.value);
+  }
+
+  return {
+    ok: true,
+    value:
+      states.sort((left, right) => right.observedAt - left.observedAt).at(0) ??
+      null,
+  };
+}
+
+export function isRecoverableDrawerAuthorityReason(
+  reason: PosDrawerAuthorityState["reason"] | undefined,
+) {
+  return reason === "lifecycle_rejected" || reason === "authority_unknown";
+}
+
+function drawerAuthorityEventKey(input: {
+  localRegisterSessionId: string;
+  storeId: string;
+  terminalId: string;
+}) {
+  return `${input.storeId}:${input.terminalId}:${input.localRegisterSessionId}`;
+}
+
+export function isDrawerAuthorityLifecycleEvent(event: PosLocalEventRecord) {
+  return (
+    event.type === "register.opened" ||
+    event.type === "register.closeout_started" ||
+    event.type === "register.reopened"
+  );
+}
+
+function assertPosLocalStoreOk<T>(
+  result: PosLocalStoreResult<T>,
+): asserts result is { ok: true; value: T } {
+  if (!result.ok) {
+    throw new Error(result.error.message);
+  }
+}

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localSyncDrainCoordinator.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localSyncDrainCoordinator.ts
@@ -1,0 +1,131 @@
+import {
+  isSyncablePosLocalEvent,
+  isUploadDeferredByValidation,
+  type PosLocalSyncUploadSupport,
+} from "./syncContract";
+import type { PosLocalSyncTrigger } from "./syncScheduler";
+import type { PosLocalEventRecord } from "./posLocalStore";
+
+export type PosLocalRuntimeSyncDebugSnapshot = {
+  appSessionUnverifiedEventCount?: number;
+  cloudValidationUncertainEventCount?: number;
+  deferredUploadEventCount?: number;
+  failedEventCount?: number;
+  localOnlyEventCount?: number;
+  mode?: "drain-enabled" | "status-only";
+  oldestPendingEventAt?: number;
+  oldestPendingEventId?: string;
+  oldestPendingEventSequence?: number;
+  oldestPendingUploadSequence?: number;
+  nextPendingUploadSequence?: number;
+  pendingUploadEventCount?: number;
+  reviewEventCount?: number;
+};
+
+export function startStatusOnlyRuntimeTriggers(refresh: () => void) {
+  const win = globalThis.window;
+  const doc = globalThis.document;
+  const interval = setInterval(refresh, 30_000);
+
+  const handleOnlineStateChange = () => refresh();
+  const handleVisibility = () => {
+    if (!doc || doc.visibilityState === "hidden") return;
+    refresh();
+  };
+
+  win?.addEventListener?.("online", handleOnlineStateChange);
+  win?.addEventListener?.("offline", handleOnlineStateChange);
+  doc?.addEventListener?.("visibilitychange", handleVisibility);
+
+  return () => {
+    clearInterval(interval);
+    win?.removeEventListener?.("online", handleOnlineStateChange);
+    win?.removeEventListener?.("offline", handleOnlineStateChange);
+    doc?.removeEventListener?.("visibilitychange", handleVisibility);
+  };
+}
+
+export function buildRuntimeSyncDebug(
+  events: PosLocalEventRecord[],
+  mode: "drain-enabled" | "status-only",
+  uploadSupport: PosLocalSyncUploadSupport = {},
+): PosLocalRuntimeSyncDebugSnapshot {
+  const pendingUploadCandidates = events.filter(isPendingUploadCandidate);
+  const pendingUploadableEvents = pendingUploadCandidates.filter((event) =>
+    isSyncablePosLocalEvent(event, uploadSupport),
+  );
+  const deferredUploadEvents = pendingUploadCandidates.filter((event) =>
+    isUploadDeferredByValidation(event, uploadSupport),
+  );
+  const nextPendingUploadableEvent = [...pendingUploadableEvents]
+    .sort(compareUploadableEventOrder)
+    .at(0);
+  const localOnlyEvents = pendingUploadCandidates.filter(
+    (event) => !isSyncablePosLocalEvent(event, uploadSupport),
+  );
+  const reviewEvents = events.filter(
+    (event) => event.sync.status === "needs_review",
+  );
+  const failedEvents = events.filter((event) => event.sync.status === "failed");
+  const oldestPendingEvent = [...events]
+    .filter((event) => event.sync.status !== "synced")
+    .sort((left, right) => left.createdAt - right.createdAt)
+    .at(0);
+
+  return {
+    appSessionUnverifiedEventCount: events.filter((event) =>
+      event.validationMetadata?.flags.includes("app-session-unverified"),
+    ).length,
+    cloudValidationUncertainEventCount: events.filter((event) =>
+      event.validationMetadata?.flags.includes("cloud-validation-uncertain"),
+    ).length,
+    deferredUploadEventCount: deferredUploadEvents.length,
+    failedEventCount: failedEvents.length,
+    localOnlyEventCount: localOnlyEvents.length,
+    mode,
+    oldestPendingEventAt: oldestPendingEvent?.createdAt,
+    oldestPendingEventId: oldestPendingEvent?.localEventId,
+    oldestPendingEventSequence: oldestPendingEvent?.sequence,
+    oldestPendingUploadSequence: oldestPendingEvent?.uploadSequence,
+    nextPendingUploadSequence: nextPendingUploadableEvent?.uploadSequence,
+    pendingUploadEventCount: pendingUploadableEvents.length,
+    reviewEventCount: reviewEvents.length,
+  };
+}
+
+export function getRuntimeUploadTrigger(input: {
+  eventAppendToken: number;
+  lastEventAppendToken: number;
+  lastManualRetryToken: number;
+  manualRetryToken: number;
+}): PosLocalSyncTrigger {
+  if (input.manualRetryToken !== input.lastManualRetryToken) {
+    return "manual-retry";
+  }
+  if (input.eventAppendToken !== input.lastEventAppendToken) {
+    return "event-appended";
+  }
+  return "route-entry";
+}
+
+function compareUploadableEventOrder(
+  left: PosLocalEventRecord,
+  right: PosLocalEventRecord,
+) {
+  const leftUploadSequence = left.uploadSequence ?? Number.POSITIVE_INFINITY;
+  const rightUploadSequence = right.uploadSequence ?? Number.POSITIVE_INFINITY;
+  if (leftUploadSequence !== rightUploadSequence) {
+    return leftUploadSequence - rightUploadSequence;
+  }
+
+  return left.sequence - right.sequence;
+}
+
+function isPendingUploadCandidate(event: PosLocalEventRecord) {
+  return (
+    event.sync.status === "pending" ||
+    event.sync.status === "syncing" ||
+    event.sync.status === "failed" ||
+    (event.sync.status === "needs_review" && event.sync.uploaded)
+  );
+}

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeReadiness.ts
@@ -1,0 +1,174 @@
+import { readPosAppShellReadiness } from "@/offline/posAppShellReadiness";
+
+import type {
+  PosDrawerAuthorityState,
+  PosLocalStaffAuthorityReadiness,
+  PosProvisionedTerminalSeed,
+  PosTerminalIntegrityState,
+} from "./posLocalStore";
+import { createPosLocalStore } from "./posLocalStore";
+import { readProjectedLocalRegisterModel } from "./localRegisterReader";
+import type { PosLocalCashDrawerReadModel } from "./registerReadModel";
+import { resolvePosLocalTerminalScope } from "./terminalScope";
+import type {
+  PosTerminalRuntimeActiveRegisterSessionInput,
+  PosTerminalRuntimeAppShellInput,
+  PosTerminalRuntimeSnapshotReadiness,
+} from "./terminalRuntimeStatus";
+import {
+  clearSettledRecoverableDrawerAuthorityBlock,
+  readLatestRuntimeDrawerAuthorityState,
+} from "./drawerAuthorityReconciliation";
+
+type PosLocalRuntimeStore = ReturnType<typeof createPosLocalStore>;
+
+export type PosTerminalRuntimeReadiness = {
+  activeRegisterSession: PosTerminalRuntimeActiveRegisterSessionInput | null;
+  appShell: PosTerminalRuntimeAppShellInput | null;
+  drawerAuthority: PosDrawerAuthorityState | null;
+  snapshots: PosTerminalRuntimeSnapshotReadiness;
+  staffAuthorityStatus: PosLocalStaffAuthorityReadiness | "unknown";
+  terminalIntegrity: PosTerminalIntegrityState | null;
+  terminalSeed: PosProvisionedTerminalSeed | null;
+};
+
+export function emptyPosTerminalRuntimeReadiness(): PosTerminalRuntimeReadiness {
+  return {
+    activeRegisterSession: null,
+    appShell: null,
+    drawerAuthority: null,
+    snapshots: {},
+    staffAuthorityStatus: "unknown",
+    terminalIntegrity: null,
+    terminalSeed: null,
+  };
+}
+
+export async function refreshTerminalRuntimeReadiness(input: {
+  store: PosLocalRuntimeStore;
+  storeId: string;
+  terminalId?: string | null;
+  terminalSeed: PosProvisionedTerminalSeed | null;
+}): Promise<PosTerminalRuntimeReadiness> {
+  const store = input.store as PosLocalRuntimeStore &
+    Partial<{
+      getStaffAuthorityReadiness: PosLocalRuntimeStore["getStaffAuthorityReadiness"];
+      readTerminalIntegrityState: PosLocalRuntimeStore["readTerminalIntegrityState"];
+      readRegisterAvailabilitySnapshot: PosLocalRuntimeStore["readRegisterAvailabilitySnapshot"];
+      readRegisterCatalogSnapshot: PosLocalRuntimeStore["readRegisterCatalogSnapshot"];
+      readRegisterServiceCatalogSnapshot: PosLocalRuntimeStore["readRegisterServiceCatalogSnapshot"];
+    }>;
+  const readDrawerAuthorityState = (
+    input.store as {
+      readDrawerAuthorityState?: PosLocalRuntimeStore["readDrawerAuthorityState"];
+    }
+  ).readDrawerAuthorityState;
+  const scope = resolvePosLocalTerminalScope({
+    storeId: input.storeId,
+    terminalId: input.terminalId,
+    terminalSeed: input.terminalSeed,
+  });
+  const [
+    catalog,
+    serviceCatalog,
+    availability,
+    staffAuthority,
+    terminalIntegrity,
+    appShell,
+  ] = await Promise.all([
+    store.readRegisterCatalogSnapshot
+      ? store.readRegisterCatalogSnapshot({ storeId: input.storeId })
+      : Promise.resolve({ ok: true as const, value: null }),
+    store.readRegisterServiceCatalogSnapshot
+      ? store.readRegisterServiceCatalogSnapshot({ storeId: input.storeId })
+      : Promise.resolve({ ok: true as const, value: null }),
+    store.readRegisterAvailabilitySnapshot
+      ? store.readRegisterAvailabilitySnapshot({ storeId: input.storeId })
+      : Promise.resolve({ ok: true as const, value: null }),
+    input.terminalId && store.getStaffAuthorityReadiness
+      ? store.getStaffAuthorityReadiness({
+          storeId: input.storeId,
+          terminalId: input.terminalId,
+        })
+      : Promise.resolve({ ok: true as const, value: "unknown" as const }),
+    input.terminalId && store.readTerminalIntegrityState
+      ? store.readTerminalIntegrityState({
+          storeId: input.storeId,
+          terminalId: input.terminalId,
+        })
+      : Promise.resolve({ ok: true as const, value: null }),
+    readPosAppShellReadiness(),
+  ]);
+  const localRegisterModel =
+    input.terminalId && readDrawerAuthorityState
+      ? await readProjectedLocalRegisterModel({
+          store,
+          storeId: input.storeId,
+          terminalId: input.terminalId,
+          isOnline:
+            typeof navigator === "undefined" ? true : navigator.onLine,
+        })
+      : ({ ok: true, value: null } as const);
+  const activeLocalRegisterSessionId =
+    localRegisterModel.ok
+      ? localRegisterModel.value?.activeRegisterSession?.localRegisterSessionId
+      : undefined;
+  let drawerAuthority =
+    activeLocalRegisterSessionId && readDrawerAuthorityState
+      ? await readLatestRuntimeDrawerAuthorityState({
+          localRegisterSessionId: activeLocalRegisterSessionId,
+          readDrawerAuthorityState,
+          storeId: input.storeId,
+          terminalIds: scope.terminalIds,
+        })
+      : ({ ok: true, value: null } as const);
+  if (drawerAuthority.ok && drawerAuthority.value && localRegisterModel.ok) {
+    const clearResult = await clearSettledRecoverableDrawerAuthorityBlock({
+      drawerAuthority: drawerAuthority.value,
+      events: localRegisterModel.value?.sourceEvents ?? [],
+      store: input.store,
+    });
+    if (clearResult.ok && clearResult.value) {
+      drawerAuthority = { ok: true, value: null };
+    }
+  }
+
+  return {
+    activeRegisterSession:
+      localRegisterModel.ok && localRegisterModel.value?.activeRegisterSession
+        ? toRuntimeActiveRegisterSession(
+            localRegisterModel.value.activeRegisterSession,
+          )
+        : null,
+    appShell,
+    drawerAuthority: drawerAuthority.ok ? drawerAuthority.value : null,
+    snapshots: {
+      ...(catalog.ok && catalog.value
+        ? { catalogRefreshedAt: catalog.value.refreshedAt }
+        : {}),
+      ...(serviceCatalog.ok && serviceCatalog.value
+        ? { serviceCatalogRefreshedAt: serviceCatalog.value.refreshedAt }
+        : {}),
+      ...(availability.ok && availability.value
+        ? { availabilityRefreshedAt: availability.value.refreshedAt }
+        : {}),
+    },
+    staffAuthorityStatus: staffAuthority.ok ? staffAuthority.value : "unknown",
+    terminalIntegrity: terminalIntegrity.ok ? terminalIntegrity.value : null,
+    terminalSeed: input.terminalSeed,
+  };
+}
+
+function toRuntimeActiveRegisterSession(
+  session: PosLocalCashDrawerReadModel,
+): PosTerminalRuntimeActiveRegisterSessionInput {
+  return {
+    ...(session.cloudRegisterSessionId
+      ? { cloudRegisterSessionId: session.cloudRegisterSessionId }
+      : {}),
+    localRegisterSessionId: session.localRegisterSessionId,
+    openedAt: session.openedAt,
+    ...(session.registerNumber ? { registerNumber: session.registerNumber } : {}),
+    status: session.status,
+  };
+}

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeStatusPublisher.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/runtimeStatusPublisher.ts
@@ -1,0 +1,98 @@
+import type { PosTerminalRuntimeStatusPayload } from "./terminalRuntimeStatus";
+
+export type RuntimeCheckInNotReadyReason =
+  | "missing_store"
+  | "missing_sync_secret"
+  | "missing_terminal";
+
+export type RuntimeCheckInPublishDebugPatch = {
+  checkInPublishAttemptedAt?: number;
+  checkInPublishCompletedAt?: number;
+  checkInPublishMessage?: string;
+  checkInPublishReason?:
+    | RuntimeCheckInNotReadyReason
+    | "authorization_failed"
+    | "not_ready"
+    | "rejected"
+    | "unavailable";
+  checkInPublishStatus?:
+    | "accepted"
+    | "failed"
+    | "not_ready"
+    | "pending"
+    | "rejected";
+};
+
+export function getRuntimeStatusSignature(input: {
+  runtimeStatus: PosTerminalRuntimeStatusPayload;
+  storeId: string;
+  terminalId: string;
+}) {
+  return JSON.stringify({
+    runtimeStatus: input.runtimeStatus,
+    storeId: input.storeId,
+    terminalId: input.terminalId,
+  });
+}
+
+export function getRuntimeStatusPublishSignature(input: {
+  observationToken: number;
+  runtimeStatus: PosTerminalRuntimeStatusPayload;
+  storeId: string;
+  terminalId: string;
+}) {
+  const stableStatus: Partial<PosTerminalRuntimeStatusPayload> = {
+    ...input.runtimeStatus,
+  };
+  delete stableStatus.reportedAt;
+  delete stableStatus.snapshots;
+
+  return JSON.stringify({
+    observationToken: input.observationToken,
+    runtimeStatus: stableStatus,
+    storeId: input.storeId,
+    terminalId: input.terminalId,
+  });
+}
+
+export function getRuntimeCheckInNotReadyReason(input: {
+  storeId?: string | null;
+  syncSecretHash?: string | null;
+  terminalId?: string | null;
+}): RuntimeCheckInNotReadyReason | null {
+  if (!input.storeId) return "missing_store";
+  if (!input.terminalId) return "missing_terminal";
+  if (!input.syncSecretHash) return "missing_sync_secret";
+  return null;
+}
+
+export function withRuntimeCheckInPublishDebug<
+  T extends RuntimeCheckInPublishDebugPatch,
+>(current: T, patch: RuntimeCheckInPublishDebugPatch): T {
+  const next = {
+    ...current,
+    ...patch,
+  };
+
+  if (
+    current.checkInPublishAttemptedAt === next.checkInPublishAttemptedAt &&
+    current.checkInPublishCompletedAt === next.checkInPublishCompletedAt &&
+    current.checkInPublishMessage === next.checkInPublishMessage &&
+    current.checkInPublishReason === next.checkInPublishReason &&
+    current.checkInPublishStatus === next.checkInPublishStatus
+  ) {
+    return current;
+  }
+
+  return next;
+}
+
+export function getRuntimeBrowserInfo(isOnline: boolean) {
+  const navigatorRef = globalThis.navigator;
+  return {
+    language: navigatorRef?.language,
+    online: isOnline,
+    platform: navigatorRef?.platform,
+    userAgent: navigatorRef?.userAgent,
+  };
+}

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalStaffAuthorityRefresh.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalStaffAuthorityRefresh.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { userError } from "~/shared/commandResult";
+
+import {
+  classifyTerminalStaffAuthorityRefreshResult,
+  refreshAndStoreTerminalStaffAuthority,
+} from "./terminalStaffAuthorityRefresh";
+import type { PosLocalStaffAuthorityRecord } from "./posLocalStore";
+
+function buildAuthorityRecord(
+  overrides: Partial<PosLocalStaffAuthorityRecord> = {},
+): PosLocalStaffAuthorityRecord {
+  return {
+    activeRoles: ["cashier"],
+    credentialId: "credential-1",
+    credentialVersion: 1,
+    displayName: "Ada",
+    expiresAt: 2_000,
+    issuedAt: 1_000,
+    organizationId: "org-1",
+    refreshedAt: 1_000,
+    staffProfileId: "staff-1",
+    status: "active",
+    storeId: "store-1",
+    terminalId: "terminal-1",
+    username: "ada",
+    verifier: {
+      algorithm: "PBKDF2-SHA256",
+      hash: "hash-1",
+      iterations: 120_000,
+      salt: "salt-1",
+      version: 1,
+    },
+    ...overrides,
+  };
+}
+
+describe("terminal staff authority refresh", () => {
+  it("preserves existing local authority when refresh returns a user error", async () => {
+    const replaceStaffAuthoritySnapshot = vi.fn();
+
+    const result = await refreshAndStoreTerminalStaffAuthority({
+      localStore: { replaceStaffAuthoritySnapshot },
+      refreshTerminalStaffAuthority: vi.fn(async () =>
+        userError({
+          code: "precondition_failed",
+          message: "Staff sign-in list is too large to refresh safely.",
+        }),
+      ),
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+    });
+
+    expect(result).toEqual({
+      code: "precondition_failed",
+      message: "Staff sign-in list is too large to refresh safely.",
+      status: "preserved",
+    });
+    expect(replaceStaffAuthoritySnapshot).not.toHaveBeenCalled();
+  });
+
+  it("clears local authority only when the server returns an authoritative empty list", async () => {
+    const replaceStaffAuthoritySnapshot = vi.fn(async () => ({
+      ok: true as const,
+      value: [],
+    }));
+
+    const result = await refreshAndStoreTerminalStaffAuthority({
+      localStore: { replaceStaffAuthoritySnapshot },
+      refreshTerminalStaffAuthority: vi.fn(async () => ({
+        data: [],
+        kind: "ok" as const,
+      })),
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+    });
+
+    expect(result).toEqual({
+      records: [],
+      status: "authority_cleared",
+    });
+    expect(replaceStaffAuthoritySnapshot).toHaveBeenCalledWith({
+      records: [],
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    });
+  });
+
+  it("stores mapped staff authority records when refresh succeeds", async () => {
+    const replaceStaffAuthoritySnapshot = vi.fn(async () => ({
+      ok: true as const,
+      value: [buildAuthorityRecord({ displayName: "Ada synced" })],
+    }));
+
+    const result = await refreshAndStoreTerminalStaffAuthority({
+      localStore: { replaceStaffAuthoritySnapshot },
+      mapRecords: vi.fn(async (records: PosLocalStaffAuthorityRecord[]) =>
+        records.map((record) => ({
+          ...record,
+          displayName: `${record.displayName} synced`,
+        })),
+      ),
+      refreshTerminalStaffAuthority: vi.fn(async () => ({
+        data: [buildAuthorityRecord()],
+        kind: "ok" as const,
+      })),
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+    });
+
+    expect(result).toEqual({
+      records: [
+        {
+          activeRoles: ["cashier"],
+          credentialId: "credential-1",
+          credentialVersion: 1,
+          displayName: "Ada synced",
+          expiresAt: 2_000,
+          issuedAt: 1_000,
+          organizationId: "org-1",
+          refreshedAt: 1_000,
+          staffProfileId: "staff-1",
+          status: "active",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          username: "ada",
+          verifier: {
+            algorithm: "PBKDF2-SHA256",
+            hash: "hash-1",
+            iterations: 120_000,
+            salt: "salt-1",
+            version: 1,
+          },
+        },
+      ],
+      status: "ready",
+    });
+    expect(replaceStaffAuthoritySnapshot).toHaveBeenCalledWith({
+      records: [
+        {
+          activeRoles: ["cashier"],
+          credentialId: "credential-1",
+          credentialVersion: 1,
+          displayName: "Ada synced",
+          expiresAt: 2_000,
+          issuedAt: 1_000,
+          organizationId: "org-1",
+          refreshedAt: 1_000,
+          staffProfileId: "staff-1",
+          status: "active",
+          storeId: "store-1",
+          terminalId: "terminal-1",
+          username: "ada",
+          verifier: {
+            algorithm: "PBKDF2-SHA256",
+            hash: "hash-1",
+            iterations: 120_000,
+            salt: "salt-1",
+            version: 1,
+          },
+        },
+      ],
+      storeId: "store-1",
+      terminalId: "terminal-1",
+    });
+  });
+
+  it("reports write failures without treating authority as refreshed", async () => {
+    const result = await refreshAndStoreTerminalStaffAuthority({
+      localStore: {
+        replaceStaffAuthoritySnapshot: vi.fn(async () => ({
+          error: {
+            code: "write_failed" as const,
+            message: "IndexedDB unavailable",
+          },
+          ok: false as const,
+        })),
+      },
+      refreshTerminalStaffAuthority: vi.fn(async () => ({
+        data: [buildAuthorityRecord()],
+        kind: "ok" as const,
+      })),
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+    });
+
+    expect(result).toEqual({
+      message: "IndexedDB unavailable",
+      status: "write_failed",
+    });
+  });
+
+  it("classifies non-ok results as preserve-existing diagnostics", () => {
+    expect(
+      classifyTerminalStaffAuthorityRefreshResult(
+        userError({
+          code: "authorization_failed",
+          message: "Not authorized.",
+        }),
+      ),
+    ).toEqual({
+      code: "authorization_failed",
+      kind: "preserve_existing",
+      message: "Not authorized.",
+      source: "result",
+    });
+  });
+});

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalStaffAuthorityRefresh.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/terminalStaffAuthorityRefresh.ts
@@ -1,0 +1,137 @@
+import type { Id } from "~/convex/_generated/dataModel";
+import type { CommandResult } from "~/shared/commandResult";
+
+import {
+  createPosLocalStore,
+  type PosLocalStaffAuthorityRecord,
+} from "./posLocalStore";
+
+type PosLocalRuntimeStore = ReturnType<typeof createPosLocalStore>;
+
+type RefreshTerminalStaffAuthority = (args: {
+  storeId: Id<"store">;
+  terminalId: Id<"posTerminal">;
+}) => Promise<CommandResult<PosLocalStaffAuthorityRecord[]>>;
+
+type TerminalStaffAuthorityRefreshClassification =
+  | {
+      kind: "accepted";
+      records: PosLocalStaffAuthorityRecord[];
+    }
+  | {
+      kind: "authoritative_empty";
+      records: [];
+    }
+  | {
+      code?: string;
+      kind: "preserve_existing";
+      message?: string;
+      source: "exception" | "result";
+    };
+
+export type TerminalStaffAuthorityRefreshOutcome =
+  | {
+      records: PosLocalStaffAuthorityRecord[];
+      status: "ready";
+    }
+  | {
+      records: [];
+      status: "authority_cleared";
+    }
+  | {
+      code?: string;
+      message?: string;
+      status: "preserved";
+    }
+  | {
+      message: string;
+      status: "write_failed";
+    };
+
+export function classifyTerminalStaffAuthorityRefreshResult(
+  result: CommandResult<PosLocalStaffAuthorityRecord[]>,
+): TerminalStaffAuthorityRefreshClassification {
+  if (result.kind !== "ok") {
+    return {
+      code: result.kind === "user_error" ? result.error.code : undefined,
+      kind: "preserve_existing",
+      message:
+        result.kind === "user_error"
+          ? result.error.message
+          : "Staff authority refresh failed.",
+      source: "result",
+    };
+  }
+
+  if (result.data.length === 0) {
+    return {
+      kind: "authoritative_empty",
+      records: [],
+    };
+  }
+
+  return {
+    kind: "accepted",
+    records: result.data,
+  };
+}
+
+export async function refreshAndStoreTerminalStaffAuthority(input: {
+  localStore: Pick<PosLocalRuntimeStore, "replaceStaffAuthoritySnapshot">;
+  mapRecords?: (
+    records: PosLocalStaffAuthorityRecord[],
+  ) => Promise<PosLocalStaffAuthorityRecord[]> | PosLocalStaffAuthorityRecord[];
+  refreshTerminalStaffAuthority: RefreshTerminalStaffAuthority;
+  storeId: Id<"store">;
+  terminalId: Id<"posTerminal">;
+}): Promise<TerminalStaffAuthorityRefreshOutcome> {
+  let result: CommandResult<PosLocalStaffAuthorityRecord[]>;
+  try {
+    result = await input.refreshTerminalStaffAuthority({
+      storeId: input.storeId,
+      terminalId: input.terminalId,
+    });
+  } catch (error) {
+    return {
+      message: error instanceof Error ? error.message : String(error),
+      status: "preserved",
+    };
+  }
+
+  const classification = classifyTerminalStaffAuthorityRefreshResult(result);
+  if (classification.kind === "preserve_existing") {
+    return {
+      code: classification.code,
+      message: classification.message,
+      status: "preserved",
+    };
+  }
+
+  const records =
+    classification.kind === "authoritative_empty"
+      ? []
+      : input.mapRecords
+        ? await input.mapRecords(classification.records)
+        : classification.records;
+  const writeResult = await input.localStore.replaceStaffAuthoritySnapshot({
+    records,
+    storeId: input.storeId,
+    terminalId: input.terminalId,
+  });
+  if (!writeResult.ok) {
+    return {
+      message: writeResult.error.message,
+      status: "write_failed",
+    };
+  }
+
+  return records.length === 0
+    ? {
+        records: [],
+        status: "authority_cleared",
+      }
+    : {
+        records,
+        status: "ready",
+      };
+}

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/usePosLocalSyncRuntime.ts
@@ -8,13 +8,11 @@ import {
   getInitialRuntimeBuildMetadata,
   readRuntimeBuildMetadata,
 } from "@/lib/runtimeBuildMetadata";
-import { readPosAppShellReadiness } from "@/offline/posAppShellReadiness";
 import { isLocalPinVerifierMetadata } from "@/lib/security/localPinVerifier";
 import {
   createIndexedDbPosLocalStorageAdapter,
   createPosLocalStore,
   type PosLocalCloudMapping,
-  type PosDrawerAuthorityState,
   type PosLocalEventRecord,
   type PosLocalStaffAuthorityRecord,
   type PosLocalStaffAuthorityReadiness,
@@ -23,9 +21,14 @@ import {
   type PosProvisionedTerminalSeed,
 } from "./posLocalStore";
 import {
+  clearRecoverableDrawerAuthorityForSyncedEvents,
+  clearSupersededRecoverableDrawerAuthorityBlocks,
+  isDrawerAuthorityLifecycleEvent,
+  persistDrawerAuthorityBlockForReviewEvents,
+} from "./drawerAuthorityReconciliation";
+import {
   buildPosLocalSyncUploadEvents,
   isSyncablePosLocalEvent,
-  isUploadDeferredByValidation,
   type PosLocalUploadEvent,
   type PosLocalSyncUploadSupport,
 } from "./syncContract";
@@ -35,23 +38,35 @@ import {
 } from "./syncScheduler";
 import { derivePosLocalSyncStatus } from "./syncStatus";
 import {
-  readProjectedLocalRegisterModel,
   readScopedPosLocalEvents,
 } from "./localRegisterReader";
-import type { PosLocalCashDrawerReadModel } from "./registerReadModel";
 import {
   isPosLocalEventInTerminalScope,
   resolvePosLocalTerminalScope,
 } from "./terminalScope";
 import {
+  emptyPosTerminalRuntimeReadiness,
+  refreshTerminalRuntimeReadiness,
+  type PosTerminalRuntimeReadiness,
+} from "./runtimeReadiness";
+import {
+  buildRuntimeSyncDebug,
+  getRuntimeUploadTrigger,
+  startStatusOnlyRuntimeTriggers,
+} from "./localSyncDrainCoordinator";
+import { refreshAndStoreTerminalStaffAuthority } from "./terminalStaffAuthorityRefresh";
+import {
+  getRuntimeBrowserInfo,
+  getRuntimeCheckInNotReadyReason,
+  getRuntimeStatusPublishSignature,
+  withRuntimeCheckInPublishDebug as withCheckInPublishDebug,
+} from "./runtimeStatusPublisher";
+import {
   buildPosTerminalRuntimeCopyDiagnostics,
   buildPosTerminalRuntimeStatus,
   toReportablePosTerminalRuntimeStatus,
-  type PosTerminalRuntimeActiveRegisterSessionInput,
-  type PosTerminalRuntimeAppShellInput,
   type PosTerminalRuntimeAppSessionRecoveryInput,
   type PosTerminalRuntimeCopyDiagnostics,
-  type PosTerminalRuntimeSnapshotReadiness,
   type PosTerminalRuntimeStatusPayload,
   type PosTerminalRuntimeStatusSource,
   type PosTerminalRuntimeSyncDebugInput,
@@ -60,6 +75,8 @@ import {
   executeTerminalRecoveryCommand,
   type PosTerminalRecoveryCommandResult,
 } from "./terminalRecoveryCommands";
+
+export { getRuntimeStatusSignature } from "./runtimeStatusPublisher";
 
 export type PosLocalRuntimeSyncStatusSource = {
   copyDiagnostics?: PosTerminalRuntimeCopyDiagnostics;
@@ -167,15 +184,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
   );
   const [events, setEvents] = useState<PosLocalEventRecord[]>([]);
   const [runtimeReadiness, setRuntimeReadiness] =
-    useState<PosTerminalRuntimeReadiness>({
-      activeRegisterSession: null,
-      appShell: null,
-      drawerAuthority: null,
-      snapshots: {},
-      staffAuthorityStatus: "unknown",
-      terminalIntegrity: null,
-      terminalSeed: null,
-    });
+    useState<PosTerminalRuntimeReadiness>(emptyPosTerminalRuntimeReadiness);
   const [readError, setReadError] = useState<string | null>(null);
   const [refreshToken, setRefreshToken] = useState(0);
   const [manualRetryToken, setManualRetryToken] = useState(0);
@@ -293,15 +302,7 @@ export function usePosLocalSyncRuntimeStatus(input: {
       if (scope.terminalIds.size === 0 || !cloudTerminalId) {
         setEvents([]);
         setReadError(null);
-        setRuntimeReadiness({
-          activeRegisterSession: null,
-          appShell: null,
-          drawerAuthority: null,
-          snapshots: {},
-          staffAuthorityStatus: "unknown",
-          terminalIntegrity: null,
-          terminalSeed: null,
-        });
+        setRuntimeReadiness(emptyPosTerminalRuntimeReadiness());
         return;
       }
       setRuntimeReadiness((current) => ({
@@ -318,12 +319,12 @@ export function usePosLocalSyncRuntimeStatus(input: {
         setRuntimeReadiness(readiness);
         setRuntimeStatusObservationToken((current) => current + 1);
       });
-      const trigger: PosLocalSyncTrigger =
-        manualRetryToken !== lastManualRetryTokenRef.current
-          ? "manual-retry"
-          : eventAppendToken !== lastEventAppendTokenRef.current
-            ? "event-appended"
-            : "route-entry";
+      const trigger = getRuntimeUploadTrigger({
+        eventAppendToken,
+        lastEventAppendToken: lastEventAppendTokenRef.current,
+        lastManualRetryToken: lastManualRetryTokenRef.current,
+        manualRetryToken,
+      });
       const triggerPriority = trigger === "event-appended" ? "high" : "normal";
       lastManualRetryTokenRef.current = manualRetryToken;
       lastEventAppendTokenRef.current = eventAppendToken;
@@ -1130,46 +1131,36 @@ export function usePosLocalSyncRuntimeStatus(input: {
             throw new Error("Local staff authority storage is unavailable.");
           }
 
-          const result = await refreshTerminalStaffAuthority({
+          const result = await refreshAndStoreTerminalStaffAuthority({
+            localStore: store,
+            refreshTerminalStaffAuthority: refreshTerminalStaffAuthority as Parameters<
+              typeof refreshAndStoreTerminalStaffAuthority
+            >[0]["refreshTerminalStaffAuthority"],
             storeId: storeId as Id<"store">,
             terminalId: terminalId as Id<"posTerminal">,
+            mapRecords: (records) =>
+              records.flatMap((record) => {
+                if (record.status !== "active" && record.status !== "revoked") {
+                  return [];
+                }
+                const verifier = record.verifier;
+                if (!isLocalPinVerifierMetadata(verifier)) {
+                  return [];
+                }
+
+                const localRecord: PosLocalStaffAuthorityRecord = {
+                  ...record,
+                  status: record.status,
+                  verifier,
+                };
+                return [localRecord];
+              }),
           });
-          if (result.kind !== "ok") {
-            await store.replaceStaffAuthoritySnapshot({
-              records: [],
-              storeId,
-              terminalId,
-            });
-            throw new Error(
-              result.kind === "user_error"
-                ? result.error.message
-                : "Staff authority refresh failed.",
-            );
+          if (result.status === "preserved") {
+            throw new Error(result.message ?? "Staff authority refresh failed.");
           }
-
-          const records = result.data.flatMap((record) => {
-            if (record.status !== "active" && record.status !== "revoked") {
-              return [];
-            }
-            const verifier = record.verifier;
-            if (!isLocalPinVerifierMetadata(verifier)) {
-              return [];
-            }
-
-            const localRecord: PosLocalStaffAuthorityRecord = {
-              ...record,
-              status: record.status,
-              verifier,
-            };
-            return [localRecord];
-          });
-          const writeResult = await store.replaceStaffAuthoritySnapshot({
-            records,
-            storeId,
-            terminalId,
-          });
-          if (!writeResult.ok) {
-            throw new Error(writeResult.error.message);
+          if (result.status === "write_failed") {
+            throw new Error(result.message);
           }
 
           return {
@@ -1318,145 +1309,6 @@ export function usePosLocalSyncRuntimeStatus(input: {
   ]);
 }
 
-type PosTerminalRuntimeReadiness = {
-  activeRegisterSession: PosTerminalRuntimeActiveRegisterSessionInput | null;
-  appShell: PosTerminalRuntimeAppShellInput | null;
-  drawerAuthority: PosDrawerAuthorityState | null;
-  snapshots: PosTerminalRuntimeSnapshotReadiness;
-  staffAuthorityStatus: PosLocalStaffAuthorityReadiness | "unknown";
-  terminalIntegrity: PosTerminalIntegrityState | null;
-  terminalSeed: PosProvisionedTerminalSeed | null;
-};
-
-async function refreshTerminalRuntimeReadiness(input: {
-  store: PosLocalRuntimeStore;
-  storeId: string;
-  terminalId?: string | null;
-  terminalSeed: PosProvisionedTerminalSeed | null;
-}): Promise<PosTerminalRuntimeReadiness> {
-  const store = input.store as PosLocalRuntimeStore &
-    Partial<{
-      getStaffAuthorityReadiness: PosLocalRuntimeStore["getStaffAuthorityReadiness"];
-      readTerminalIntegrityState: PosLocalRuntimeStore["readTerminalIntegrityState"];
-      readRegisterAvailabilitySnapshot: PosLocalRuntimeStore["readRegisterAvailabilitySnapshot"];
-      readRegisterCatalogSnapshot: PosLocalRuntimeStore["readRegisterCatalogSnapshot"];
-      readRegisterServiceCatalogSnapshot: PosLocalRuntimeStore["readRegisterServiceCatalogSnapshot"];
-    }>;
-  const readDrawerAuthorityState = (
-    input.store as {
-      readDrawerAuthorityState?: PosLocalRuntimeStore["readDrawerAuthorityState"];
-    }
-  ).readDrawerAuthorityState;
-  const scope = resolvePosLocalTerminalScope({
-    storeId: input.storeId,
-    terminalId: input.terminalId,
-    terminalSeed: input.terminalSeed,
-  });
-  const [
-    catalog,
-    serviceCatalog,
-    availability,
-    staffAuthority,
-    terminalIntegrity,
-    appShell,
-  ] = await Promise.all([
-    store.readRegisterCatalogSnapshot
-      ? store.readRegisterCatalogSnapshot({ storeId: input.storeId })
-      : Promise.resolve({ ok: true as const, value: null }),
-    store.readRegisterServiceCatalogSnapshot
-      ? store.readRegisterServiceCatalogSnapshot({ storeId: input.storeId })
-      : Promise.resolve({ ok: true as const, value: null }),
-    store.readRegisterAvailabilitySnapshot
-      ? store.readRegisterAvailabilitySnapshot({ storeId: input.storeId })
-      : Promise.resolve({ ok: true as const, value: null }),
-    input.terminalId && store.getStaffAuthorityReadiness
-      ? store.getStaffAuthorityReadiness({
-          storeId: input.storeId,
-          terminalId: input.terminalId,
-        })
-      : Promise.resolve({ ok: true as const, value: "unknown" as const }),
-    input.terminalId && store.readTerminalIntegrityState
-      ? store.readTerminalIntegrityState({
-          storeId: input.storeId,
-          terminalId: input.terminalId,
-        })
-      : Promise.resolve({ ok: true as const, value: null }),
-    readPosAppShellReadiness(),
-  ]);
-  const localRegisterModel =
-    input.terminalId && readDrawerAuthorityState
-      ? await readProjectedLocalRegisterModel({
-          store,
-          storeId: input.storeId,
-          terminalId: input.terminalId,
-          isOnline:
-            typeof navigator === "undefined" ? true : navigator.onLine,
-        })
-      : ({ ok: true, value: null } as const);
-  const activeLocalRegisterSessionId =
-    localRegisterModel.ok
-      ? localRegisterModel.value?.activeRegisterSession?.localRegisterSessionId
-      : undefined;
-  let drawerAuthority =
-    activeLocalRegisterSessionId && readDrawerAuthorityState
-      ? await readLatestRuntimeDrawerAuthorityState({
-          localRegisterSessionId: activeLocalRegisterSessionId,
-          readDrawerAuthorityState,
-          storeId: input.storeId,
-          terminalIds: scope.terminalIds,
-        })
-      : ({ ok: true, value: null } as const);
-  if (drawerAuthority.ok && drawerAuthority.value && localRegisterModel.ok) {
-    const clearResult = await clearSettledRecoverableDrawerAuthorityBlock({
-      drawerAuthority: drawerAuthority.value,
-      events: localRegisterModel.value?.sourceEvents ?? [],
-      store: input.store,
-    });
-    if (clearResult.ok && clearResult.value) {
-      drawerAuthority = { ok: true, value: null };
-    }
-  }
-
-  return {
-    activeRegisterSession:
-      localRegisterModel.ok && localRegisterModel.value?.activeRegisterSession
-        ? toRuntimeActiveRegisterSession(
-            localRegisterModel.value.activeRegisterSession,
-          )
-        : null,
-    appShell,
-    drawerAuthority: drawerAuthority.ok ? drawerAuthority.value : null,
-    snapshots: {
-      ...(catalog.ok && catalog.value
-        ? { catalogRefreshedAt: catalog.value.refreshedAt }
-        : {}),
-      ...(serviceCatalog.ok && serviceCatalog.value
-        ? { serviceCatalogRefreshedAt: serviceCatalog.value.refreshedAt }
-        : {}),
-      ...(availability.ok && availability.value
-        ? { availabilityRefreshedAt: availability.value.refreshedAt }
-        : {}),
-    },
-    staffAuthorityStatus: staffAuthority.ok ? staffAuthority.value : "unknown",
-    terminalIntegrity: terminalIntegrity.ok ? terminalIntegrity.value : null,
-    terminalSeed: input.terminalSeed,
-  };
-}
-
-function toRuntimeActiveRegisterSession(
-  session: PosLocalCashDrawerReadModel,
-): PosTerminalRuntimeActiveRegisterSessionInput {
-  return {
-    ...(session.cloudRegisterSessionId
-      ? { cloudRegisterSessionId: session.cloudRegisterSessionId }
-      : {}),
-    localRegisterSessionId: session.localRegisterSessionId,
-    openedAt: session.openedAt,
-    ...(session.registerNumber ? { registerNumber: session.registerNumber } : {}),
-    status: session.status,
-  };
-}
-
 async function clearAcceptedTerminalIntegrityState(input: {
   checkInTerminalId: string;
   store: PosLocalRuntimeStore;
@@ -1576,481 +1428,6 @@ function toTerminalRecoveryCommandAckResult(
   return "failed" as const;
 }
 
-async function persistDrawerAuthorityBlockForReviewEvents(input: {
-  events: PosLocalEventRecord[];
-  reason: NonNullable<PosDrawerAuthorityState["reason"]>;
-  reviewEventIds: string[];
-  store: PosLocalRuntimeStore;
-}) {
-  const writeDrawerAuthorityState = (
-    input.store as {
-      writeDrawerAuthorityState?: PosLocalRuntimeStore["writeDrawerAuthorityState"];
-    }
-  ).writeDrawerAuthorityState;
-  if (
-    input.reviewEventIds.length === 0 ||
-    !writeDrawerAuthorityState
-  ) {
-    return;
-  }
-
-  const reviewEventIds = new Set(input.reviewEventIds);
-  const event = input.events.find(
-    (candidate) =>
-      reviewEventIds.has(candidate.localEventId) &&
-      isDrawerAuthorityLifecycleEvent(candidate) &&
-      candidate.localRegisterSessionId,
-  );
-  if (!event?.localRegisterSessionId) return;
-
-  const mappings = await input.store.listLocalCloudMappings?.();
-  if (mappings && !mappings.ok) return;
-  const cloudRegisterSessionId = mappings?.value.find(
-    (mapping) =>
-      mapping.entity === "registerSession" &&
-      mapping.localId === event.localRegisterSessionId,
-  )?.cloudId;
-
-  const result = await writeDrawerAuthorityState({
-    ...(cloudRegisterSessionId ? { cloudRegisterSessionId } : {}),
-    localRegisterSessionId: event.localRegisterSessionId,
-    message:
-      "Cloud sync needs review before this local drawer can continue.",
-    observedAt: Date.now(),
-    reason: input.reason,
-    registerNumber: event.registerNumber,
-    status: "blocked",
-    storeId: event.storeId,
-    terminalId: event.terminalId,
-  });
-  assertPosLocalStoreOk(result);
-}
-
-async function clearRecoverableDrawerAuthorityForSyncedEvents(input: {
-  events: PosLocalEventRecord[];
-  reviewEventIds: string[];
-  store: PosLocalRuntimeStore;
-  syncedEventIds: string[];
-}) {
-  const clearDrawerAuthorityState = (
-    input.store as {
-      clearDrawerAuthorityState?: PosLocalRuntimeStore["clearDrawerAuthorityState"];
-    }
-  ).clearDrawerAuthorityState;
-  const readDrawerAuthorityState = (
-    input.store as {
-      readDrawerAuthorityState?: PosLocalRuntimeStore["readDrawerAuthorityState"];
-    }
-  ).readDrawerAuthorityState;
-  if (
-    !clearDrawerAuthorityState ||
-    !readDrawerAuthorityState ||
-    input.syncedEventIds.length === 0
-  ) {
-    return;
-  }
-
-  const syncedEventIds = new Set(input.syncedEventIds);
-  const reviewEventIds = new Set(input.reviewEventIds);
-  const remainingReviewDrawers = new Set(
-    input.events
-      .filter(
-        (event) =>
-          ((event.sync.status === "needs_review" && event.sync.uploaded) ||
-            reviewEventIds.has(event.localEventId)) &&
-          !syncedEventIds.has(event.localEventId) &&
-          event.localRegisterSessionId &&
-          isDrawerAuthorityLifecycleEvent(event),
-      )
-      .map((event) =>
-        drawerAuthorityEventKey({
-          localRegisterSessionId: event.localRegisterSessionId!,
-          storeId: event.storeId,
-          terminalId: event.terminalId,
-        }),
-      ),
-  );
-  const cleared = new Set<string>();
-  for (const event of input.events) {
-    if (
-      !syncedEventIds.has(event.localEventId) ||
-      !event.localRegisterSessionId ||
-      !isDrawerAuthorityLifecycleEvent(event)
-    ) {
-      continue;
-    }
-
-    const key = drawerAuthorityEventKey({
-      localRegisterSessionId: event.localRegisterSessionId,
-      storeId: event.storeId,
-      terminalId: event.terminalId,
-    });
-    if (remainingReviewDrawers.has(key)) continue;
-    if (cleared.has(key)) continue;
-    cleared.add(key);
-
-    const drawerAuthority = await readDrawerAuthorityState({
-      localRegisterSessionId: event.localRegisterSessionId,
-      storeId: event.storeId,
-      terminalId: event.terminalId,
-    });
-    assertPosLocalStoreOk(drawerAuthority);
-    if (!isRecoverableDrawerAuthorityReason(drawerAuthority.value?.reason)) {
-      continue;
-    }
-
-    const result: PosLocalStoreResult<null> = await clearDrawerAuthorityState({
-      localRegisterSessionId: event.localRegisterSessionId,
-      storeId: event.storeId,
-      terminalId: event.terminalId,
-    });
-    assertPosLocalStoreOk(result);
-  }
-}
-
-function isRecoverableDrawerAuthorityReason(
-  reason: PosDrawerAuthorityState["reason"] | undefined,
-) {
-  return reason === "lifecycle_rejected" || reason === "authority_unknown";
-}
-
-async function clearSupersededRecoverableDrawerAuthorityBlocks(input: {
-  acceptedEvents: Array<{
-    localEventId: string;
-    status: string;
-  }>;
-  events: PosLocalEventRecord[];
-  returnedMappings: Array<{
-    cloudId: string;
-    localId: string;
-    localIdKind: string;
-  }>;
-  store: PosLocalRuntimeStore;
-}) {
-  const clearDrawerAuthorityState:
-    | PosLocalRuntimeStore["clearDrawerAuthorityState"]
-    | undefined = (
-    input.store as {
-      clearDrawerAuthorityState?: PosLocalRuntimeStore["clearDrawerAuthorityState"];
-    }
-  ).clearDrawerAuthorityState;
-  const readDrawerAuthorityState:
-    | PosLocalRuntimeStore["readDrawerAuthorityState"]
-    | undefined = (
-    input.store as {
-      readDrawerAuthorityState?: PosLocalRuntimeStore["readDrawerAuthorityState"];
-    }
-  ).readDrawerAuthorityState;
-  const listLocalCloudMappings:
-    | PosLocalRuntimeStore["listLocalCloudMappings"]
-    | undefined = (
-    input.store as {
-      listLocalCloudMappings?: PosLocalRuntimeStore["listLocalCloudMappings"];
-    }
-  ).listLocalCloudMappings;
-  if (
-    !clearDrawerAuthorityState ||
-    !readDrawerAuthorityState ||
-    !listLocalCloudMappings
-  ) {
-    return;
-  }
-
-  const acceptedProjectedEventIds = new Set(
-    input.acceptedEvents
-      .filter((event) => event.status === "projected")
-      .map((event) => event.localEventId),
-  );
-  const replacementDrawerOpenings = input.returnedMappings
-    .filter((mapping) => mapping.localIdKind === "registerSession")
-    .map((mapping) => {
-      const event = input.events.find(
-        (candidate) =>
-          candidate.type === "register.opened" &&
-          candidate.localRegisterSessionId === mapping.localId &&
-          acceptedProjectedEventIds.has(candidate.localEventId),
-      );
-      return event
-        ? {
-            cloudRegisterSessionId: mapping.cloudId,
-            event,
-          }
-        : null;
-    })
-    .filter((entry): entry is {
-      cloudRegisterSessionId: string;
-      event: PosLocalEventRecord;
-    } => Boolean(entry));
-  if (replacementDrawerOpenings.length === 0) {
-    return;
-  }
-
-  const mappings = await listLocalCloudMappings();
-  assertPosLocalStoreOk(mappings);
-
-  for (const replacement of replacementDrawerOpenings) {
-    const supersededRegisterSessionIds = mappings.value
-      .filter(
-        (mapping) =>
-          mapping.entity === "registerSession" &&
-          mapping.cloudId === replacement.cloudRegisterSessionId &&
-          mapping.localId !== replacement.event.localRegisterSessionId,
-      )
-      .map((mapping) => mapping.localId);
-    const uniqueSupersededRegisterSessionIds = [
-      ...new Set(supersededRegisterSessionIds),
-    ];
-
-    for (const localRegisterSessionId of uniqueSupersededRegisterSessionIds) {
-      const terminalIds = [
-        ...new Set(
-          input.events
-            .filter(
-              (event) =>
-                event.storeId === replacement.event.storeId &&
-                event.localRegisterSessionId === localRegisterSessionId,
-            )
-            .map((event) => event.terminalId),
-        ),
-      ];
-      for (const terminalId of terminalIds) {
-        const drawerAuthority: PosLocalStoreResult<PosDrawerAuthorityState | null> =
-          await readDrawerAuthorityState({
-          localRegisterSessionId,
-          storeId: replacement.event.storeId,
-          terminalId,
-        });
-        assertPosLocalStoreOk(drawerAuthority);
-        if (
-          drawerAuthority.value?.status !== "blocked" ||
-          !isRecoverableDrawerAuthorityReason(drawerAuthority.value.reason) ||
-          drawerAuthority.value.observedAt > replacement.event.createdAt ||
-          (drawerAuthority.value.cloudRegisterSessionId &&
-            drawerAuthority.value.cloudRegisterSessionId !==
-              replacement.cloudRegisterSessionId)
-        ) {
-          continue;
-        }
-
-        const result: PosLocalStoreResult<null> = await clearDrawerAuthorityState({
-          localRegisterSessionId,
-          storeId: replacement.event.storeId,
-          terminalId,
-        });
-        assertPosLocalStoreOk(result);
-      }
-    }
-  }
-}
-
-async function clearSettledRecoverableDrawerAuthorityBlock(input: {
-  drawerAuthority: PosDrawerAuthorityState;
-  events: PosLocalEventRecord[];
-  store: PosLocalRuntimeStore;
-}): Promise<PosLocalStoreResult<boolean>> {
-  const clearDrawerAuthorityState = (
-    input.store as {
-      clearDrawerAuthorityState?: PosLocalRuntimeStore["clearDrawerAuthorityState"];
-    }
-  ).clearDrawerAuthorityState;
-  if (
-    !clearDrawerAuthorityState ||
-    input.drawerAuthority.status !== "blocked" ||
-    !isRecoverableDrawerAuthorityReason(input.drawerAuthority.reason)
-  ) {
-    return { ok: true, value: false };
-  }
-
-  const drawerLifecycleEvents = input.events.filter(
-    (event) =>
-      event.localRegisterSessionId ===
-        input.drawerAuthority.localRegisterSessionId &&
-      event.storeId === input.drawerAuthority.storeId &&
-      event.terminalId === input.drawerAuthority.terminalId &&
-      isDrawerAuthorityLifecycleEvent(event),
-  );
-  if (drawerLifecycleEvents.length === 0) {
-    return { ok: true, value: false };
-  }
-
-  const hasUnsettledLifecycleEvent = drawerLifecycleEvents.some(
-    (event) => event.sync.status !== "synced",
-  );
-  if (hasUnsettledLifecycleEvent) {
-    return { ok: true, value: false };
-  }
-
-  const hasRemainingLifecycleReview = drawerLifecycleEvents.some(
-    (event) =>
-      event.sync.status === "needs_review" &&
-      event.sync.uploaded,
-  );
-  if (hasRemainingLifecycleReview) {
-    return { ok: true, value: false };
-  }
-
-  const result = await clearDrawerAuthorityState({
-    localRegisterSessionId: input.drawerAuthority.localRegisterSessionId,
-    storeId: input.drawerAuthority.storeId,
-    terminalId: input.drawerAuthority.terminalId,
-  });
-  if (!result.ok) return result;
-
-  return { ok: true, value: true };
-}
-
-async function readLatestRuntimeDrawerAuthorityState(input: {
-  localRegisterSessionId: string;
-  readDrawerAuthorityState: NonNullable<
-    PosLocalRuntimeStore["readDrawerAuthorityState"]
-  >;
-  storeId: string;
-  terminalIds: Set<string>;
-}): Promise<PosLocalStoreResult<PosDrawerAuthorityState | null>> {
-  if (input.terminalIds.size === 0) {
-    return { ok: true, value: null };
-  }
-
-  const states: PosDrawerAuthorityState[] = [];
-  for (const terminalId of input.terminalIds) {
-    const result = await input.readDrawerAuthorityState({
-      localRegisterSessionId: input.localRegisterSessionId,
-      storeId: input.storeId,
-      terminalId,
-    });
-    if (!result.ok) return result;
-    if (result.value) states.push(result.value);
-  }
-
-  return {
-    ok: true,
-    value:
-      states.sort((left, right) => right.observedAt - left.observedAt).at(0) ??
-      null,
-  };
-}
-
-function drawerAuthorityEventKey(input: {
-  localRegisterSessionId: string;
-  storeId: string;
-  terminalId: string;
-}) {
-  return `${input.storeId}:${input.terminalId}:${input.localRegisterSessionId}`;
-}
-
-function isDrawerAuthorityLifecycleEvent(event: PosLocalEventRecord) {
-  return (
-    event.type === "register.opened" ||
-    event.type === "register.closeout_started" ||
-    event.type === "register.reopened"
-  );
-}
-
-function getRuntimeBrowserInfo(isOnline: boolean) {
-  const navigatorRef = globalThis.navigator;
-  return {
-    language: navigatorRef?.language,
-    online: isOnline,
-    platform: navigatorRef?.platform,
-    userAgent: navigatorRef?.userAgent,
-  };
-}
-
-export function getRuntimeStatusSignature(input: {
-  runtimeStatus: PosTerminalRuntimeStatusPayload;
-  storeId: string;
-  terminalId: string;
-}) {
-  return JSON.stringify({
-    runtimeStatus: input.runtimeStatus,
-    storeId: input.storeId,
-    terminalId: input.terminalId,
-  });
-}
-
-export function getRuntimeStatusPublishSignature(input: {
-  observationToken: number;
-  runtimeStatus: PosTerminalRuntimeStatusPayload;
-  storeId: string;
-  terminalId: string;
-}) {
-  const stableStatus: Partial<PosTerminalRuntimeStatusPayload> = {
-    ...input.runtimeStatus,
-  };
-  delete stableStatus.reportedAt;
-  delete stableStatus.snapshots;
-
-  return JSON.stringify({
-    observationToken: input.observationToken,
-    runtimeStatus: stableStatus,
-    storeId: input.storeId,
-    terminalId: input.terminalId,
-  });
-}
-
-function startStatusOnlyRuntimeTriggers(refresh: () => void) {
-  const win = globalThis.window;
-  const doc = globalThis.document;
-  const interval = setInterval(refresh, 30_000);
-
-  const handleOnlineStateChange = () => refresh();
-  const handleVisibility = () => {
-    if (!doc || doc.visibilityState === "hidden") return;
-    refresh();
-  };
-
-  win?.addEventListener?.("online", handleOnlineStateChange);
-  win?.addEventListener?.("offline", handleOnlineStateChange);
-  doc?.addEventListener?.("visibilitychange", handleVisibility);
-
-  return () => {
-    clearInterval(interval);
-    win?.removeEventListener?.("online", handleOnlineStateChange);
-    win?.removeEventListener?.("offline", handleOnlineStateChange);
-    doc?.removeEventListener?.("visibilitychange", handleVisibility);
-  };
-}
-
-function getRuntimeCheckInNotReadyReason(input: {
-  storeId?: string | null;
-  syncSecretHash?: string | null;
-  terminalId?: string | null;
-}): PosLocalRuntimeSyncDebug["checkInPublishReason"] | null {
-  if (!input.storeId) return "missing_store";
-  if (!input.terminalId) return "missing_terminal";
-  if (!input.syncSecretHash) return "missing_sync_secret";
-  return null;
-}
-
-function withCheckInPublishDebug(
-  current: PosLocalRuntimeSyncDebug,
-  patch: Pick<
-    PosLocalRuntimeSyncDebug,
-    | "checkInPublishAttemptedAt"
-    | "checkInPublishCompletedAt"
-    | "checkInPublishMessage"
-    | "checkInPublishReason"
-    | "checkInPublishStatus"
-  >,
-) {
-  const next = {
-    ...current,
-    ...patch,
-  };
-
-  if (
-    current.checkInPublishAttemptedAt === next.checkInPublishAttemptedAt &&
-    current.checkInPublishCompletedAt === next.checkInPublishCompletedAt &&
-    current.checkInPublishMessage === next.checkInPublishMessage &&
-    current.checkInPublishReason === next.checkInPublishReason &&
-    current.checkInPublishStatus === next.checkInPublishStatus
-  ) {
-    return current;
-  }
-
-  return next;
-}
-
 function toIngestLocalEventsArgs(input: {
   events: PosLocalUploadEvent[];
   storeId: string;
@@ -2113,54 +1490,6 @@ async function readScopedPosLocalUploadEvents(input: {
   };
 }
 
-function buildRuntimeSyncDebug(
-  events: PosLocalEventRecord[],
-  mode: PosLocalSyncRuntimeMode,
-  uploadSupport: PosLocalSyncUploadSupport = {},
-): PosLocalRuntimeSyncDebug {
-  const pendingUploadCandidates = events.filter(isPendingUploadCandidate);
-  const pendingUploadableEvents = pendingUploadCandidates.filter(
-    (event) => isSyncablePosLocalEvent(event, uploadSupport),
-  );
-  const deferredUploadEvents = pendingUploadCandidates.filter((event) =>
-    isUploadDeferredByValidation(event, uploadSupport),
-  );
-  const nextPendingUploadableEvent = [...pendingUploadableEvents]
-    .sort(compareUploadableEventOrder)
-    .at(0);
-  const localOnlyEvents = pendingUploadCandidates.filter(
-    (event) => !isSyncablePosLocalEvent(event, uploadSupport),
-  );
-  const reviewEvents = events.filter(
-    (event) => event.sync.status === "needs_review",
-  );
-  const failedEvents = events.filter((event) => event.sync.status === "failed");
-  const oldestPendingEvent = [...events]
-    .filter((event) => event.sync.status !== "synced")
-    .sort((left, right) => left.createdAt - right.createdAt)
-    .at(0);
-
-  return {
-    appSessionUnverifiedEventCount: events.filter((event) =>
-      event.validationMetadata?.flags.includes("app-session-unverified"),
-    ).length,
-    cloudValidationUncertainEventCount: events.filter((event) =>
-      event.validationMetadata?.flags.includes("cloud-validation-uncertain"),
-    ).length,
-    deferredUploadEventCount: deferredUploadEvents.length,
-    failedEventCount: failedEvents.length,
-    localOnlyEventCount: localOnlyEvents.length,
-    mode,
-    oldestPendingEventAt: oldestPendingEvent?.createdAt,
-    oldestPendingEventId: oldestPendingEvent?.localEventId,
-    oldestPendingEventSequence: oldestPendingEvent?.sequence,
-    oldestPendingUploadSequence: oldestPendingEvent?.uploadSequence,
-    nextPendingUploadSequence: nextPendingUploadableEvent?.uploadSequence,
-    pendingUploadEventCount: pendingUploadableEvents.length,
-    reviewEventCount: reviewEvents.length,
-  };
-}
-
 function getAppSessionUploadSupport(
   recovery?: PosTerminalRuntimeAppSessionRecoveryInput | null,
 ): PosLocalSyncUploadSupport {
@@ -2174,28 +1503,6 @@ function getAppSessionUploadSupport(
         ? "supported"
         : "unverified",
   };
-}
-
-function compareUploadableEventOrder(
-  left: PosLocalEventRecord,
-  right: PosLocalEventRecord,
-) {
-  const leftUploadSequence = left.uploadSequence ?? Number.POSITIVE_INFINITY;
-  const rightUploadSequence = right.uploadSequence ?? Number.POSITIVE_INFINITY;
-  if (leftUploadSequence !== rightUploadSequence) {
-    return leftUploadSequence - rightUploadSequence;
-  }
-
-  return left.sequence - right.sequence;
-}
-
-function isPendingUploadCandidate(event: PosLocalEventRecord) {
-  return (
-    event.sync.status === "pending" ||
-    event.sync.status === "syncing" ||
-    event.sync.status === "failed" ||
-    (event.sync.status === "needs_review" && event.sync.uploaded)
-  );
 }
 
 export function collectServerSyncedLocalEventIds(


### PR DESCRIPTION
## Summary
- Decouples the local POS runtime into readiness, sync drain, drawer authority reconciliation, status publishing, and staff authority refresh helpers.
- Moves POS terminal runtime-status side effects behind a server-side helper while preserving cashier-continuity semantics.
- Makes Terminal Health prefer structured recovery previews while preserving legacy blocker fallback for unstructured snapshots.
- Adds the delivery plan, solution note, tests, and regenerated graph/harness artifacts.

## Linear
- V26-744 Decouple POS runtime readiness, sync drain, and status publisher
- V26-745 Extract POS recovery command runtime and staff authority classifier
- V26-746 Isolate POS runtime-status server side effects
- V26-747 Make Terminal Health preview-first with roster/detail parity
- V26-748 Integrate POS runtime decoupling batch and validate delivery

## Validation
- bun run pr:athena
- Focused POS runtime, staff authority, server terminal, and Terminal Health test slices during implementation
- Reviewer loop: correctness, data integrity, testing, and maintainability all approved after fixes