### PR TITLE
[V26-756]: Improve POS continuity and dark action tokens

### DIFF
--- a/docs/solutions/logic-errors/athena-pos-synced-closeout-readiness-2026-06-17.md
+++ b/docs/solutions/logic-errors/athena-pos-synced-closeout-readiness-2026-06-17.md
@@ -1,0 +1,79 @@
+---
+title: Athena POS Synced Closeouts Should Not Keep Local Sales Blocked
+date: 2026-06-17
+category: logic-errors
+module: athena-webapp
+problem_type: pos_synced_closeout_stale_local_block
+component: pos-local-readiness
+symptoms:
+  - "A register can stay blocked by local closeout state after the closeout has synced"
+  - "Opening the next drawer can be rejected by a stale drawer_closed sale block"
+  - "Cashiers can be prevented from starting the next sale even though the prior drawer is settled"
+root_cause: local_readiness_treated_all_closed_locally_closeouts_as_active_blocks_without_checking_sync_settlement
+resolution_type: synced_closeout_settlement_releases_local_drawer_block
+severity: high
+tags:
+  - pos
+  - local-first
+  - drawer-lifecycle
+  - sync
+  - cashier-continuity
+---
+
+# Athena POS Synced Closeouts Should Not Keep Local Sales Blocked
+
+## Problem
+
+Local-first POS must block sales while a drawer closeout is still only local.
+That protects cash-control lifecycle integrity. The same block becomes stale
+after the closeout event has synced successfully, because the prior drawer is no
+longer an unresolved local-only fact.
+
+If readiness only checks `closeoutState.status === "closed_locally"`, the POS
+entry gate can keep reporting a local closeout blocker after cloud settlement.
+If the command gateway also treats every `drawer_closed` sale block as hard, the
+next drawer open can be rejected even though the previous closeout was already
+accepted.
+
+## Solution
+
+Distinguish active local closeouts from settled closeouts:
+
+- Keep blocking when the latest `register.closeout_started` event for the active
+  local register session is not synced.
+- Release the local readiness block when that latest closeout event has
+  `sync.status === "synced"`.
+- Let `openDrawer` proceed past a `drawer_closed` sale block only when that
+  block is backed by a synced closeout for the same local register session.
+- Keep other sale blocks intact, including unresolved drawer authority blocks
+  and unsynced local closeouts.
+
+This keeps the cashier-continuity rule precise: unresolved local closeout work
+still blocks new sales, but settled drawer history does not keep the next drawer
+from starting.
+
+## Regression Targets
+
+- Local readiness tests should prove unsynced `closed_locally` closeouts still
+  return `local_closeout`.
+- Local readiness tests should prove a synced closeout returns `ready` when the
+  store day is otherwise started.
+- Local command-gateway tests should prove `openDrawer` succeeds after the prior
+  closeout event has synced.
+- Command-gateway tests should continue proving unrelated sale blockers reject
+  sale-affecting appends and drawer reuse.
+
+## Prevention
+
+- Do not treat all projected closeout state as current authority. Check the
+  underlying event sync state before deciding whether it still blocks cashiers.
+- Keep the settlement check scoped to the same local register session. A synced
+  closeout for another drawer must not release this drawer's block.
+- Do not clear history to unblock POS. Preserve closeout evidence and interpret
+  it correctly.
+
+## Related
+
+- [Athena POS Stale Terminal Sale Blocks](./athena-pos-stale-terminal-sale-block-2026-05-29.md)
+- [Athena POS Drawer Authority Replacement Recovery](./athena-pos-drawer-authority-replacement-recovery-2026-06-06.md)
+- [Athena POS Local First Register](../architecture/athena-pos-always-local-first-register-2026-05-14.md)

--- a/docs/solutions/logic-errors/athena-webapp-strong-neutral-action-tokens-2026-06-17.md
+++ b/docs/solutions/logic-errors/athena-webapp-strong-neutral-action-tokens-2026-06-17.md
@@ -1,0 +1,73 @@
+---
+title: Athena Strong Neutral Actions Need Dedicated Theme Tokens
+date: 2026-06-17
+category: logic-errors
+module: athena-webapp
+problem_type: dark_mode_strong_neutral_action_contrast
+component: athena-webapp-theme
+symptoms:
+  - "A high-emphasis neutral button can render as a pale filled control in dark mode"
+  - "Hard-coded text-white on foreground-filled buttons breaks once foreground becomes light"
+  - "Receipt and internal evidence actions drift from the design system in dark mode"
+root_cause: strong_neutral_actions_reused_foreground_as_a_fill_color_instead_of_theme_specific_action_tokens
+resolution_type: semantic_strong_neutral_action_token_pair
+severity: medium
+tags:
+  - athena-webapp
+  - frontend
+  - design-system
+  - dark-mode
+  - accessibility
+---
+
+# Athena Strong Neutral Actions Need Dedicated Theme Tokens
+
+## Problem
+
+Some high-emphasis neutral commands, such as receipt printing, were styled by
+filling the button with `--foreground` and forcing `text-white`. That reads as a
+dark, neutral command in light mode, but it fails in dark mode because
+`--foreground` becomes light. The result is a light filled button with white text
+or weak contrast.
+
+Using `--foreground` as a background also hides intent. Foreground is a text
+role, not an action-fill role, so components end up duplicating hover, border,
+shadow, and foreground choices instead of using a reusable command treatment.
+
+## Solution
+
+Create an explicit strong-neutral action token family:
+
+- `--action-neutral-strong`
+- `--action-neutral-strong-foreground`
+- `--action-neutral-strong-border`
+
+Map those through Tailwind under `action.neutral-strong`, then expose them via a
+shared button variant such as `utility-strong`. Components keep their local size
+and radius while the theme owns the fill, text, border, shadow, and dark-mode
+contrast.
+
+This preserves the intended hierarchy in both themes: strong neutral commands
+remain visibly actionable without pretending to be commit, workflow, success, or
+danger actions.
+
+## Regression Targets
+
+- Button primitive tests should assert the strong-neutral variant uses
+  `bg-action-neutral-strong` and `text-action-neutral-strong-foreground`.
+- Foundation/design-system tests should assert the token family exists in
+  `src/index.css`.
+- Search for `bg-[hsl(var(--foreground))]` plus hard-coded white text when
+  touching dark-mode action surfaces.
+
+## Prevention
+
+- Do not use text tokens as filled-button background tokens.
+- Do not hard-code `text-white` for semantic app actions unless the theme token
+  itself is white by design.
+- Add a token-backed variant when a command treatment repeats across POS,
+  expenses, or operations evidence surfaces.
+
+## Related
+
+- [Athena Dark Mode Should Resolve Through Tokens Before Legacy Utility Colors](./athena-webapp-dark-mode-token-compatibility-2026-06-13.md)

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6902 nodes · 7726 edges · 1879 communities detected
+- 6904 nodes · 7729 edges · 1879 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -2361,44 +2361,44 @@ Cohesion: 0.21
 Nodes (5): formatDeposit(), formatMoney(), handleCancelEdit(), handleSaveEdit(), summarizeService()
 
 ### Community 111 - "Community 111"
