### PR TITLE
Fix POS recovery audit timeline leak

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -5,7 +5,7 @@
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6986 nodes · 7893 edges · 1886 communities detected
+- 6987 nodes · 7895 edges · 1886 communities detected
 - Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
 - Token cost: 0 input · 0 output
 
@@ -1944,12 +1944,12 @@ Cohesion: 0.06
 Nodes (26): asRecord(), createEmptyMemoryStore(), createMemoryPosLocalStorageAdapter(), getExpenseLocalSessionId(), getUploadSequenceScopeId(), normalizeCashierPresenceRecord(), normalizeDrawerAuthorityState(), normalizeLocalEventPayload() (+18 more)
 
 ### Community 5 - "Community 5"
-Cohesion: 0.1
-Nodes (46): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectHarnessSafetySignalFindings(), collectHarnessScriptTestUpdateFindings(), createOutput() (+38 more)
+Cohesion: 0.08
+Nodes (44): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents(), buildWeekMetricForDate(), buildWeekMetrics(), compareDailyOperationsTimelineEvents() (+36 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.08
-Nodes (43): attentionSeverity(), buildDailyOperationsSnapshotWithCtx(), buildLanes(), buildPendingRegisterCountTimelineMessage(), buildRegisterCloseoutTimelineEvents(), buildWeekMetricForDate(), buildWeekMetrics(), compareDailyOperationsTimelineEvents() (+35 more)
+Cohesion: 0.1
+Nodes (46): buildFinding(), buildHumanReport(), buildSemanticPrompt(), buildShadowSummary(), buildShellCommandPattern(), collectHarnessSafetySignalFindings(), collectHarnessScriptTestUpdateFindings(), createOutput() (+38 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.09
@@ -2497,19 +2497,19 @@ Nodes (8): fileExists(), isJsonObject(), normalizeGraphJsonArtifact(), normalize
 
 ### Community 143 - "Community 143"
 Cohesion: 0.39
-Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
+Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
 
 ### Community 144 - "Community 144"
 Cohesion: 0.39
-Nodes (6): buildInventoryMovement(), buildSkuActivityForInventoryMovement(), getSkuActivityTypeForMovement(), recordInventoryMovementWithCtx(), recordInventoryMovementWithDispositionWithCtx(), recordSkuActivityForInventoryMovementWithCtx()
-
-### Community 145 - "Community 145"
-Cohesion: 0.39
 Nodes (7): assertActiveTerminal(), getActiveManagerElevationByIdWithCtx(), getActiveManagerElevationWithCtx(), getCandidateElevations(), getStaffDisplayName(), startManagerElevationWithCtx(), toActiveElevation()
 
-### Community 146 - "Community 146"
+### Community 145 - "Community 145"
 Cohesion: 0.22
 Nodes (0):
+
+### Community 146 - "Community 146"
+Cohesion: 0.39
+Nodes (7): resolveVerificationCodeRecipient(), sendDiscountCodeEmail(), sendDiscountReminderEmail(), sendFeedbackRequestEmail(), sendNewOrderEmail(), sendOrderEmail(), sendVerificationCode()
 
 ### Community 147 - "Community 147"
 Cohesion: 0.5
@@ -2812,16 +2812,16 @@ Cohesion: 0.29
 Nodes (0):
 
 ### Community 222 - "Community 222"
+Cohesion: 0.33
+Nodes (2): getProductName(), sortProduct()
+
+### Community 223 - "Community 223"
 Cohesion: 0.29
 Nodes (0):
 
-### Community 223 - "Community 223"
+### Community 224 - "Community 224"
 Cohesion: 0.52
 Nodes (6): addItemToSavedBag(), getActiveSavedBag(), getBaseUrl(), removeItemFromSavedBag(), updateSavedBagItem(), updateSavedBagOwner()
-
-### Community 224 - "Community 224"
-Cohesion: 0.33
-Nodes (2): getProductName(), sortProduct()
 
 ### Community 225 - "Community 225"
 Cohesion: 0.43
@@ -11965,4 +11965,4 @@ _Questions this graph is uniquely positioned to answer:_
 - **Should `Community 4` be split into smaller, more focused modules?**
   _Cohesion score 0.06 - nodes in this community are weakly interconnected._
 - **Should `Community 5` be split into smaller, more focused modules?**
-  _Cohesion score 0.1 - nodes in this community are weakly interconnected._
+  _Cohesion score 0.08 - nodes in this community are weakly interconnected._

--- a/graphify-out/wiki/index.md
+++ b/graphify-out/wiki/index.md
@@ -8,8 +8,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 
 ## Repo Summary
 - Code files discovered: 1959
-- Graph nodes: 6986
-- Graph edges: 7893
+- Graph nodes: 6987
+- Graph edges: 7895
 - Communities: 1886
 
 ## Graph Hotspots
@@ -18,8 +18,8 @@ Graphify is the navigation layer for the repo graph. Use the entry docs below fo
 - `ingestLocalEvents.ts` (54 edges, Community 2) - [`packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/ingestLocalEvents.ts)
 - `projectLocalEvents.ts` (53 edges, Community 3) - [`packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts`](../../packages/athena-webapp/convex/pos/application/sync/projectLocalEvents.ts)
 - `posLocalStore.ts` (48 edges, Community 4) - [`packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts`](../../packages/athena-webapp/src/lib/pos/infrastructure/local/posLocalStore.ts)
-- `harness-inferential-review.ts` (47 edges, Community 5) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
-- `dailyOperations.ts` (46 edges, Community 6) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
+- `dailyOperations.ts` (47 edges, Community 5) - [`packages/athena-webapp/convex/operations/dailyOperations.ts`](../../packages/athena-webapp/convex/operations/dailyOperations.ts)
+- `harness-inferential-review.ts` (47 edges, Community 6) - [`scripts/harness-inferential-review.ts`](../../scripts/harness-inferential-review.ts)
 - `storefrontJourneyEvents.ts` (45 edges, Community 7) - [`packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts`](../../packages/storefront-webapp/src/lib/storefrontJourneyEvents.ts)
 
 ## Registered Packages

--- a/packages/athena-webapp/convex/operations/dailyOperations.test.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.test.ts
@@ -989,6 +989,19 @@ describe("daily operations overview read model", () => {
             subjectType: "posTransaction",
           },
           {
+            _id: "event-pos-recovery-code-updated",
+            createdAt: Date.UTC(2026, 4, 8, 19),
+            eventType: "pos_recovery_code_login_succeeded",
+            message: "POS recovery-code credential updated.",
+            metadata: {
+              reason: "verified",
+              status: "active",
+            },
+            storeId: "store-1",
+            subjectId: "pos-recovery-credential-1",
+            subjectType: "posRecoveryCredential",
+          },
+          {
             _id: "event-pending-checkout-item-reused",
             createdAt: Date.UTC(2026, 4, 8, 17),
             eventType: "pos_pending_checkout_item_reused",
@@ -1043,6 +1056,9 @@ describe("daily operations overview read model", () => {
     ]);
     expect(snapshot.timeline.map((event) => event.id)).not.toContain(
       "event-pending-checkout-item-reused",
+    );
+    expect(snapshot.timeline.map((event) => event.id)).not.toContain(
+      "event-pos-recovery-code-updated",
     );
     expect(
       snapshot.timeline.find((event) => event.id === "event-pos-sale-synced")

--- a/packages/athena-webapp/convex/operations/dailyOperations.ts
+++ b/packages/athena-webapp/convex/operations/dailyOperations.ts
@@ -697,6 +697,9 @@ async function mapOperationalTimelineEvent(
   },
 ): Promise<DailyOperationsTimelineEvent | null> {
   const metadata = event.metadata ?? {};
+  if (isDailyOperationsTimelineAuditEvent(event)) {
+    return null;
+  }
   if (isSaleBackedPendingCheckoutReuseEvent(event.eventType, metadata)) {
     return null;
   }
@@ -808,6 +811,16 @@ async function mapOperationalTimelineEvent(
     transactionLink,
     type: event.eventType,
   };
+}
+
+function isDailyOperationsTimelineAuditEvent(event: {
+  eventType: string;
+  subjectType: string;
+}) {
+  return (
+    event.subjectType === "posRecoveryCredential" ||
+    event.eventType.startsWith("pos_recovery_code_")
+  );
 }
 
 function isSaleBackedPendingCheckoutReuseEvent(


### PR DESCRIPTION
## Summary
- Hide POS recovery credential audit events from the Daily Operations store-day timeline
- Add regression coverage for the exact recovery-code event leaking from production E2E sign-ins
- Refresh graphify artifacts after the Convex read-model change

## Why
CI production POS recovery sign-ins should remain auditable, but account-security audit events are not store-day operating activity and should not appear in the operator timeline.

## Validation
- bun run --filter @athena/webapp test -- convex/operations/dailyOperations.test.ts convex/pos/public/posRecoveryCodes.test.ts
- bun run --filter @athena/webapp audit:convex
- bun run --filter @athena/webapp lint:convex:changed
- bunx tsc --noEmit -p packages/athena-webapp/tsconfig.json
- bun run graphify:rebuild
- Production Convex deployed and verified the Operations timeline no longer shows POS recovery-code credential updated.