+Cohesion: 0.24
+Nodes (6): blocked(), evaluateLocalPosReadiness(), hasSettledLocalCloseout(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
+
+### Community 112 - "Community 112"
 Cohesion: 0.29
 Nodes (8): isFiniteNumber(), isPointInsideViewport(), isPositiveFiniteNumber(), isRecord(), isValidViewport(), validateKeyEvent(), validatePointerEvent(), validateRemoteAssistControlEvent()
 
-### Community 112 - "Community 112"
+### Community 113 - "Community 113"
 Cohesion: 0.18
 Nodes (2): formatBlockerList(), runPrePushReview()
 
-### Community 113 - "Community 113"
+### Community 114 - "Community 114"
 Cohesion: 0.29
 Nodes (7): formatDeliveryAddress(), getAmountPaidForOrder(), getDiscountValue(), getOrderAmount(), getOrderState(), getPickupActionState(), getPotentialPoints()
 
-### Community 114 - "Community 114"
+### Community 115 - "Community 115"
 Cohesion: 0.36
 Nodes (10): buildApprovalDecisionRequirement(), buildApprovalDecisionSubject(), consumeApprovalDecisionProofWithCtx(), decideApprovalRequestAsAuthenticatedUserWithCtx(), decideApprovalRequestAsCommandWithCtx(), decideApprovalRequestWithCtx(), mapDecideApprovalRequestError(), omitUndefined() (+2 more)
 
-### Community 115 - "Community 115"
+### Community 116 - "Community 116"
 Cohesion: 0.36
 Nodes (10): buildQuickAddEventMessage(), findExistingSku(), findOrCreateQuickAddCategory(), findOrCreateQuickAddSubcategory(), generateSKU(), getActorLabel(), isBarcodeLike(), mapSkuToCatalogResult() (+2 more)
 
-### Community 116 - "Community 116"
+### Community 117 - "Community 117"
 Cohesion: 0.22
 Nodes (4): buildCtx(), buildManagerProof(), buildRegisterOpenedEvent(), createFakeConvexCtx()
 
-### Community 117 - "Community 117"
+### Community 118 - "Community 118"
 Cohesion: 0.33
 Nodes (2): OrdersTableToolbarProvider(), useOrdersTableToolbar()
 
-### Community 118 - "Community 118"
+### Community 119 - "Community 119"
 Cohesion: 0.24
 Nodes (5): formatBackendLabel(), formatInventoryNumber(), formatQuantity(), getActivityTitle(), pluralize()
 
-### Community 119 - "Community 119"
+### Community 120 - "Community 120"
 Cohesion: 0.31
 Nodes (7): buildCustomerCreateInput(), cancelPendingAdd(), commitCustomer(), handleAddFromSearch(), handleClearCustomer(), handleSelectCustomer(), toCustomerInfo()
-
-### Community 120 - "Community 120"
-Cohesion: 0.25
-Nodes (5): blocked(), evaluateLocalPosReadiness(), localReadinessMatchesInput(), localReadinessRecordFromSnapshots(), refreshLocalPosReadinessFromSnapshots()
 
 ### Community 121 - "Community 121"
 Cohesion: 0.2
@@ -2521,104 +2521,104 @@ Cohesion: 0.36
 Nodes (7): assertValidPosCartLine(), calculatePosCartLineSubtotal(), calculatePosCartTotals(), calculatePosItemTotal(), getPosEffectivePrice(), isPosServiceCartLine(), roundPosAmount()
 
 ### Community 151 - "Community 151"
+Cohesion: 0.22
+Nodes (0):
+
+### Community 152 - "Community 152"
 Cohesion: 0.42
 Nodes (8): applyAcceptedControlResult(), applyKeyEvent(), applyPointerEvent(), applyRemoteAssistControlIntent(), getRecentControlResult(), getRemoteAssistControlTarget(), prepareRemoteAssistControlIntent(), rememberControlResult()
 
-### Community 152 - "Community 152"
+### Community 153 - "Community 153"
 Cohesion: 0.36
 Nodes (7): buildPosOfflineReadinessSummary(), buildSignal(), formatAge(), getSignalDescription(), getSignalStatus(), getSummaryDescription(), getSummaryTitle()
 
-### Community 153 - "Community 153"
+### Community 154 - "Community 154"
 Cohesion: 0.22
 Nodes (0):
 
-### Community 154 - "Community 154"
+### Community 155 - "Community 155"
 Cohesion: 0.22
 Nodes (2): ClusterRedis, StandaloneRedis
 
-### Community 155 - "Community 155"
+### Community 156 - "Community 156"
 Cohesion: 0.42
 Nodes (8): assertCoverageToolchainParity(), checkCoverageToolchainParity(), collectCoverageToolchainFailures(), declaredVersion(), formatFailureMessage(), installedVersion(), readManifest(), runFrozenInstall()
 
-### Community 156 - "Community 156"
+### Community 157 - "Community 157"
 Cohesion: 0.46
 Nodes (7): deleteDirectoryInR2(), deleteFileInR2(), getR2(), listItemsInR2Directory(), readEnvValue(), resolveR2ConfigFromEnv(), uploadFileToR2()
 
-### Community 157 - "Community 157"
+### Community 158 - "Community 158"
 Cohesion: 0.25
 Nodes (0):
 
-### Community 158 - "Community 158"
+### Community 159 - "Community 159"
 Cohesion: 0.5
 Nodes (6): findAthenaUserByEmailWithCtx(), getAuthenticatedAthenaUserWithCtx(), getAuthenticatedUserRecord(), normalizeEmail(), requireAuthenticatedAthenaUserWithCtx(), syncAuthenticatedAthenaUserWithCtx()
 
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.43
 Nodes (6): buildMtnCollectionsLookupPrefixes(), isTargetEnvironment(), readScopedValue(), resolveConfigForPrefix(), resolveMtnCollectionsConfigFromEnv(), toEnvSegment()
 
-### Community 160 - "Community 160"
+### Community 161 - "Community 161"
 Cohesion: 0.46
 Nodes (7): recordApprovalAuditEventWithCtx(), recordApprovalDecisionRecordedAuditEventWithCtx(), recordApprovalProofConsumedAuditEventWithCtx(), recordApprovalRequiredAuditEventWithCtx(), recordApprovedCommandAppliedAuditEventWithCtx(), recordAsyncApprovalRequestCreatedAuditEventWithCtx(), recordManagerApprovalGrantedAuditEventWithCtx()
 
-### Community 161 - "Community 161"
+### Community 162 - "Community 162"
 Cohesion: 0.36
 Nodes (5): buildPaymentAllocation(), correctSameAmountSinglePaymentAllocationWithCtx(), findSameAmountSinglePaymentAllocation(), listPaymentAllocationsForTargetWithCtx(), recordPaymentAllocationWithCtx()
 
-### Community 162 - "Community 162"
+### Community 163 - "Community 163"
 Cohesion: 0.43
 Nodes (6): buildPosSessionTraceEvent(), buildPosSessionTraceRecord(), buildTraceSummary(), formatPaymentMethod(), recordPosSessionTraceBestEffort(), safeTraceWrite()
-
-### Community 163 - "Community 163"
-Cohesion: 0.25
-Nodes (0):
 
 ### Community 164 - "Community 164"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 165 - "Community 165"
+Cohesion: 0.25
+Nodes (0):
+
+### Community 166 - "Community 166"
 Cohesion: 0.36
 Nodes (3): buildGrant(), isAlreadyExistsError(), LiveKitRemoteAssistTransportProvider
 
-### Community 166 - "Community 166"
+### Community 167 - "Community 167"
 Cohesion: 0.39
 Nodes (6): buildOfferProductEmailItem(), createOffer(), formatOfferProductPrice(), getDiscountedOfferProductPrice(), isDuplicate(), updateStoreFrontActorEmail()
 
-### Community 167 - "Community 167"
+### Community 168 - "Community 168"
 Cohesion: 0.25
 Nodes (1): DataTableRowActions()
 
-### Community 168 - "Community 168"
+### Community 169 - "Community 169"
 Cohesion: 0.32
 Nodes (3): handleCreateCustomer(), handleSaveEdit(), showCommandError()
 
-### Community 169 - "Community 169"
+### Community 170 - "Community 170"
 Cohesion: 0.25
 Nodes (1): ResizeObserverStub
 
-### Community 170 - "Community 170"
+### Community 171 - "Community 171"
 Cohesion: 0.25
 Nodes (0):
-
-### Community 171 - "Community 171"
-Cohesion: 0.29
-Nodes (2): handleKeyDown(), isDebugShortcut()
 
 ### Community 172 - "Community 172"
-Cohesion: 0.25
-Nodes (0):
+Cohesion: 0.29
+Nodes (2): handleKeyDown(), isDebugShortcut()
 
 ### Community 173 - "Community 173"
 Cohesion: 0.25
 Nodes (0):
 
 ### Community 174 - "Community 174"
-Cohesion: 0.39
-Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
-
-### Community 175 - "Community 175"
 Cohesion: 0.25
 Nodes (0):
+
+### Community 175 - "Community 175"
+Cohesion: 0.39
+Nodes (4): isMoneyOperation(), parseOperationValue(), useBulkOperations(), validateOperationValue()
 
 ### Community 176 - "Community 176"
 Cohesion: 0.25
@@ -2925,8 +2925,8 @@ Cohesion: 0.53
 Nodes (3): handleUpdateFees(), parseDeliveryFeeInputs(), parseOptionalDeliveryFeeInput()
 
 ### Community 252 - "Community 252"
-Cohesion: 0.47
-Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 253 - "Community 253"
 Cohesion: 0.33
@@ -2945,12 +2945,12 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 257 - "Community 257"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 258 - "Community 258"
 Cohesion: 0.53
 Nodes (4): calculatePosChange(), calculatePosRemainingDue(), calculatePosTotalPaid(), roundPosAmount()
+
+### Community 258 - "Community 258"
+Cohesion: 0.33
+Nodes (0):
 
 ### Community 259 - "Community 259"
 Cohesion: 0.33
@@ -2969,52 +2969,52 @@ Cohesion: 0.33
 Nodes (0):
 
 ### Community 263 - "Community 263"
-Cohesion: 0.33
-Nodes (0):
-
-### Community 264 - "Community 264"
 Cohesion: 0.53
 Nodes (4): isBarcodeShapedSearchQuery(), matchesSkuSearchTerms(), normalizeIdentifier(), scoreSkuSearchTerms()
 
-### Community 265 - "Community 265"
+### Community 264 - "Community 264"
 Cohesion: 0.6
 Nodes (5): isExcludedFromPosAppShellCache(), isPosAppShellNavigationRequest(), isPosAppShellRoutePath(), isPosAppShellStaticAssetRequest(), readHeader()
 
-### Community 266 - "Community 266"
+### Community 265 - "Community 265"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 266 - "Community 266"
+Cohesion: 0.4
+Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 267 - "Community 267"
 Cohesion: 0.4
 Nodes (2): onSubmit(), saveStoreChanges()
 
 ### Community 268 - "Community 268"
-Cohesion: 0.4
-Nodes (2): onSubmit(), saveStoreChanges()
-
-### Community 269 - "Community 269"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 270 - "Community 270"
+### Community 269 - "Community 269"
 Cohesion: 0.47
 Nodes (4): fetchPosTransaction(), getBaseUrl(), getPosTransactionByReceiptToken(), PosTransactionReceiptError
 
-### Community 271 - "Community 271"
+### Community 270 - "Community 270"
 Cohesion: 0.47
 Nodes (3): getBaseUrl(), getPromoCodes(), redeemPromoCode()
 
-### Community 272 - "Community 272"
+### Community 271 - "Community 271"
 Cohesion: 0.33
 Nodes (0):
 
-### Community 273 - "Community 273"
+### Community 272 - "Community 272"
 Cohesion: 0.4
 Nodes (2): handleConfirm(), handlePrimaryAction()
 
-### Community 274 - "Community 274"
+### Community 273 - "Community 273"
 Cohesion: 0.33
 Nodes (0):
+
+### Community 274 - "Community 274"
+Cohesion: 0.47
+Nodes (3): onDrop(), removeImage(), unmarkForDeletion()
 
 ### Community 275 - "Community 275"
 Cohesion: 0.53

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1952
-- Graph nodes: 6902
-- Graph edges: 7726
+- Graph nodes: 6904
+- Graph edges: 7729
 - Communities: 1879
 
 ## Graph Hotspots

--- a/graphify-out/wiki/packages/valkey-proxy-server.md
+++ b/graphify-out/wiki/packages/valkey-proxy-server.md
@@ -18,7 +18,7 @@ Landing page for packages/valkey-proxy-server. Use this page to orient around gr
 
 ## Graph Hotspots
 - `app.js` (14 edges, Community 88) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
-- `app.test.js` (6 edges, Community 154) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
+- `app.test.js` (6 edges, Community 155) - [`packages/valkey-proxy-server/app.test.js`](../../../packages/valkey-proxy-server/app.test.js)
 - `createRedisClient()` (4 edges, Community 88) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `createRedisCluster()` (3 edges, Community 88) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)
 - `deleteKeysIndividually()` (3 edges, Community 88) - [`packages/valkey-proxy-server/app.js`](../../../packages/valkey-proxy-server/app.js)

--- a/packages/athena-webapp/docs/agent/design.md
+++ b/packages/athena-webapp/docs/agent/design.md
@@ -28,6 +28,7 @@ Core token map:
 | Raised surface        | `--surface-raised`                   | dialogs, inspectors, important panels  |
 | Shell                 | `--shell` / `--shell-foreground`     | deep navigation and structural framing |
 | Primary action signal | `--signal` / `--signal-foreground`   | one action accent                      |
+| Strong neutral action | `--action-neutral-strong` / `--action-neutral-strong-foreground` | high-emphasis neutral commands |
 | Success               | `--success` / `--success-foreground` | completed or healthy state             |
 | Warning               | `--warning` / `--warning-foreground` | pending risk or degraded state         |
 | Danger                | `--danger` / `--danger-foreground`   | destructive or blocked state           |

--- a/packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx
+++ b/packages/athena-webapp/src/components/expense/ExpenseCompletion.tsx
@@ -112,8 +112,8 @@ export function ExpenseCompletion({
                 type="button"
                 onClick={onPrintReceipt}
                 disabled={!onPrintReceipt}
-                className="h-14 rounded-2xl border-[hsl(var(--foreground))] bg-[hsl(var(--foreground))] px-5 text-sm font-semibold text-white shadow-[hsl(var(--foreground))/0.18] hover:border-[hsl(var(--primary))] hover:bg-[hsl(var(--primary))] hover:text-[hsl(var(--primary-foreground))]"
-                variant="outline"
+                className="h-14 rounded-2xl px-5 text-sm font-semibold"
+                variant="utility-strong"
               >
                 <Printer className="h-4 w-4" />
                 Print receipt

--- a/packages/athena-webapp/src/components/landing/AthenaLandingPage.tsx
+++ b/packages/athena-webapp/src/components/landing/AthenaLandingPage.tsx
@@ -281,7 +281,7 @@ export function AthenaLandingPage() {
       <section className="border-t border-border bg-shell px-layout-lg py-layout-3xl text-shell-foreground md:px-layout-2xl">
         <Reveal className="mx-auto flex max-w-6xl flex-col gap-layout-xl md:flex-row md:items-end md:justify-between">
           <div className="max-w-3xl space-y-layout-md">
-            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-action-workflow-foreground/80">
+            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-action-workflow">
               Athena
             </p>
             <h2 className="font-display text-5xl leading-none md:text-7xl">
@@ -544,7 +544,7 @@ function OwnerPanel() {
       whileHover={{ y: -4 }}
     >
       <div className="space-y-layout-md">
-        <Eye className="h-6 w-6 text-action-workflow-foreground" />
+        <Eye className="h-6 w-6 text-action-workflow" />
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.22em] text-shell-foreground/62">
             Owner visibility
@@ -565,7 +565,7 @@ function OwnerPanel() {
               className="flex items-center justify-between rounded-md border border-shell-foreground/10 bg-shell-foreground/5 px-layout-md py-layout-sm"
             >
               <span>{item}</span>
-              <span className="font-numeric text-sm text-action-workflow-foreground">
+              <span className="font-numeric text-sm text-action-workflow">
                 {index + 12} events
               </span>
             </div>

--- a/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyCloseView.tsx
@@ -547,7 +547,7 @@ function SuccessCheckIcon({
 function getStatusRailBadgeClassName(status: DailyCloseStatus) {
   return cn(
     status === "blocked" && "text-danger",
-    status === "needs_review" && "text-warning-foreground",
+    status === "needs_review" && "text-warning",
     status === "carry_forward" && "text-action-workflow",
     (status === "ready" || status === "completed") && "text-success",
   );
@@ -2773,7 +2773,7 @@ function CompletionRail({
                   className={cn(
                     "shrink-0 text-right font-medium text-foreground",
                     item.valueTone === "danger" && "text-danger",
-                    item.valueTone === "warning" && "text-warning-foreground",
+                    item.valueTone === "warning" && "text-warning",
                     item.valueTone === "workflow" && "text-action-workflow",
                   )}
                 >

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.test.tsx
@@ -702,7 +702,9 @@ describe("DailyOpeningViewContent", () => {
 
     expect(screen.getByText("Store day started")).toBeInTheDocument();
     expect(
-      screen.getByText("Athena started the store day with manager review items."),
+      screen.getByText(
+        "Store day started. Review the carried-forward items when a manager is available.",
+      ),
     ).toBeInTheDocument();
     expect(
       screen.getByText("Register session still needs closeout"),

--- a/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOpeningView.tsx
@@ -686,25 +686,37 @@ function OpeningAutomationReviewPanel({
   if (items.length === 0) return null;
 
   return (
-    <section className="rounded-lg border border-warning/30 bg-warning/10 p-layout-md shadow-surface">
-      <h3 className="flex items-center gap-layout-xs text-base font-medium text-foreground">
-        <ClipboardCheck aria-hidden="true" className="h-4 w-4" />
-        Opening review
-      </h3>
-      <p className="mt-layout-sm text-sm leading-6 text-foreground">
-        Athena started the store day with manager review items.
-      </p>
-      <p className="mt-1 text-sm leading-6 text-muted-foreground">
-        Review these items in the owning workflow. They were preserved from the
-        opening check and were not resolved by automation.
-      </p>
-      <div className="mt-layout-md space-y-layout-md">
+    <section className="rounded-lg border border-warning/25 bg-surface-raised p-layout-md shadow-surface">
+      <div className="flex flex-col gap-layout-sm sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <h3 className="flex items-center gap-layout-xs text-base font-medium text-foreground">
+            <ClipboardCheck aria-hidden="true" className="h-4 w-4 text-warning" />
+            Opening review
+          </h3>
+          <p className="mt-layout-xs text-sm leading-6 text-foreground">
+            Store day started. Review the carried-forward items when a manager
+            is available.
+          </p>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            These items stayed visible from the opening check and were not
+            resolved by automation.
+          </p>
+        </div>
+        <Badge
+          className="border-warning/30 bg-warning/10 text-warning-foreground shadow-sm"
+          variant="outline"
+        >
+          {items.length} to review
+        </Badge>
+      </div>
+      <div className="mt-layout-md space-y-layout-xs">
         {items.map((item) => (
           <OpeningItemCard
             currency={currency}
             item={item}
             key={getItemId(item)}
             orgUrlSlug={orgUrlSlug}
+            showCollapsedDescription={false}
             storeUrlSlug={storeUrlSlug}
           />
         ))}
@@ -725,7 +737,7 @@ function getStatusRailIconClassName(status: DailyOpeningStatus) {
 function getStatusRailBadgeClassName(status: DailyOpeningStatus) {
   return cn(
     status === "blocked" && "text-danger",
-    status === "needs_attention" && "text-warning-foreground",
+    status === "needs_attention" && "text-warning",
     (status === "ready" || status === "started") && "text-success",
   );
 }
@@ -924,6 +936,7 @@ function OpeningItemCard({
   orgUrlSlug,
   requiresAcknowledgement,
   selected,
+  showCollapsedDescription = true,
   storeUrlSlug,
   onSelectedChange,
 }: {
@@ -933,6 +946,7 @@ function OpeningItemCard({
   orgUrlSlug: string;
   requiresAcknowledgement?: boolean;
   selected?: boolean;
+  showCollapsedDescription?: boolean;
   storeUrlSlug: string;
 }) {
   const itemId = getItemId(item);
@@ -976,6 +990,7 @@ function OpeningItemCard({
           />
         ) : null
       }
+      showCollapsedDescription={showCollapsedDescription}
       title={item.title}
     />
   );
@@ -1292,7 +1307,7 @@ function OpeningRail({
                   className={cn(
                     "shrink-0 text-right font-medium text-foreground",
                     item.valueTone === "danger" && "text-danger",
-                    item.valueTone === "warning" && "text-warning-foreground",
+                    item.valueTone === "warning" && "text-warning",
                     item.valueTone === "workflow" && "text-action-workflow",
                   )}
                 >

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.test.tsx
@@ -855,7 +855,7 @@ describe("DailyOperationsViewContent", () => {
     ).toBeInTheDocument();
     expect(
       screen.getAllByText(
-        "Athena started the store day with manager review items.",
+        "Store day started. Review the carried-forward items when a manager is available.",
       ).length,
     ).toBeGreaterThan(0);
     expect(

--- a/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
+++ b/packages/athena-webapp/src/components/operations/DailyOperationsView.tsx
@@ -42,6 +42,7 @@ import {
 import { EmptyState } from "../states/empty/empty-state";
 import { NoPermissionView } from "../states/no-permission/NoPermissionView";
 import { ProtectedAdminSignInView } from "../states/signed-out/ProtectedAdminSignInView";
+import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { Calendar } from "../ui/calendar";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
@@ -140,6 +141,10 @@ type DailyOperationsAutomationStatus = {
     to?: string;
   };
 };
+
+type DailyOperationsReviewEvidence = NonNullable<
+  DailyOperationsAutomationStatus["reviewEvidence"]
+>[number];
 
 export type DailyOperationsSnapshot = {
   automationStatuses?: DailyOperationsAutomationStatus[];
@@ -989,43 +994,52 @@ function AutomationReviewEvidencePanel({
   if (evidenceItems.length === 0) return null;
 
   return (
-    <section className="rounded-lg border border-warning/30 bg-warning/10 p-layout-md shadow-surface">
-      <h3 className="flex items-center gap-layout-xs text-base font-medium text-foreground">
-        <CircleAlert aria-hidden="true" className="h-4 w-4" />
-        Opening review
-      </h3>
-      <p className="mt-layout-sm text-sm leading-6 text-foreground">
-        Athena started the store day with manager review items.
-      </p>
-      <p className="mt-1 text-sm leading-6 text-muted-foreground">
-        Review these items in the owning workflow. POS stays open through the
-        started store-day record.
-      </p>
-      <div className="mt-layout-md space-y-layout-xs">
+    <section className="rounded-lg border border-warning/25 bg-surface-raised p-layout-md shadow-surface">
+      <div className="flex flex-col gap-layout-sm sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <h3 className="flex items-center gap-layout-xs text-base font-medium text-foreground">
+            <CircleAlert aria-hidden="true" className="h-4 w-4 text-warning" />
+            Opening review
+          </h3>
+          <p className="mt-layout-xs text-sm leading-6 text-foreground">
+            Store day started. Review the carried-forward items when a manager
+            is available.
+          </p>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            POS stays open while these items remain visible in their owning
+            workflows.
+          </p>
+        </div>
+        <Badge
+          className="border-warning/30 bg-warning/10 text-warning-foreground shadow-sm"
+          variant="outline"
+        >
+          {evidenceItems.length} to review
+        </Badge>
+      </div>
+      <div className="mt-layout-md divide-y divide-border/70 overflow-hidden rounded-md border border-border/70 bg-background/60">
         {evidenceItems.map((item) => (
           <article
-            className="flex flex-col gap-layout-xs rounded-md border border-border/70 bg-background/60 px-layout-md py-layout-sm sm:flex-row sm:items-start sm:justify-between"
+            className="flex flex-col gap-layout-xs px-layout-md py-layout-sm transition-colors hover:bg-surface/80 sm:flex-row sm:items-center sm:justify-between"
             key={item.id}
           >
             <div className="min-w-0">
               <p className="text-sm font-medium text-foreground">
-                {item.label}
+                {getReviewEvidenceTitle(item)}
               </p>
-              {item.message ? (
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                {getReviewEvidenceContextLabel(item)}
+              </p>
+              {getReviewEvidenceDetail(item) ? (
                 <p className="mt-1 text-xs leading-5 text-muted-foreground">
-                  {item.message}
-                </p>
-              ) : null}
-              {item.source?.label ? (
-                <p className="mt-1 text-xs text-muted-foreground">
-                  {item.source.label}
+                  {getReviewEvidenceDetail(item)}
                 </p>
               ) : null}
             </div>
             {item.sourceLink?.to ? (
               <Button
                 asChild
-                className="h-8 shrink-0 self-start px-2 text-xs"
+                className="h-8 shrink-0 self-start px-2 text-xs sm:self-center"
                 size="sm"
                 variant="ghost"
               >
@@ -1054,6 +1068,34 @@ function AutomationReviewEvidencePanel({
       </div>
     </section>
   );
+}
+
+const PENDING_CHECKOUT_REVIEW_PREFIX = "Review pending checkout item:";
+const DEFAULT_CARRY_FORWARD_DETAIL =
+  "This unresolved carry-forward item remains open and must be acknowledged for Opening.";
+
+function getReviewEvidenceTitle(item: DailyOperationsReviewEvidence) {
+  if (item.label.startsWith(PENDING_CHECKOUT_REVIEW_PREFIX)) {
+    return item.label.slice(PENDING_CHECKOUT_REVIEW_PREFIX.length).trim();
+  }
+
+  return item.label;
+}
+
+function getReviewEvidenceContextLabel(item: DailyOperationsReviewEvidence) {
+  if (item.label.startsWith(PENDING_CHECKOUT_REVIEW_PREFIX)) {
+    return "Pending checkout item";
+  }
+
+  return item.source?.label ?? "Manager review item";
+}
+
+function getReviewEvidenceDetail(item: DailyOperationsReviewEvidence) {
+  if (!item.message || item.message === DEFAULT_CARRY_FORWARD_DETAIL) {
+    return null;
+  }
+
+  return item.message;
 }
 
 function HistoricalWorkflowPanel({

--- a/packages/athena-webapp/src/components/pos/OrderSummary.tsx
+++ b/packages/athena-webapp/src/components/pos/OrderSummary.tsx
@@ -927,8 +927,8 @@ export function OrderSummary({
           </div>
           <Button
             onClick={handlePrintReceipt}
-            variant="outline"
-            className="h-11 w-full rounded-xl border-[hsl(var(--foreground))] bg-[hsl(var(--foreground))] px-4 text-sm font-semibold text-white shadow-[hsl(var(--foreground))/0.18] hover:border-[hsl(var(--primary))] hover:bg-[hsl(var(--primary))] hover:text-[hsl(var(--primary-foreground))]"
+            variant="utility-strong"
+            className="h-11 w-full rounded-xl px-4 text-sm font-semibold"
           >
             <Printer className="h-4 w-4" />
             Print receipt
@@ -1054,8 +1054,8 @@ export function OrderSummary({
                 >
                   <Button
                     onClick={handlePrintReceipt}
-                    variant="outline"
-                    className="h-14 rounded-2xl border-[hsl(var(--foreground))] bg-[hsl(var(--foreground))] px-5 text-sm font-semibold text-white shadow-[hsl(var(--foreground))/0.18] hover:border-[hsl(var(--primary))] hover:bg-[hsl(var(--primary))] hover:text-[hsl(var(--primary-foreground))]"
+                    variant="utility-strong"
+                    className="h-14 rounded-2xl px-5 text-sm font-semibold"
                   >
                     <Printer className="h-4 w-4" />
                     Print receipt

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.test.tsx
@@ -73,7 +73,7 @@ describe("RegisterDrawerGate", () => {
 
     expect(screen.getByText("GH₵100.02")).toBeInTheDocument();
     expect(screen.getByText("GH₵100")).toBeInTheDocument();
-    expect(screen.getByText("GH₵0.02")).toHaveClass("text-emerald-700");
+    expect(screen.getByText("GH₵0.02")).toHaveClass("text-success");
   });
 
   it("does not render a reopen action when no reopen handler is available", () => {
@@ -124,7 +124,7 @@ describe("RegisterDrawerGate", () => {
     });
 
     expect(screen.getByText("GH₵100.02")).toBeInTheDocument();
-    expect(screen.getByText("GH₵-0.02")).toHaveClass("text-red-700");
+    expect(screen.getByText("GH₵-0.02")).toHaveClass("text-danger");
   });
 
   it("runs the closeout secondary action for return-to-sale states", async () => {

--- a/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
+++ b/packages/athena-webapp/src/components/pos/register/RegisterDrawerGate.tsx
@@ -64,10 +64,10 @@ function formatCurrency(currency: string, amount?: number | null) {
 
 function getVarianceTone(variance?: number) {
   if (variance === undefined || variance === 0) {
-    return "text-stone-900";
+    return "text-foreground";
   }
 
-  return variance > 0 ? "text-emerald-700" : "text-red-700";
+  return variance > 0 ? "text-success" : "text-danger";
 }
 
 export function RegisterDrawerGate({
@@ -169,12 +169,12 @@ export function RegisterDrawerGate({
     const currency = drawerGate.currency ?? "GHS";
 
     return (
-      <div className="mx-auto max-w-2xl rounded-lg border border-stone-200 bg-white p-8 shadow-sm">
+      <div className="mx-auto max-w-2xl rounded-lg border border-border bg-surface-raised p-8 shadow-surface">
         <div className="space-y-1">
-          <h2 className="text-2xl font-semibold text-stone-900">
+          <h2 className="text-2xl font-semibold text-foreground">
             Correct opening float
           </h2>
-          <p className="text-sm text-stone-600">
+          <p className="text-sm text-muted-foreground">
             Update the starting cash for register {drawerGate.registerNumber}.
             This adjusts expected cash and records an audit event.
           </p>
@@ -184,21 +184,21 @@ export function RegisterDrawerGate({
           className="mt-8 space-y-5"
           onSubmit={handleOpeningFloatCorrectionSubmit}
         >
-          <div className="rounded-lg border border-stone-200 bg-stone-50/70 p-4">
+          <div className="rounded-lg border border-border bg-surface p-4">
             <dl className="grid grid-cols-2 gap-3 text-sm">
               <div className="space-y-1">
-                <dt className="text-[11px] uppercase tracking-[0.16em] text-stone-500">
+                <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
                   Current float
                 </dt>
-                <dd className="font-mono text-stone-900">
+                <dd className="font-mono text-foreground">
                   {formatCurrency(currency, drawerGate.currentOpeningFloat)}
                 </dd>
               </div>
               <div className="space-y-1">
-                <dt className="text-[11px] uppercase tracking-[0.16em] text-stone-500">
+                <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
                   Expected cash
                 </dt>
-                <dd className="font-mono text-stone-900">
+                <dd className="font-mono text-foreground">
                   {formatCurrency(currency, drawerGate.expectedCash)}
                 </dd>
               </div>
@@ -206,7 +206,7 @@ export function RegisterDrawerGate({
           </div>
 
           <label className="block space-y-2">
-            <span className="text-sm font-medium text-stone-700">
+            <span className="text-sm font-medium text-foreground">
               Corrected opening float ({currencyDisplaySymbol(currency)})
             </span>
             <Input
@@ -222,7 +222,7 @@ export function RegisterDrawerGate({
           </label>
 
           <label className="block space-y-2">
-            <span className="text-sm font-medium text-stone-700">Reason</span>
+            <span className="text-sm font-medium text-foreground">Reason</span>
             <Textarea
               disabled={drawerGate.isCorrectingOpeningFloat}
               onChange={(event) =>
@@ -235,7 +235,7 @@ export function RegisterDrawerGate({
           </label>
 
           {drawerGate.errorMessage ? (
-            <p className="text-sm text-red-600" role="alert">
+            <p className="text-sm text-danger" role="alert">
               {drawerGate.errorMessage}
             </p>
           ) : null}
@@ -277,24 +277,24 @@ export function RegisterDrawerGate({
       closeoutSubmittedReason === "manager_review";
 
     return (
-      <div className="mx-auto max-w-2xl rounded-lg border border-stone-200 bg-white p-8 shadow-sm">
+      <div className="mx-auto max-w-2xl rounded-lg border border-border bg-surface-raised p-8 shadow-surface">
         {isSubmittedCloseout ? (
           <div className="space-y-8">
             <div className="flex flex-wrap items-start gap-5">
-              <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-amber-50 text-amber-700">
+              <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-warning/15 text-warning">
                 <Clock3Icon className="h-5 w-5" />
               </div>
               <div className="min-w-0 flex-1 space-y-4">
-                <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-amber-800">
+                <p className="text-[11px] font-medium uppercase tracking-[0.18em] text-warning">
                   {isManagerReviewCloseout
                     ? "Manager approval required"
                     : "Closeout syncing"}
                 </p>
                 <div className="space-y-2">
-                  <h2 className="text-2xl font-semibold text-stone-900">
+                  <h2 className="text-2xl font-semibold text-foreground">
                     Register {drawerGate.registerNumber} closeout submitted
                   </h2>
-                  <p className="max-w-xl text-sm leading-6 text-stone-600">
+                  <p className="max-w-xl text-sm leading-6 text-muted-foreground">
                     {isManagerReviewCloseout
                       ? "Waiting for manager review. Selling is paused until the variance is approved or the register is reopened."
                       : "Closeout is saved on this register. Selling is paused until sync finishes or the register is reopened."}
@@ -303,21 +303,21 @@ export function RegisterDrawerGate({
               </div>
             </div>
 
-            <div className="rounded-lg border border-amber-200 bg-amber-50/40 p-5">
+            <div className="rounded-lg border border-warning/30 bg-warning/10 p-5">
               <dl className="grid gap-4 text-sm sm:grid-cols-3">
                 <div className="space-y-1">
-                  <dt className="text-[11px] uppercase tracking-[0.16em] text-stone-500">
+                  <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
                     Expected
                   </dt>
-                  <dd className="font-mono text-stone-900">
+                  <dd className="font-mono text-foreground">
                     {formatCurrency(currency, drawerGate.expectedCash)}
                   </dd>
                 </div>
                 <div className="space-y-1">
-                  <dt className="text-[11px] uppercase tracking-[0.16em] text-stone-500">
+                  <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
                     Counted
                   </dt>
-                  <dd className="font-mono text-stone-900">
+                  <dd className="font-mono text-foreground">
                     {formatCurrency(
                       currency,
                       drawerGate.closeoutSubmittedCountedCash,
@@ -325,7 +325,7 @@ export function RegisterDrawerGate({
                   </dd>
                 </div>
                 <div className="space-y-1">
-                  <dt className="text-[11px] uppercase tracking-[0.16em] text-stone-500">
+                  <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
                     Variance
                   </dt>
                   <dd
@@ -375,7 +375,7 @@ export function RegisterDrawerGate({
             </div>
 
             {drawerGate.errorMessage ? (
-              <p className="text-sm text-red-600" role="alert">
+              <p className="text-sm text-danger" role="alert">
                 {drawerGate.errorMessage}
               </p>
             ) : null}
@@ -383,28 +383,28 @@ export function RegisterDrawerGate({
         ) : (
           <>
             <div className="space-y-1">
-              <h2 className="text-2xl font-semibold text-stone-900">
+              <h2 className="text-2xl font-semibold text-foreground">
                 Register {drawerGate.registerNumber} closeout in progress
               </h2>
-              <p className="text-sm text-stone-600">
+              <p className="text-sm text-muted-foreground">
                 Finish this register closeout in Cash Controls before selling
                 here.
               </p>
             </div>
 
             <form className="mt-8 space-y-5" onSubmit={handleCloseoutSubmit}>
-              <div className="rounded-lg border border-stone-200 bg-stone-50/70 p-4">
+              <div className="rounded-lg border border-border bg-surface p-4">
                 <dl className="grid grid-cols-2 gap-3 text-sm">
                   <div className="space-y-1">
-                    <dt className="text-[11px] uppercase tracking-[0.16em] text-stone-500">
+                    <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
                       Expected
                     </dt>
-                    <dd className="font-mono text-stone-900">
+                    <dd className="font-mono text-foreground">
                       {formatCurrency(currency, drawerGate.expectedCash)}
                     </dd>
                   </div>
                   <div className="space-y-1">
-                    <dt className="text-[11px] uppercase tracking-[0.16em] text-stone-500">
+                    <dt className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
                       Draft variance
                     </dt>
                     <dd
@@ -422,7 +422,7 @@ export function RegisterDrawerGate({
               </div>
 
               <label className="block space-y-2">
-                <span className="text-sm font-medium text-stone-700">
+                <span className="text-sm font-medium text-foreground">
                   Counted cash ({currencyDisplaySymbol(currency)})
                 </span>
                 <Input
@@ -438,7 +438,7 @@ export function RegisterDrawerGate({
               </label>
 
               <label className="block space-y-2">
-                <span className="text-sm font-medium text-stone-700">
+                <span className="text-sm font-medium text-foreground">
                   Closeout notes
                 </span>
                 <Textarea
@@ -453,7 +453,7 @@ export function RegisterDrawerGate({
               </label>
 
               {drawerGate.errorMessage ? (
-                <p className="text-sm text-red-600" role="alert">
+                <p className="text-sm text-danger" role="alert">
                   {drawerGate.errorMessage}
                 </p>
               ) : null}
@@ -514,23 +514,23 @@ export function RegisterDrawerGate({
   }
 
   return (
-    <div className="mx-auto max-w-2xl rounded-lg border border-stone-200 bg-white p-8 shadow-sm">
+    <div className="mx-auto max-w-2xl rounded-lg border border-border bg-surface-raised p-8 shadow-surface">
       <div className="space-y-4">
         <div className="flex flex-wrap items-start justify-between gap-3">
-          <p className="text-sm font-medium uppercase tracking-[0.2em] text-stone-500">
+          <p className="text-sm font-medium uppercase tracking-[0.2em] text-muted-foreground">
             Register {drawerGate.registerNumber}
           </p>
-          <span className="rounded-full border border-stone-200 bg-stone-50 px-2.5 py-1 text-xs font-medium text-stone-600">
+          <span className="rounded-full border border-border bg-surface px-2.5 py-1 text-xs font-medium text-muted-foreground">
             Drawer closed
           </span>
         </div>
         <div className="space-y-2">
-          <h2 className="text-2xl font-semibold text-stone-900">
+          <h2 className="text-2xl font-semibold text-foreground">
             {isRecovery
               ? "Open drawer to continue"
               : "Open drawer to start selling"}
           </h2>
-          <p className="text-sm leading-6 text-stone-600">
+          <p className="text-sm leading-6 text-muted-foreground">
             {isRecovery
               ? `${drawerGate.registerLabel} is closed. Open the drawer to continue this sale.`
               : `${drawerGate.registerLabel} is closed. Enter the opening float before starting sales.`}
@@ -540,7 +540,7 @@ export function RegisterDrawerGate({
 
       <form className="mt-8 space-y-5" onSubmit={handleSubmit}>
         <label className="block space-y-2">
-          <span className="text-sm font-medium text-stone-700">
+          <span className="text-sm font-medium text-foreground">
             Opening float ({currencyDisplaySymbol(drawerGate.currency ?? "GHS")}
             )
           </span>
@@ -557,7 +557,7 @@ export function RegisterDrawerGate({
         </label>
 
         <label className="block space-y-2">
-          <span className="text-sm font-medium text-stone-700">
+          <span className="text-sm font-medium text-foreground">
             Notes (optional)
           </span>
           <Textarea
@@ -570,11 +570,11 @@ export function RegisterDrawerGate({
         </label>
 
         {drawerGate.errorMessage ? (
-          <p className="text-sm text-red-600" role="alert">
+          <p className="text-sm text-danger" role="alert">
             {drawerGate.errorMessage}
           </p>
         ) : drawerGate.canOpenDrawer === false ? (
-          <p className="text-sm text-stone-600">
+          <p className="text-sm text-muted-foreground">
             Cashier or manager sign-in required to open this drawer.
           </p>
         ) : null}

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.test.tsx
@@ -342,7 +342,9 @@ describe("POSTerminalDetailViewContent", () => {
     render(<POSTerminalDetailViewContent detail={detail} isLoading={false} />);
 
     expect(screen.getByText("Staff authority")).toBeInTheDocument();
-    expect(screen.getByText("Expired")).toBeInTheDocument();
+    expect(screen.getByText("Expired").parentElement).toHaveClass(
+      "text-warning",
+    );
   });
 
   it("starts Remote Assist from an enrolled online terminal", async () => {

--- a/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
+++ b/packages/athena-webapp/src/components/pos/terminals/POSTerminalDetailView.tsx
@@ -295,7 +295,7 @@ function ReadyReadinessValue() {
 
 function ExpiredReadinessValue() {
   return (
-    <span className="inline-flex items-center justify-end gap-1 text-warning-foreground">
+    <span className="inline-flex items-center justify-end gap-1 text-warning">
       <AlertTriangle className="h-3 w-3" aria-hidden="true" />
       <span>Expired</span>
     </span>
@@ -357,7 +357,7 @@ function RailSignalRow({
           tone === "success"
             ? "text-success"
             : tone === "warning"
-              ? "text-warning-foreground"
+              ? "text-warning"
               : "text-foreground",
         )}
       >

--- a/packages/athena-webapp/src/components/ui/button.test.tsx
+++ b/packages/athena-webapp/src/components/ui/button.test.tsx
@@ -25,6 +25,7 @@ describe("Button", () => {
         <Button variant="workflow">Correct</Button>
         <Button variant="workflow-soft">Selected correction</Button>
         <Button variant="utility">View receipt</Button>
+        <Button variant="utility-strong">Print receipt</Button>
       </>
     );
 
@@ -40,6 +41,10 @@ describe("Button", () => {
     ).toHaveClass("bg-action-workflow-soft");
     expect(screen.getByRole("button", { name: "View receipt" })).toHaveClass(
       "text-action-neutral",
+    );
+    expect(screen.getByRole("button", { name: "Print receipt" })).toHaveClass(
+      "bg-action-neutral-strong",
+      "text-action-neutral-strong-foreground",
     );
   });
 });

--- a/packages/athena-webapp/src/components/ui/button.tsx
+++ b/packages/athena-webapp/src/components/ui/button.tsx
@@ -19,6 +19,8 @@ const buttonVariants = cva(
           "border border-action-workflow-border bg-action-workflow-soft text-action-workflow hover:bg-action-workflow-soft/75",
         utility:
           "border border-border bg-background text-action-neutral hover:bg-action-neutral-soft hover:text-action-neutral",
+        "utility-strong":
+          "border border-action-neutral-strong-border bg-action-neutral-strong text-action-neutral-strong-foreground shadow-[hsl(var(--action-neutral-strong)/0.18)] hover:border-primary hover:bg-primary hover:text-primary-foreground",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:

--- a/packages/athena-webapp/src/design-system-build-config.test.ts
+++ b/packages/athena-webapp/src/design-system-build-config.test.ts
@@ -35,6 +35,14 @@ describe("design system build config", () => {
     expect(indexHtml).not.toContain('type="text/tailwindcss"');
   });
 
+  it("keeps warning foreground legible on dark soft-warning surfaces", () => {
+    const indexCss = fs.readFileSync(path.join(packageDir, "src/index.css"), "utf8");
+
+    expect(indexCss).toContain(".dark .bg-warning\\/10.text-warning-foreground");
+    expect(indexCss).toContain(".dark .bg-warning\\/10 .text-warning-foreground");
+    expect(indexCss).toContain("color: hsl(var(--warning));");
+  });
+
   it("routes deployment helpers through the active checkout", () => {
     const repoRoot = path.resolve(packageDir, "../..");
     const interactiveDeployScript = fs.readFileSync(

--- a/packages/athena-webapp/src/index.css
+++ b/packages/athena-webapp/src/index.css
@@ -82,6 +82,9 @@
     --action-workflow-border: 232 38% 82%;
     --action-neutral: 225 18% 35%;
     --action-neutral-soft: 225 20% 96%;
+    --action-neutral-strong: var(--foreground);
+    --action-neutral-strong-foreground: 0 0% 100%;
+    --action-neutral-strong-border: var(--foreground);
     --success: 151 42% 34%;
     --success-foreground: 145 60% 96%;
     --warning: 35 79% 52%;
@@ -181,6 +184,9 @@
     --action-workflow-border: 233 36% 44%;
     --action-neutral: 225 18% 76%;
     --action-neutral-soft: 225 17% 22%;
+    --action-neutral-strong: var(--shell);
+    --action-neutral-strong-foreground: var(--shell-foreground);
+    --action-neutral-strong-border: 222 12% 28%;
     --success: 151 44% 34%;
     --success-foreground: 145 56% 94%;
     --warning: 38 92% 61%;

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.test.ts
@@ -156,6 +156,68 @@ describe("createLocalCommandGateway", () => {
     expect(onEventAppended).toHaveBeenCalledTimes(1);
   });
 
+  it("opens the next drawer after a local closeout has synced", async () => {
+    let nextId = 1;
+    const store = createPosLocalStore({
+      adapter: createMemoryPosLocalStorageAdapter(),
+      createLocalId: (kind) => `local-event-${kind}-${nextId++}`,
+    });
+    const opened = await store.appendEvent({
+      type: "register.opened",
+      terminalId: "terminal-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      localRegisterSessionId: "drawer-1",
+      staffProfileId: "staff-1",
+      payload: { localRegisterSessionId: "drawer-1", openingFloat: 100 },
+    });
+    const closeout = await store.appendEvent({
+      type: "register.closeout_started",
+      terminalId: "terminal-1",
+      storeId: "store-1",
+      registerNumber: "1",
+      localRegisterSessionId: "drawer-1",
+      staffProfileId: "staff-1",
+      payload: { countedCash: 100 },
+    });
+    expect(opened.ok).toBe(true);
+    expect(closeout.ok).toBe(true);
+    if (!opened.ok || !closeout.ok) return;
+    await store.markEventsSynced(
+      [opened.value.localEventId, closeout.value.localEventId],
+      { uploaded: true },
+    );
+
+    const gateway = createLocalCommandGateway({
+      store,
+      createLocalId: (kind) => `${kind}-next`,
+    });
+    const nextDrawer = await gateway.openDrawer({
+      storeId: "store-1" as never,
+      terminalId: "terminal-1" as never,
+      staffProfileId: "staff-1" as never,
+      registerNumber: "1",
+      openingFloat: 250,
+    });
+
+    expect(nextDrawer).toMatchObject({
+      kind: "ok",
+      data: {
+        localRegisterSessionId: "local-register-session-next",
+        openingFloat: 250,
+      },
+    });
+    await expect(store.listEvents()).resolves.toMatchObject({
+      ok: true,
+      value: expect.arrayContaining([
+        expect.objectContaining({
+          localRegisterSessionId: "local-register-session-next",
+          type: "register.opened",
+        }),
+      ]),
+    });
+  });
+
   it("persists app-session validation metadata on sale-affecting commands", async () => {
     const store = createPosLocalStore({
       adapter: createMemoryPosLocalStorageAdapter(),

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localCommandGateway.ts
@@ -445,10 +445,18 @@ export function createLocalCommandGateway(
       const isLifecycleReviewDrawerBlock =
         existingModel.value.saleBlockReason === "drawer_authority" &&
         existingModel.value.drawerAuthorityReason === "lifecycle_rejected";
+      const isSettledClosedDrawerBlock =
+        existingModel.value.saleBlockReason === "drawer_closed" &&
+        hasSettledRegisterCloseout({
+          events: existingModel.value.sourceEvents,
+          localRegisterSessionId:
+            existingModel.value.activeRegisterSession?.localRegisterSessionId,
+        });
       if (
         existingModel.value.saleBlockReason &&
         !isClosedCloudDrawerBlock &&
-        !isLifecycleReviewDrawerBlock
+        !isLifecycleReviewDrawerBlock &&
+        !isSettledClosedDrawerBlock
       ) {
         return toLocalUserError(
           blockedSaleMessage(existingModel.value.saleBlockReason),
@@ -705,6 +713,23 @@ function hasLocalSaleActivity(
 
 function isOpenLocalRegisterSessionStatus(status: string) {
   return status === "open" || status === "active";
+}
+
+function hasSettledRegisterCloseout(input: {
+  events: PosLocalEventRecord[];
+  localRegisterSessionId?: string;
+}) {
+  if (!input.localRegisterSessionId) return false;
+
+  const latestCloseout = [...input.events]
+    .reverse()
+    .find(
+      (event) =>
+        event.type === "register.closeout_started" &&
+        event.localRegisterSessionId === input.localRegisterSessionId,
+    );
+
+  return latestCloseout?.sync.status === "synced";
 }
 
 function toLocalUserError(message: string) {

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.test.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.test.ts
@@ -174,6 +174,51 @@ describe("localPosReadiness", () => {
     });
   });
 
+  it("allows POS after a local drawer closeout has synced", () => {
+    expect(
+      evaluateLocalPosReadiness({
+        entryContext,
+        operatingDate: "2026-05-14",
+        localReadiness: {
+          storeId: "store-1",
+          operatingDate: "2026-05-14",
+          status: "started",
+          source: "daily_opening",
+          updatedAt: 1_000,
+        },
+        registerReadModel: {
+          canSell: false,
+          closeoutState: {
+            status: "closed_locally",
+            localRegisterSessionId: "local-register-1",
+            updatedAt: 1_100,
+          },
+          sourceEvents: [
+            {
+              localEventId: "event-1",
+              schemaVersion: 1,
+              sequence: 1,
+              uploadSequence: 1,
+              type: "register.closeout_started",
+              terminalId: "terminal-1",
+              storeId: "store-1",
+              registerNumber: "1",
+              localRegisterSessionId: "local-register-1",
+              staffProfileId: "staff-1",
+              payload: { countedCash: 100 },
+              createdAt: 1_100,
+              sync: { status: "synced" },
+            },
+          ],
+        } as PosLocalRegisterReadModel,
+      }),
+    ).toEqual({
+      status: "ready",
+      source: "local_readiness",
+      storeDayStatus: "started",
+    });
+  });
+
   it("shows store-day start readiness before local drawer recovery", () => {
     expect(
       evaluateLocalPosReadiness({

--- a/packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts
+++ b/packages/athena-webapp/src/lib/pos/infrastructure/local/localPosReadiness.ts
@@ -7,6 +7,7 @@ import type { PosLocalRegisterReadModel } from "./registerReadModel";
 import {
   createIndexedDbPosLocalStorageAdapter,
   createPosLocalStore,
+  type PosLocalEventRecord,
   type PosLocalStoreDayReadiness,
   type PosLocalStoreResult,
 } from "./posLocalStore";
@@ -176,7 +177,10 @@ export function evaluateLocalPosReadiness(input: {
     );
   }
 
-  if (input.registerReadModel?.closeoutState?.status === "closed_locally") {
+  if (
+    input.registerReadModel?.closeoutState?.status === "closed_locally" &&
+    !hasSettledLocalCloseout(input.registerReadModel)
+  ) {
     return blocked(
       "local_closeout",
       "Drawer closeout started. Reopen the drawer before starting sales.",
@@ -231,6 +235,21 @@ export function evaluateLocalPosReadiness(input: {
     "unknown",
     "Store day status unavailable. Connect this terminal before starting sales.",
   );
+}
+
+function hasSettledLocalCloseout(model: PosLocalRegisterReadModel) {
+  const localRegisterSessionId = model.closeoutState?.localRegisterSessionId;
+  if (!localRegisterSessionId) return false;
+
+  const latestCloseout = [...(model.sourceEvents ?? [])]
+    .reverse()
+    .find(
+      (event: PosLocalEventRecord) =>
+        event.type === "register.closeout_started" &&
+        event.localRegisterSessionId === localRegisterSessionId,
+    );
+
+  return latestCloseout?.sync.status === "synced";
 }
 
 export function evaluateLocalPosServiceCatalogReadiness(

--- a/packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx
+++ b/packages/athena-webapp/src/stories/Foundations/foundations-content.test.tsx
@@ -66,5 +66,6 @@ describe("AthenaFoundationsPage", () => {
     expect(indexCss).toContain("--action-commit-soft: 338 72% 96%;");
     expect(indexCss).toContain("--action-workflow: 232 42% 45%;");
     expect(indexCss).toContain("--action-workflow-soft: 232 58% 96%;");
+    expect(indexCss).toContain("--action-neutral-strong: var(--foreground);");
   });
 });

--- a/packages/athena-webapp/tailwind.config.js
+++ b/packages/athena-webapp/tailwind.config.js
@@ -115,6 +115,10 @@ export default {
           "workflow-border": "hsl(var(--action-workflow-border))",
           neutral: "hsl(var(--action-neutral))",
           "neutral-soft": "hsl(var(--action-neutral-soft))",
+          "neutral-strong": "hsl(var(--action-neutral-strong))",
+          "neutral-strong-foreground":
+            "hsl(var(--action-neutral-strong-foreground))",
+          "neutral-strong-border": "hsl(var(--action-neutral-strong-border))",
         },
         success: {
           DEFAULT: "hsl(var(--success))",


### PR DESCRIPTION
## Summary
- Release synced local POS closeouts from stale local readiness and drawer blockers so cashiers can continue the next sale flow.
- Move strong neutral action styling to semantic theme tokens and apply the dark-mode-safe action variant to receipt and completion controls.
- Refresh affected operations review/readiness surfaces, tests, design docs, solution notes, and graphify artifacts.

## Validation
- bun run pr:athena

## Notes
- Browser visual validation intentionally left to the requester.

Linear: https://linear.app/v26-labs/issue/V26-756/deliver-pos-continuity-and-dark-action-token-cleanup